### PR TITLE
Require authentication for grant management views

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,5 +6,5 @@ DATABASE_PORT=5432
 DATABASE_NAME=postgres
 DATABASE_SECRET='{"username":"postgres","password":"postgres"}'  # pragma: allowlist secret
 
-GOVUK_NOTIFY_API_KEY=<get from notifications.service.gov.uk>
+GOVUK_NOTIFY_API_KEY=<generate a `test`-scoped key from notifications.service.gov.uk - "The Funding Service">
 GOVUK_NOTIFY_DISABLE=false

--- a/README.md
+++ b/README.md
@@ -51,12 +51,17 @@ To run any E2E tests include the `e2e` option in the pytest command:
 ```shell
 uv run pytest --e2e
 ```
-This will, by default, run the browser tests headless - i.e. you won't see a browser appear. To display the browser so you can visually inspect the test journey, use `pytest --e2e --headed --slowmo 1000`. `--headed` displays the browser, and `--slowmo 1000` makes Playwright insert 1 second pauses between various steps so that you can follow what the test is doing more easily.
+This will, by default, run the browser tests headless - i.e. you won't see a browser appear.
+
+To display the browser so you can visually inspect the test journey, add the `--headed` flag.
+
+To slow the test down, add `--slowmo 1000` to have Playwright insert 1 second pauses between each step so that you can follow what the test is doing more easily.
 
 [This function](./tests/conftest.py#L22) skips e2e or non-e2e tests depending on if they are in the `e2e` module under `tests`, so no individual tests need to be marked with the `e2e` marker.
 
-### Run E2E tests against deployed dev environment
+### Run E2E tests against an AWS environment
 
-An additional flag must be passed to the `pytest` command:
+Additional flags must be passed to the `pytest` command:
 
-* `--e2e-env dev`
+* dev: `--e2e-env dev --e2e-aws-vault-profile <your_dev_aws_profile_name>`
+* test: `--e2e-env test --e2e-aws-vault-profile <your_test_aws_profile_name>`

--- a/app/common/auth/__init__.py
+++ b/app/common/auth/__init__.py
@@ -28,7 +28,7 @@ def request_a_link_to_sign_in() -> ResponseReturnValue:
         user = get_or_create_user(email_address=email)
         magic_link = interfaces.magic_link.create_magic_link(
             user=user,
-            redirect_to_path=sanitise_redirect_url(session.get("next", url_for("index"))),
+            redirect_to_path=sanitise_redirect_url(session.pop("next", url_for("index"))),
         )
 
         notification_service.send_magic_link(

--- a/app/common/auth/decorators.py
+++ b/app/common/auth/decorators.py
@@ -1,0 +1,37 @@
+import functools
+from typing import Callable, cast
+
+from flask import abort, redirect, request, session, url_for
+from flask.typing import ResponseReturnValue
+from flask_login import current_user
+
+from app.common.data.models import User
+
+
+def login_required[**P](
+    func: Callable[P, ResponseReturnValue],
+) -> Callable[P, ResponseReturnValue]:
+    @functools.wraps(func)
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> ResponseReturnValue:
+        if not current_user.is_authenticated:
+            session["next"] = request.full_path
+            return redirect(url_for("auth.request_a_link_to_sign_in"))
+
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+def mhclg_login_required[**P](
+    func: Callable[P, ResponseReturnValue],
+) -> Callable[P, ResponseReturnValue]:
+    @functools.wraps(func)
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> ResponseReturnValue:
+        # This decorator is itself wrapped by `login_required`, so we know that `current_user` exists and is
+        # not an anonymous user (ie a user is definitely logged-in) if we get here.
+        if not cast(User, current_user).email.endswith("@communities.gov.uk"):
+            abort(403)
+
+        return func(*args, **kwargs)
+
+    return login_required(wrapper)

--- a/app/common/templates/common/partials/navigation.html
+++ b/app/common/templates/common/partials/navigation.html
@@ -1,12 +1,8 @@
 {% from "govuk_frontend_jinja/components/service-navigation/macro.html" import govukServiceNavigation %}
 
 {% set nav_items = [
-    {
-    "text": "Grants",
-    "href": url_for("platform.list_grants"),
-    "current": active_item_identifier == "grants"
-    },
-] %}
+    {"text": "Grants", "href": url_for("platform.list_grants"), "current": active_item_identifier == "grants"},
+] if current_user.is_authenticated else [] %}
 
 {{ govukServiceNavigation({
     "serviceName": "Grant Management",

--- a/app/platform/__init__.py
+++ b/app/platform/__init__.py
@@ -4,6 +4,7 @@ from pydantic import UUID4
 from werkzeug import Response
 from wtforms.fields.core import Field
 
+from app.common.auth.decorators import mhclg_login_required
 from app.common.data import interfaces
 from app.common.data.interfaces.exceptions import DuplicateValueError
 from app.extensions import auto_commit_after_request
@@ -13,6 +14,7 @@ platform_blueprint = Blueprint(name="platform", import_name=__name__)
 
 
 @platform_blueprint.route("/grants/set-up", methods=["GET", "POST"])
+@mhclg_login_required
 @auto_commit_after_request
 def create_grant() -> ResponseReturnValue:
     form = GrantForm()
@@ -28,24 +30,28 @@ def create_grant() -> ResponseReturnValue:
 
 
 @platform_blueprint.route("/grants", methods=["GET"])
+@mhclg_login_required
 def list_grants() -> str:
     grants = interfaces.grants.get_all_grants()
     return render_template("platform/grant_list.html", grants=grants)
 
 
 @platform_blueprint.route("/grants/<uuid:grant_id>", methods=["GET"])
+@mhclg_login_required
 def view_grant(grant_id: UUID4) -> str:
     grant = interfaces.grants.get_grant(grant_id)
     return render_template("platform/grant_view.html", grant=grant)
 
 
 @platform_blueprint.route("/grants/<uuid:grant_id>/settings", methods=["GET"])
+@mhclg_login_required
 def grant_settings(grant_id: UUID4) -> str:
     grant = interfaces.grants.get_grant(grant_id)
     return render_template("platform/grant_settings.html", grant=grant)
 
 
 @platform_blueprint.route("/grants/<uuid:grant_id>/change-name", methods=["GET", "POST"])
+@mhclg_login_required
 @auto_commit_after_request
 def grant_change_name(grant_id: UUID4) -> str | Response:
     grant = interfaces.grants.get_grant(grant_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,8 @@ dev = [
     "html5lib==1.1",
     "types-html5lib==1.1.11.20241018",
     "types-pytz==2025.2.0.20250326",
+    "boto3>=1.37.34",
+    "types-boto3>=1.37.34",
 ]
 
 [tool.ruff]
@@ -106,6 +108,8 @@ env = [
 ]
 markers = [
     "e2e: Run E2E (browser) tests using playwright",
+    "user_domain: For e2e tests, the domain to use when generating emails for the `user_auth` fixture.",
+
     "authenticate_as: Email address to use for `authenticated_client` fixture; default `test@communities.gov.uk`"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,8 @@ env = [
     "DATABASE_URL=postgresql+psycopg://overridden-by-fixture"
 ]
 markers = [
-    "e2e: Run E2E (browser) tests using playwright"
+    "e2e: Run E2E (browser) tests using playwright",
+    "authenticate_as: Email address to use for `authenticated_client` fixture; default `test@communities.gov.uk`"
 ]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,12 @@ def pytest_addoption(parser: Parser) -> None:
     )
 
     parser.addoption(
+        "--e2e-aws-vault-profile",
+        action="store",
+        help="the aws-vault profile matching the env set in --e2e-env (for `dev` or `test` only)",
+    )
+
+    parser.addoption(
         "--viewport",
         default="1920x1080",
         type=str,

--- a/tests/e2e/config.py
+++ b/tests/e2e/config.py
@@ -1,0 +1,65 @@
+import json
+import re
+import subprocess
+from typing import Literal, Protocol, cast
+
+import boto3
+
+
+class EndToEndTestSecrets(Protocol):
+    @property
+    def GOVUK_NOTIFY_API_KEY(self) -> str: ...
+
+
+class LocalEndToEndSecrets:
+    @property
+    def GOVUK_NOTIFY_API_KEY(self) -> str:
+        with open(".env") as env_file:
+            notify_key_line = re.search(r"^GOVUK_NOTIFY_API_KEY=(.+)$", env_file.read(), flags=re.MULTILINE)
+            if not notify_key_line:
+                raise ValueError("Could not read GOV.UK Notify API key from local .env file")
+
+            return notify_key_line.group(1)
+
+
+class AWSEndToEndSecrets:
+    def __init__(self, e2e_env: Literal["dev", "test"], e2e_aws_vault_profile: str | None):
+        self.e2e_env = e2e_env
+        self.e2e_aws_vault_profile = e2e_aws_vault_profile
+
+        if self.e2e_env == "prod":  # type: ignore[comparison-overlap]
+            # It shouldn't be possible to set e2e_env to `prod` based on current setup; this is a safeguard against it
+            # being added in the future without thinking about this fixture. When it comes to prod secrets, remember:
+            #   keep it secret; keep it safe.
+            raise ValueError("Refusing to init against prod environment because it would read production secrets")
+
+    def _read_aws_parameter_store_value(self, parameter: str) -> str:
+        # This flow is used to collect secrets when running tests *from* your local machine
+        if self.e2e_aws_vault_profile:
+            value = json.loads(
+                subprocess.check_output(
+                    [
+                        "aws-vault",
+                        "exec",
+                        self.e2e_aws_vault_profile,
+                        "--",
+                        "aws",
+                        "ssm",
+                        "get-parameter",
+                        "--name",
+                        parameter,
+                        "--with-decryption",
+                    ],
+                ).decode()
+            )["Parameter"]["Value"]
+
+        # This flow is used when running tests *in* CI/CD, where AWS credentials are available from OIDC auth
+        else:
+            ssm_client = boto3.client("ssm")
+            value = ssm_client.get_parameter(Name=parameter, WithDecryption=True)["Parameter"]["Value"]
+
+        return cast(str, value)
+
+    @property
+    def GOVUK_NOTIFY_API_KEY(self) -> str:
+        return self._read_aws_parameter_store_value("/apprunner/funding-service/GOVUK_NOTIFY_API_KEY")

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -4,6 +4,11 @@ import pytest
 from playwright.sync_api import Page
 from pytest import FixtureRequest
 
+from tests.e2e.config import AWSEndToEndSecrets, EndToEndTestSecrets, LocalEndToEndSecrets
+from tests.e2e.dataclasses import E2ETestUser
+from tests.e2e.helpers import generate_email_address, retrieve_magic_link
+from tests.e2e.pages import RequestALinkToSignInPage
+
 
 @pytest.fixture(autouse=True)
 def _viewport(request: FixtureRequest, page: Page) -> None:
@@ -29,3 +34,42 @@ def domain(request: pytest.FixtureRequest, get_e2e_params: dict[str, str]) -> st
         return "https://vniusepvmn.eu-west-2.awsapprunner.com/"
     else:
         raise ValueError(f"not configured for {e2e_env}")
+
+
+@pytest.fixture
+def e2e_test_secrets(request: FixtureRequest) -> EndToEndTestSecrets:
+    e2e_env = request.config.getoption("e2e_env")
+    e2e_aws_vault_profile = request.config.getoption("e2e_aws_vault_profile")
+
+    if e2e_env == "local":
+        return LocalEndToEndSecrets()
+
+    if e2e_env in {"dev", "test"}:
+        return AWSEndToEndSecrets(e2e_env=e2e_env, e2e_aws_vault_profile=e2e_aws_vault_profile)
+
+    raise ValueError(f"Unknown e2e_env: {e2e_env}.")
+
+
+@pytest.fixture()
+def user_auth(
+    request: FixtureRequest,
+    domain: str,
+    e2e_test_secrets: EndToEndTestSecrets,
+    page: Page,
+) -> E2ETestUser:
+    email_domain_marker = request.node.get_closest_marker("user_domain")
+    email_domain = email_domain_marker.args[0] if email_domain_marker else "communities.gov.uk"
+    email_address = generate_email_address(test_name=request.node.originalname, email_domain=email_domain)
+
+    # Duplicative of `test_magic_link_auth.py`, but intentionally to hopefully keep things readable/debuggable.
+    email = generate_email_address(request.node.originalname)
+    request_a_link_page = RequestALinkToSignInPage(page, domain)
+    request_a_link_page.navigate()
+
+    request_a_link_page.fill_email_address(email)
+    request_a_link_page.click_request_a_link()
+
+    magic_link_url = retrieve_magic_link(email, e2e_test_secrets)
+    page.goto(magic_link_url)
+
+    return E2ETestUser(email_address=email_address)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -31,7 +31,7 @@ def domain(request: pytest.FixtureRequest, get_e2e_params: dict[str, str]) -> st
     if e2e_env == "local":
         return "https://funding.communities.gov.localhost:8080"
     if e2e_env == "dev":
-        return "https://vniusepvmn.eu-west-2.awsapprunner.com/"
+        return "https://vniusepvmn.eu-west-2.awsapprunner.com"
     else:
         raise ValueError(f"not configured for {e2e_env}")
 

--- a/tests/e2e/dataclasses.py
+++ b/tests/e2e/dataclasses.py
@@ -1,0 +1,6 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class E2ETestUser:
+    email_address: str

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -1,0 +1,37 @@
+import re
+import secrets
+from typing import cast
+
+from notifications_python_client import NotificationsAPIClient  # type: ignore[attr-defined]
+
+from tests.e2e.config import EndToEndTestSecrets
+
+
+def generate_email_address(
+    test_name: str,
+    email_domain: str = "communities.gov.uk",
+) -> str:
+    # Help disambiguate tests running around the same time by injecting a random token into the email, so that
+    # when we lookup the email it should be unique. We avoid a UUID so as to keep the emails 'short enough'.
+    token = secrets.token_urlsafe(8)
+    email_address = f"e2e+{test_name}-{token}@{email_domain}".lower()
+
+    return email_address
+
+
+def extract_email_link(email: dict[str, str]) -> str:
+    pattern = r"https?:\/\/[\w-]+(?:\.[\w]+)+(?:[\w.,@?^=%&:\/~+#-]*[\w@?^=%&\/~+#-])?"
+
+    return cast(str, re.findall(pattern, email["body"])[0])
+
+
+def retrieve_magic_link(email_address: str, e2e_test_secrets: EndToEndTestSecrets) -> str:
+    client = NotificationsAPIClient(e2e_test_secrets.GOVUK_NOTIFY_API_KEY)  # type: ignore[no-untyped-call]
+
+    emails = client.get_all_notifications(template_type="email", status="delivered")["notifications"]  # type: ignore[no-untyped-call]
+    for email in emails:
+        if email["email_address"] == email_address:
+            print(email)
+            return extract_email_link(email)
+
+    raise LookupError("Could not find a corresponding find magic link in GOV.UK Notify")

--- a/tests/e2e/pages.py
+++ b/tests/e2e/pages.py
@@ -29,6 +29,24 @@ class LandingPage(TopNavMixin, BasePage):
         self.page.goto(self.domain)
 
 
+class RequestALinkToSignInPage(BasePage):
+    def __init__(self, page: Page, domain: str) -> None:
+        super().__init__(page, domain)
+        self.title = self.page.get_by_role("heading", name="Request a link to sign in")
+        self.email_address = self.page.get_by_role("textbox", name="Email address")
+        self.request_a_link = self.page.get_by_role("button", name="Request a link")
+
+    def navigate(self) -> None:
+        self.page.goto(f"{self.domain}/request-a-link-to-sign-in")
+        expect(self.title).to_be_visible()
+
+    def fill_email_address(self, email_address: str) -> None:
+        self.email_address.fill(email_address)
+
+    def click_request_a_link(self) -> None:
+        self.request_a_link.click()
+
+
 class AllGrantsPage(TopNavMixin, BasePage):
     title: Locator
 

--- a/tests/e2e/test_create_view_edit_grant.py
+++ b/tests/e2e/test_create_view_edit_grant.py
@@ -2,10 +2,14 @@ import uuid
 
 from playwright.sync_api import Page
 
+from tests.e2e.config import EndToEndTestSecrets
+from tests.e2e.dataclasses import E2ETestUser
 from tests.e2e.pages import AllGrantsPage
 
 
-def test_create_view_edit_grant_success(page: Page, domain: str):
+def test_create_view_edit_grant_success(
+    page: Page, domain: str, e2e_test_secrets: EndToEndTestSecrets, user_auth: E2ETestUser
+):
     all_grants_page = AllGrantsPage(page, domain)
     all_grants_page.navigate()
 

--- a/tests/e2e/test_magic_link_auth.py
+++ b/tests/e2e/test_magic_link_auth.py
@@ -1,0 +1,28 @@
+import re
+
+from _pytest.fixtures import FixtureRequest
+from playwright.sync_api import Page, expect
+
+from tests.e2e.config import EndToEndTestSecrets
+from tests.e2e.helpers import generate_email_address, retrieve_magic_link
+from tests.e2e.pages import RequestALinkToSignInPage
+
+
+def test_magic_link_redirect_journey(
+    request: FixtureRequest, page: Page, domain: str, e2e_test_secrets: EndToEndTestSecrets
+):
+    page.goto(f"{domain}/grants")
+
+    # Redirected to request a magic link page; go through that flow.
+    email = generate_email_address(request.node.originalname)
+    request_a_link_page = RequestALinkToSignInPage(page, domain)
+    request_a_link_page.fill_email_address(email)
+    request_a_link_page.click_request_a_link()
+
+    page.wait_for_url(re.compile(rf"{domain}/check-your-email/.+"))
+
+    magic_link_url = retrieve_magic_link(email, e2e_test_secrets)
+    page.goto(magic_link_url)
+
+    # JavaScript on the page automatically claims the link and should redirect to where they started.
+    expect(page).to_have_url(f"{domain}/grants")

--- a/tests/integration/common/auth/test_auth.py
+++ b/tests/integration/common/auth/test_auth.py
@@ -69,6 +69,9 @@ class TestSignInView:
         assert response.status_code == 200
         assert db_session.scalar(select(MagicLink).order_by(MagicLink.created_at.desc())).redirect_to_path == safe_next
 
+        with anonymous_client.session_transaction() as session:
+            assert "next" not in session
+
 
 class TestCheckEmailPage:
     def test_get(self, anonymous_client, factories):

--- a/tests/integration/common/auth/test_decorators.py
+++ b/tests/integration/common/auth/test_decorators.py
@@ -1,0 +1,62 @@
+import pytest
+from flask_login import login_user
+from werkzeug.exceptions import Forbidden
+
+from app.common.auth.decorators import login_required, mhclg_login_required
+
+
+class TestLoginRequired:
+    def test_logged_in_user_gets_response(self, app, factories):
+        @login_required
+        def test_login_required():
+            return "OK"
+
+        user = factories.user.create(email="test@anything.com")
+
+        with app.test_client(), app.test_request_context("/"):
+            login_user(user)
+            response = test_login_required()
+            assert response == "OK"
+
+    def test_anonymous_user_gets_redirect(self, app):
+        @login_required
+        def test_login_required():
+            return "OK"
+
+        with app.test_client(), app.test_request_context("/"):
+            response = test_login_required()
+            assert response.status_code == 302
+
+
+class TestMHCLGLoginRequired:
+    def test_logged_in_mhclg_user_gets_response(self, app, factories):
+        @mhclg_login_required
+        def test_login_required():
+            return "OK"
+
+        user = factories.user.create(email="test@communities.gov.uk")
+
+        with app.test_client(), app.test_request_context("/"):
+            login_user(user)
+            response = test_login_required()
+            assert response == "OK"
+
+    def test_non_mhclg_user_is_forbidden(self, app, factories):
+        @mhclg_login_required
+        def test_login_required():
+            return "OK"
+
+        user = factories.user.create(email="test@anything.com")
+
+        with app.test_client(), app.test_request_context("/"), pytest.raises(Forbidden):
+            login_user(user)
+            test_login_required()
+
+    def test_anonymous_user_gets_redirect(self, app):
+        @mhclg_login_required
+        def test_login_required():
+            return "OK"
+
+        with app.test_client(), app.test_request_context("/"):
+            response = test_login_required()
+            assert response.status_code == 302

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -10,6 +10,7 @@ from _pytest.fixtures import FixtureRequest
 from _pytest.monkeypatch import MonkeyPatch
 from flask import Flask, template_rendered
 from flask.testing import FlaskClient
+from flask_login import login_user
 from flask_migrate import upgrade
 from flask_sqlalchemy_lite import SQLAlchemy
 from jinja2 import Template
@@ -183,3 +184,17 @@ def mock_notification_service_calls(mocker: MockerFixture) -> Generator[list[_Ca
     )
 
     yield calls
+
+
+@pytest.fixture()
+def authenticated_client(
+    client: FlaskClient, factories: _Factories, request: FixtureRequest
+) -> Generator[FlaskClient, None, None]:
+    email_mark = request.node.get_closest_marker("authenticate_as")
+    email = email_mark.args[0] if email_mark else "test@communities.gov.uk"
+
+    user = factories.user.create(email=email)
+
+    login_user(user)
+
+    yield client

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -84,7 +84,7 @@ def app(db: Generator[SQLAlchemy]) -> Generator[Flask, None, None]:
 
 
 @pytest.fixture()
-def client(app: Flask) -> FlaskClient:
+def anonymous_client(app: Flask) -> FlaskClient:
     class CustomClient(FundingServiceTestClient):
         # We want to be sure that any data methods that act during the request have been
         # committed by the flask app lifecycle before continuing. Because of the way we configure
@@ -188,7 +188,7 @@ def mock_notification_service_calls(mocker: MockerFixture) -> Generator[list[_Ca
 
 @pytest.fixture()
 def authenticated_client(
-    client: FlaskClient, factories: _Factories, request: FixtureRequest
+    anonymous_client: FlaskClient, factories: _Factories, request: FixtureRequest
 ) -> Generator[FlaskClient, None, None]:
     email_mark = request.node.get_closest_marker("authenticate_as")
     email = email_mark.args[0] if email_mark else "test@communities.gov.uk"
@@ -197,4 +197,4 @@ def authenticated_client(
 
     login_user(user)
 
-    yield client
+    yield anonymous_client

--- a/tests/integration/healthcheck/test_healthcheck.py
+++ b/tests/integration/healthcheck/test_healthcheck.py
@@ -1,4 +1,4 @@
-def test_healthcheck(client) -> None:
-    response = client.get("/healthcheck")
+def test_healthcheck(anonymous_client) -> None:
+    response = anonymous_client.get("/healthcheck")
     assert response.status_code == 200
     assert "OK" in response.get_data(as_text=True)

--- a/uv.lock
+++ b/uv.lock
@@ -78,6 +78,46 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.37.34"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/5d/6b1ca20ba4da350799509a69f2d295ae11d5ec08a98e82f74b5708a8180c/boto3-1.37.34.tar.gz", hash = "sha256:94ca07328474db3fa605eb99b011512caa73f7161740d365a1f00cfebfb6dd90", size = 111701 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/2e/ad43d1e87d46d11dcf4104f97b9a7f6beb38a52a0e752edfadf3eb8b6e38/boto3-1.37.34-py3-none-any.whl", hash = "sha256:586bfa72a00601c04067f9adcbb08ecaf63b05b7d731103f33cb2ce0d6950b1b", size = 139920 },
+]
+
+[[package]]
+name = "botocore"
+version = "1.37.34"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/60/9ec251a0e2d3994f3eac8bd9741576757c3aad189abbdec8fab6011f5a1a/botocore-1.37.34.tar.gz", hash = "sha256:2909b6dbf9c90347c71a6fa0364acee522d6a7664f13d6f7996c9dd1b1f46fac", size = 13817141 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/51/19fff717cc5000708c4ce3d081bb0e63ca117c6823975b33101d52fdd9f5/botocore-1.37.34-py3-none-any.whl", hash = "sha256:bd9af0db1097befd2028ba8525e32cacc04f26ccb9dbd5d48d6ecd05bc16c27a", size = 13483679 },
+]
+
+[[package]]
+name = "botocore-stubs"
+version = "1.37.29"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "types-awscrt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/84/3c6f85a562fc2c0b6856a7742ccc0f59c7ff1ea2595e0159bc3b12ff7122/botocore_stubs-1.37.29.tar.gz", hash = "sha256:c59898bf1d09bf6a9f491f4705c5696e74b83156b766aa1716867f11b8a04ea1", size = 42239 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/26/8857ff237c8d70fb8591575749468eb8973e16c65931226b856dda50c160/botocore_stubs-1.37.29-py3-none-any.whl", hash = "sha256:923127abb5fac0b8b0f11837a4641f2863bb4398b5bd6b11d1604134966c4bb6", size = 65569 },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.1.31"
 source = { registry = "https://pypi.org/simple" }
@@ -415,6 +455,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "beautifulsoup4" },
+    { name = "boto3" },
     { name = "debugpy" },
     { name = "factory-boy" },
     { name = "flask-debugtoolbar" },
@@ -432,6 +473,7 @@ dev = [
     { name = "ruff" },
     { name = "sqlalchemy-utils" },
     { name = "testcontainers" },
+    { name = "types-boto3" },
     { name = "types-flask-migrate" },
     { name = "types-html5lib" },
     { name = "types-pytz" },
@@ -464,6 +506,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "beautifulsoup4", specifier = "==4.13.3" },
+    { name = "boto3", specifier = ">=1.37.34" },
     { name = "debugpy", specifier = "==1.8.14" },
     { name = "factory-boy", specifier = "==3.3.3" },
     { name = "flask-debugtoolbar", specifier = "==0.16.0" },
@@ -481,6 +524,7 @@ dev = [
     { name = "ruff", specifier = "==0.11.5" },
     { name = "sqlalchemy-utils", specifier = "==0.41.2" },
     { name = "testcontainers", extras = ["postgres"], specifier = "==4.10.0" },
+    { name = "types-boto3", specifier = ">=1.37.34" },
     { name = "types-flask-migrate", specifier = "==4.1.0.20250112" },
     { name = "types-html5lib", specifier = "==1.1.11.20241018" },
     { name = "types-pytz", specifier = "==2025.2.0.20250326" },
@@ -599,6 +643,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/af/92/b3130cbbf5591acf9ade8708c365f3238046ac7cb8ccba6e81abccb0ccff/jinja2-3.1.5.tar.gz", hash = "sha256:8fefff8dc3034e27bb80d67c671eb8a9bc424c0ef4c0826edbff304cceff43bb", size = 244674 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/0f/2ba5fbcd631e3e88689309dbe978c5769e883e4b84ebfe7da30b43275c5a/jinja2-3.1.5-py3-none-any.whl", hash = "sha256:aba0f4dc9ed8013c424088f68a5c226f7d6097ed89b246d7749c2ec4175c6adb", size = 134596 },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe", size = 25843 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980", size = 20256 },
 ]
 
 [[package]]
@@ -958,6 +1011,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892 },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1078,6 +1143,18 @@ wheels = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.11.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/ec/aa1a215e5c126fe5decbee2e107468f51d9ce190b9763cb649f76bb45938/s3transfer-0.11.4.tar.gz", hash = "sha256:559f161658e1cf0a911f45940552c696735f5c74e64362e515f333ebed87d679", size = 148419 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/62/8d3fc3ec6640161a5649b2cddbbf2b9fa39c92541225b33f117c37c5a2eb/s3transfer-0.11.4-py3-none-any.whl", hash = "sha256:ac265fa68318763a03bf2dc4f39d5cbd6a9e178d81cc9483ad27da33637e320d", size = 84412 },
+]
+
+[[package]]
 name = "sentry-sdk"
 version = "2.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1172,6 +1249,28 @@ wheels = [
 ]
 
 [[package]]
