### PR TITLE
Changing startup order so vite doesn't stop the flask run from executing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,13 +24,13 @@ services:
       - "8081:8081" # debugpy
     stdin_open: true
     tty: true
-    command: >
+    command: > # The single & on line 33 puts vite into background mode so it doesn't take over the logs
       bash -c "
       cp /app/certs/rootCA.pem /usr/local/share/ca-certificates/rootCA.crt && \
       update-ca-certificates && \
-      uv run flask vite install && \
-      uv run flask vite start && \
-      python -m flask db upgrade & \
+      uv run flask db upgrade
+
+      (uv run flask vite install && uv run flask vite start) &
       python -m debugpy --listen 0.0.0.0:8081 -m flask run --host 0.0.0.0 --port 8080 --reload --debug --cert=/app/certs/cert.pem --key=/app/certs/key.pem
       "
     environment:


### PR DESCRIPTION
Had to update the startup commands for docker compose as per these changes to stop vite taking over and preventing the migrations from running.