### PR TITLE
Custom sentry logging integration

### DIFF
--- a/app/logging.py
+++ b/app/logging.py
@@ -63,6 +63,21 @@ def get_default_logging_config(app: Flask) -> dict[str, Any]:
             "null": {
                 "class": "logging.NullHandler",
             },
+            "sentry": {
+                "class": "sentry_sdk.integrations.logging.SentryLogsHandler",
+                # These filters do not actually affect what ends up in Sentry - request_extra_context is not actually
+                # used in this codebase as of 22/04/25, and even if it _was_ used, the SentryLogsHandler would not
+                # include that extra info in the log shipped to sentry. We'd need to inject a `before_send_logs`
+                # handler in sentry directly (this is currently experimental). Leaving for the future, if we need it.
+                # "filters": ["request_extra_context", "reject_mutable_data_structures"],
+                #
+                # ---
+                #
+                # Likewise, the formatter doesn't affect what gets sent to Sentry as of 22/04/25 - it reads the message
+                # template directly rather than the interpolated string. So passing this through a JSON formatter
+                # does not actually mean we send JSON logs to Sentry.
+                # "formatter": formatter,
+            },
             "default": {
                 "filters": ["request_extra_context", "reject_mutable_data_structures"],
                 "formatter": formatter,
@@ -78,7 +93,7 @@ def get_default_logging_config(app: Flask) -> dict[str, Any]:
                 "disabled": True,
             },
             app.name: {
-                "handlers": ["default"],
+                "handlers": ["default", "sentry"],
                 "level": log_level,
             },
         },

--- a/app/sentry.py
+++ b/app/sentry.py
@@ -1,4 +1,3 @@
-import logging
 import os
 
 import sentry_sdk
@@ -44,7 +43,7 @@ def init_sentry() -> None:
                 "enable_logs": True,
             },
             integrations=[
-                LoggingIntegration(sentry_logs_level=logging.INFO),
+                LoggingIntegration(sentry_logs_level=None),
             ],
         )
 


### PR DESCRIPTION
Disable Sentry's built-in integration with logging, which will log more than we expect/configure. Add a sentry handler specifically to our config and add that handler to our app log configuration. This will mean that the logs shown on stdout/in cloudwatch will match what we see in Sentry.