### PR TITLE
Fspt 278 e2e bootstrap

### DIFF
--- a/.github/workflows/run_e2e_tests.yml
+++ b/.github/workflows/run_e2e_tests.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - fspt-278-e2e-bootstrap
 
 jobs:
   e2e_tests:
@@ -30,3 +29,18 @@ jobs:
 
       - name: run e2e tests
         run: uv run --frozen pytest --e2e --tracing=retain-on-failure --browser chromium
+
+  notify_slack:
+    needs:
+      - e2e_tests
+    if: ${{ always() && needs.e2e_tests.result == 'failure' && github.ref_name == 'main'}}
+    uses: communitiesuk/funding-service-design-workflows/.github/workflows/notify-slack-deployment-failed.yml@main
+    with:
+      app_name: FS E2E Tests
+      env_name: 'dev'
+      github_username: ${{ github.actor }}
+      workflow_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      compare_url: ${{ github.event_name == 'push' && github.event.compare || null }}
+    secrets:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_NOTIFICATION_CHANNEL_ID: ${{ secrets.TEMP_SLACK_CHANNEL_ID }}

--- a/.github/workflows/run_e2e_tests.yml
+++ b/.github/workflows/run_e2e_tests.yml
@@ -29,4 +29,4 @@ jobs:
         run: uv run --frozen playwright install --with-deps chromium
 
       - name: run e2e tests
-        run: uv run --frozen pytest -k e2e --tracing=retain-on-failure --browser chromium
+        run: uv run --frozen pytest --e2e --tracing=retain-on-failure --browser chromium

--- a/.github/workflows/run_e2e_tests.yml
+++ b/.github/workflows/run_e2e_tests.yml
@@ -30,17 +30,18 @@ jobs:
       - name: run e2e tests
         run: uv run --frozen pytest --e2e --tracing=retain-on-failure --browser chromium
 
-  notify_slack:
-    needs:
-      - e2e_tests
-    if: ${{ always() && needs.e2e_tests.result == 'failure' && github.ref_name == 'main'}}
-    uses: communitiesuk/funding-service-design-workflows/.github/workflows/notify-slack-deployment-failed.yml@main
-    with:
-      app_name: FS E2E Tests
-      env_name: 'dev'
-      github_username: ${{ github.actor }}
-      workflow_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-      compare_url: ${{ github.event_name == 'push' && github.event.compare || null }}
-    secrets:
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      SLACK_NOTIFICATION_CHANNEL_ID: ${{ secrets.TEMP_SLACK_CHANNEL_ID }}
+# TODO add this when we are running against real environments
+#  notify_slack:
+#    needs:
+#      - e2e_tests
+#    if: ${{ always() && needs.e2e_tests.result == 'failure' && github.ref_name == 'main'}}
+#    uses: communitiesuk/funding-service-design-workflows/.github/workflows/notify-slack-deployment-failed.yml@main
+#    with:
+#      app_name: FS E2E Tests
+#      env_name: 'dev'
+#      github_username: ${{ github.actor }}
+#      workflow_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+#      compare_url: ${{ github.event_name == 'push' && github.event.compare || null }}
+#    secrets:
+#      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+#      SLACK_NOTIFICATION_CHANNEL_ID: ${{ secrets.TEMP_SLACK_CHANNEL_ID }}

--- a/.github/workflows/run_e2e_tests.yml
+++ b/.github/workflows/run_e2e_tests.yml
@@ -1,0 +1,32 @@
+name: Run e2e tests
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - fspt-278-e2e-bootstrap
+
+jobs:
+  e2e_tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v4.2.2
+
+      - name: Set up Python
+        uses: actions/setup-python@v5.5.0
+        with:
+          python-version: 3.13.x
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5.4.1
+        with:
+          enable-cache: true
+
+      - name: Install playwright browsers
+        run: uv run --frozen playwright install --with-deps chromium
+
+      - name: run e2e tests
+        run: uv run --frozen pytest -k e2e --tracing=retain-on-failure --browser chromium

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-ast
+        language_version: python3.13
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.9.6
     hooks:

