### PR TITLE
Generate and use magic links

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -38,6 +38,18 @@ def create_app() -> Flask:
     toolbar.init_app(app)
     notification_service.init_app(app)
 
+    # This section is needed for url_for("foo", _external=True) to
+    # automatically generate http scheme when this sample is
+    # running on localhost, and to generate https scheme when it is
+    # deployed behind reversed proxy.
+    # See also #proxy_setups section at
+    # flask.palletsprojects.com/en/1.0.x/deploying/wsgi-standalone
+    from werkzeug.middleware.proxy_fix import ProxyFix
+
+    app.wsgi_app = (  # type: ignore[method-assign]
+        ProxyFix(app.wsgi_app, x_proto=app.config["PROXY_FIX_PROTO"], x_host=app.config["PROXY_FIX_HOST"])
+    )
+
     # Configure templates
     app.jinja_loader = ChoiceLoader(
         [

--- a/app/common/auth/__init__.py
+++ b/app/common/auth/__init__.py
@@ -16,9 +16,9 @@ auth_blueprint = Blueprint(
 )
 
 
-@auth_blueprint.route("/sign-in", methods=["GET", "POST"])
+@auth_blueprint.route("/request-a-link-to-sign-in", methods=["GET", "POST"])
 @auto_commit_after_request
-def sign_in() -> ResponseReturnValue:
+def request_a_link_to_sign_in() -> ResponseReturnValue:
     form = SignInForm()
     if form.validate_on_submit():
         email = cast(str, form.email_address.data)
@@ -34,7 +34,7 @@ def sign_in() -> ResponseReturnValue:
             email,
             magic_link_url=url_for("auth.claim_magic_link", magic_link_code=magic_link.code, _external=True),
             magic_link_expires_at_utc=magic_link.expires_at_utc,
-            request_new_magic_link_url=url_for("auth.sign_in", _external=True),
+            request_new_magic_link_url=url_for("auth.request_a_link_to_sign_in", _external=True),
         )
 
         return redirect(url_for("auth.check_email", magic_link_id=magic_link.id))
@@ -56,7 +56,7 @@ def check_email(magic_link_id: uuid.UUID) -> ResponseReturnValue:
 def claim_magic_link(magic_link_code: str) -> ResponseReturnValue:
     magic_link = interfaces.magic_link.get_magic_link(code=magic_link_code)
     if not magic_link or not magic_link.usable:
-        return redirect(url_for("auth.sign_in"))
+        return redirect(url_for("auth.request_a_link_to_sign_in"))
 
     form = ClaimMagicLinkForm()
     if form.validate_on_submit():

--- a/app/common/auth/__init__.py
+++ b/app/common/auth/__init__.py
@@ -1,11 +1,13 @@
-import datetime
-from zoneinfo import ZoneInfo
+import uuid
+from typing import cast
 
-from flask import Blueprint, redirect, render_template, session, url_for
+from flask import Blueprint, abort, redirect, render_template, url_for
 from flask.typing import ResponseReturnValue
 
-from app.common.auth.forms import SignInForm
-from app.extensions import notification_service
+from app.common.auth.forms import ClaimMagicLinkForm, SignInForm
+from app.common.data import interfaces
+from app.common.data.interfaces.user import get_or_create_user
+from app.extensions import auto_commit_after_request, notification_service
 
 auth_blueprint = Blueprint(
     "auth",
@@ -15,30 +17,51 @@ auth_blueprint = Blueprint(
 
 
 @auth_blueprint.route("/sign-in", methods=["GET", "POST"])
+@auto_commit_after_request
 def sign_in() -> ResponseReturnValue:
     form = SignInForm()
     if form.validate_on_submit():
-        email = form.email_address.data
+        email = cast(str, form.email_address.data)
 
-        # TODO: all session stuff will be revisited as part of FSPT-334
-        session["email_address"] = email
+        user = get_or_create_user(email_address=email)
 
-        notification_service.send_magic_link(
-            email,  # type: ignore[arg-type]
-            magic_link_url="https://magic-link-tbd",
-            magic_link_expires_at_utc=datetime.datetime.now(ZoneInfo("UTC")) + datetime.timedelta(minutes=15),
-            request_new_magic_link_url="https://new-magic-link-tbd",
+        # TODO: read+validate redirect from query params
+        magic_link = interfaces.magic_link.create_magic_link(
+            user=user, redirect_to_path=url_for("platform.list_grants")
         )
 
-        return redirect(url_for("auth.check_email"))
+        notification_service.send_magic_link(
+            email,
+            magic_link_url=url_for("auth.claim_magic_link", magic_link_code=magic_link.code, _external=True),
+            magic_link_expires_at_utc=magic_link.expires_at_utc,
+            request_new_magic_link_url=url_for("auth.sign_in", _external=True),
+        )
+
+        return redirect(url_for("auth.check_email", magic_link_id=magic_link.id))
 
     return render_template("common/auth/sign_in.html", form=form)
 
 
-@auth_blueprint.get("/check-your-email")
-def check_email() -> ResponseReturnValue:
-    if "email_address" not in session:
+@auth_blueprint.get("/check-your-email/<uuid:magic_link_id>")
+def check_email(magic_link_id: uuid.UUID) -> ResponseReturnValue:
+    magic_link = interfaces.magic_link.get_magic_link(id_=magic_link_id)
+    if not magic_link or not magic_link.usable:
+        abort(404)
+
+    return render_template("common/auth/check_email.html", user=magic_link.user)
+
+
+@auth_blueprint.route("/sign-in/<magic_link_code>", methods=["GET", "POST"])
+@auto_commit_after_request
+def claim_magic_link(magic_link_code: str) -> ResponseReturnValue:
+    magic_link = interfaces.magic_link.get_magic_link(code=magic_link_code)
+    if not magic_link or not magic_link.usable:
         return redirect(url_for("auth.sign_in"))
 
-    email_address = session.get("email_address")
-    return render_template("common/auth/check_email.html", email_address=email_address)
+    form = ClaimMagicLinkForm()
+    if form.validate_on_submit():
+        interfaces.magic_link.claim_magic_link(magic_link=magic_link)
+        # TODO: actually create auth'd session
+        return redirect(magic_link.redirect_to_path)
+
+    return render_template("common/auth/claim_magic_link.html", form=form, magic_link=magic_link)

--- a/app/common/auth/forms.py
+++ b/app/common/auth/forms.py
@@ -22,3 +22,7 @@ class SignInForm(FlaskForm):
         widget=GovTextInput(),
     )
     submit = SubmitField("Request a link", widget=GovSubmitInput())
+
+
+class ClaimMagicLinkForm(FlaskForm):
+    submit = SubmitField("Sign in", widget=GovSubmitInput())

--- a/app/common/data/interfaces/__init__.py
+++ b/app/common/data/interfaces/__init__.py
@@ -1,3 +1,5 @@
-from app.common.data.interfaces import grants
+import app.common.data.interfaces.grants as grants
+import app.common.data.interfaces.magic_link as magic_link
+import app.common.data.interfaces.user as user
 
-__all__ = ["grants"]
+__all__ = ["grants", "magic_link", "user"]

--- a/app/common/data/interfaces/magic_link.py
+++ b/app/common/data/interfaces/magic_link.py
@@ -1,0 +1,37 @@
+import datetime
+import uuid
+
+from sqlalchemy import func, select, update
+
+from app.common.data.models import MagicLink, User
+from app.extensions import db
+
+
+def create_magic_link(user: User, *, redirect_to_path: str) -> MagicLink:
+    db.session.execute(update(MagicLink).where(MagicLink.user == user).values(expires_at_utc=func.current_timestamp()))
+
+    magic_link = MagicLink(
+        user=user,
+        redirect_to_path=redirect_to_path,
+        expires_at_utc=func.current_timestamp() + datetime.timedelta(minutes=15),
+    )
+
+    db.session.add(magic_link)
+    db.session.flush()
+
+    return magic_link
+
+
+def get_magic_link(id_: uuid.UUID | None = None, code: str | None = None) -> MagicLink | None:
+    if (id_ and code) or (not id_ and not code):
+        raise ValueError("Must provide exactly one of `id_` and `code`")
+
+    if id_:
+        return db.session.scalar(select(MagicLink).where(MagicLink.id == id_))
+
+    return db.session.scalar(select(MagicLink).where(MagicLink.code == code))
+
+
+def claim_magic_link(magic_link: MagicLink) -> None:
+    magic_link.claimed_at_utc = func.current_timestamp()
+    db.session.flush()

--- a/app/common/data/interfaces/user.py
+++ b/app/common/data/interfaces/user.py
@@ -1,0 +1,19 @@
+from sqlalchemy.dialects.postgresql import insert as postgresql_upsert
+
+from app.common.data.models import User
+from app.extensions import db
+
+
+def get_or_create_user(email_address: str) -> User:
+    # This feels like it should be a `on_conflict_do_nothing`, except in that case the DB won't return any rows
+    # So we use `on_conflict_do_update` with a noop change, so that this upsert will always return the User regardless
+    # of if its doing an insert or an 'update'.
+    user = db.session.scalars(
+        postgresql_upsert(User)
+        .values(email=email_address)
+        .on_conflict_do_update(index_elements=["email"], set_={"email": email_address})
+        .returning(User),
+        execution_options={"populate_existing": True},
+    ).one()
+
+    return user

--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-003_make_grant_name_citext
+004_user_and_magic_links

--- a/app/common/data/migrations/versions/004_user_and_magic_links.py
+++ b/app/common/data/migrations/versions/004_user_and_magic_links.py
@@ -1,0 +1,54 @@
+"""Add user and magic_link tables
+
+Revision ID: 004_user_and_magic_links
+Revises: 003_make_grant_name_citext
+Create Date: 2025-04-09 15:39:03.617536
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "004_user_and_magic_links"
+down_revision = "003_make_grant_name_citext"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.Column("email", postgresql.CITEXT(), nullable=False),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_user")),
+        sa.UniqueConstraint("email", name=op.f("uq_user_email")),
+    )
+    op.create_table(
+        "magic_link",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.Column("code", sa.String(), nullable=False),
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("redirect_to_path", sa.String(), nullable=False),
+        sa.Column("expires_at_utc", sa.DateTime(), nullable=False),
+        sa.Column("claimed_at_utc", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], name=op.f("fk_magic_link_user_id_user")),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_magic_link")),
+        sa.UniqueConstraint("code", name=op.f("uq_magic_link_code")),
+    )
+    with op.batch_alter_table("magic_link", schema=None) as batch_op:
+        batch_op.create_index(
+            batch_op.f("ix_magic_link_code"), ["code"], unique=True, postgresql_where="claimed_at_utc IS NOT NULL"
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("magic_link", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_magic_link_code"), postgresql_where="claimed_at_utc IS NOT NULL")
+
+    op.drop_table("magic_link")
+    op.drop_table("user")

--- a/app/common/data/models/__init__.py
+++ b/app/common/data/models/__init__.py
@@ -2,6 +2,7 @@ import datetime
 import secrets
 import uuid
 
+from pytz import utc
 from sqlalchemy import ForeignKey, Index
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -34,3 +35,7 @@ class MagicLink(BaseModel):
     user: Mapped[User] = relationship("User", back_populates="magic_links")
 
     __table_args__ = (Index(None, code, unique=True, postgresql_where="claimed_at_utc IS NOT NULL"),)
+
+    @property
+    def usable(self) -> bool:
+        return self.claimed_at_utc is None and self.expires_at_utc > datetime.datetime.now(utc).replace(tzinfo=None)

--- a/app/common/data/models/__init__.py
+++ b/app/common/data/models/__init__.py
@@ -1,4 +1,9 @@
-from sqlalchemy.orm import Mapped, mapped_column
+import datetime
+import secrets
+import uuid
+
+from sqlalchemy import ForeignKey, Index
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.common.data.base import BaseModel, CIStr
 
@@ -7,3 +12,25 @@ class Grant(BaseModel):
     __tablename__ = "grant"
 
     name: Mapped[CIStr] = mapped_column(unique=True)
+
+
+class User(BaseModel):
+    __tablename__ = "user"
+
+    email: Mapped[CIStr] = mapped_column(unique=True)
+
+    magic_links: Mapped[list["MagicLink"]] = relationship("MagicLink", back_populates="user")
+
+
+class MagicLink(BaseModel):
+    __tablename__ = "magic_link"
+
+    code: Mapped[str] = mapped_column(unique=True, default=lambda: secrets.token_urlsafe(12))
+    user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("user.id"))
+    redirect_to_path: Mapped[str]
+    expires_at_utc: Mapped[datetime.datetime]
+    claimed_at_utc: Mapped[datetime.datetime | None]
+
+    user: Mapped[User] = relationship("User", back_populates="magic_links")
+
+    __table_args__ = (Index(None, code, unique=True, postgresql_where="claimed_at_utc IS NOT NULL"),)

--- a/app/common/templates/common/auth/check_email.html
+++ b/app/common/templates/common/auth/check_email.html
@@ -15,7 +15,7 @@
 
             <h2 class="govuk-heading-s">If you do not receive the email</h2>
             <p class="govuk-body">The email may take a few minutes to arrive.</p>
-            <p class="govuk-body">Check your spam or junk folders – if it still has not arrived, <a href="{{ url_for('auth.sign_in') }}" class="govuk-link govuk-link--no-visited-state">request a new link</a>.</p>
+            <p class="govuk-body">Check your spam or junk folders – if it still has not arrived, <a href="{{ url_for('auth.request_a_link_to_sign_in') }}" class="govuk-link govuk-link--no-visited-state">request a new link</a>.</p>
         </div>
     </div>
 {% endblock content %}

--- a/app/common/templates/common/auth/check_email.html
+++ b/app/common/templates/common/auth/check_email.html
@@ -10,7 +10,7 @@
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             <h1 class="govuk-heading-l">Check your email</h1>
-            <p class="govuk-body">We've sent an email to {{ email_address }}.</p>
+            <p class="govuk-body">We've sent an email to {{ user.email }}.</p>
             {{ govukInsetText(params={"text": "The link will work once and stop working after 15 minutes."}) }}
 
             <h2 class="govuk-heading-s">If you do not receive the email</h2>

--- a/app/common/templates/common/auth/claim_magic_link.html
+++ b/app/common/templates/common/auth/claim_magic_link.html
@@ -1,0 +1,18 @@
+{% extends "common/base.html" %}
+
+{% block pageTitle %}
+    Sign in - MHCLG Funding Service
+{% endblock pageTitle %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            {# TODO: Add JS to auto submit this form #}
+
+            <form method="post" novalidate>
+              {{ form.csrf_token }}
+              {{ form.submit }}
+            </form>
+        </div>
+    </div>
+{% endblock content %}

--- a/app/common/templates/common/base.html
+++ b/app/common/templates/common/base.html
@@ -18,7 +18,7 @@
     "productName": "MHCLG Funding Service",
     "homepageUrl": "#",
     "classes": "govuk-header--full-width-border app-!-no-wrap",
-    "navigation": [{ "text": ("Sign in"), "href": url_for('auth.sign_in') }],
+    "navigation": [{ "text": ("Sign in"), "href": url_for('auth.request_a_link_to_sign_in') }],
     "navigationClasses": "govuk-header__navigation--end",
     "assetPath": assetPath
 }) }}

--- a/app/config/__init__.py
+++ b/app/config/__init__.py
@@ -11,6 +11,7 @@ from app.types import LogFormats, LogLevels
 class Environment(str, Enum):
     UNIT_TEST = "unit_test"
     LOCAL = "local"
+    PULLPREVIEW = "pullpreview"
     DEV = "dev"
     UAT = "uat"
     PROD = "prod"
@@ -60,6 +61,8 @@ class _SharedConfig(_BaseConfig):
     SERVER_NAME: str
     SECRET_KEY: str
     WTF_CSRF_ENABLED: bool = True
+    PROXY_FIX_PROTO: int = 0
+    PROXY_FIX_HOST: int = 0
 
     # Databases
     DATABASE_HOST: str
@@ -158,6 +161,18 @@ class DevConfig(_SharedConfig):
     DEBUG_TB_ENABLED: bool = False
 
 
+class PullPreviewConfig(_SharedConfig):
+    """
+    Overrides / default configuration for our PR PullPreview environments
+    """
+
+    # Flask app
+    FLASK_ENV: Environment = Environment.DEV
+    DEBUG_TB_ENABLED: bool = False
+    PROXY_FIX_PROTO: int = 1
+    PROXY_FIX_HOST: int = 1
+
+
 class UatConfig(_SharedConfig):
     """
     Overrides / default configuration for our deployed 'uat' environment
@@ -185,6 +200,8 @@ def get_settings() -> _SharedConfig:
             return LocalConfig()  # type: ignore[call-arg]
         case Environment.DEV:
             return DevConfig()  # type: ignore[call-arg]
+        case Environment.PULLPREVIEW:
+            return PullPreviewConfig()  # type: ignore[call-arg]
         case Environment.UAT:
             return UatConfig()  # type: ignore[call-arg]
         case Environment.PROD:

--- a/docker-compose.pullpreview.yml
+++ b/docker-compose.pullpreview.yml
@@ -45,13 +45,13 @@ services:
       "
     env_file: .env
     environment:
-      FLASK_ENV: dev
+      FLASK_ENV: pullpreview
       FLASK_PORT: 8080
       DATABASE_HOST: "db"
       DATABASE_PORT: 5432
       DATABASE_NAME: "postgres"
       DATABASE_SECRET: '{"username":"postgres","password":"postgres"}'  # pragma:allowlist secret
-      SERVER_NAME: web:8080
+      SERVER_NAME: ${PULLPREVIEW_PUBLIC_DNS}
       SECRET_KEY: unsafe  # pragma: allowlist secret
       DEBUG_TB_ENABLED: true
       # Removes the ConfigPanel, which could show sensitive configuration.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
     "types-wtforms>=3.2.1.20250304",
     "html5lib>=1.1",
     "types-html5lib>=1.1.11.20241018",
+    "types-pytz>=2025.2.0.20250326",
 ]
 
 [tool.ruff]

--- a/tests/integration/common/auth/test_auth.py
+++ b/tests/integration/common/auth/test_auth.py
@@ -1,7 +1,9 @@
+import datetime
+
 from bs4 import BeautifulSoup
 from flask import url_for
 
-from tests.utils import page_has_error
+from tests.utils import AnyStringMatching, page_has_error
 
 
 def test_sign_in_page_get(client):
@@ -34,22 +36,69 @@ def test_sign_in_page_post_valid_email(client, mock_notification_service_calls):
     assert b"Check your email" in response.data
     assert b"test@communities.gov.uk" in response.data
     assert len(mock_notification_service_calls) == 1
-    with client.session_transaction() as sess:
-        assert sess["email_address"] == "test@communities.gov.uk"
+    assert mock_notification_service_calls[0].kwargs["personalisation"]["magic_link"] == AnyStringMatching(
+        r"http://funding.communities.gov.localhost:8080/sign-in/.*"
+    )
+    assert (
+        mock_notification_service_calls[0].kwargs["personalisation"]["request_new_magic_link"]
+        == "http://funding.communities.gov.localhost:8080/sign-in"
+    )
 
 
-def test_check_email_page_with_session(client):
-    with client.session_transaction() as sess:
-        sess["email_address"] = "test@communities.gov.uk"
-
-    response = client.get("/check-your-email")
+def test_check_email_page(client, factories):
+    magic_link = factories.magic_link.create(user__email="test@communities.gov.uk")
+    response = client.get(url_for("auth.check_email", magic_link_id=magic_link.id))
     assert response.status_code == 200
     assert b"Check your email" in response.data
     assert b"test@communities.gov.uk" in response.data
 
 
-def test_check_email_page_without_session(client):
-    response = client.get("/check-your-email", follow_redirects=True)
-    assert response.status_code == 200
-    assert b"Request a link to sign in" in response.data
-    assert url_for("auth.sign_in") in response.request.path
+class TestClaimMagicLinkView:
+    def test_get(self, client, factories):
+        magic_link = factories.magic_link.create()
+
+        response = client.get(url_for("auth.claim_magic_link", magic_link_code=magic_link.code))
+        assert response.status_code == 200
+        assert b"Sign in" in response.data
+
+    def test_redirect_on_unknown_magic_link(self, client):
+        response = client.get(url_for("auth.claim_magic_link", magic_link_code="unknown-code"))
+        assert response.status_code == 302
+        assert response.location == url_for("auth.sign_in")
+
+    def test_redirect_on_used_magic_link(self, client, factories):
+        magic_link = factories.magic_link.create(
+            user__email="test@communities.gov.uk",
+            redirect_to_path="/my-redirect",
+            claimed_at_utc=datetime.datetime.now() - datetime.timedelta(hours=1),
+        )
+
+        response = client.get(url_for("auth.claim_magic_link", magic_link_code=magic_link.code))
+        assert response.status_code == 302
+        assert response.location == url_for("auth.sign_in")
+
+    def test_redirect_on_expired_magic_link(self, client, factories):
+        magic_link = factories.magic_link.create(
+            user__email="test@communities.gov.uk",
+            redirect_to_path="/my-redirect",
+            expires_at_utc=datetime.datetime.now() - datetime.timedelta(hours=1),
+        )
+
+        response = client.get(url_for("auth.claim_magic_link", magic_link_code=magic_link.code))
+        assert response.status_code == 302
+        assert response.location == url_for("auth.sign_in")
+
+    def test_post_claims_link_and_redirects(self, client, factories):
+        magic_link = factories.magic_link.create(
+            user__email="test@communities.gov.uk", redirect_to_path="/my-redirect", claimed_at_utc=None
+        )
+
+        response = client.post(
+            url_for("auth.claim_magic_link", magic_link_code=magic_link.code),
+            json={"submit": "yes"},
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 302
+        assert response.location == "/my-redirect"
+        assert magic_link.claimed_at_utc is not None

--- a/tests/integration/common/data/test_magic_link.py
+++ b/tests/integration/common/data/test_magic_link.py
@@ -1,0 +1,62 @@
+import datetime
+
+from sqlalchemy import func, select
+
+from app.common.data import interfaces
+
+
+class TestCreateMagicLink:
+    def test_create_magic_link(self, db_session, factories):
+        user = factories.user.create()
+
+        magic_link = interfaces.magic_link.create_magic_link(user, redirect_to_path="/")
+
+        assert magic_link.user == user
+
+    def test_create_magic_link_expiry(self, db_session, factories):
+        user = factories.user.create()
+
+        magic_link = interfaces.magic_link.create_magic_link(user, redirect_to_path="/")
+
+        # FIXME: if/when FSPT-366 is done
+        should_expire_at = db_session.scalar(select(func.current_timestamp() + datetime.timedelta(minutes=15))).replace(
+            tzinfo=None
+        )
+        assert magic_link.expires_at_utc == should_expire_at
+
+    def test_create_magic_link_expires_other_magic_links_for_the_user(self, db_session, factories):
+        old_magic_link = factories.magic_link.create()
+        expiry = old_magic_link.expires_at_utc
+
+        interfaces.magic_link.create_magic_link(user=old_magic_link.user, redirect_to_path="/")
+
+        now = db_session.scalar(func.current_timestamp()).replace(tzinfo=None)
+        assert expiry != now
+        assert old_magic_link.expires_at_utc == now
+
+
+class TestGetMagicLink:
+    def test_get_magic_link_by_id(self, db_session, factories):
+        magic_link = factories.magic_link.create()
+
+        retrieved_magic_link = interfaces.magic_link.get_magic_link(id_=magic_link.id)
+
+        assert magic_link is retrieved_magic_link
+
+    def test_get_magic_link_by_code(self, db_session, factories):
+        magic_link = factories.magic_link.create()
+
+        retrieved_magic_link = interfaces.magic_link.get_magic_link(code=magic_link.code)
+
+        assert magic_link is retrieved_magic_link
+
+
+class TestClaimMagicLink:
+    def test_claim_magic_link(self, db_session, factories):
+        magic_link = factories.magic_link.create()
+        now = db_session.scalar(func.current_timestamp()).replace(tzinfo=None)
+        assert magic_link.claimed_at_utc is None
+
+        interfaces.magic_link.claim_magic_link(magic_link)
+
+        assert magic_link.claimed_at_utc == now

--- a/tests/integration/common/data/test_user.py
+++ b/tests/integration/common/data/test_user.py
@@ -1,0 +1,23 @@
+from sqlalchemy import func, select
+
+from app.common.data import interfaces
+from app.common.data.models import User
+
+
+class TestGetOrCreateUser:
+    def test_create_new_user(self, db_session):
+        assert db_session.scalar(select(func.count()).select_from(User)) == 0
+
+        user = interfaces.user.get_or_create_user(email_address="test@communities.gov.uk")
+
+        assert db_session.scalar(select(func.count()).select_from(User)) == 1
+        assert user.email == "test@communities.gov.uk"
+
+    def test_get_existing_user(self, db_session, factories):
+        factories.user.create(email="test@communities.gov.uk")
+        assert db_session.scalar(select(func.count()).select_from(User)) == 1
+
+        user = interfaces.user.get_or_create_user(email_address="test@communities.gov.uk")
+
+        assert db_session.scalar(select(func.count()).select_from(User)) == 1
+        assert user.email == "test@communities.gov.uk"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -23,7 +23,7 @@ from app import create_app
 from app.services.notify import Notification
 from tests.conftest import FundingServiceTestClient
 from tests.integration.example_models import ExampleAccountFactory, ExamplePersonFactory
-from tests.integration.models import _GrantFactory
+from tests.integration.models import _GrantFactory, _MagicLinkFactory, _UserFactory
 
 
 @pytest.fixture(scope="session")
@@ -149,12 +149,12 @@ def db_session(app: Flask, db: SQLAlchemy) -> Generator[Session, None, None]:
             connection.close()
 
 
-_Factories = namedtuple("_Factories", ["grant"])
+_Factories = namedtuple("_Factories", ["grant", "user", "magic_link"])
 
 
 @pytest.fixture(scope="function")
 def factories(db_session: Session) -> _Factories:
-    return _Factories(grant=_GrantFactory)
+    return _Factories(grant=_GrantFactory, user=_UserFactory, magic_link=_MagicLinkFactory)
 
 
 _ExampleFactories = namedtuple("_ExampleFactories", ["person", "account"])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,8 @@
-from typing import cast
+import re
+from functools import lru_cache
+from re import Pattern
+from types import MappingProxyType
+from typing import Any, Callable, Mapping, cast
 
 from bs4 import BeautifulSoup, Tag
 
@@ -10,3 +14,75 @@ def page_has_error(soup: BeautifulSoup, message: str) -> bool:
 
     error_messages = error_summary.select("li a")
     return any(message in error_message.text for error_message in error_messages)
+
+
+class RestrictedAny:
+    """
+    Analogous to mock.ANY, this class takes an arbitrary callable in its constructor and the returned instance will
+    appear to "equal" anything that produces a truthy result when passed as an argument to the ``condition`` callable.
+
+    Useful when wanting to assert the contents of a larger structure but be more flexible for certain members, e.g.
+
+    # only care that second number is odd
+    >>> (4, 5, 6,) == (4, RestrictedAny(lambda x: x % 2), 6,)
+    True
+    >>> (4, 9, 6,) == (4, RestrictedAny(lambda x: x % 2), 6,)
+    True
+    """
+
+    def __init__(self, condition: Callable[[Any], bool]) -> None:
+        self._condition = condition
+
+    def __eq__(self, other: Any) -> bool:
+        return self._condition(other)
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self._condition})"
+
+    def __hash__(self) -> None:  # type: ignore[override]
+        return None
+
+
+class AnySupersetOf(RestrictedAny):
+    """
+    Instance will appear to "equal" any dictionary-like object that is a "superset" of the the constructor-supplied
+    ``subset_dict``, i.e. will ignore any keys present in the dictionary in question but missing from the reference
+    dict. e.g.
+
+    >>> [{"a": 123, "b": 456, "less": "predictabananas"}, 789] == [AnySupersetOf({"a": 123, "b": 456}), 789]
+    True
+    """
+
+    def __init__(self, subset_dict: Mapping[str, Any]) -> None:
+        # take an immutable dict copy of supplied dict-like object
+        self._subset_dict = MappingProxyType(dict(subset_dict))
+
+    def _condition(self, other: Any) -> bool:
+        return self._subset_dict == {k: v for k, v in other.items() if k in self._subset_dict}
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self._subset_dict})"
+
+
+class AnyStringMatching(RestrictedAny):
+    """
+    Instance will appear to "equal" any string that matches the constructor-supplied regex pattern
+
+    >>> {"a": "Metempsychosis", "b": "c"} == {"a": AnyStringMatching(r"m+.+psycho.*", flags=re.I), "b": "c"}
+    True
+    """
+
+    _cached_re_compile = staticmethod(lru_cache(maxsize=32)(re.compile))
+
+    def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
+        """
+        Construct an instance which will equal any string matching the supplied regex pattern. Supports all arguments
+        recognized by ``re.compile``, alternatively accepts an existing regex pattern object as a single argument.
+        """
+        self._regex = (
+            args[0] if len(args) == 1 and isinstance(args[0], Pattern) else self._cached_re_compile(*args, **kwargs)
+        )
+        super().__init__(lambda other: isinstance(other, str | bytes) and bool(self._regex.match(other)))
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self._regex})"

