### PR TITLE
Fix some HTML and add HTML tag validation

### DIFF
--- a/app/common/templates/common/base.html
+++ b/app/common/templates/common/base.html
@@ -24,7 +24,7 @@
 {% block main %}
 <div class="govuk-width-container {%- if containerClasses %} {{ containerClasses }}{% endif %}">
   {% block beforeContent %}{% endblock %}
-  <main class="govuk-main-wrapper {%- if mainClasses %} {{ mainClasses }}{% endif %}" id="main-content" {%- if mainLang %} lang="{{ mainLang }}"{% endif %}>
+  <div class="govuk-main-wrapper {%- if mainClasses %} {{ mainClasses }}{% endif %}">
     {% block mainWrapper %}
       <main id="main-content" {%- if mainLang %} lang="{{ mainLang }}"{% endif %}>
       {% block errorSummary %}
@@ -41,7 +41,7 @@
       {% endblock content%}
       </main>
     {% endblock mainWrapper%}
-  </main>
+  </div>
 </div>
 {% endblock %}
 

--- a/app/healthcheck/__init__.py
+++ b/app/healthcheck/__init__.py
@@ -1,11 +1,12 @@
 from flask import Blueprint, render_template
+from flask.typing import ResponseReturnValue
 
 healthcheck_blueprint = Blueprint(name="healthcheck", import_name=__name__)
 
 
 @healthcheck_blueprint.route("/healthcheck")
-def healthcheck() -> str:
-    return "OK"
+def healthcheck() -> ResponseReturnValue:
+    return "OK", 200, {"content-type": "text/plain"}
 
 
 @healthcheck_blueprint.route("/")

--- a/app/platform/templates/platform/grant.html
+++ b/app/platform/templates/platform/grant.html
@@ -11,9 +11,6 @@
 {% block content %}
     <div class="govuk-grid-row">
          <div class="govuk-grid-column-two-thirds">
-             {% if form.errors %}
-                 {{ govukErrorSummary(wtforms_errors(form)) }}
-             {% endif %}
              <h1 class="govuk-heading-l">Set up a new grant</h1>
              <form method="post" novalidate>
                  {{ form.csrf_token }}

--- a/app/platform/templates/platform/manage_grant_base.html
+++ b/app/platform/templates/platform/manage_grant_base.html
@@ -35,5 +35,4 @@
             </div>
         </div>
     </div>
