### PR TITLE
Precompile Jinja templates when running tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -68,10 +68,21 @@ def db(setup_db_container: Generator[None], app: Flask) -> Generator[SQLAlchemy,
             engine.dispose()
 
 
+def _precompile_templates(app: Flask) -> None:
+    # Precompile all of our Jinja2 templates so that this doesn't happen within individual tests. It can lead to the
+    # first test that hits templates taking significantly longer than its baseline, which makes it harder for us
+    # to add time limits on tests that we run (see `_integration_test_timeout` below).
+    # This doesn't *completely* warm up the flask app - still seeing that some first runs are a bit slower, but this
+    # takes away a significant amount of the difference between the first and second pass.
+    for template_name in app.jinja_env.list_templates():
+        app.jinja_env.get_template(template_name)
+
+
 @pytest.fixture(scope="session")
 def app(setup_db_container: Generator[SQLAlchemy]) -> Generator[Flask, None, None]:
     app = create_app()
     app.config.update({"TESTING": True})
+    _precompile_templates(app)
     yield app
 
 
@@ -104,7 +115,7 @@ def _integration_test_timeout(request: FixtureRequest) -> None:
     These tests may talk over the network (eg to the DB), so we need to make some allowance for that, but they should
     still be able to be fairly fast.
     """
-    request.node.add_marker(pytest.mark.fail_slow("400ms"))
+    request.node.add_marker(pytest.mark.fail_slow("250ms"))
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
We're trying to keep integration tests running quickly, and in order to do that we've added a timeout as an autouse fixture. If an integration test takes over x ms, we'll mark it as failed. We've had to bump this up a few times since we first added it.

From profiling the tests, we found that the first time the test hits an endpoint and has to render templates, Jinja needs to do a bunch of work reading the files and compiling them. This only happens the first time, so the first test run is artificially slower than it is on subsequent runs, which has caused the first run to breach our timeouts.

By precompiling all of the templates as part of the app fixture setup, we can take this compilation time out of the individual test run time, which helps us stay within our timeout budget.

Without precompilation, we saw roughly these kind of times for the `test_create_grant_handler` test:

0.21s call     tests/integration/test_handlers.py::test_create_grant_handler[1-2]
0.04s call     tests/integration/test_handlers.py::test_create_grant_handler[2-2]

After adding this precompilation step, the difference is drastically reduced (but not a complete baseline so there may still be some cold code paths to investigate later if we ever really want to):

0.08s call     tests/integration/test_handlers.py::test_create_grant_handler[1-2]
0.04s call     tests/integration/test_handlers.py::test_create_grant_handler[2-2]