### PR TITLE
Remove pullpreview from main branch

### DIFF
--- a/.github/workflows/pullpreview.yml
+++ b/.github/workflows/pullpreview.yml
@@ -3,15 +3,12 @@ on:
   # the schedule is optional, but helps to make sure no dangling resources are left when GitHub Action does not behave properly
   schedule:
     - cron: "30 2 * * *"
-  push:
-    branches:
-      - main
   pull_request:
     types: [labeled, unlabeled, synchronize, closed, reopened]
 
 jobs:
   deploy:
-    if: github.event_name == 'schedule' || github.event_name == 'push' || github.event.label.name == 'pullpreview' || contains(github.event.pull_request.labels.*.name, 'pullpreview')
+    if: github.event_name == 'schedule' || github.event.label.name == 'pullpreview' || contains(github.event.pull_request.labels.*.name, 'pullpreview')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: dev


### PR DESCRIPTION
This is frequently giving us a red :cross:, which we haven't been fixing lately and so let's just remove it so we don't get redcrossblindness.

We also deploy to the dev env on merge, so pullpreviews on main don't feel that useful.