-    </div>
 {% endblock %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,8 @@ dev = [
     "testcontainers>=4.9.1",
     "types-flask-migrate>=4.1.0.20250112",
     "types-wtforms>=3.2.1.20250304",
+    "html5lib>=1.1",
+    "types-html5lib>=1.1.11.20241018",
 ]
 
 [tool.ruff]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,17 @@
+import typing as t
 from typing import Any, Generator
 
+import html5lib
 import pytest
 from _pytest.config import Config
 from _pytest.config.argparsing import Parser
 from flask import Flask
+from flask.testing import FlaskClient
+from werkzeug.test import TestResponse
 
 from app import create_app
+
+html5parser = html5lib.HTMLParser(strict=False)
 
 
 def pytest_addoption(parser: Parser) -> None:
@@ -29,9 +35,39 @@ def pytest_collection_modifyitems(config: Config, items: list[Any]) -> None:
                 item.add_marker(skip_e2e)
 
 
+class FundingServiceTestClient(FlaskClient):
+    def open(
+        self,
+        *args: t.Any,
+        buffered: bool = False,
+        follow_redirects: bool = False,
+        **kwargs: t.Any,
+    ) -> TestResponse:
+        response = super().open(*args, buffered=buffered, follow_redirects=follow_redirects, **kwargs)
+
+        # Validate that our HTML is well-structured.
+        if response.content_type.startswith("text/html"):
+            html = response.data.decode()
+            html5parser.parse(html)
+
+            if html5parser.errors:
+                location, error, _extra_info = html5parser.errors[-1]
+                line_number, character_number = location
+                line_with_context = "\n".join(html.splitlines()[line_number - 10 : line_number])
+
+                # TODO: remove this when https://github.com/communitiesuk/funding-service/pull/36 has been merged.
+                if "FLASK_VITE_HEADER" not in line_with_context and "^ unexpected-end-tag" not in line_with_context:
+                    raise html5lib.html5parser.ParseError(
+                        f"\n\n{line_with_context}\n{' ' * (character_number - 1)}^ {error}"
+                    )
+
+        return response
+
+
 @pytest.fixture(scope="session")
 def app() -> Generator[Flask, None, None]:
     app = create_app()
+    app.test_client_class = FundingServiceTestClient
     app.config.update({"TESTING": True})
 
     yield app

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -21,6 +21,7 @@ from werkzeug.test import TestResponse
 
 from app import create_app
 from app.services.notify import Notification
+from tests.conftest import FundingServiceTestClient
 from tests.integration.example_models import ExampleAccountFactory, ExamplePersonFactory
 from tests.integration.models import _GrantFactory
 
@@ -93,7 +94,7 @@ def app(setup_db_container: Generator[SQLAlchemy]) -> Generator[Flask, None, Non
 
 @pytest.fixture()
 def client(app: Flask) -> FlaskClient:
-    class CustomClient(FlaskClient):
+    class CustomClient(FundingServiceTestClient):
         # We want to be sure that any data methods that act during the request have been
         # committed by the flask app lifecycle before continuing. Because of the way we configure
         # savepoints and rollbacks for test isolation a `flush` is considered the same as a

--- a/uv.lock
+++ b/uv.lock
@@ -407,20 +407,22 @@ dev = [
     { name = "debugpy" },
     { name = "factory-boy" },
     { name = "flask-debugtoolbar" },
+    { name = "html5lib" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-env" },
     { name = "pytest-fail-slow" },
     { name = "pytest-flask" },
-    { name = "pytest-playwright" },
     { name = "pytest-mock" },
+    { name = "pytest-playwright" },
     { name = "pytest-xdist" },
     { name = "responses" },
     { name = "ruff" },
     { name = "sqlalchemy-utils" },
     { name = "testcontainers" },
     { name = "types-flask-migrate" },
+    { name = "types-html5lib" },
     { name = "types-wtforms" },
 ]
 
@@ -452,20 +454,22 @@ dev = [
     { name = "debugpy", specifier = ">=1.8.12" },
     { name = "factory-boy", specifier = ">=3.3.3" },
     { name = "flask-debugtoolbar", specifier = ">=0.16.0" },
+    { name = "html5lib", specifier = ">=1.1" },
     { name = "mypy", specifier = ">=1.15.0" },
     { name = "pre-commit", specifier = ">=4.1.0" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-env", specifier = ">=1.1.5" },
     { name = "pytest-fail-slow", specifier = ">=0.6.0" },
     { name = "pytest-flask", specifier = ">=1.3.0" },
-    { name = "pytest-playwright", specifier = ">=0.7.0" },
     { name = "pytest-mock", specifier = ">=3.14.0" },
+    { name = "pytest-playwright", specifier = ">=0.7.0" },
     { name = "pytest-xdist", specifier = ">=3.6.1" },
     { name = "responses", specifier = ">=0.25.7" },
     { name = "ruff", specifier = ">=0.9.6" },
     { name = "sqlalchemy-utils", specifier = ">=0.41.2" },
     { name = "testcontainers", specifier = ">=4.9.1" },
     { name = "types-flask-migrate", specifier = ">=4.1.0.20250112" },
+    { name = "types-html5lib", specifier = ">=1.1.11.20241018" },
     { name = "types-wtforms", specifier = ">=3.2.1.20250304" },
 ]
 
@@ -520,6 +524,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/18/87/470e01a940307796f1d25f8167b551a968540fbe0551c0ebb853cb527dd6/greenlet-3.1.1-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6510bf84a6b643dabba74d3049ead221257603a253d0a9873f55f6a59a65f822", size = 602753 },
     { url = "https://files.pythonhosted.org/packages/e2/72/576815ba674eddc3c25028238f74d7b8068902b3968cbe456771b166455e/greenlet-3.1.1-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:04b013dc07c96f83134b1e99888e7a79979f1a247e2a9f59697fa14b5862ed01", size = 1122731 },
     { url = "https://files.pythonhosted.org/packages/ac/38/08cc303ddddc4b3d7c628c3039a61a3aae36c241ed01393d00c2fd663473/greenlet-3.1.1-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:411f015496fec93c1c8cd4e5238da364e1da7a124bcb293f085bf2860c32c6f6", size = 1142112 },
+]
+
+[[package]]
+name = "html5lib"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/b6/b55c3f49042f1df3dcd422b7f224f939892ee94f22abcf503a9b7339eaf2/html5lib-1.1.tar.gz", hash = "sha256:b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f", size = 272215 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/dd/a834df6482147d48e225a49515aabc28974ad5a4ca3215c18a882565b028/html5lib-1.1-py2.py3-none-any.whl", hash = "sha256:0d78f8fde1c230e99fe37986a60526d7049ed4bf8a9fadbad5f00e22e58e041d", size = 112173 },
 ]
 
 [[package]]
@@ -883,6 +900,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-mock"
+version = "3.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/90/a955c3ab35ccd41ad4de556596fa86685bf4fc5ffcc62d22d856cfd4e29a/pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0", size = 32814 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/3b/b26f90f74e2986a82df6e7ac7e319b8ea7ccece1caec9f8ab6104dc70603/pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f", size = 9863 },
+]
+
+[[package]]
 name = "pytest-playwright"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -895,17 +924,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e3/47/38e292ad92134a00ea05e6fc4fc44577baaa38b0922ab7ea56312b7a6663/pytest_playwright-0.7.0.tar.gz", hash = "sha256:b3f2ea514bbead96d26376fac182f68dcd6571e7cb41680a89ff1673c05d60b6", size = 16666 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/96/5f8a4545d783674f3de33f0ebc4db16cc76ce77a4c404d284f43f09125e3/pytest_playwright-0.7.0-py3-none-any.whl", hash = "sha256:2516d0871fa606634bfe32afbcc0342d68da2dbff97fe3459849e9c428486da2", size = 16618 },