--- a/README.md
+++ b/README.md
@@ -40,3 +40,13 @@ Developers are expected to run the app locally using [docker-compose](https://do
 * `make down` / `docker compose down` will stop the Funding Service.
 * `make build` / `docker compose build` will rebuild the Funding Service image.
 * `make clean-build` / `docker compose build --no-cache` will rebuild the Funding Service image, bypassing caching. This should rarely be needed.
+
+# Tests
+## E2E Tests
+All E2E (browser) tests should live inside [/tests/e2e](./tests/e2e).
+
+To run any E2E tests include the `e2e` option in the pytest command:
+```shell
+uv run pytest --e2e
+```
+[This function](./tests/conftest.py#L15) skips e2e or non-e2e tests depending on the presence of the `--e2e` option.

--- a/app/common/data/interfaces/grants.py
+++ b/app/common/data/interfaces/grants.py
@@ -21,7 +21,7 @@ def get_all_grants() -> Sequence[Grant]:
 def create_grant(name: str) -> Grant:
     grant: Grant = Grant(name=name)
     db.session.add(grant)
-    
+
     try:
         db.session.flush()
     except IntegrityError as e:

--- a/app/platform/__init__.py
+++ b/app/platform/__init__.py
@@ -10,7 +10,7 @@ from app.common.data.interfaces.grants import (
     get_grant,
     update_grant,
 )
-from app.extensions import auto_commit_after_request, db
+from app.extensions import auto_commit_after_request
 from app.platform.forms import GrantForm
 
 # TODO do we call this platform

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dev = [
     "flask-debugtoolbar>=0.16.0",
     "mypy>=1.15.0",
     "pre-commit>=4.1.0",
+    "pytest-playwright>=0.7.0",
     "pytest>=8.3.4",
     "pytest-env>=1.1.5",
     "pytest-fail-slow>=0.6.0",
@@ -95,6 +96,9 @@ implicit_reexport = true
 env = [
     "FLASK_ENV=unit_test",
     "DATABASE_URL=postgresql+psycopg://overridden-by-fixture"
+]
+markers = [
+    "e2e: Run E2E (browser) tests using playwright"
 ]
 
 filterwarnings = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ markers = [
     "e2e: Run E2E (browser) tests using playwright"
 ]
 
+
 filterwarnings = [
     "error",
     "ignore:Could not insert debug toolbar:UserWarning"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,32 @@
-from typing import Generator
+from typing import Any, Generator
 
 import pytest
+from _pytest.config import Config
+from _pytest.config.argparsing import Parser
 from flask import Flask
 
 from app import create_app
+
+
+def pytest_addoption(parser: Parser) -> None:
+    parser.addoption("--e2e", action="store_true", default=False, help="run e2e (browser) tests")
+
+
+def pytest_collection_modifyitems(config: Config, items: list[Any]) -> None:
+    # Determines whether e2e tests have been requested. If not, skips anything marked as e2e.
+    # If e2e tests are requested, skips everything not marked as e2e
+    skip_e2e = pytest.mark.skip(reason="only running non-e2e tests")
+    skip_non_e2e = pytest.mark.skip(reason="only running e2e tests")
+
+    e2e_run = config.getoption("--e2e")
+    if e2e_run:
+        for item in items:
+            if "e2e" not in item.keywords:
+                item.add_marker(skip_non_e2e)
+    else:
+        for item in items:
+            if "e2e" in item.keywords:
+                item.add_marker(skip_e2e)
 
 
 @pytest.fixture(scope="session")

--- a/tests/e2e/test_playwright_example.py
+++ b/tests/e2e/test_playwright_example.py
@@ -1,0 +1,12 @@
+import re
+
+import pytest
+from playwright.sync_api import Page, expect
+
+
+@pytest.mark.e2e
+def test_playwright_example(page: Page):
+    page.goto("https://playwright.dev/")
+
+    # Expect a title "to contain" a substring.
+    expect(page).to_have_title(re.compile("Playwright"))

--- a/tests/e2e/test_playwright_example.py
+++ b/tests/e2e/test_playwright_example.py
@@ -1,10 +1,8 @@
 import re
 
-import pytest
 from playwright.sync_api import Page, expect
 
 
-@pytest.mark.e2e
 def test_playwright_example(page: Page):
     page.goto("https://playwright.dev/")
 

--- a/uv.lock
+++ b/uv.lock
@@ -384,6 +384,7 @@ dev = [
     { name = "pytest-env" },
     { name = "pytest-fail-slow" },
     { name = "pytest-flask" },
+    { name = "pytest-playwright" },
     { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "sqlalchemy-utils" },
@@ -425,6 +426,7 @@ dev = [
     { name = "pytest-env", specifier = ">=1.1.5" },
     { name = "pytest-fail-slow", specifier = ">=0.6.0" },
     { name = "pytest-flask", specifier = ">=1.3.0" },
+    { name = "pytest-playwright", specifier = ">=0.7.0" },
     { name = "pytest-xdist", specifier = ">=3.6.1" },
     { name = "ruff", specifier = ">=0.9.6" },
     { name = "sqlalchemy-utils", specifier = ">=0.41.2" },
@@ -639,6 +641,24 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.51.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/e9/db98b5a8a41b3691be52dcc9b9d11b5db01bfc9b835e8e3ffe387b5c9266/playwright-1.51.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:bcaaa3d5d73bda659bfb9ff2a288b51e85a91bd89eda86eaf8186550973e416a", size = 39634776 },
+    { url = "https://files.pythonhosted.org/packages/32/4a/5f2ff6866bdf88e86147930b0be86b227f3691f4eb01daad5198302a8cbe/playwright-1.51.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2e0ae6eb44297b24738e1a6d9c580ca4243b4e21b7e65cf936a71492c08dd0d4", size = 37986511 },
+    { url = "https://files.pythonhosted.org/packages/ba/b1/061c322319072225beba45e8c6695b7c1429f83bb97bdb5ed51ea3a009fc/playwright-1.51.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:ab4c0ff00bded52c946be60734868febc964c8a08a9b448d7c20cb3811c6521c", size = 39634776 },
+    { url = "https://files.pythonhosted.org/packages/7a/fd/bc60798803414ecab66456208eeff4308344d0c055ca0d294d2cdd692b60/playwright-1.51.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:d5c9f67bc6ef49094618991c78a1466c5bac5ed09157660d78b8510b77f92746", size = 45164868 },
+    { url = "https://files.pythonhosted.org/packages/0d/14/13db550d7b892aefe80f8581c6557a17cbfc2e084383cd09d25fdd488f6e/playwright-1.51.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:814e4ec2a1a0d6f6221f075622c06b31ceb2bdc6d622258cfefed900c01569ae", size = 44564157 },
+    { url = "https://files.pythonhosted.org/packages/51/e4/4342f0bd51727df790deda95ee35db066ac05cf4593a73d0c42249fa39a6/playwright-1.51.0-py3-none-win32.whl", hash = "sha256:4cef804991867ea27f608b70fa288ee52a57651e22d02ab287f98f8620b9408c", size = 34862688 },
+    { url = "https://files.pythonhosted.org/packages/20/0f/098488de02e3d52fc77e8d55c1467f6703701b6ea6788f40409bb8c00dd4/playwright-1.51.0-py3-none-win_amd64.whl", hash = "sha256:9ece9316c5d383aed1a207f079fc2d552fff92184f0ecf37cc596e912d00a8c3", size = 34862693 },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -728,6 +748,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pyee"
+version = "12.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0a/37/8fb6e653597b2b67ef552ed49b438d5398ba3b85a9453f8ada0fd77d455c/pyee-12.1.1.tar.gz", hash = "sha256:bbc33c09e2ff827f74191e3e5bbc6be7da02f627b7ec30d86f5ce1a6fb2424a3", size = 30915 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/68/7e150cba9eeffdeb3c5cecdb6896d70c8edd46ce41c0491e12fb2b2256ff/pyee-12.1.1-py3-none-any.whl", hash = "sha256:18a19c650556bb6b32b406d7f017c8f513aceed1ef7ca618fb65de7bd2d347ef", size = 15527 },
+]
+
+[[package]]
 name = "pytest"
 version = "8.3.5"
 source = { registry = "https://pypi.org/simple" }
@@ -740,6 +772,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634 },
+]
+
+[[package]]
+name = "pytest-base-url"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/1a/b64ac368de6b993135cb70ca4e5d958a5c268094a3a2a4cac6f0021b6c4f/pytest_base_url-2.1.0.tar.gz", hash = "sha256:02748589a54f9e63fcbe62301d6b0496da0d10231b753e950c63e03aee745d45", size = 6702 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/1c/b00940ab9eb8ede7897443b771987f2f4a76f06be02f1b3f01eb7567e24a/pytest_base_url-2.1.0-py3-none-any.whl", hash = "sha256:3ad15611778764d451927b2a53240c1a7a591b521ea44cebfe45849d2d2812e6", size = 5302 },
 ]
 
 [[package]]
@@ -782,6 +827,21 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-playwright"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "playwright" },
+    { name = "pytest" },
+    { name = "pytest-base-url" },
+    { name = "python-slugify" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/47/38e292ad92134a00ea05e6fc4fc44577baaa38b0922ab7ea56312b7a6663/pytest_playwright-0.7.0.tar.gz", hash = "sha256:b3f2ea514bbead96d26376fac182f68dcd6571e7cb41680a89ff1673c05d60b6", size = 16666 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/96/5f8a4545d783674f3de33f0ebc4db16cc76ce77a4c404d284f43f09125e3/pytest_playwright-0.7.0-py3-none-any.whl", hash = "sha256:2516d0871fa606634bfe32afbcc0342d68da2dbff97fe3459849e9c428486da2", size = 16618 },
+]
+
+[[package]]
 name = "pytest-xdist"
 version = "3.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -810,6 +870,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e3/c4/358cd13daa1d912ef795010897a483ab2f0b41c9ea1b35235a8b2f7d15a7/python_json_logger-3.2.1.tar.gz", hash = "sha256:8eb0554ea17cb75b05d2848bc14fb02fbdbd9d6972120781b974380bfa162008", size = 16287 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4b/72/2f30cf26664fcfa0bd8ec5ee62ec90c03bd485e4a294d92aabc76c5203a5/python_json_logger-3.2.1-py3-none-any.whl", hash = "sha256:cdc17047eb5374bd311e748b42f99d71223f3b0e186f4206cc5d52aefe85b090", size = 14924 },
