### PR TITLE
BAU Tweak vite build settings

### DIFF
--- a/app/vite/vite.config.mjs
+++ b/app/vite/vite.config.mjs
@@ -1,16 +1,22 @@
 /* jshint esversion: 6 */
-
 import { viteStaticCopy } from 'vite-plugin-static-copy';
 
 export default {
   server: {
     port: 3000,
     strictPort: true,
+    warmup:{
+      clientFiles: ['*']
+    },
   },
+
+  clearScreen: false,
+  appType: 'custom',
 
   build: {
     manifest: true,
-    quietDeps: true
+    quietDeps: true,
+    cssCodeSplit: false
   },
 
   resolve: {

--- a/app/vite/vite.config.mjs
+++ b/app/vite/vite.config.mjs
@@ -6,7 +6,7 @@ export default {
     port: 3000,
     strictPort: true,
     warmup:{
-      clientFiles: ['*']
+      clientFiles: ['./src/main.js']
     },
   },
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       cp /app/certs/rootCA.pem /usr/local/share/ca-certificates/rootCA.crt && \
       update-ca-certificates && \
       uv run flask vite install && \
-      (cd app/vite && npm run dev) & \
+      uv run flask vite start && \
       python -m flask db upgrade & \
       python -m debugpy --listen 0.0.0.0:8081 -m flask run --host 0.0.0.0 --port 8080 --reload --debug --cert=/app/certs/cert.pem --key=/app/certs/key.pem
       "


### PR DESCRIPTION
Tweaks the config to:
- stop the docker compose logs being hijacked by vite
- have the vite styles ready to go when booting up the dev server for the first time
- use the flask interface rather than dipping into node

The intention was to have the bundler split out the CSS instead of having it load the SASS bundled in a dynamic JavaScript import. The dynamic JavaScript import isn't cached by the browser and is what's causing the flash of unstyled content. Splitting it out into a separate CSS file would allow us to continue to get watch/ live reload but avoid the FOUC. I wasn't able to appease it this time round.