### PR TITLE
Handle sign in and sign out with Flask-Session

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,11 +5,13 @@ from govuk_frontend_wtf.main import WTFormsHelpers
 from jinja2 import ChoiceLoader, PackageLoader, PrefixLoader
 
 from app import logging
+from app.common.data.models import User
 from app.config import get_settings
 from app.extensions import (
     auto_commit_after_request,
     db,
     flask_assets_vite,
+    login_manager,
     migrate,
     notification_service,
     talisman,
@@ -42,6 +44,11 @@ def create_app() -> Flask:
     toolbar.init_app(app)
     notification_service.init_app(app)
     talisman.init_app(app, **app.config["TALISMAN_SETTINGS"])
+    login_manager.init_app(app)
+
+    @login_manager.user_loader  # type: ignore[misc]
+    def load_user(user_id: str) -> User | None:
+        return db.session.get(User, user_id)
 
     # This section is needed for url_for("foo", _external=True) to
     # automatically generate http scheme when this sample is

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,6 +5,7 @@ from govuk_frontend_wtf.main import WTFormsHelpers
 from jinja2 import ChoiceLoader, PackageLoader, PrefixLoader
 
 from app import logging
+from app.common.data import interfaces
 from app.common.data.models import User
 from app.config import get_settings
 from app.extensions import (
@@ -48,7 +49,7 @@ def create_app() -> Flask:
 
     @login_manager.user_loader  # type: ignore[misc]
     def load_user(user_id: str) -> User | None:
-        return db.session.get(User, user_id)
+        return interfaces.user.get_user(user_id)
 
     # This section is needed for url_for("foo", _external=True) to
     # automatically generate http scheme when this sample is

--- a/app/common/auth/__init__.py
+++ b/app/common/auth/__init__.py
@@ -3,6 +3,7 @@ from typing import cast
 
 from flask import Blueprint, abort, redirect, render_template, url_for
 from flask.typing import ResponseReturnValue
+from flask_login import login_user
 
 from app.common.auth.forms import ClaimMagicLinkForm, SignInForm
 from app.common.data import interfaces
@@ -61,7 +62,9 @@ def claim_magic_link(magic_link_code: str) -> ResponseReturnValue:
     form = ClaimMagicLinkForm()
     if form.validate_on_submit():
         interfaces.magic_link.claim_magic_link(magic_link=magic_link)
-        # TODO: actually create auth'd session
+        if not login_user(magic_link.user):
+            abort(400)
+
         return redirect(magic_link.redirect_to_path)
 
     return render_template("common/auth/claim_magic_link.html", form=form, magic_link=magic_link)

--- a/app/common/auth/__init__.py
+++ b/app/common/auth/__init__.py
@@ -3,7 +3,7 @@ from typing import cast
 
 from flask import Blueprint, abort, redirect, render_template, url_for
 from flask.typing import ResponseReturnValue
-from flask_login import login_user
+from flask_login import login_user, logout_user
 
 from app.common.auth.forms import ClaimMagicLinkForm, SignInForm
 from app.common.data import interfaces
@@ -68,3 +68,10 @@ def claim_magic_link(magic_link_code: str) -> ResponseReturnValue:
         return redirect(magic_link.redirect_to_path)
 
     return render_template("common/auth/claim_magic_link.html", form=form, magic_link=magic_link)
+
+
+@auth_blueprint.get("/sign-out")
+def sign_out() -> ResponseReturnValue:
+    logout_user()
+
+    return redirect(url_for("index"))

--- a/app/common/data/interfaces/user.py
+++ b/app/common/data/interfaces/user.py
@@ -1,7 +1,13 @@
+import uuid
+
 from sqlalchemy.dialects.postgresql import insert as postgresql_upsert
 
 from app.common.data.models import User
 from app.extensions import db
+
+
+def get_user(id_: str | uuid.UUID) -> User | None:
+    return db.session.get(User, id_)
 
 
 def get_or_create_user(email_address: str) -> User:

--- a/app/common/data/models/__init__.py
+++ b/app/common/data/models/__init__.py
@@ -22,6 +22,23 @@ class User(BaseModel):
 
     magic_links: Mapped[list["MagicLink"]] = relationship("MagicLink", back_populates="user")
 
+    # Required by Flask-Login; should be provided by UserMixin, except that breaks our type hinting
+    # when using this class in SQLAlchemy queries. So we've just lifted the key attributes here directly.
+    @property
+    def is_active(self) -> bool:
+        return True
+
+    @property
+    def is_authenticated(self) -> bool:
+        return self.is_active
+
+    @property
+    def is_anonymous(self) -> bool:
+        return False
+
+    def get_id(self) -> str:
+        return str(self.id)
+
 
 class MagicLink(BaseModel):
     __tablename__ = "magic_link"

--- a/app/common/templates/common/base.html
+++ b/app/common/templates/common/base.html
@@ -19,7 +19,7 @@
     "productName": "MHCLG Funding Service",
     "homepageUrl": "#",
     "classes": "govuk-header--full-width-border app-!-no-wrap",
-    "navigation": [{ "text": ("Sign in"), "href": url_for('auth.request_a_link_to_sign_in') }],
+    "navigation": [{ "text": ("Sign out"), "href": url_for('auth.sign_out') }] if current_user.is_authenticated else [],
     "navigationClasses": "govuk-header__navigation--end",
     "assetPath": assetPath
 }) }}

