### PR TITLE
FSPT-379 End to end tests authorise once across distributed workers

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -53,7 +53,7 @@ jobs:
       - name: install dependencies
         run: uv sync --frozen
       - name: run unit tests
-        run: uv run pytest -nauto .
+        run: uv run pytest -n auto .
         env:
           FLASK_ENV: unit_test
           DATABASE_HOST: localhost

--- a/.github/workflows/run_e2e_tests.yml
+++ b/.github/workflows/run_e2e_tests.yml
@@ -60,7 +60,7 @@ jobs:
           aws-region: eu-west-2
 
       - name: run e2e tests
-        run: uv run --frozen pytest --e2e --e2e-env ${{ inputs.environment }} --tracing=retain-on-failure --browser chromium
+        run: uv run --frozen pytest --e2e --e2e-env ${{ inputs.environment }} --tracing=retain-on-failure --browser chromium -n auto
 
       - name: Save test failure tracing
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4


### PR DESCRIPTION
This proposes setting up a file lock in the user auth fixture for end to end tests. This allows any number of workers to spin up and re-use a session which is correctly authorised once.

Currently all end to end tests that pull in `user_auth` will create a new random user in the system and take the time to go through the magic link process individually.

This change means even if running pytest with `-n auto` the same authorised session can be used across tests.

Note that this doesn't guard against the scenario when you're not running in parallel mode as the fixture is function scoped which would result in all tests authorising individually - this behaviour doesn't feel quite right so we should interrogate if we can reproduce this behaviour without manipulating the individual `page` fixture (it feels like its reproducing pytests session fixture caching rather than working with it).