### PR TITLE
Enable experimental logging to sentry

### DIFF
--- a/app/sentry.py
+++ b/app/sentry.py
@@ -34,7 +34,7 @@ def init_sentry() -> None:
         env = Environment(os.getenv("FLASK_ENV", Environment.PROD.value))
 
         sentry_sdk.init(
-            environment=env,
+            environment=env.value,
             send_default_pii=env is not Environment.PROD,
             error_sampler=errors_sampler,
             traces_sampler=traces_sampler,

--- a/app/sentry.py
+++ b/app/sentry.py
@@ -1,6 +1,8 @@
+import logging
 import os
 
 import sentry_sdk
+from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.types import Event, Hint
 
 from app.config import Environment
@@ -38,4 +40,10 @@ def init_sentry() -> None:
             traces_sampler=traces_sampler,
             profiles_sampler=profiles_sampler,
             release=os.getenv("GITHUB_SHA"),
+            _experiments={
+                "enable_logs": True,
+            },
+            integrations=[
+                LoggingIntegration(sentry_logs_level=logging.INFO),
+            ],
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,11 +20,11 @@ dependencies = [
     "pydantic-settings==2.8.1",
     "python-json-logger==3.3.0",
     "sqlalchemy==2.0.38",
-    "sentry-sdk==2.25.1",
     "wtforms[email]==3.2.1",
     "notifications-python-client==10.0.1",
     "flask-talisman==1.1.0",
     "flask-login==0.6.3",
+    "sentry-sdk>=2.26.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -122,7 +122,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -456,7 +456,7 @@ requires-dist = [
     { name = "pydantic", specifier = "==2.11.3" },
     { name = "pydantic-settings", specifier = "==2.8.1" },
     { name = "python-json-logger", specifier = "==3.3.0" },
-    { name = "sentry-sdk", specifier = "==2.25.1" },
+    { name = "sentry-sdk", specifier = ">=2.26.0" },
     { name = "sqlalchemy", specifier = "==2.0.38" },
     { name = "wtforms", extras = ["email"], specifier = "==3.2.1" },
 ]
@@ -1079,15 +1079,15 @@ wheels = [
 
 [[package]]
 name = "sentry-sdk"
-version = "2.25.1"
+version = "2.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/85/2f/a0f732270cc7c1834f5ec45539aec87c360d5483a8bd788217a9102ccfbd/sentry_sdk-2.25.1.tar.gz", hash = "sha256:f9041b7054a7cf12d41eadabe6458ce7c6d6eea7a97cfe1b760b6692e9562cf0", size = 322190 }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/e2/f8ebb2086046d89cb692f12cc7f9d84e02669d19e263f9b0347553ac6e8c/sentry_sdk-2.26.0.tar.gz", hash = "sha256:88643459716dd0c6e412e5141fcc94ce3b5725e4b6b312210b91332b3b46a0e2", size = 322738 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/b6/84049ab0967affbc7cc7590d86ae0170c1b494edb69df8786707100420e5/sentry_sdk-2.25.1-py2.py3-none-any.whl", hash = "sha256:60b016d0772789454dc55a284a6a44212044d4a16d9f8448725effee97aaf7f6", size = 339851 },
+    { url = "https://files.pythonhosted.org/packages/dd/da/195136b1113e5bc34f31ba04a345bc15c1e66a4eacfc1b317de111abe8c5/sentry_sdk-2.26.0-py2.py3-none-any.whl", hash = "sha256:82496fc359296dac57ec923300b18cc1f14a1279c1e7108d46d35dbb4cf8f5f8", size = 340184 },
 ]
 
 [[package]]


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FSPT-376

Sentry is exploring integrating with logging so that errors, traces and logs can all be seen through a single pane of glass.

The instrumentation is likely to be basic, but we've had a fairly poor logging story on Funding Service for a while, so if we can easily turn on a single integration and get some basic integrated logging in place, this feels like a quick win worth testing.

https://github.com/getsentry/sentry-python/discussions/4220

If we decide to turn this off later, we won't strictly be any worse off.