### PR TITLE
Disable CI runs on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,6 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened]
-  push:
-    branches: [main]
 
 jobs:
   build_and_test:


### PR DESCRIPTION
We currently require branches to be up-to-date with main, so running CI again after merge is redundant.