### PR TITLE
Adding instructions to fix certs permission problems during bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@
 2. `make bootstrap`
 3. `make up`
 
-If you see permission errors around certs (eg. `ERROR: failed to read the CA key: open certs/rootCA-key.pem: permission denied`) follow these instructions instead of step 2. above:
+If you see permission errors around certs (eg. `ERROR: failed to read the CA key: open certs/rootCA-key.pem: permission denied`) follow these instructions instead of step 2. above.
+
+Assumes your are on an MHCLG-managed macbook and you have 2 accounts. Your ADMIN_USER is the account with full admin permissions, and your STANDARD_USER is the normal account you use for day to day work.
 1. `su <ADMIN_USER>`
 2. `sudo make certs`  Read the output - should be no apparent errors.
 3. `chown -R <STANDARD_USER>:staff certs`


### PR DESCRIPTION
Update `README` to include instructions for how to generate certificates on an MHCLG owned macbook