### PR TITLE
BAU Constrain Postgres versions for tests and CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dev = [
     "responses==0.25.7",
     "ruff==0.11.5",
     "sqlalchemy-utils==0.41.2",
-    "testcontainers==4.10.0",
+    "testcontainers[postgres]==4.10.0",
     "types-flask-migrate==4.1.0.20250112",
     "types-wtforms==3.2.1.20250401",
     "html5lib==1.1",

--- a/renovate.json
+++ b/renovate.json
@@ -19,9 +19,9 @@
     {
       "groupName": "Postgres in line with deployed environments",
       "matchPackageNames": ["postgres"],
-      "matchDepTypes": ["docker-compose", "github-actions"],
-      "allowedVersions": "16.6",
-      "description": "If updating to a new minor version, update testcontainers in tests/integration/conftest"
+      "matchManagers": ["docker-compose", "github-actions"],
+      "allowedVersions": "<17",
+      "description": "If updating to a new major version, update testcontainers in tests/integration/conftest"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,13 @@
       "matchManagers": ["npm"],
       "matchPackageNames": ["govuk-frontend"],
       "automerge": false
+    },
+    {
+      "groupName": "Postgres in line with deployed environments",
+      "matchPackageNames": ["postgres"],
+      "matchDepTypes": ["docker-compose", "github-actions"],
+      "allowedVersions": "16.6",
+      "description": "If updating to a new minor version, update testcontainers in tests/integration/conftest"
     }
   ]
 }

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -34,7 +34,7 @@ def setup_db_container() -> Generator[None, None, None]:
     # off a little bit of time - why not.
     testcontainers_config.sleep_time = 0.1
 
-    test_postgres = PostgresContainer("postgres:16")
+    test_postgres = PostgresContainer("postgres:16.6")
     test_postgres.start()
 
     monkeypatch = MonkeyPatch()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -34,7 +34,7 @@ def setup_db_container() -> Generator[None, None, None]:
     # off a little bit of time - why not.
     testcontainers_config.sleep_time = 0.1
 
-    test_postgres = PostgresContainer("postgres:16.6")
+    test_postgres = PostgresContainer("postgres:16")
     test_postgres.start()
 
     monkeypatch = MonkeyPatch()

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.13"
 
 [[package]]
@@ -481,7 +480,7 @@ dev = [
     { name = "responses", specifier = "==0.25.7" },
     { name = "ruff", specifier = "==0.11.5" },
     { name = "sqlalchemy-utils", specifier = "==0.41.2" },
-    { name = "testcontainers", specifier = "==4.10.0" },
+    { name = "testcontainers", extras = ["postgres"], specifier = "==4.10.0" },
     { name = "types-flask-migrate", specifier = "==4.1.0.20250112" },
     { name = "types-html5lib", specifier = "==1.1.11.20241018" },
     { name = "types-pytz", specifier = "==2025.2.0.20250326" },


### PR DESCRIPTION
Our workflows/ CI/ test environment should aim to reflect the deployed environments as much as possible to give us confidence that automated checks are relevant to what will then be run.

This attempts to tell renovate to give us pinned patch upgrades but keep the major/ minor version of postgres the same as our deployed version, this should then be bumped when minor/ major upgrades are made (this needs to be sense checked against our DB upgrade policy, I believe its constrained to minor versions but if there's an automatic upgrade policy the rules here may need to change).

I'm not confident in the renovate syntax proposed here that may take some trial and error.