### PR TITLE
Redirect to `next` when claiming magic link

### DIFF
--- a/app/common/auth/forms.py
+++ b/app/common/auth/forms.py
@@ -1,11 +1,7 @@
-from urllib.parse import urlsplit
-
-from flask import current_app, request, url_for
 from flask_wtf import FlaskForm
 from govuk_frontend_wtf.wtforms_widgets import GovSubmitInput, GovTextInput
 from wtforms import StringField, SubmitField
 from wtforms.validators import DataRequired, Email, ValidationError
-from wtforms.widgets.core import HiddenInput
 
 
 def validate_communities_gov_uk_email(form: FlaskForm, field: StringField) -> None:
@@ -14,35 +10,7 @@ def validate_communities_gov_uk_email(form: FlaskForm, field: StringField) -> No
             raise ValidationError("Email address must end with @communities.gov.uk")
 
 
-def sanitise_redirect_url(url: str) -> str:
-    safe_fallback_url = url_for("index")
-
-    url_next = urlsplit(url)
-    current_base_url = urlsplit(request.host_url)
-
-    if (url_next.netloc or url_next.scheme) and url_next.netloc != current_base_url.netloc:
-        current_app.logger.warning(
-            "Attempt to redirect to unsafe URL %(bad_url)s; sanitised to %(safe_url)s",
-            dict(bad_url=url, safe_url=safe_fallback_url),
-        )
-        return safe_fallback_url
-
-    if url_next.scheme and url_next.scheme not in {"http", "https"}:
-        current_app.logger.warning(
-            "Attempt to redirect to URL with unexpected protocol %(bad_url)s; sanitised to %(safe_url)s",
-            dict(bad_url=url, safe_url=safe_fallback_url),
-        )
-        return safe_fallback_url
-
-    sanitised_url_next = url_next.path
-    if url_next.query:
-        sanitised_url_next += "?" + url_next.query
-
-    return sanitised_url_next
-
-
 class SignInForm(FlaskForm):
