### PR TITLE
Escape DB username and password

### DIFF
--- a/app/config/__init__.py
+++ b/app/config/__init__.py
@@ -1,5 +1,6 @@
 import copy
 import os
+import urllib.parse
 from enum import Enum
 from typing import Any, Tuple, Type
 
@@ -99,8 +100,10 @@ class _SharedConfig(_BaseConfig):
     """
 
     def build_database_uri(self) -> PostgresDsn:
+        urlsafe_username = urllib.parse.quote(self.DATABASE_SECRET.username)
+        urlsafe_password = urllib.parse.quote(self.DATABASE_SECRET.password)
         return PostgresDsn(
-            url=f"postgresql+psycopg://{self.DATABASE_SECRET.username}:{self.DATABASE_SECRET.password}@{self.DATABASE_HOST}:{self.DATABASE_PORT}/{self.DATABASE_NAME}"
+            f"postgresql+psycopg://{urlsafe_username}:{urlsafe_password}@{self.DATABASE_HOST}:{self.DATABASE_PORT}/{self.DATABASE_NAME}"
         )
 
     # Flask app


### PR DESCRIPTION
These could contain special characters, which need to be %-encoded when used in URIs.

AWS rotated our RDS DB's password last night, and this password contains some characters which needed escaping, but weren't being escaped, leading to Pydantic throwing an error when trying to validate the URI.