--- a/app/config/__init__.py
+++ b/app/config/__init__.py
@@ -129,7 +129,7 @@ class _SharedConfig(_BaseConfig):
     TALISMAN_REFERRER_POLICY: str = "strict-origin-when-cross-origin"
     TALISMAN_SESSION_COOKIE_SECURE: bool = True
     TALISMAN_SESSION_COOKIE_HTTP_ONLY: bool = True
-    TALISMAN_SESSION_COOKIE_SAMESITE: str = "Strict"
+    TALISMAN_SESSION_COOKIE_SAMESITE: str = "Lax"
     TALISMAN_X_CONTENT_TYPE_OPTIONS: bool = True
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-XSS-Protection - use CSP instead
     TALISMAN_X_XSS_PROTECTION: bool = False

--- a/app/extensions/__init__.py
+++ b/app/extensions/__init__.py
@@ -1,4 +1,5 @@
 from flask_debugtoolbar import DebugToolbarExtension
+from flask_login import LoginManager
 from flask_migrate import Migrate
 from flask_sqlalchemy_lite import SQLAlchemy
 from flask_talisman import Talisman
@@ -14,6 +15,7 @@ toolbar = DebugToolbarExtension()
 notification_service = NotificationService()
 talisman = Talisman()
 flask_assets_vite = FlaskAssetsViteExtension()
+login_manager = LoginManager()
 
 __all__ = [
     "db",
@@ -23,4 +25,5 @@ __all__ = [
     "notification_service",
     "talisman",
     "flask_assets_vite",
+    "login_manager",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "wtforms[email]>=3.2.1",
     "notifications-python-client>=10.0.1",
     "flask-talisman>=1.1.0",
+    "flask-login>=0.6.3",
 ]
 
 [dependency-groups]
@@ -86,7 +87,7 @@ exclude = ['.*test_.*']
 
 [[tool.mypy.overrides]]
 module = [
-  "flask_wtf", "govuk_frontend_wtf.*", "testcontainers.*", "flask_babel", "sqlalchemy_utils", "flask_talisman.*"
+  "flask_wtf", "govuk_frontend_wtf.*", "testcontainers.*", "flask_babel", "sqlalchemy_utils", "flask_talisman.*", "flask_login"
 ]
 ignore_missing_imports = true
 

--- a/tests/integration/common/data/test_user.py
+++ b/tests/integration/common/data/test_user.py
@@ -4,6 +4,16 @@ from app.common.data import interfaces
 from app.common.data.models import User
 
 
+class TestGetUser:
+    def test_get_user_by_id(self, db_session, factories):
+        user_id = factories.user.create(email="test@communities.gov.uk").id
+
+        user = interfaces.user.get_user(user_id)
+
+        assert user.id == user_id
+        assert user.email == "test@communities.gov.uk"
+
+
 class TestGetOrCreateUser:
     def test_create_new_user(self, db_session):
         assert db_session.scalar(select(func.count()).select_from(User)) == 0

--- a/uv.lock
+++ b/uv.lock
@@ -302,6 +302,19 @@ wheels = [
 ]
 
 [[package]]
+name = "flask-login"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flask" },
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/6e/2f4e13e373bb49e68c02c51ceadd22d172715a06716f9299d9df01b6ddb2/Flask-Login-0.6.3.tar.gz", hash = "sha256:5e23d14a607ef12806c699590b89d0f0e0d67baeec599d75947bf9c147330333", size = 48834 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/f5/67e9cc5c2036f58115f9fe0f00d203cf6780c3ff8ae0e705e7a9d9e8ff9e/Flask_Login-0.6.3-py3-none-any.whl", hash = "sha256:849b25b82a436bf830a054e74214074af59097171562ab10bfa999e6b78aae5d", size = 17303 },
+]
+
+[[package]]
 name = "flask-migrate"
 version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -382,6 +395,7 @@ dependencies = [
     { name = "babel" },
     { name = "flask" },
     { name = "flask-babel" },
+    { name = "flask-login" },
     { name = "flask-migrate" },
     { name = "flask-sqlalchemy-lite" },
     { name = "flask-talisman" },
@@ -430,6 +444,7 @@ requires-dist = [
     { name = "babel", specifier = "==2.17.0" },
     { name = "flask", specifier = ">=3.1.0" },
     { name = "flask-babel", specifier = "==4.0.0" },
+    { name = "flask-login", specifier = ">=0.6.3" },
     { name = "flask-migrate", specifier = ">=4.1.0" },
     { name = "flask-sqlalchemy-lite", specifier = ">=0.1.0" },
     { name = "flask-talisman", specifier = ">=1.1.0" },


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FSPT-357

## Summary
When a user claims their magic link, let's actually persist that login session by logging them in with Flask-Login. This adds data to their session. When they return in subsequent requests, we can load their user directly and thereby give them persistent access to the service.

We add a 'Sign out' link to the header if a user is logged in, and remove the 'Sign in' link; users will get directed to log in whenever they try to access a restricted page (not yet implemented).

The session is being stored as a client-side signed cookie for now, in line with [option 1 of the RFC](https://github.com/communitiesuk/funding-service-requests-for-comments/discussions/27). This is because Flask-Session does not yet support a Flask-SQLAlchemy-Lite extension (only the Flask-SQLAlchemy extension), so using server-side sessions stored in postgres is a bit of extra work. We'll try and get a fix upstream; if we do, we can switch to postgres sessions.

![2025-04-11 14 45 53](https://github.com/user-attachments/assets/ba50e995-6e40-4dcc-9484-74772c5c04be)