+]
+
+[[package]]
+name = "python-slugify"
+version = "8.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "text-unidecode" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856", size = 10921 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8", size = 10051 },
 ]
 
 [[package]]
@@ -962,6 +1034,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e6/be/32bcd4143bca261b70e02109d75c2dbb5eb3e47e72e99efac9ca6ae88f76/testcontainers-4.9.1.tar.gz", hash = "sha256:37fe9a222549ddb788463935965b16f91809e9a8d654f437d6a59eac9b77f76f", size = 62463 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/d1/bba4ad5dca32d48c0e9c4845e84fa44933308c595d22c9e4b977a5007c4b/testcontainers-4.9.1-py3-none-any.whl", hash = "sha256:315fb94b42a383872df530aa45319745278ef0cc18b9cfcdc231a75d14afa5a0", size = 105478 },
+]
+
+[[package]]
+name = "text-unidecode"
+version = "1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154 },
 ]
 
 [[package]]


### PR DESCRIPTION
Adding some basic setup for playwright e2e tests:
- Installed playwright
- Added an example (non-fs) e2e test
- Added config to automatically exclude the e2e tests from regular pytest runs. They are runnable only with the `--e2e` option
- Updated the README
- Added a github action to run th e2e tests manually or on a push to main. Triggers to be revisited when we can hook this up to a deploy and a real environment