### PR TITLE
BAU: Add additional files for startup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+DATABASE_HOST=db
+DATABASE_PORT=5432
+DATABASE_NAME=postgres
+DATABASE_SECRET='{"username":"postgres","password":"postgres"}'  # pragma: allowlist secret
+SERVER_NAME=funding.communities.gov.localhost:8080
+SECRET_KEY=pretend_secret_key

--- a/.gitignore
+++ b/.gitignore
@@ -165,6 +165,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.envrc
 
 # Spyder project settings
 .spyderproject

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,17 @@ SHELL := bash
 .SHELLFLAGS := -eu -o pipefail -c
 
 .PHONY: bootstrap
-bootstrap: certs vite clean-build
+bootstrap: certs pre-commit vite clean-build
 
 .PHONY: certs
 certs:
 	mkdir -p certs
 	CAROOT=certs mkcert -install
 	CAROOT=certs mkcert -cert-file certs/cert.pem -key-file certs/key.pem "funding.communities.gov.localhost"
+
+.PHONY: pre-commit
+pre-commit:
+	uv run pre-commit install
 
 .PHONY: vite
 vite:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 - Node (version defined in  `./app/vite/.nvmrc`). We recommend using [nvm](https://github.com/nvm-sh/nvm) to manage node versions.
 - [uv](https://github.com/astral-sh/uv) installed globally
+- Copy .env.example to fresh .env file and leave values as is or use [direnv](https://direnv.net/)/.envrc for these variables
 
 ### Quickstart
 
@@ -20,9 +21,10 @@ Assumes your are on an MHCLG-managed macbook and you have 2 accounts. Your ADMIN
 2. `sudo make certs`  Read the output - should be no apparent errors.
 3. `chown -R <STANDARD_USER>:staff certs`
 4. `exit` to return to your standard user shell.
-5. `make vite`
-6. `make clean-build`
-7. Continue with step 3. above
+5. `make pre-commit`
+6. `make vite`
+7. `make clean-build`
+8. Continue with step 3. above
 
 * If you hit the error `SecTrustSettingsSetTrustSettings: The authorization was denied since no user interaction was possible.` when doing the above `su -` steps, then you may need to actually logout and login as your admin user instead of using `su`
 * If you subsequently hit git errors that mention `dubious ownership in repository` this is to do with changing the directory permissions above. A terminal restart should fix this.


### PR DESCRIPTION
Adds additional necessary bootstrapping context and scripts:
- Add information regarding environment variables to README and in .env.example so that the vite install can work in the initial bootstrapping
- Adds .envrc to .gitignore.
- Add basic VS Code pytest config.
- Add `pre-commit install` to the bootstrapping script