### PR TITLE
Adding new database connections env vars to pullpreview docker compose

### DIFF
--- a/docker-compose.pullpreview.yml
+++ b/docker-compose.pullpreview.yml
@@ -42,7 +42,10 @@ services:
     environment:
       FLASK_ENV: dev
       FLASK_PORT: 8080
-      DATABASE_URI: "postgresql+psycopg://postgres:postgres@db:5432/postgres"  # pragma: allowlist secret
+      DATABASE_HOST: "db"
+      DATABASE_PORT: 5432
+      DATABASE_NAME: "postgres"
+      DATABASE_SECRET: '{"username":"postgres","password":"postgres"}'  # pragma:allowlist secret
       SERVER_NAME: web:8080
       SECRET_KEY: unsafe  # pragma: allowlist secret
       DEBUG_TB_ENABLED: true


### PR DESCRIPTION
Fixing the docker compose setup for pull preview environments.

(This PR)[https://github.com/communitiesuk/funding-service/pull/6] changed the environment variables needed to connect to the database. So this change brings the pullpreview setup in line with those changes.