### PR TITLE
Add ProxyFix config for AWS environments

### DIFF
--- a/app/config/__init__.py
+++ b/app/config/__init__.py
@@ -110,8 +110,8 @@ class _SharedConfig(_BaseConfig):
     FLASK_ENV: Environment
     SECRET_KEY: str
     WTF_CSRF_ENABLED: bool = True
-    PROXY_FIX_PROTO: int = 0
-    PROXY_FIX_HOST: int = 0
+    PROXY_FIX_PROTO: int = 1  # AWS CloudFront
+    PROXY_FIX_HOST: int = 1  # AWS CloudFront
 
     # Talisman security settings
     TALISMAN_FEATURE_POLICY: dict[str, str] = {}
@@ -222,6 +222,8 @@ class LocalConfig(_SharedConfig):
     # Flask app
     FLASK_ENV: Environment = Environment.LOCAL
     SECRET_KEY: str = "unsafe"  # pragma: allowlist secret
+    PROXY_FIX_PROTO: int = 0
+    PROXY_FIX_HOST: int = 0
 
     # Talisman security settings
     TALISMAN_CONTENT_SECURITY_POLICY: dict[str, list[str]] = make_development_csp()
@@ -276,8 +278,8 @@ class PullPreviewConfig(_SharedConfig):
     # Flask app
     FLASK_ENV: Environment = Environment.DEV
     DEBUG_TB_ENABLED: bool = False
-    PROXY_FIX_PROTO: int = 1
-    PROXY_FIX_HOST: int = 1
+    PROXY_FIX_PROTO: int = 1  # Caddy server
+    PROXY_FIX_HOST: int = 1  # Caddy server
 
     # Talisman security settings
     TALISMAN_CONTENT_SECURITY_POLICY: dict[str, list[str]] = make_development_csp()


### PR DESCRIPTION
We need to tell our app that it has a proxy in front of it, which will be inserting its own (eg) X-Forwarded-Host headers and overriding the initial Host header.

ProxyFix will pop off CloudFront's host header and then trust the next one in the stack, which is our intended 'external' domain. Otherwise Flask will always think it's being served on the AppRunner domain, and therefore build URLs that point at AppRunner instead of CloudFront.