-]
-[[package]]
-name = "pytest-mock"
-version = "3.14.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/90/a955c3ab35ccd41ad4de556596fa86685bf4fc5ffcc62d22d856cfd4e29a/pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0", size = 32814 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/3b/b26f90f74e2986a82df6e7ac7e319b8ea7ccece1caec9f8ab6104dc70603/pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f", size = 9863 },
 ]
 
 [[package]]
@@ -1055,6 +1073,15 @@ wheels = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050 },
+]
+
+[[package]]
 name = "soupsieve"
 version = "2.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1140,6 +1167,15 @@ wheels = [
 ]
 
 [[package]]
+name = "types-html5lib"
+version = "1.1.11.20241018"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/9d/f6fbcc8246f5e46845b4f989c4e17e6fb3ce572f7065b185e515bf8a3be7/types-html5lib-1.1.11.20241018.tar.gz", hash = "sha256:98042555ff78d9e3a51c77c918b1041acbb7eb6c405408d8a9e150ff5beccafa", size = 11370 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/7c/f862b1dc31268ef10fe95b43dcdf216ba21a592fafa2d124445cd6b92e93/types_html5lib-1.1.11.20241018-py3-none-any.whl", hash = "sha256:3f1e064d9ed2c289001ae6392c84c93833abb0816165c6ff0abfc304a779f403", size = 17292 },
+]
+
+[[package]]
 name = "types-wtforms"
 version = "3.2.1.20250304"
 source = { registry = "https://pypi.org/simple" }
@@ -1190,6 +1226,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f1/88/dacc875dd54a8acadb4bcbfd4e3e86df8be75527116c91d8f9784f5e9cab/virtualenv-20.29.2.tar.gz", hash = "sha256:fdaabebf6d03b5ba83ae0a02cfe96f48a716f4fae556461d180825866f75b728", size = 4320272 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/93/fa/849483d56773ae29740ae70043ad88e068f98a6401aa819b5d6bee604683/virtualenv-20.29.2-py3-none-any.whl", hash = "sha256:febddfc3d1ea571bdb1dc0f98d7b45d24def7428214d4fb73cc486c9568cce6a", size = 4301478 },
+]
+
+[[package]]
+name = "webencodings"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774 },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes two issues:
- We had two error summaries on the create grant page
- We had two `<main>` elements on the common/base template.

Also adds a meta test that will run all HTML responses from our app through an html5 validation lib and flag any structural errors. This didn't catch things like the double main or duplicate IDs, but did catch some unmatched closing tags so does provide _some_ value.