### PR TITLE
Initial terraform setup

### DIFF
--- a/terraform/backends/dev.conf
+++ b/terraform/backends/dev.conf
@@ -1,4 +1,4 @@
-bucket = "mhclg-fs-terraform-state"
+bucket = "mhclg-fs-terraform-state-dev"
 key    = "global/s3/terraform.tfstate"
 region = "eu-west-2"
 use_lockfile = "true"

--- a/terraform/bootstrap/main.tf
+++ b/terraform/bootstrap/main.tf
@@ -10,7 +10,7 @@ variable fs_tags {
 data "aws_caller_identity" "current" {}
 
 resource "aws_s3_bucket" "fs_terraform_state_bucket" {
-  bucket = "mhclg-fs-terraform-state"
+  bucket = "mhclg-fs-terraform-state-${terraform.workspace}"
 
   lifecycle {
     prevent_destroy = true


### PR DESCRIPTION
This PR creates 2 new workflows:

## Terraform Bootstrap
- Expected to be run manually against each environment, once only, to create the S3 bucket to store terraform state in.
- Runs inside the terraform/bootstrap directory

## Terraform Plan
- Uses the bucket above to store terraform state
- Runs the following terraform commands from the main terraform directory
    - `terraform init`
    - `terraform validate`
    - `terraform apply -auto-approve`
- While we only have a single environment, dev, it can be triggered manually to update aws on that environment

## Future Intentions
When we have future environments, the intention is to create a new workflow that only goes as far as `terraform plan` (for each environment) then appends that output to a pull request. Approving the PR will involve reviewing the output of `plan`, and then once merged workflows will be triggered to execute `apply` against each environment from that plan.