### PR TITLE
FSPT-379 E2E lookup magic links by reference

### DIFF
--- a/app/common/templates/common/auth/check_email.html
+++ b/app/common/templates/common/auth/check_email.html
@@ -10,7 +10,12 @@
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             <h1 class="govuk-heading-l">Check your email</h1>
-            <p class="govuk-body">We've sent an email to {{ user.email }}.</p>
+            <p
+                class="govuk-body"
+                {% if not config.IS_PRODUCTION %}data-notification-id="{{ notification_id }}"{% endif %}
+            >
+                We've sent an email to {{ user.email }}.
+            </p>
             {{ govukInsetText(params={"text": "The link will work once and stop working after 15 minutes."}) }}
 
             <h2 class="govuk-heading-s">If you do not receive the email</h2>

--- a/app/config/__init__.py
+++ b/app/config/__init__.py
@@ -228,6 +228,10 @@ class _SharedConfig(_BaseConfig):
     ASSETS_VITE_BASE_URL: str = "http://localhost:5173"
     ASSETS_VITE_LIVE_ENABLED: bool = False
 
+    @property
+    def IS_PRODUCTION(self) -> bool:
+        return self.FLASK_ENV == Environment.PROD
+
 
 class LocalConfig(_SharedConfig):
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,9 +108,7 @@ env = [
 ]
 markers = [
     "e2e: Run E2E (browser) tests using playwright",
-    "user_domain: For e2e tests, the domain to use when generating emails for the `user_auth` fixture.",
-
-    "authenticate_as: Email address to use for `authenticated_client` fixture; default `test@communities.gov.uk`"
+    "authenticate_as: Email address to use for `authenticated_client` (integration) and `authenticated_browser` (e2e)"
 ]
 
 filterwarnings = [

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -1,22 +1,9 @@
 import re
-import secrets
 from typing import cast
 
 from notifications_python_client import NotificationsAPIClient  # type: ignore[attr-defined]
 
 from tests.e2e.config import EndToEndTestSecrets
-
-
-def generate_email_address(
-    test_name: str,
-    email_domain: str = "communities.gov.uk",
-) -> str:
-    # Help disambiguate tests running around the same time by injecting a random token into the email, so that
-    # when we lookup the email it should be unique. We avoid a UUID so as to keep the emails 'short enough'.
-    token = secrets.token_urlsafe(8)
-    email_address = f"e2e+{test_name}-{token}@{email_domain}".lower()
-
-    return email_address
 
 
 def extract_email_link(email: dict[str, str]) -> str:
@@ -25,13 +12,11 @@ def extract_email_link(email: dict[str, str]) -> str:
     return cast(str, re.findall(pattern, email["body"])[0])
 
 
-def retrieve_magic_link(email_address: str, e2e_test_secrets: EndToEndTestSecrets) -> str:
+def retrieve_magic_link(notification_id: str, e2e_test_secrets: EndToEndTestSecrets) -> str:
     client = NotificationsAPIClient(e2e_test_secrets.GOVUK_NOTIFY_API_KEY)  # type: ignore[no-untyped-call]
+    email = client.get_notification_by_id(notification_id)  # type: ignore[no-untyped-call]
 
-    emails = client.get_all_notifications(template_type="email", status="delivered")["notifications"]  # type: ignore[no-untyped-call]
-    for email in emails:
-        if email["email_address"] == email_address:
-            print(email)
-            return extract_email_link(email)
+    if not email:
+        raise LookupError("Could not find a corresponding find magic link in GOV.UK Notify")
 
-    raise LookupError("Could not find a corresponding find magic link in GOV.UK Notify")
+    return extract_email_link(email)

--- a/tests/e2e/test_create_view_edit_grant.py
+++ b/tests/e2e/test_create_view_edit_grant.py
@@ -8,7 +8,7 @@ from tests.e2e.pages import AllGrantsPage
 
 
 def test_create_view_edit_grant_success(
-    page: Page, domain: str, e2e_test_secrets: EndToEndTestSecrets, user_auth: E2ETestUser
+    page: Page, domain: str, e2e_test_secrets: EndToEndTestSecrets, authenticated_browser: E2ETestUser
 ):
     all_grants_page = AllGrantsPage(page, domain)
     all_grants_page.navigate()

--- a/tests/e2e/test_magic_link_auth.py
+++ b/tests/e2e/test_magic_link_auth.py
@@ -1,27 +1,24 @@
 import re
 
-from _pytest.fixtures import FixtureRequest
 from playwright.sync_api import Page, expect
 
 from tests.e2e.config import EndToEndTestSecrets
-from tests.e2e.helpers import generate_email_address, retrieve_magic_link
+from tests.e2e.helpers import retrieve_magic_link
 from tests.e2e.pages import RequestALinkToSignInPage
 
 
-def test_magic_link_redirect_journey(
-    request: FixtureRequest, page: Page, domain: str, e2e_test_secrets: EndToEndTestSecrets
-):
+def test_magic_link_redirect_journey(page: Page, domain: str, e2e_test_secrets: EndToEndTestSecrets, email: str):
     page.goto(f"{domain}/grants")
 
     # Redirected to request a magic link page; go through that flow.
-    email = generate_email_address(request.node.originalname)
     request_a_link_page = RequestALinkToSignInPage(page, domain)
     request_a_link_page.fill_email_address(email)
     request_a_link_page.click_request_a_link()
 
     page.wait_for_url(re.compile(rf"{domain}/check-your-email/.+"))
+    notification_id = page.locator("[data-notification-id]").get_attribute("data-notification-id")
 
-    magic_link_url = retrieve_magic_link(email, e2e_test_secrets)
+    magic_link_url = retrieve_magic_link(notification_id, e2e_test_secrets)
     page.goto(magic_link_url)
 
     # JavaScript on the page automatically claims the link and should redirect to where they started.


### PR DESCRIPTION
Adds an ephemeral reference to the notification sent during the magic link auth to the page using a `[data-x]` attribute.

Remove the logic where we generate random unique email addresses to then be able to look them up in Notify. Instead directly tie the notification that was sent in that session to the page checking the email.

This will now let us use one email address that actually sends emails, while we're running end to end tests against actual environments this allows us to use an API key that sends email allowing pre-production users to not log into the Notify admin console.

The method should also work without a problem for test Notify keys that pretend to send emails.

We're making the choice to only include the `[data-x]` attribute if we're not in a production Flask environment but that can be removed if necessary - there should be nothing sensitive about the emails reference.

A follow up PR will then switch the fixture providing `user_auth` for end to end tests to share a single session rather than uniquely authenticating every test.