-    redirect_to = StringField(widget=HiddenInput(), filters=[sanitise_redirect_url])
     email_address = StringField(
         "Email address",
         validators=[

--- a/app/common/auth/forms.py
+++ b/app/common/auth/forms.py
@@ -1,7 +1,11 @@
+from urllib.parse import urlsplit
+
+from flask import current_app, request, url_for
 from flask_wtf import FlaskForm
 from govuk_frontend_wtf.wtforms_widgets import GovSubmitInput, GovTextInput
 from wtforms import StringField, SubmitField
 from wtforms.validators import DataRequired, Email, ValidationError
+from wtforms.widgets.core import HiddenInput
 
 
 def validate_communities_gov_uk_email(form: FlaskForm, field: StringField) -> None:
@@ -10,7 +14,35 @@ def validate_communities_gov_uk_email(form: FlaskForm, field: StringField) -> No
             raise ValidationError("Email address must end with @communities.gov.uk")
 
 
+def sanitise_redirect_url(url: str) -> str:
+    safe_fallback_url = url_for("index")
+
+    url_next = urlsplit(url)
+    current_base_url = urlsplit(request.host_url)
+
+    if (url_next.netloc or url_next.scheme) and url_next.netloc != current_base_url.netloc:
+        current_app.logger.warning(
+            "Attempt to redirect to unsafe URL %(bad_url)s; sanitised to %(safe_url)s",
+            dict(bad_url=url, safe_url=safe_fallback_url),
+        )
+        return safe_fallback_url
+
+    if url_next.scheme and url_next.scheme not in {"http", "https"}:
+        current_app.logger.warning(
+            "Attempt to redirect to URL with unexpected protocol %(bad_url)s; sanitised to %(safe_url)s",
+            dict(bad_url=url, safe_url=safe_fallback_url),
+        )
+        return safe_fallback_url
+
+    sanitised_url_next = url_next.path
+    if url_next.query:
+        sanitised_url_next += "?" + url_next.query
+
+    return sanitised_url_next
+
+
 class SignInForm(FlaskForm):
+    redirect_to = StringField(widget=HiddenInput(), filters=[sanitise_redirect_url])
     email_address = StringField(
         "Email address",
         validators=[

--- a/app/common/security/utils.py
+++ b/app/common/security/utils.py
@@ -1,0 +1,30 @@
+from urllib.parse import urlsplit
+
+from flask import current_app, request, url_for
+
+
+def sanitise_redirect_url(url: str) -> str:
+    safe_fallback_url = url_for("index")
+
+    url_next = urlsplit(url)
+    current_base_url = urlsplit(request.host_url)
+
+    if (url_next.netloc or url_next.scheme) and url_next.netloc != current_base_url.netloc:
+        current_app.logger.warning(
+            "Attempt to redirect to unsafe URL %(bad_url)s; sanitised to %(safe_url)s",
+            dict(bad_url=url, safe_url=safe_fallback_url),
+        )
+        return safe_fallback_url
+
+    if url_next.scheme and url_next.scheme not in {"http", "https"}:
+        current_app.logger.warning(
+            "Attempt to redirect to URL with unexpected protocol %(bad_url)s; sanitised to %(safe_url)s",
+            dict(bad_url=url, safe_url=safe_fallback_url),
+        )
+        return safe_fallback_url
+
+    sanitised_url_next = url_next.path
+    if url_next.query:
+        sanitised_url_next += "?" + url_next.query
+
+    return sanitised_url_next

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,3 +71,13 @@ def app() -> Generator[Flask, None, None]:
     app.config.update({"TESTING": True})
 
     yield app
+
+
+def _precompile_templates(app: Flask) -> None:
+    # Precompile all of our Jinja2 templates so that this doesn't happen within individual tests. It can lead to the
+    # first test that hits templates taking significantly longer than its baseline, which makes it harder for us
+    # to add time limits on tests that we run (see `_integration_test_timeout` below).
+    # This doesn't *completely* warm up the flask app - still seeing that some first runs are a bit slower, but this
+    # takes away a significant amount of the difference between the first and second pass.
+    for template_name in app.jinja_env.list_templates():
+        app.jinja_env.get_template(template_name)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -21,7 +21,7 @@ from werkzeug.test import TestResponse
 
 from app import create_app
 from app.services.notify import Notification
-from tests.conftest import FundingServiceTestClient
+from tests.conftest import FundingServiceTestClient, _precompile_templates
 from tests.integration.example_models import ExampleAccountFactory, ExamplePersonFactory
 from tests.integration.models import _GrantFactory, _MagicLinkFactory, _UserFactory
 
@@ -72,16 +72,6 @@ def db(setup_db_container: Generator[None], app: Flask) -> Generator[SQLAlchemy,
     with app.app_context():
         for engine in app.extensions["sqlalchemy"].engines.values():
             engine.dispose()
-
-
-def _precompile_templates(app: Flask) -> None:
-    # Precompile all of our Jinja2 templates so that this doesn't happen within individual tests. It can lead to the
-    # first test that hits templates taking significantly longer than its baseline, which makes it harder for us
-    # to add time limits on tests that we run (see `_integration_test_timeout` below).
-    # This doesn't *completely* warm up the flask app - still seeing that some first runs are a bit slower, but this
-    # takes away a significant amount of the difference between the first and second pass.
-    for template_name in app.jinja_env.list_templates():
-        app.jinja_env.get_template(template_name)
 
 
 @pytest.fixture(scope="session")

--- a/tests/unit/app/common/auth/test_forms.py
+++ b/tests/unit/app/common/auth/test_forms.py
@@ -1,0 +1,24 @@
+import pytest
+
+from app.common.auth import SignInForm
+
+
+class TestSignInForm:
+    @pytest.mark.parametrize(
+        "redirect_to, expected_clean_redirect_to",
+        (
+            ("/", "/"),
+            ("/blah/blah", "/blah/blah"),
+            ("http://funding.communities.gov.localhost:8080/blah", "/blah"),
+            ("mailto://funding.communities.gov.localhost:8080/blah", "/"),
+            ("http://bad.domain.localhost:8080/blah", "/"),
+            ("//blah", "/"),
+            ("///blah", "/blah"),
+            ("/blah?query=param", "/blah?query=param"),
+        ),
+    )
+    def test_redirect_sanitisation(self, client, redirect_to, expected_clean_redirect_to):
+        form = SignInForm()
+        form.process(data={"email_address": "test@communities.gov.uk", "redirect_to": redirect_to})
+        assert not form.errors
+        assert form.redirect_to.data == expected_clean_redirect_to

--- a/tests/unit/app/common/auth/test_utils.py
+++ b/tests/unit/app/common/auth/test_utils.py
@@ -1,11 +1,11 @@
 import pytest
 
-from app.common.auth import SignInForm
+from app.common.security.utils import sanitise_redirect_url
 
 
-class TestSignInForm:
+class TestSanitiseRedirectURL:
     @pytest.mark.parametrize(
-        "redirect_to, expected_clean_redirect_to",
+        "url, expected_url",
         (
             ("/", "/"),
             ("/blah/blah", "/blah/blah"),
@@ -17,8 +17,5 @@ class TestSignInForm:
             ("/blah?query=param", "/blah?query=param"),
         ),
     )
-    def test_redirect_sanitisation(self, client, redirect_to, expected_clean_redirect_to):
-        form = SignInForm()
-        form.process(data={"email_address": "test@communities.gov.uk", "redirect_to": redirect_to})
-        assert not form.errors
-        assert form.redirect_to.data == expected_clean_redirect_to
+    def test_redirect_sanitisation(self, app, url, expected_url):
+        assert sanitise_redirect_url(url) == expected_url

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,5 +1,13 @@
+import json
+from typing import Generator
+
 import pytest
 from _pytest.fixtures import FixtureRequest
+from _pytest.monkeypatch import MonkeyPatch
+from flask import Flask
+
+from app import create_app
+from tests.conftest import _precompile_templates
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -11,3 +19,23 @@ def _unit_test_timeout(request: FixtureRequest) -> None:
     amount of code under test fairly tight, so this should not be hard to meet.
     """
     request.node.add_marker(pytest.mark.fail_slow("1ms"))
+
+
+@pytest.fixture(scope="session")
+def noop_db() -> Generator[None, None, None]:
+    monkeypatch = MonkeyPatch()
+    with monkeypatch.context():
+        monkeypatch.setenv("DATABASE_HOST", "localhost")
+        monkeypatch.setenv("DATABASE_PORT", "5432")
+        monkeypatch.setenv("DATABASE_NAME", "db-access-not-available-for-unit-tests")
+        # pragma: allowlist nextline secret
+        monkeypatch.setenv("DATABASE_SECRET", json.dumps({"username": "invalid", "password": "invalid"}))
+        yield
+
+
+@pytest.fixture(scope="session")
+def app(noop_db: Generator[None]) -> Generator[Flask, None, None]:
+    app = create_app()
+    app.config.update({"TESTING": True})
+    _precompile_templates(app)
+    yield app


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FSPT-357

## Summary
The 'request a magic link' endpoint now knows about a `next` entry in the user's session, which will get validated+sanitised and then stored in on the MagicLink record. When the magic link is claimed, we'll redirect the user to that URL, so that they can pick up where they were when we made them sign in.

Another ticket will add the decorator and enforce auth on all the pages to make use of this functionality.