### PR TITLE
Tweak logging for Sentry

### DIFF
--- a/app/logging.py
+++ b/app/logging.py
@@ -102,7 +102,7 @@ def attach_request_loggers(app: Flask) -> None:
 
         if request.path != "/healthcheck":
             current_app.logger.info(
-                "Received request %(method)s %(url)s",
+                "--- %(method)s %(url)s",
                 _common_request_extra_log_context(),
                 extra=_common_request_extra_log_context(),
             )
@@ -125,7 +125,7 @@ def attach_request_loggers(app: Flask) -> None:
                 **_common_request_extra_log_context(),
             }
             current_app.logger.info(
-                "%(status)s %(method)s %(url)s took real=%(duration_real).2fs, process=%(duration_process).2fs",
+                "%(status)s %(method)s %(url)s - [real:%(duration_real).2fs] [process:%(duration_process).2fs]",
                 log_data,
                 extra=log_data,
             )

--- a/app/sentry.py
+++ b/app/sentry.py
@@ -2,7 +2,7 @@ import logging
 import os
 
 import sentry_sdk
-from sentry_sdk.integrations.logging import LoggingIntegration
+from sentry_sdk.integrations.logging import LoggingIntegration, ignore_logger
 from sentry_sdk.types import Event, Hint
 
 from app.config import Environment
@@ -47,3 +47,8 @@ def init_sentry() -> None:
                 LoggingIntegration(sentry_logs_level=logging.INFO),
             ],
         )
+
+        # We disable the werkzeug logger in app/logging.py because we inject our own request+response log lines. This
+        # should stay in sync with the logging config we use for the app. This may need to change when we add a proper
+        # WSGI server (eg gunicorn) in front of Flask.
+        ignore_logger("werkzeug")


### PR DESCRIPTION
Sentry does not integrate with our app logging config, instead working at a slightly higher level - so the logs printed to stdout by our config are not the logs shipped to Sentry.

This isn't great, but for now Sentry logging is probably still a slightly better win than nothing.

This tweaks the logs in two ways:
- disable the werkzeug logger in Sentry explicitly; we disable this in our own app logging config. Annoying to duplicate this, but fine for now.
- Tweak the log messages for request received/response sent logs so that they stack on top of each other nicely for reading/scanning.

![image](https://github.com/user-attachments/assets/75425368-093d-4476-bd6a-ab101ad04431)
