### PR TITLE
FSPT-377: Make AppRunner deploy manual

### DIFF
--- a/.github/workflows/build_deploy_e2e_pipeline.yml
+++ b/.github/workflows/build_deploy_e2e_pipeline.yml
@@ -14,33 +14,26 @@ on:
 
 jobs:
   paketo_build:
-    name: Paketo build & publish
+    name: Build
     uses: ./.github/workflows/package.yml
-    concurrency:
-      group: fs-paketo-dev
-      cancel-in-progress: false
     secrets:
       AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       TEMP_SLACK_CHANNEL_ID: ${{ secrets.TEMP_SLACK_CHANNEL_ID }}
 
-  # Commenting out these steps until we have a nice way of checking the AppRunner deployment has completed
-  # before running e2e tests, otherwise this behaviour will be odd
-
-  # wait_for_deploy:
-  #   # TODO: Replace this with a nice way of checking the AppRunner deployment has completed
-  #   name: Wait for AppRunner deploy
-  #   needs:
-  #     - paketo_build
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Wait for 4 minutes
-  #       shell: bash
-  #       run: sleep 240s
-
-  # e2e_tests:
-  #   name: Python E2E tests
-  #   needs:
-  #     - paketo_build
-  #     - wait_for_deploy
-  #   uses: ./.github/workflows/run_e2e_tests.yml
+  deploy_dev:
+    name: Dev deploy and test
+    needs:
+      - paketo_build
+    uses: ./.github/workflows/deploy.yml
+    concurrency:
+      group: fs-deploy-dev
+      cancel-in-progress: false
+    with:
+      environment: dev
+      image_location: ${{ needs.paketo_build.outputs.image_location }}
+      run_e2e_tests: true
+    secrets:
+      AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      TEMP_SLACK_CHANNEL_ID: ${{ secrets.TEMP_SLACK_CHANNEL_ID }}

--- a/.github/workflows/build_deploy_e2e_pipeline.yml
+++ b/.github/workflows/build_deploy_e2e_pipeline.yml
@@ -7,7 +7,6 @@ permissions:
   id-token: write  # This is required for authenticating with aws
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - main
@@ -22,7 +21,7 @@ jobs:
       TEMP_SLACK_CHANNEL_ID: ${{ secrets.TEMP_SLACK_CHANNEL_ID }}
 
   deploy_dev:
-    name: Dev deploy and test
+    name: Deploy to dev
     needs:
       - paketo_build
     uses: ./.github/workflows/deploy.yml
@@ -31,7 +30,25 @@ jobs:
       cancel-in-progress: false
     with:
       environment: dev
-      image_location: ${{ needs.paketo_build.outputs.image_location }}
+      ghcr_image_location: ${{ needs.paketo_build.outputs.ghcr_image_location }}
+      run_e2e_tests: true
+    secrets:
+      AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      TEMP_SLACK_CHANNEL_ID: ${{ secrets.TEMP_SLACK_CHANNEL_ID }}
+
+  deploy_test:
+    name: Deploy to test
+    needs:
+      - paketo_build
+      - deploy_dev
+    uses: ./.github/workflows/deploy.yml
+    concurrency:
+      group: fs-deploy-test
+      cancel-in-progress: false
+    with:
+      environment: test
+      ghcr_image_location: ${{ needs.paketo_build.outputs.ghcr_image_location }}
       run_e2e_tests: true
     secrets:
       AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,10 +70,14 @@ jobs:
       - name: Push image to ECR
         id: push_image
         run: |
-          ECR_IMAGE_LOCATION=${{ secrets.AWS_ACCOUNT }}.dkr.ecr.eu-west-2.amazonaws.com/${{ inputs.environment }}-funding-service:${{ github.sha }}
+          ECR_REPO=${{ secrets.AWS_ACCOUNT }}.dkr.ecr.eu-west-2.amazonaws.com/${{ inputs.environment }}-funding-service
 
-          docker image tag ${{ inputs.ghcr_image_location }} $ECR_IMAGE_LOCATION
-          docker push $ECR_IMAGE_LOCATION
+          docker image tag ${{ inputs.ghcr_image_location }} $ECR_REPO:${{ github.sha }}
+          docker image tag ${{ inputs.ghcr_image_location }} $ECR_REPO:latest
+          docker push $ECR_REPO:${{ github.sha }}
+          docker push $ECR_REPO:latest
+
+          ECR_IMAGE_LOCATION=$ECR_REPO:${{ github.sha }}
 
           echo "ecr_image_location=$ECR_IMAGE_LOCATION" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,95 @@