+name = "types-awscrt"
+version = "0.26.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/29/d0597055f1b700193463361b4b2284cf4548acbb10287d6253ce429728d5/types_awscrt-0.26.1.tar.gz", hash = "sha256:aca96f889b3745c0e74f42f08f277fed3bf6e9baa2cf9b06a36f78d77720e504", size = 15537 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/c0/4708ee11a50d4e80c4dfb88dc2d6d69b1c296cd7397f1fe6352f119fd310/types_awscrt-0.26.1-py3-none-any.whl", hash = "sha256:176d320a26990efc057d4bf71396e05be027c142252ac48cc0d87aaea0704280", size = 19575 },
+]
+
+[[package]]
+name = "types-boto3"
+version = "1.37.34"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore-stubs" },
+    { name = "types-s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/aa/60b5c65fd279c352ef7480544bb52e6afe1f9e972ce1342ed4a530a39547/types_boto3-1.37.34.tar.gz", hash = "sha256:ec2610bcd1ebc2f8de3fc0cfa11eb6a072c153f9e95f93c84a59432a2fa329e1", size = 99549 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/41/ba3b03926e45d5dc71944b7d4364b39413fb9ad5c3e7bdceb5e4a32e88e6/types_boto3-1.37.34-py3-none-any.whl", hash = "sha256:8bdde84f53d9c924ba2e6013687b7ecd2b72417338099e236f9f84f96437caaf", size = 68558 },
+]
+
+[[package]]
 name = "types-flask-migrate"
 version = "4.1.0.20250112"
 source = { registry = "https://pypi.org/simple" }
