### PR TITLE
Add PR write permission

### DIFF
--- a/.github/workflows/pullpreview.yml
+++ b/.github/workflows/pullpreview.yml
@@ -18,9 +18,9 @@ jobs:
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: read  # This is required for actions/checkout
-      statuses: write
-      pull-requests: read
-      deployments: write
+      statuses: write  # Allows setting a status on a PR
+      pull-requests: write  # Allows removing labels from PRs
+      deployments: write  # Allows creating an environment/deployment
     steps:
       - uses: actions/checkout@v4
       - name: configure aws credentials


### PR DESCRIPTION
Seeing this error in the logs when closing a PR with a pullpreview env:

I, [2025-04-01T12:11:53.110021 #1]  INFO -- : Setting deployment status for repo="communitiesuk/funding-service", branch="bau-fix-pull-preview", sha="3bebf2498ab77d25768832bebc22264094518b6f", status=:error, params={:headers=>{:accept=>"application/vnd.github.ant-man-preview+json"}, :auto_inactive=>true}
Error: DELETE https://api.github.com/repos/communitiesuk/funding-service/issues/13/labels/pullpreview: 403 - Resource not accessible by integration // See: https://docs.github.com/rest/issues/labels#remove-a-label-from-an-issue
E, [2025-04-01T12:11:53.579525 #1] ERROR -- : /usr/local/bundle/gems/octokit-8.0.0/lib/octokit/response/raise_error.rb:14:in `on_complete'