### PR TITLE
BAU: Update e2e test urls

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ def pytest_addoption(parser: Parser) -> None:
     parser.addoption(
         "--e2e-env",
         default="local",
-        choices=["local", "dev"],
+        choices=["local", "dev", "test"],
         action="store",
         help="choose the environment that e2e tests will target",
     )

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -31,7 +31,9 @@ def domain(request: pytest.FixtureRequest, get_e2e_params: dict[str, str]) -> st
     if e2e_env == "local":
         return "https://funding.communities.gov.localhost:8080"
     if e2e_env == "dev":
-        return "https://vniusepvmn.eu-west-2.awsapprunner.com"
+        return "https://mjq6qj6jmg.eu-west-2.awsapprunner.com"
+    if e2e_env == "test":
+        return "https://9zmqrmjg7a.eu-west-2.awsapprunner.com"
     else:
         raise ValueError(f"not configured for {e2e_env}")
 


### PR DESCRIPTION
Following the terraform updates to dev and the new test environment this updates the urls for the e2e tests to the new apprunner urls.