### PR TITLE
FSPT-352: Enabling slack notifications on failure

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -74,3 +74,18 @@ jobs:
           aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.eu-west-2.amazonaws.com
 
           pack build $IMAGE_LOCATION --tag $IMAGE_ID:${{github.sha}} --tag $IMAGE_ID:latest --builder paketobuildpacks/builder-jammy-full --publish
+
+  notify_slack:
+    needs:
+      - paketo_build
+    if: ${{ always() && needs.paketo_build.result == 'failure' && github.ref_name == 'main'}}
+    uses: communitiesuk/funding-service-design-workflows/.github/workflows/notify-slack-deployment-failed.yml@main
+    with:
+      app_name: FS Paketo
+      env_name: 'build'
+      github_username: ${{ github.actor }}
+      workflow_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      compare_url: ${{ github.event_name == 'push' && github.event.compare || null }}
+    secrets:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_NOTIFICATION_CHANNEL_ID: ${{ secrets.TEMP_SLACK_CHANNEL_ID }}


### PR DESCRIPTION
Will send a notification to slack if the build job fails.

For now it uses the repo secret `TEMP_SLACK_CHANNEL_ID` which is set to the Platform channel. Once we have a more refined pipeline, and multiple environments we can change it to use the org secret `SLACK_NOTIFICATION_CHANNEL_ID` to go to the main fs deployments slack channel