### PR TITLE
BAU: Properly set pipeline permissions & secrets

### DIFF
--- a/.github/workflows/build_deploy_e2e_pipeline.yml
+++ b/.github/workflows/build_deploy_e2e_pipeline.yml
@@ -1,6 +1,11 @@
 name: Deployment pipeline
 run-name: Build, deploy and e2e test ${{github.ref_name}}
 
+permissions:
+  packages: write
+  contents: read  # This is required for actions/checkout
+  id-token: write  # This is required for authenticating with aws
+
 on:
   workflow_dispatch:
   push:
@@ -11,13 +16,13 @@ jobs:
   paketo_build:
     name: Paketo build & publish
     uses: ./.github/workflows/package.yml
-    permissions:
-      packages: write
-      contents: read  # This is required for actions/checkout
-      id-token: write  # This is required for authenticating with aws
     concurrency:
       group: fs-paketo-dev
       cancel-in-progress: false
+    secrets:
+      AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      TEMP_SLACK_CHANNEL_ID: ${{ secrets.TEMP_SLACK_CHANNEL_ID }}
 
   # Commenting out these steps until we have a nice way of checking the AppRunner deployment has completed
   # before running e2e tests, otherwise this behaviour will be odd

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -8,6 +8,13 @@ permissions:
 
 on:
   workflow_call:
+    secrets:
+      AWS_ACCOUNT:
+        required: true
+      SLACK_BOT_TOKEN:
+        required: true
+      TEMP_SLACK_CHANNEL_ID:
+        required: true
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Now we're calling the package.yml workflow from another workflow we need to pass it the necessary secrets explicitly.

As it's a workflow in this same repo, we also just need to set the permissions for the calling pipeline workflow at the top.