### PR TITLE
Auto-claim magic link via JS

### DIFF
--- a/app/assets/main.scss
+++ b/app/assets/main.scss
@@ -9,6 +9,12 @@ $govuk-assets-path: "/static/assets/";
     white-space: nowrap;
 }
 
+// this class will only be applied if GOV.UK Frontend Jinja has set the `.js-enabled` class meaning
+// it could execute JavaScript
+.js-enabled .app-js-hidden {
+    display: none;
+}
+
 .fs-nav-item>a {
     display: block;
     padding: 7px 0;

--- a/app/common/templates/common/auth/claim_magic_link.html
+++ b/app/common/templates/common/auth/claim_magic_link.html
@@ -16,3 +16,7 @@
         </div>
     </div>
 {% endblock content %}
+
+{% block bodyEnd %}
+  <script nonce="{{ csp_nonce() }}">document.getElementById('submit').click();</script>
+{% endblock bodyEnd %}

--- a/app/common/templates/common/auth/claim_magic_link.html
+++ b/app/common/templates/common/auth/claim_magic_link.html
@@ -7,9 +7,7 @@
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-            {# TODO: Add JS to auto submit this form #}
-
-            <form method="post" novalidate>
+            <form class="app-js-hidden" method="post" novalidate>
               {{ form.csrf_token }}
               {{ form.submit }}
             </form>


### PR DESCRIPTION
We don't need users to click a button manually when using their magic link. The reason we add a button is to prevent email clients, which may preload the magic link URL for various reasons, from expiring the magic link. Email clients won't run JS on the page, so this shouldn't undermine the reason for us having this interstitial page.