+name: Deploy
+run-name: Deploy ${{ github.ref_name }} to ${{ github.event.inputs.environment }}
+
+permissions:
+  contents: read  # This is required for actions/checkout
+  id-token: write  # This is required for authenticating with aws
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: "AWS environment to deploy to."
+        type: string
+        required: true
+        default: dev
+      image_location:
+        description: "Location of the image to deploy."
+        type: string
+        required: false
+      run_e2e_tests:
+          description: "Run end-to-end tests?"
+          type: boolean
+          default: true
+          required: true
+    secrets:
+      AWS_ACCOUNT:
+        required: true
+      SLACK_BOT_TOKEN:
+        required: true
+      TEMP_SLACK_CHANNEL_ID:
+        required: true
+
+jobs:
+  deploy:
+    environment: ${{ inputs.environment }}
+    runs-on: ubuntu-latest
+    name: Paketo
+
+    steps:
+      - name: Get current date
+        shell: bash
+        id: currentdatetime
+        run: echo "datetime=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_OUTPUT
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/GithubCopilotDeploy
+          role-session-name: "funding-service_deploy_${{ inputs.environment }}_${{ steps.currentdatetime.outputs.datetime }}"
+          aws-region: eu-west-2
+
+      - name: Login to ECR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.eu-west-2.amazonaws.com
+
+      - name: Deploy image to AppRunner
+        id: deploy
+        uses: awslabs/amazon-app-runner-deploy@main
+        with:
+          service: ${{ inputs.environment }}-funding-service
+          image: ${{ inputs.image_location }}
+          access-role-arn: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/${{ inputs.environment }}-funding-service-app-runner-build-role
+          region: eu-west-2
+          port: 5000
+          cpu : 1
+          memory : 2
+          wait-for-service-stability-seconds: 360
+
+  e2e_tests:
+    name: Python E2E tests
+    if: ${{ inputs.run_e2e_tests == true }}
+    needs:
+      - deploy
+    uses: ./.github/workflows/run_e2e_tests.yml
+    with:
+      environment: ${{ inputs.environment }}
+    secrets:
+      AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
+
+  notify_slack:
+    needs:
+      - deploy
+      - e2e_tests
+    if: ${{ always() && (needs.deploy.result == 'failure' || needs.e2e_tests.result == 'failure') && github.ref_name == 'main'}}
+    uses: communitiesuk/funding-service-design-workflows/.github/workflows/notify-slack-deployment-failed.yml@main
+    with:
+      app_name: FS Deploy & Build
+      env_name: ${{ inputs.environment }}
+      github_username: ${{ github.actor }}
+      workflow_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      compare_url: ${{ github.event_name == 'push' && github.event.compare || null }}
+    secrets:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_NOTIFICATION_CHANNEL_ID: ${{ secrets.TEMP_SLACK_CHANNEL_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ run-name: Deploy ${{ github.ref_name }} to ${{ github.event.inputs.environment }
 
 permissions:
   contents: read  # This is required for actions/checkout
+  packages: read # This is required for pulling from GHCR
   id-token: write  # This is required for authenticating with aws
 
 on:
@@ -13,7 +14,7 @@ on:
         type: string
         required: true
         default: dev
-      image_location:
+      ghcr_image_location:
         description: "Location of the image to deploy."
         type: string
         required: false
@@ -34,9 +35,21 @@ jobs:
   deploy:
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
-    name: Paketo
+    name: Deploy
 
     steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull image from GHCR
+        id: pull_image
+        run: |
+          docker pull ${{ inputs.ghcr_image_location }}
+
       - name: Get current date
         shell: bash
         id: currentdatetime
@@ -54,12 +67,22 @@ jobs:
         with:
           registry: ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.eu-west-2.amazonaws.com
 
+      - name: Push image to ECR
+        id: push_image
+        run: |
+          ECR_IMAGE_LOCATION=${{ secrets.AWS_ACCOUNT }}.dkr.ecr.eu-west-2.amazonaws.com/${{ inputs.environment }}-funding-service:${{ github.sha }}
+
+          docker image tag ${{ inputs.ghcr_image_location }} $ECR_IMAGE_LOCATION
+          docker push $ECR_IMAGE_LOCATION
+
+          echo "ecr_image_location=$ECR_IMAGE_LOCATION" >> $GITHUB_OUTPUT
+
       - name: Deploy image to AppRunner
         id: deploy
         uses: awslabs/amazon-app-runner-deploy@main
         with:
           service: ${{ inputs.environment }}-funding-service
-          image: ${{ inputs.image_location }}
+          image: ${{ steps.push_image.outputs.ecr_image_location }}
           access-role-arn: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/${{ inputs.environment }}-funding-service-app-runner-build-role
           region: eu-west-2
           port: 5000

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -16,16 +16,16 @@ on:
       TEMP_SLACK_CHANNEL_ID:
         required: true
     outputs:
-      image_location:
+      ghcr_image_location:
         description: "A URI pointing to the paketo-built image"
-        value: ${{ jobs.paketo_build.outputs.image_location }}
+        value: ${{ jobs.paketo_build.outputs.ghcr_image_location }}
 
 jobs:
   paketo_build:
     runs-on: ubuntu-latest
     name: Paketo
     outputs:
-      image_location: ${{ steps.build_and_publish.outputs.image_location }}
+      ghcr_image_location: ${{ steps.build_and_publish.outputs.ghcr_image_location }}
 
     steps:
       - uses: buildpacks/github-actions/setup-pack@d82294e03fd6b8e8484cde2ee166788876e366e3 # v5.8.10
@@ -49,29 +49,19 @@ jobs:
           npm ci
           npm run build
 
-      - name: Get current date
-        shell: bash
-        id: currentdatetime
-        run: echo "datetime=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_OUTPUT
-
-      - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/GithubCopilotDeploy
-          role-session-name: "funding-service_build_${{ steps.currentdatetime.outputs.datetime }}"
-          aws-region: eu-west-2
-
-      - name: Login to ECR
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
-        with:
-          registry: ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.eu-west-2.amazonaws.com
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and publish app image
         id: build_and_publish
         run: |
-          IMAGE_ID=${{ secrets.AWS_ACCOUNT }}.dkr.ecr.eu-west-2.amazonaws.com/dev-funding-service
+          IMAGE_ID=ghcr.io/${{ github.repository }}
           VERSION=${{ github.sha }}
-          IMAGE_LOCATION="$IMAGE_ID:$VERSION"
+          GHCR_IMAGE_LOCATION="$IMAGE_ID:$VERSION"
           LATEST_TAG=""
           if [ ${{ github.ref_name }} == "main" ]; then
             LATEST_TAG="--tag $IMAGE_ID:latest"
@@ -79,11 +69,11 @@ jobs:
 
           uv export --format requirements-txt --no-hashes > requirements.txt
 
-          pack build $IMAGE_LOCATION $LATEST_TAG \
+          pack build $GHCR_IMAGE_LOCATION $LATEST_TAG \
             --builder paketobuildpacks/builder-jammy-full \
             --publish
 
-          echo "image_location=$IMAGE_LOCATION" >> $GITHUB_OUTPUT
+          echo "ghcr_image_location=$GHCR_IMAGE_LOCATION" >> $GITHUB_OUTPUT
 
   notify_slack:
     needs:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,5 +1,5 @@
 name: Paketo build
-run-name: Paketo build ${{github.ref_name}}
+run-name: Build ${{github.ref_name}}
 
 permissions:
   packages: write
@@ -15,11 +15,13 @@ on:
         required: true
       TEMP_SLACK_CHANNEL_ID:
         required: true
-  workflow_dispatch:
+    outputs:
+      image_location:
+        description: "A URI pointing to the paketo-built image"
+        value: ${{ jobs.paketo_build.outputs.image_location }}
 
 jobs:
   paketo_build:
-    environment: dev
     runs-on: ubuntu-latest
     name: Paketo
     outputs:
@@ -68,14 +70,20 @@ jobs:
         id: build_and_publish
         run: |
           IMAGE_ID=${{ secrets.AWS_ACCOUNT }}.dkr.ecr.eu-west-2.amazonaws.com/dev-funding-service
-
-          VERSION=${{ github.ref_name }}
+          VERSION=${{ github.sha }}
+          IMAGE_LOCATION="$IMAGE_ID:$VERSION"
+          LATEST_TAG=""
+          if [ ${{ github.ref_name }} == "main" ]; then
+            LATEST_TAG="--tag $IMAGE_ID:latest"
+          fi
 
           uv export --format requirements-txt --no-hashes > requirements.txt
 
-          IMAGE_LOCATION="$IMAGE_ID:$VERSION"
+          pack build $IMAGE_LOCATION $LATEST_TAG \
+            --builder paketobuildpacks/builder-jammy-full \
+            --publish
 
-          pack build $IMAGE_LOCATION --tag $IMAGE_ID:${{github.sha}} --tag $IMAGE_ID:latest --builder paketobuildpacks/builder-jammy-full --publish
+          echo "image_location=$IMAGE_LOCATION" >> $GITHUB_OUTPUT
 
   notify_slack:
     needs:

--- a/.github/workflows/run_e2e_tests.yml
+++ b/.github/workflows/run_e2e_tests.yml
@@ -23,6 +23,7 @@ on:
         required: true
         options:
         - dev
+        - test
 
 jobs:
   e2e_tests:

--- a/.github/workflows/run_e2e_tests.yml
+++ b/.github/workflows/run_e2e_tests.yml
@@ -1,13 +1,34 @@
 name: Run e2e tests
 
+permissions:
+  contents: read  # This is required for actions/checkout
+  id-token: write  # This is required for authenticating with aws
+
 on:
   workflow_call:
+    inputs:
+      environment:
+        description: "Which AWS environment to test against."
+        type: string
+        required: true
+        default: dev
+    secrets:
+      AWS_ACCOUNT:
+        required: true
   workflow_dispatch:
+    inputs:
+      environment:
+        description:  Which AWS Account to use
+        type: choice
+        required: true
+        options:
+        - dev
 
 jobs:
   e2e_tests:
+    name: Run E2E tests
     runs-on: ubuntu-latest
-
+    environment: ${{ inputs.environment }}
     steps:
       - name: checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -25,8 +46,20 @@ jobs:
       - name: Install playwright browsers
         run: uv run --frozen playwright install --with-deps chromium
 
+      - name: Get current date
+        shell: bash
+        id: currentdatetime
+        run: echo "datetime=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_OUTPUT
+
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/GithubCopilotDeploy
+          role-session-name: "funding-service_test_${{ steps.currentdatetime.outputs.datetime }}"
+          aws-region: eu-west-2
+
       - name: run e2e tests
-        run: uv run --frozen pytest --e2e --e2e-env dev --tracing=retain-on-failure --browser chromium
+        run: uv run --frozen pytest --e2e --e2e-env ${{ inputs.environment }} --tracing=retain-on-failure --browser chromium
 
       - name: Save test failure tracing
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -34,18 +67,3 @@ jobs:
         with:
           name: playwright-traces
           path: test-results/*
-
-  notify_slack:
-    needs:
-      - e2e_tests
-    if: ${{ always() && needs.e2e_tests.result == 'failure' && github.ref_name == 'main'}}
-    uses: communitiesuk/funding-service-design-workflows/.github/workflows/notify-slack-deployment-failed.yml@main
-    with:
-      app_name: FS E2E Tests
-      env_name: 'dev'
-      github_username: ${{ github.actor }}
-      workflow_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-      compare_url: ${{ github.event_name == 'push' && github.event.compare || null }}
-    secrets:
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      SLACK_NOTIFICATION_CHANNEL_ID: ${{ secrets.TEMP_SLACK_CHANNEL_ID }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,9 +113,9 @@ markers = [
     "authenticate_as: Email address to use for `authenticated_client` fixture; default `test@communities.gov.uk`"
 ]
 
-
 filterwarnings = [
     "error",
     "ignore:Could not insert debug toolbar:UserWarning",
-    "ignore:cannot collect test class 'TestConfig' because it has a __init__ constructor:pytest.PytestCollectionWarning"
+    "ignore:cannot collect test class 'TestConfig' because it has a __init__ constructor:pytest.PytestCollectionWarning",
+    "ignore:datetime\\.datetime\\.utcnow\\(\\) is deprecated and scheduled for removal in a future version*:DeprecationWarning"
 ]


### PR DESCRIPTION
We want visibility and control over the AppRunner deployments rather than relying on automatic deployments when a new image with the `latest` tag is pushed to ECR.

We're not sure if we'll continue to use AppRunner so for the time being we can use the AWS AppRunner deploy action and specify deploying the image we've just built in the pipeline. This allows us to then run the e2e tests after a successful deploy or catch any issues with deployments (which before now could fail silently). We're also now tagging images with the sha as well as `latest`, as the pipeline now only runs on merges to main.

### But also multiple envs now - what to do with ECR?

With multiple deployed environments now we run into the issue that each AWS account has its own ECR. We only want to build our images once and deploy this same image to each environment in turn, which becomes tricky when we push the built image to the ECR of the lowest environment first.

The team discussed allowing each account to have access to the ECR of the account/environment beneath it, but this would require updates to the terraform setup and injecting unique account IDs conditionally (as you'd only want test to be able to access dev, and prod to access test etc.), and feels like it could run into some rough edges.

We discussed having a separate AWS CI account which would host all the built images and then our pipeline would pull the image to that environment's ECR and deploy it (or deploy it directly from that AWS CI ECR). While we wait to have a separate AWS CI account set up, we agreed to use GitHub Container Registry as an interim solution, as it's what we already use in our existing services.


### Deprecation Warning ignored

The additional ignored `DeprecationWarning` is ignoring a warning from an implementation of a method in the botocore library, so not something we have any control over (see [failed run](https://github.com/communitiesuk/funding-service/actions/runs/14493055489/job/40653795696) for context)
```
self = <botocore.auth.SigV4Auth object at 0x7fc573fa7ed0>
request = <botocore.awsrequest.AWSRequest object at 0x7fc573fa65d0>

    def add_auth(self, request):
        if self.credentials is None:
            raise NoCredentialsError()
>       datetime_now = datetime.datetime.utcnow()
E       DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
```