--- a/uv.lock
+++ b/uv.lock
@@ -122,7 +122,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -410,6 +410,7 @@ dev = [
     { name = "testcontainers" },
     { name = "types-flask-migrate" },
     { name = "types-html5lib" },
+    { name = "types-pytz" },
     { name = "types-wtforms" },
 ]
 
@@ -456,6 +457,7 @@ dev = [
     { name = "testcontainers", specifier = ">=4.9.1" },
     { name = "types-flask-migrate", specifier = ">=4.1.0.20250112" },
     { name = "types-html5lib", specifier = ">=1.1.11.20241018" },
+    { name = "types-pytz", specifier = ">=2025.2.0.20250326" },
     { name = "types-wtforms", specifier = ">=3.2.1.20250304" },
 ]
 
@@ -1159,6 +1161,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b6/9d/f6fbcc8246f5e46845b4f989c4e17e6fb3ce572f7065b185e515bf8a3be7/types-html5lib-1.1.11.20241018.tar.gz", hash = "sha256:98042555ff78d9e3a51c77c918b1041acbb7eb6c405408d8a9e150ff5beccafa", size = 11370 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/7c/f862b1dc31268ef10fe95b43dcdf216ba21a592fafa2d124445cd6b92e93/types_html5lib-1.1.11.20241018-py3-none-any.whl", hash = "sha256:3f1e064d9ed2c289001ae6392c84c93833abb0816165c6ff0abfc304a779f403", size = 17292 },
+]
+
+[[package]]
+name = "types-pytz"
+version = "2025.2.0.20250326"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/66/38c89861242f2c61c8315ddbcc7d7bbf64979f4b0bdc48db0ba62aeec330/types_pytz-2025.2.0.20250326.tar.gz", hash = "sha256:deda02de24f527066fc8d6a19e284ab3f3ae716a42b4adb6b40e75e408c08d36", size = 10595 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/e0/17f3a6670db5c95dc195f346e2e7290f22ba8327c188133959389b578cbd/types_pytz-2025.2.0.20250326-py3-none-any.whl", hash = "sha256:3c397fd1b845cd2b3adc9398607764ced9e578a98a5d1fbb4a9bc9253edfb162", size = 10222 },
 ]
 
 [[package]]


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FSPT-357

## Summary
This PR adds basic User and MagicLink tables, and updates the sign in flow to generate a magic link and insert it into the email.

A new stub page is added to claim the magic link, but no auth session is actually created yet. This stub page will eventually be mostly-invisible to users, as we'll add JS to automatically submit the form and claim the link.

The redirected-to page after claiming a magic link is currently hard-coded to the list grants page; again, this to be updated separately.

## Show it
![2025-04-10 09 54 07](https://github.com/user-attachments/assets/6a26ac69-39c7-45d8-b829-fab06264bc6a)