@@ -1200,6 +1299,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4b/66/38c89861242f2c61c8315ddbcc7d7bbf64979f4b0bdc48db0ba62aeec330/types_pytz-2025.2.0.20250326.tar.gz", hash = "sha256:deda02de24f527066fc8d6a19e284ab3f3ae716a42b4adb6b40e75e408c08d36", size = 10595 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4e/e0/17f3a6670db5c95dc195f346e2e7290f22ba8327c188133959389b578cbd/types_pytz-2025.2.0.20250326-py3-none-any.whl", hash = "sha256:3c397fd1b845cd2b3adc9398607764ced9e578a98a5d1fbb4a9bc9253edfb162", size = 10222 },
+]
+
+[[package]]
+name = "types-s3transfer"
+version = "0.11.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/a9/440d8ba72a81bcf2cc5a56ef63f23b58ce93e7b9b62409697553bdcdd181/types_s3transfer-0.11.4.tar.gz", hash = "sha256:05fde593c84270f19fd053f0b1e08f5a057d7c5f036b9884e68fb8cd3041ac30", size = 14074 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/69/0b5ae42c3c33d31a32f7dcb9f35a3e327365360a6e4a2a7b491904bd38aa/types_s3transfer-0.11.4-py3-none-any.whl", hash = "sha256:2a76d92c07d4a3cb469e5343b2e7560e0b8078b2e03696a65407b8c44c861b61", size = 19516 },
 ]
 
 [[package]]


### PR DESCRIPTION
A very basic decorator to require a logged-in communities.gov.uk user when accessing grant management pages.

This will need a lot of extending and further development when we come to do multiple user types, but for now this is sufficient.