### PR TITLE
Autouse DB fixture; remove redundant fixtures

### DIFF
--- a/tests/integration/common/data/test_grants.py
+++ b/tests/integration/common/data/test_grants.py
@@ -16,12 +16,12 @@ def test_get_all_grants(factories):
     assert len(result) == 5
 
 
-def test_create_grant(db) -> None:
+def test_create_grant(db_session) -> None:
     result = create_grant(name="test_grant")
     assert result is not None
     assert result.id is not None
 
-    from_db = db.get_session().get(Grant, result.id)
+    from_db = db_session.get(Grant, result.id)
     assert from_db is not None
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -85,7 +85,7 @@ def _precompile_templates(app: Flask) -> None:
 
 
 @pytest.fixture(scope="session")
-def app(setup_db_container: Generator[SQLAlchemy]) -> Generator[Flask, None, None]:
+def app(db: Generator[SQLAlchemy]) -> Generator[Flask, None, None]:
     app = create_app()
     app.config.update({"TESTING": True})
     _precompile_templates(app)
@@ -124,7 +124,7 @@ def _integration_test_timeout(request: FixtureRequest) -> None:
     request.node.add_marker(pytest.mark.fail_slow("250ms"))
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="function", autouse=True)
 def db_session(app: Flask, db: SQLAlchemy) -> Generator[Session, None, None]:
     # Set up a DB session that is fully isolated for each specific test run. We override Flask-SQLAlchemy-Lite's (FSL)
     # sessionmaker configuration to use a connection with a transaction started, and configure FSL to use savepoints

--- a/tests/integration/platform/test_routes.py
+++ b/tests/integration/platform/test_routes.py
@@ -34,7 +34,7 @@ def test_view_grant_settings(client, factories, templates_rendered):
     assert "Settings" in soup.h1.text.strip()
 
 
-def test_edit_grant_get(client, factories, templates_rendered, db):
+def test_edit_grant_get(client, factories, templates_rendered):
     grant = factories.grant.create()
     result = client.get(url_for("platform.edit_grant", grant_id=grant.id))
     assert result.status_code == 200
@@ -45,7 +45,7 @@ def test_edit_grant_get(client, factories, templates_rendered, db):
     assert "Edit grant details" in soup.h1.text.strip()
 
 
-def test_edit_grant_post(client, factories, templates_rendered, db, db_session):
+def test_edit_grant_post(client, factories, templates_rendered, db_session):
     grant = factories.grant.create()
     # Update the name
     form = GrantForm()
@@ -58,7 +58,7 @@ def test_edit_grant_post(client, factories, templates_rendered, db, db_session):
     assert grant_from_db.name == "New name"
 
 
-def test_edit_grant_post_with_errors(client, factories, templates_rendered, db):
+def test_edit_grant_post_with_errors(client, factories, templates_rendered):
     grants = factories.grant.create_batch(2)
     # Test error handling on an update
     form = GrantForm(data={"name": grants[1].name})
@@ -71,7 +71,7 @@ def test_edit_grant_post_with_errors(client, factories, templates_rendered, db):
     assert soup.find_all("a", href="#name")[0].text.strip() == "Grant name already in use"
 
 
-def test_create_grant(client, db, db_session):
+def test_create_grant(client, db_session):
     url = url_for("platform.add_grant")
     client.get(url)
     response = client.post(


### PR DESCRIPTION
The `app` fixture was relying on `setup_db_container`, which spins up postgres but does not run migrations. Anything that needs the db to exist should be relying on the `db` fixture.

This patch changes app to rely on the `db` fixture, which gives it a migrated db.

I've also set the `db_session` fixture as an autouse one. This means every single test in the `integrations` folder will always have a transactionally-isolated session. It means a slight bit of waste/overhead on any 'integration' tests that don't need the db, but the confidence it gives us that future developers will always be writing tests with in a safe space feels worth this for now.