### PR TITLE
Specify python version for buildpack

### DIFF
--- a/project.toml
+++ b/project.toml
@@ -13,5 +13,6 @@ exclude = [
 ]
 
 [[io.buildpacks.build.env]]
+# If updating the version here, also update in pyproject.toml, .python-version, Dockerfile
 name = "BP_CPYTHON_VERSION"
 value = "3.13.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "funding-service"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
+# If updating the version here, also update in project.toml, .python-version, Dockerfile
 requires-python = ">=3.13"
 dependencies = [
     "alembic-utils==0.8.6",


### PR DESCRIPTION
The app was failing to start on apprunner with a syntax error around `type CIStr...`.

The `type` keyword was only introduced in python 3.12, but we were running on the buildpack default of 3.10.

Added a `project.toml` file to specify the runtime version we want (3.13 to match the pyproject.toml). That means we run on 3.13 so `type` is allowed.