### PR TITLE
BAU Configure docker compose to shut down quickly

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
 
   funding-service:
     build: .
+    init: true
     volumes:
       - .:/app
       - /app/node_modules


### PR DESCRIPTION
`docker stop` sends a `SIGNT` signal to the running docker container that asks it to end its process, after 10 seconds docker then sends a `SIGKILL` if the container has not appropriately exited.

Because we're running two long running processes in our `command` instruction (vite runs to process assets in the background with `&` and flask runs in debug mode on the main process) the `SIGINT` will be sent to the main process but will not be sent to the background process.

This means `docker compose stop` will always take 10 seconds because one of the processes isn't shutting down until `SIGKILL` forces everything to stop.

There are a number of ways to avoid this but the way we have things configured now is convenient so we don't want to go too far out of our way - we could write some bash that backgrounds both processes and then traps the `SIGNT` signal and manually kills both PIDs.

Alternatively we could change the `stop_signal:` in docker compose to `SIGKILL`, that would force all processes to immediately stop but could leave apps and data in an undesired state when they start again.

Intead instruct docker to use [tini](https://github.com/krallin/tini) which is a `init` script which will deal with the exit lifecycle and cleanups better than we could. As of recent Docker versions this is handily built in! You can either specify a custom `init:` parameter or set it to `true` to use the default.

Now when `docker stop` passes a `SIGINT` signal both the background and foreground process will be safely stopped immediately.


https://github.com/user-attachments/assets/858330b8-0026-4aa7-87ad-d2bc9c4cc6b9


Everyone will need to decide what they do with their 10 seconds back.