### PR TITLE
Stop link splitting over a newline

### DIFF
--- a/app/common/templates/common/auth/check_email.html
+++ b/app/common/templates/common/auth/check_email.html
@@ -15,7 +15,7 @@
 
             <h2 class="govuk-heading-s">If you do not receive the email</h2>
             <p class="govuk-body">The email may take a few minutes to arrive.</p>
-            <p class="govuk-body">Check your spam or junk folders – if it still has not arrived, you can <a href="{{ url_for('auth.sign_in') }}" class="govuk-link govuk-link--no-visited-state">request a new link</a>.</p>
+            <p class="govuk-body">Check your spam or junk folders – if it still has not arrived, <a href="{{ url_for('auth.sign_in') }}" class="govuk-link govuk-link--no-visited-state">request a new link</a>.</p>
         </div>
     </div>
 {% endblock content %}


### PR DESCRIPTION
## Before
![image](https://github.com/user-attachments/assets/f0ab1c7d-fb92-486a-be22-bf1ab5333a10)


## After
![image](https://github.com/user-attachments/assets/dc71f45c-0234-48ef-a5fa-5ee8dffeb7f3)