### PR TITLE
FSPT-341 Format HTML 

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Prettier HTML format
+0b49b94fb1627006ef18f27ffcafec3f45fa75ef

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -75,6 +75,23 @@ jobs:
       - name: run type checking
         run: uv run mypy
 
+  lint_html_formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Read .nvmrc
+        id: nvmrc
+        run: echo "nodeVersion=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"
+      - name: Setup node ${{ steps.nvmrc.outputs.nodeVersion }}
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: ${{ steps.nvmrc.outputs.nodeVersion }}
+      - name: install dependencies
+        run: npm ci
+      - name: check HTML formatting
+        run: make check-html
+
 
   lint_imports:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ci:
   autofix_prs: false
-  skip: ["mypy"]
+  skip: ["mypy", "format-html"]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -29,6 +29,11 @@ repos:
           ]
         exclude: tests/pre_award/keys/rsa256
 
+  - repo: https://github.com/seddonym/import-linter
+    rev: v2.3
+    hooks:
+      - id: import-linter
+
   - repo: local
     hooks:
       - id: mypy
@@ -37,8 +42,12 @@ repos:
         types: [python]
         entry: uv run mypy
         pass_filenames: false
-
-  - repo: https://github.com/seddonym/import-linter
-    rev: v2.3
-    hooks:
-      - id: import-linter
+      - id: format-html
+        name: Format Jinja HTML templates with Prettier
+        entry: make format-html
+        language: node
+        files: \.html$
+        additional_dependencies:
+          - 'prettier@^3.5.3'
+          - 'prettier-plugin-jinja-template@^2.1.0'
+        pass_filenames: false

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "plugins": ["prettier-plugin-jinja-template"]
+}

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,14 @@ vite:
 	npm install
 	npm run build
 
+.PHONY: check-html
+check-html:
+	npx prettier --plugin=prettier-plugin-jinja-template --parser=jinja-template --tab-width=2 --html-whitespace-sensitivity ignore --bracket-same-line=true --print-width=240 --check **/*.html
+
+.PHONY: format-html
+format-html:
+	npx prettier --plugin=prettier-plugin-jinja-template --parser=jinja-template --tab-width=2 --html-whitespace-sensitivity ignore --bracket-same-line=true --print-width=240 --write **/*.html
+
 .PHONY: build
 build:
 	docker compose build

--- a/app/common/templates/common/auth/mhclg-user-not-authorised.html
+++ b/app/common/templates/common/auth/mhclg-user-not-authorised.html
@@ -9,7 +9,11 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Access denied</h1>
       <p class="govuk-body">You do not have permission to log into the Funding Service.</p>
-      <p class="govuk-body">If you think you should have access, please contact us through our <a class="govuk-link govuk-link--no-visited-state" href="{{ service_desk_url }}" target="_blank">support desk</a>.</p>
+      <p class="govuk-body">
+        If you think you should have access, please contact us through our
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ service_desk_url }}" target="_blank">support desk</a>
+        .
+      </p>
     </div>
   </div>
 {% endblock content %}

--- a/app/common/templates/common/base.html
+++ b/app/common/templates/common/base.html
@@ -28,11 +28,11 @@
 {% endblock header %}
 
 {% block main %}
-  <div class="govuk-width-container {%- if containerClasses %}{{ containerClasses }}{% endif %}">
+  <div class="govuk-width-container {% if containerClasses %}{{ containerClasses }}{% endif %}">
     {% block beforeContent %}{% endblock %}
-    <div class="govuk-main-wrapper {%- if mainClasses %}{{ mainClasses }}{% endif %}">
+    <div class="govuk-main-wrapper {% if mainClasses %}{{ mainClasses }}{% endif %}">
       {% block mainWrapper %}
-        <main id="main-content" {%- if mainLang %}lang="{{ mainLang }}"{% endif %}>
+        <main id="main-content" {% if mainLang %}lang="{{ mainLang }}"{% endif %}>
           {% block errorSummary %}
             <div class="govuk-grid-row">
               <div class="govuk-grid-column-two-thirds">

--- a/app/common/templates/common/errors/403.html
+++ b/app/common/templates/common/errors/403.html
@@ -1,20 +1,19 @@
 {% extends "common/base.html" %}
 
 {% block pageTitle %}
-Sorry, you don't currently have permission to access this page
+  Sorry, you don't currently have permission to access this page
 {% endblock pageTitle %}
 
 {% block content %}
-<div class="govuk-grid-row">
+  <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l">Sorry, you don't currently have permission to access this page</h1>
-        <p class="govuk-body">
-            If you believe this is incorrect, please contact us through our
-            <a class="govuk-link govuk-link--no-visited-state" href="{{ service_desk_url }}" target="_blank">support
-                desk</a> if you
-            need help.
-        </p>
-        <p class="govuk-body">Monday to Friday: 9am to 5pm (except public holidays).</p>
+      <h1 class="govuk-heading-l">Sorry, you don't currently have permission to access this page</h1>
+      <p class="govuk-body">
+        If you believe this is incorrect, please contact us through our
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ service_desk_url }}" target="_blank">support desk</a>
+        if you need help.
+      </p>
+      <p class="govuk-body">Monday to Friday: 9am to 5pm (except public holidays).</p>
     </div>
-</div>
+  </div>
 {% endblock content %}

--- a/app/common/templates/common/macros/status.html
+++ b/app/common/templates/common/macros/status.html
@@ -1,10 +1,12 @@
 {% from "govuk_frontend_jinja/components/tag/macro.html" import govukTag %}
 
 {% macro status(status, statuses) %}
-    {% set classMap = {
+  {%
+    set classMap = {
         statuses.NOT_STARTED: "govuk-tag--grey",
         statuses.IN_PROGRESS: "govuk-tag--blue",
         statuses.COMPLETED: "govuk-tag--green",
-    } %}
-    {{ govukTag({"text": status, "classes": classMap[status] }) }}
+    }
+  %}
+  {{ govukTag({"text": status, "classes": classMap[status] }) }}
 {% endmacro %}

--- a/app/common/templates/common/partials/mhclg-header.html
+++ b/app/common/templates/common/partials/mhclg-header.html
@@ -8,7 +8,7 @@
     <img src="{{ params.assetPath }}/images/mhclg-crest.png" alt="MHCLG Crest" width="32" height="32" style="color: white; filter: brightness(0) invert(1);" nonce="{{ csp_nonce() }}" />
   {% endset -%}
 
-  <header class="govuk-header {%- if params.classes %}{{ params.classes }}{% endif %}" data-module="govuk-header" {{- govukAttributes(params.attributes) }}>
+  <header class="govuk-header {% if params.classes %}{{ params.classes }}{% endif %}" data-module="govuk-header" {{- govukAttributes(params.attributes) }}>
     <div class="govuk-header__container {{ params.containerClasses | default("govuk-width-container", true) }}">
       <div class="govuk-header__logo govuk-!-margin-bottom-1">
         <a href="{{ params.homepageUrl | default("/", true) }}" class="govuk-header__link govuk-header__link--homepage">
@@ -34,7 +34,7 @@
             {% endif %}
           {% endif %}
           {% if params.navigation | length %}
-            <nav aria-label="{{ params.navigationLabel | default(menuButtonText, true) }}" class="govuk-header__navigation {%- if params.navigationClasses %}{{ params.navigationClasses }}{% endif %}">
+            <nav aria-label="{{ params.navigationLabel | default(menuButtonText, true) }}" class="govuk-header__navigation {% if params.navigationClasses %}{{ params.navigationClasses }}{% endif %}">
               {# <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" {%- if params.menuButtonLabel and params.menuButtonLabel != menuButtonText %} aria-label="{{ params.menuButtonLabel }}"{% endif %} hidden>
           {{ menuButtonText }}
         </button> #}
@@ -42,7 +42,7 @@
               <ul class="govuk-header__navigation-list">
                 {% for item in params.navigation %}
                   {% if item.text or item.html %}
-                    <li class="govuk-header__navigation-item {%- if item.active %}govuk-header__navigation-item--active{% endif %}">
+                    <li class="govuk-header__navigation-item {% if item.active %}govuk-header__navigation-item--active{% endif %}">
                       {% if item.href %}
                         <a class="govuk-header__link" href="{{ item.href }}" {{- govukAttributes(item.attributes) -}}>{{ item.text }}</a>
                       {% else %}

--- a/app/common/templates/common/partials/mhclg-header.html
+++ b/app/common/templates/common/partials/mhclg-header.html
@@ -52,10 +52,10 @@
             {% if item.href %}
             <a class="govuk-header__link" href="{{ item.href }}"
               {{- govukAttributes(item.attributes) -}}>
-            {% endif %}
-              {{ item.html | safe | trim | indent(14) if item.html else item.text }}
-            {% if item.href %}
+              {{ item.text }}
             </a>
+            {% else %}
+              {{ item.html | safe | trim | indent(14) if item.html else item.text }}
             {% endif %}
           </li>
           {% endif %}

--- a/app/common/templates/common/partials/mhclg-header.html
+++ b/app/common/templates/common/partials/mhclg-header.html
@@ -1,70 +1,61 @@
 {% macro mhclgHeader(params) %}
-{% from "govuk_frontend_jinja/macros/attributes.html" import govukAttributes %}
+  {% from "govuk_frontend_jinja/macros/attributes.html" import govukAttributes %}
 
-{%- set menuButtonText = params.menuButtonText if params.menuButtonText else 'Menu' -%}
+  {%- set menuButtonText = params.menuButtonText if params.menuButtonText else 'Menu' -%}
 
-{%- set _hmgInsignia %}
-  <img src="{{ params.assetPath }}/images/mhclg-crest.png" alt="MHCLG Crest" width="32" height="32" style="color: white; filter: brightness(0) invert(1);" nonce="{{ csp_nonce() }}"/>
-{% endset -%}
 
-<header class="govuk-header {%- if params.classes %} {{ params.classes }}{% endif %}" data-module="govuk-header"
-  {{- govukAttributes(params.attributes) }}>
-  <div class="govuk-header__container {{ params.containerClasses | default("govuk-width-container", true) }}">
-    <div class="govuk-header__logo govuk-!-margin-bottom-1">
-      <a href="{{ params.homepageUrl | default("/", true) }}" class="govuk-header__link govuk-header__link--homepage">
-        {#- The SVG needs `focusable="false"` so that Internet Explorer does
+  {%- set _hmgInsignia %}
+    <img src="{{ params.assetPath }}/images/mhclg-crest.png" alt="MHCLG Crest" width="32" height="32" style="color: white; filter: brightness(0) invert(1);" nonce="{{ csp_nonce() }}" />
+  {% endset -%}
+
+  <header class="govuk-header {%- if params.classes %}{{ params.classes }}{% endif %}" data-module="govuk-header" {{- govukAttributes(params.attributes) }}>
+    <div class="govuk-header__container {{ params.containerClasses | default("govuk-width-container", true) }}">
+      <div class="govuk-header__logo govuk-!-margin-bottom-1">
+        <a href="{{ params.homepageUrl | default("/", true) }}" class="govuk-header__link govuk-header__link--homepage">
+          {#- The SVG needs `focusable="false"` so that Internet Explorer does
         not treat it as an interactive element - without this it will be
         'focusable' when using the keyboard to navigate.
 
         We use a single compound path for the logo to prevent subpixel rounding
         shifting different elements unevenly relative to one another. #}
-        {{ _hmgInsignia | safe | trim | indent(8) }}
-        {% if (params.productName) %}
-        <span class="govuk-header__product-name">
-          {{ params.productName }}
-        </span>
-        {% endif %}
-      </a>
-    </div>
-  {% if params.serviceName or params.navigation | length %}
-    <div class="govuk-header__content">
-    {% if params.serviceName %}
-      {% if params.serviceUrl %}
-      <a href="{{ params.serviceUrl }}" class="govuk-header__link govuk-header__service-name">
-        {{ params.serviceName }}
-      </a>
-      {% else %}
-      <span class="govuk-header__service-name">
-        {{ params.serviceName }}
-      </span>
-      {% endif %}
-    {% endif %}
-    {% if params.navigation | length %}
-      <nav aria-label="{{ params.navigationLabel | default(menuButtonText, true) }}" class="govuk-header__navigation {%- if params.navigationClasses %} {{ params.navigationClasses }}{% endif %}">
-        {# <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" {%- if params.menuButtonLabel and params.menuButtonLabel != menuButtonText %} aria-label="{{ params.menuButtonLabel }}"{% endif %} hidden>
+          {{ _hmgInsignia | safe | trim | indent(8) }}
+          {% if (params.productName) %}
+            <span class="govuk-header__product-name">{{ params.productName }}</span>
+          {% endif %}
+        </a>
+      </div>
+      {% if params.serviceName or params.navigation | length %}
+        <div class="govuk-header__content">
+          {% if params.serviceName %}
+            {% if params.serviceUrl %}
+              <a href="{{ params.serviceUrl }}" class="govuk-header__link govuk-header__service-name">{{ params.serviceName }}</a>
+            {% else %}
+              <span class="govuk-header__service-name">{{ params.serviceName }}</span>
+            {% endif %}
+          {% endif %}
+          {% if params.navigation | length %}
+            <nav aria-label="{{ params.navigationLabel | default(menuButtonText, true) }}" class="govuk-header__navigation {%- if params.navigationClasses %}{{ params.navigationClasses }}{% endif %}">
+              {# <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" {%- if params.menuButtonLabel and params.menuButtonLabel != menuButtonText %} aria-label="{{ params.menuButtonLabel }}"{% endif %} hidden>
           {{ menuButtonText }}
         </button> #}
 
-        <ul class="govuk-header__navigation-list">
-        {% for item in params.navigation %}
-          {% if item.text or item.html %}
-          <li class="govuk-header__navigation-item {%- if item.active %} govuk-header__navigation-item--active{% endif %}">
-            {% if item.href %}
-            <a class="govuk-header__link" href="{{ item.href }}"
-              {{- govukAttributes(item.attributes) -}}>
-              {{ item.text }}
-            </a>
-            {% else %}
-              {{ item.html | safe | trim | indent(14) if item.html else item.text }}
-            {% endif %}
-          </li>
+              <ul class="govuk-header__navigation-list">
+                {% for item in params.navigation %}
+                  {% if item.text or item.html %}
+                    <li class="govuk-header__navigation-item {%- if item.active %}govuk-header__navigation-item--active{% endif %}">
+                      {% if item.href %}
+                        <a class="govuk-header__link" href="{{ item.href }}" {{- govukAttributes(item.attributes) -}}>{{ item.text }}</a>
+                      {% else %}
+                        {{ item.html | safe | trim | indent(14) if item.html else item.text }}
+                      {% endif %}
+                    </li>
+                  {% endif %}
+                {% endfor %}
+              </ul>
+            </nav>
           {% endif %}
-        {% endfor %}
-        </ul>
-      </nav>
-    {% endif %}
+        </div>
+      {% endif %}
     </div>
-  {% endif %}
-  </div>
-</header>
+  </header>
 {% endmacro %}

--- a/app/common/templates/common/partials/navigation.html
+++ b/app/common/templates/common/partials/navigation.html
@@ -2,7 +2,7 @@
 
 {%
   set nav_items = [
-  {"text": "Grants", "href": url_for("deliver_grant_funding.list_grants"), "current": active_item_identifier == "grants"},
+      {"text": "Grants", "href": url_for("deliver_grant_funding.list_grants"), "current": active_item_identifier == "grants"},
   ] if current_user.is_authenticated else []
 %}
 

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_setup/contact.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_setup/contact.html
@@ -21,7 +21,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <span class="govuk-caption-xl">
-        <span class="govuk-visually-hidden">This section is: </span>Set up the grant
+        <span class="govuk-visually-hidden">This section is:</span>
+        Set up the grant
       </span>
       <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Who is the main contact for this grant?</h1>
 

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_setup/description.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_setup/description.html
@@ -17,20 +17,18 @@
   }}
 {% endblock beforeContent %}
 
+
 {% set before_input_text %}
-  <p class="govuk-body">
-    Provide a brief description of the main purpose of the grant. This information will be seen by potential grant recipients.
-  </p>
-  <p class="govuk-hint">
-    Do not include personal information.
-  </p>
+  <p class="govuk-body">Provide a brief description of the main purpose of the grant. This information will be seen by potential grant recipients.</p>
+  <p class="govuk-hint">Do not include personal information.</p>
 {% endset %}
 
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <span class="govuk-caption-xl">
-        <span class="govuk-visually-hidden">This section is: </span>Set up the grant
+        <span class="govuk-visually-hidden">This section is:</span>
+        Set up the grant
       </span>
 
       <form method="post" novalidate>

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_setup/ggis_number.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_setup/ggis_number.html
@@ -21,7 +21,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <span class="govuk-caption-xl">
-        <span class="govuk-visually-hidden">This section is: </span>Set up the grant
+        <span class="govuk-visually-hidden">This section is:</span>
+        Set up the grant
       </span>
 
       <form method="post" novalidate>

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_setup/intro.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_setup/intro.html
@@ -21,7 +21,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <span class="govuk-caption-xl">
-        <span class="govuk-visually-hidden">This section is: </span>Set up the grant
+        <span class="govuk-visually-hidden">This section is:</span>
+        Set up the grant
       </span>
       <h1 class="govuk-heading-xl">Tell us about the grant</h1>
 

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_setup/name.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_setup/name.html
@@ -21,7 +21,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <span class="govuk-caption-xl">
-        <span class="govuk-visually-hidden">This section is: </span>Set up the grant
+        <span class="govuk-visually-hidden">This section is:</span>
+        Set up the grant
       </span>
 
       <form method="post" novalidate>

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/manage_grant_base.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/manage_grant_base.html
@@ -31,8 +31,8 @@
 
 {% block main %}
   <div {% if show_watermark %}class="app-watermark-container"{% endif %}>
-    <div class="govuk-width-container {%- if containerClasses %}{{ containerClasses }}{% endif %}">
-      <div class="govuk-main-wrapper {%- if mainClasses %}{{ mainClasses }}{% endif %}">
+    <div class="govuk-width-container {% if containerClasses %}{{ containerClasses }}{% endif %}">
+      <div class="govuk-main-wrapper {% if mainClasses %}{{ mainClasses }}{% endif %}">
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-one-quarter">
             <ul class="govuk-list">
@@ -47,7 +47,7 @@
             {% block mainWrapper %}
               {% block beforeContent %}
               {% endblock beforeContent %}
-              <main id="main-content" {%- if mainLang %}lang="{{ mainLang }}"{% endif %}>
+              <main id="main-content" {% if mainLang %}lang="{{ mainLang }}"{% endif %}>
                 {% block errorSummary %}
                   {% if form is defined and form.errors %}
                     {{ govukErrorSummary(wtforms_errors(form)) }}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/manage_grant_base.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/manage_grant_base.html
@@ -4,7 +4,8 @@
 {% set active_item_identifier = "grants" %}
 {% set cspNonce = csp_nonce() %}
 
-{% set settingsNav = [
+{%
+  set settingsNav = [
       {
           "text": "Dashboard",
           "key": "grant_dashboard",
@@ -15,48 +16,50 @@
           "key": "grant_settings",
           "href": url_for("deliver_grant_funding.grant_settings", grant_id=grant.id)
       },
-  ] %}
+  ]
+%}
 
 {% if current_user.is_platform_admin %}
-    {% do settingsNav.append({
-      "text": "Developers",
-      "key": "grant_developers",
-      "href": url_for("developers.grant_developers", grant_id=grant.id)
-  }) %}
+  {%
+    do settingsNav.append({
+        "text": "Developers",
+        "key": "grant_developers",
+        "href": url_for("developers.grant_developers", grant_id=grant.id)
+    })
+  %}
 {% endif %}
 
 {% block main %}
-    <div {% if show_watermark %} class="app-watermark-container"{% endif %}>
-        <div class="govuk-width-container {%- if containerClasses %}{{ containerClasses }}{% endif %}">
-            <div class="govuk-main-wrapper {%- if mainClasses %}{{ mainClasses }}{% endif %}">
-                <div class="govuk-grid-row">
-                    <div class="govuk-grid-column-one-quarter">
-                        <ul class="govuk-list">
-                            {% for item in settingsNav %}
-                                <li class="app-left-nav__item">
-                                    <a href="{{ item.href }}"
-                                       class="{{ 'govuk-link govuk-link--no-visited-state govuk-link--no-underline ' + ('govuk-!-font-weight-bold' if active_sub_navigation_tab == item.key else '') }}">{{ item.text }}</a>
-                                </li>
-                            {% endfor %}
-                        </ul>
-                    </div>
-                    <div class="govuk-grid-column-three-quarters">
-                        {% block mainWrapper %}
-                            {% block beforeContent %}
-                            {% endblock beforeContent %}
-                            <main id="main-content" {%- if mainLang %}lang="{{ mainLang }}"{% endif %}>
-                                {% block errorSummary %}
-                                    {% if form is defined and form.errors %}
-                                        {{ govukErrorSummary(wtforms_errors(form)) }}
-                                    {% endif %}
-                                {% endblock errorSummary %}
-                                {% block content %}
-                                {% endblock content %}
-                            </main>
-                        {% endblock mainWrapper %}
-                    </div>
-                </div>
-            </div>
+  <div {% if show_watermark %}class="app-watermark-container"{% endif %}>
+    <div class="govuk-width-container {%- if containerClasses %}{{ containerClasses }}{% endif %}">
+      <div class="govuk-main-wrapper {%- if mainClasses %}{{ mainClasses }}{% endif %}">
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-one-quarter">
+            <ul class="govuk-list">
+              {% for item in settingsNav %}
+                <li class="app-left-nav__item">
+                  <a href="{{ item.href }}" class="{{ 'govuk-link govuk-link--no-visited-state govuk-link--no-underline ' + ('govuk-!-font-weight-bold' if active_sub_navigation_tab == item.key else '') }}">{{ item.text }}</a>
+                </li>
+              {% endfor %}
+            </ul>
+          </div>
+          <div class="govuk-grid-column-three-quarters">
+            {% block mainWrapper %}
+              {% block beforeContent %}
+              {% endblock beforeContent %}
+              <main id="main-content" {%- if mainLang %}lang="{{ mainLang }}"{% endif %}>
+                {% block errorSummary %}
+                  {% if form is defined and form.errors %}
+                    {{ govukErrorSummary(wtforms_errors(form)) }}
+                  {% endif %}
+                {% endblock errorSummary %}
+                {% block content %}
+                {% endblock content %}
+              </main>
+            {% endblock mainWrapper %}
+          </div>
         </div>
+      </div>
     </div>
+  </div>
 {% endblock %}

--- a/app/developers/templates/developers/access_grant_funding_base.html
+++ b/app/developers/templates/developers/access_grant_funding_base.html
@@ -24,11 +24,11 @@ This is only OK because we're in the `developers` package and nothing here shoul
 {% endblock header %}
 
 {% block main %}
-  <div class="govuk-width-container {%- if containerClasses %}{{ containerClasses }}{% endif %}">
+  <div class="govuk-width-container {% if containerClasses %}{{ containerClasses }}{% endif %}">
     {% block beforeContent %}
     {% endblock beforeContent %}
 
-    <main id="main-content" class="govuk-main-wrapper" {%- if mainLang %}lang="{{ mainLang }}"{% endif %}>
+    <main id="main-content" class="govuk-main-wrapper" {% if mainLang %}lang="{{ mainLang }}"{% endif %}>
       {% block errorSummary %}
         {% if form is defined and form.errors %}
           {{ govukErrorSummary(wtforms_errors(form)) }}

--- a/app/developers/templates/developers/access_grant_funding_base.html
+++ b/app/developers/templates/developers/access_grant_funding_base.html
@@ -5,7 +5,6 @@
 {% set active_item_identifier = "grants" %}
 {% set cspNonce = csp_nonce() %}
 
-
 {#
 common/base.html embeds "Deliver grant funding" in the service navigation. That doesn't feel right here, so this just removes it.
 

--- a/app/developers/templates/developers/ask_a_question.html
+++ b/app/developers/templates/developers/ask_a_question.html
@@ -6,7 +6,8 @@
 {% extends "developers/access_grant_funding_base.html" %}
 
 {% block pageTitle %}
-  {{ question.text }} - MHCLG Funding Service
+  {{ question.text }}
+  - MHCLG Funding Service
 {% endblock pageTitle %}
 
 {% block beforeContent %}
@@ -14,19 +15,19 @@
 {% endblock beforeContent %}
 
 {% block content %}
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <form method="post" novalidate>
-      {{ form.csrf_token }}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form method="post" novalidate>
+        {{ form.csrf_token }}
 
-      {% if question.data_type == question_types.TEXT_SINGLE_LINE or question.data_type == question_types.TEXT_MULTI_LINE %}
-      {{ form.question(params={"label": {"classes": "govuk-label--l", "isPageHeading": true} }) }}
-      {% elif question.data_type == question_types.INTEGER %}
-      {{ form.question(params={"label": {"classes": "govuk-label--l", "isPageHeading": true}, "inputmode": "numeric", "spellcheck": false }) }}
-      {% endif %}
+        {% if question.data_type == question_types.TEXT_SINGLE_LINE or question.data_type == question_types.TEXT_MULTI_LINE %}
+          {{ form.question(params={"label": {"classes": "govuk-label--l", "isPageHeading": true} }) }}
+        {% elif question.data_type == question_types.INTEGER %}
+          {{ form.question(params={"label": {"classes": "govuk-label--l", "isPageHeading": true}, "inputmode": "numeric", "spellcheck": false }) }}
+        {% endif %}
 
-      {{ form.submit }}
-    </form>
+        {{ form.submit }}
+      </form>
+    </div>
   </div>
-</div>
 {% endblock content %}

--- a/app/developers/templates/developers/check_your_answers.html
+++ b/app/developers/templates/developers/check_your_answers.html
@@ -17,32 +17,36 @@
 {% endblock beforeContent %}
 
 {% block content %}
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-l">{{ form.name }}</span>
-    <h1 class="govuk-heading-l">Check your answers</h1>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l">{{ form.name }}</span>
+      <h1 class="govuk-heading-l">Check your answers</h1>
 
-    {% set rows = [] %}
-    {% for question in collection_helper.get_ordered_visible_questions_for_form(form) %}
-      {% set answer = collection_helper.get_answer_for_question(question.id) %}
-      {% if answer is not none %}
-        {% do rows.append({
-            "key": {"text": question.text},
-            "value": {"text": answer.root},
-            "actions": {"items": [{"href": url_for('developers.ask_a_question', collection_id=collection_helper.collection.id, question_id=question.id, source=back_link_source_enum.CHECK_YOUR_ANSWERS.value), "text": "Change", "visuallyHiddenText": question.name}]},
-          })
-        %}
-      {% else %}
-        {% set valueLink %}
-        <a href="{{ url_for('developers.ask_a_question', collection_id=collection_helper.collection.id, question_id=question.id, source=back_link_source_enum.CHECK_YOUR_ANSWERS.value) }}" class="govuk-link govuk-link--no-visited-state">Enter {{ question.name }}</a>
-        {% endset %}
-        {% do rows.append({
-            "key": {"text": question.text},
-            "value": {"html": valueLink}
-          })
-        %}
-      {% endif %}
-    {% endfor %}
+      {% set rows = [] %}
+      {% for question in collection_helper.get_ordered_visible_questions_for_form(form) %}
+        {% set answer = collection_helper.get_answer_for_question(question.id) %}
+        {% if answer is not none %}
+          {%
+            do rows.append({
+              "key": {"text": question.text},
+              "value": {"text": answer.root},
+              "actions": {"items": [{"href": url_for('developers.ask_a_question', collection_id=collection_helper.collection.id, question_id=question.id, source=back_link_source_enum.CHECK_YOUR_ANSWERS.value), "text": "Change", "visuallyHiddenText": question.name}]},
+            })
+          %}
+        {% else %}
+          {% set valueLink %}
+            <a href="{{ url_for('developers.ask_a_question', collection_id=collection_helper.collection.id, question_id=question.id, source=back_link_source_enum.CHECK_YOUR_ANSWERS.value) }}" class="govuk-link govuk-link--no-visited-state">
+              Enter {{ question.name }}
+            </a>
+          {% endset %}
+          {%
+            do rows.append({
+              "key": {"text": question.text},
+              "value": {"html": valueLink}
+            })
+          %}
+        {% endif %}
+      {% endfor %}
 
       {{
         govukSummaryList({
@@ -51,10 +55,12 @@
         })
       }}
 
-    {{ govukButton({
-      "text": "Save and continue",
-      "href": url_for("developers.collection_tasklist", collection_id=collection_helper.collection.id)
-    })}}
+      {{
+        govukButton({
+          "text": "Save and continue",
+          "href": url_for("developers.collection_tasklist", collection_id=collection_helper.collection.id)
+        })
+      }}
+    </div>
   </div>
-</div>
 {% endblock content %}

--- a/app/developers/templates/developers/collection_tasklist.html
+++ b/app/developers/templates/developers/collection_tasklist.html
@@ -20,58 +20,58 @@
 {% endblock beforeContent %}
 
 {% block content %}
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l">{{ collection_helper.name }}</span>
+        Collection
+      </h1>
 
-    <h1 class="govuk-heading-l">
-      <span class="govuk-caption-l">{{ collection_helper.name }}</span>
-      Collection
-    </h1>
+      {# NOTE: Should we have this as a custom component or macro-ize it? #}
+      <dl class="app-metadata govuk-!-margin-bottom-7">
+        <dt class="app-metadata__key">Status:</dt>
+        <dd class="app-metadata__value">{{ status(collection_helper.status, statuses) }}</dd>
+      </dl>
 
-    {# NOTE: Should we have this as a custom component or macro-ize it? #}
-    <dl class="app-metadata govuk-!-margin-bottom-7">
-      <dt class="app-metadata__key">Status:</dt>
-      <dd class="app-metadata__value">{{ status(collection_helper.status, statuses) }}</dd>
-    </dl>
+      {% for section in collection_helper.get_ordered_visible_sections() %}
+        <h2 class="govuk-heading-m">{{ section.title }}</h2>
 
-    {% for section in collection_helper.get_ordered_visible_sections() %}
-      <h2 class="govuk-heading-m">{{ section.title }}</h2>
-
-      {% set forms = collection_helper.get_ordered_visible_forms_for_section(section) %}
-      {% if not forms %}
-        <p class="govuk-body">This section has no forms.</p>
-      {% else %}
-        {% set rows=[] %}
-        {% for form in forms %}
-          {% set linkHref = (
-              url_for("developers.ask_a_question", collection_id=collection_helper.collection.id, question_id=collection_helper.get_first_question_for_form(form).id)
-              if collection_helper.get_status_for_form(form) == statuses.NOT_STARTED else
-              url_for("developers.check_your_answers", collection_id=collection_helper.collection.id, form_id=form.id, source=back_link_source_enum.TASKLIST.value)
-            )
-          %}
-          {%
-            do rows.append({
-                  "title": {
-                    "text": form.title,
+        {% set forms = collection_helper.get_ordered_visible_forms_for_section(section) %}
+        {% if not forms %}
+          <p class="govuk-body">This section has no forms.</p>
+        {% else %}
+          {% set rows=[] %}
+          {% for form in forms %}
+            {%
+              set linkHref = (
+                url_for("developers.ask_a_question", collection_id=collection_helper.collection.id, question_id=collection_helper.get_first_question_for_form(form).id)
+                if collection_helper.get_status_for_form(form) == statuses.NOT_STARTED else
+                url_for("developers.check_your_answers", collection_id=collection_helper.collection.id, form_id=form.id, source=back_link_source_enum.TASKLIST.value)
+              )
+            %}
+            {%
+              do rows.append({
+                    "title": {
+                      "text": form.title,
+                    },
+                  "status": {
+                    "html": status(collection_helper.get_status_for_form(form), statuses)
                   },
-                "status": {
-                  "html": status(collection_helper.get_status_for_form(form), statuses)
-                },
-              "href": linkHref,
-            })
-          %}
-        {% endfor %}
+                "href": linkHref,
+              })
+            %}
+          {% endfor %}
 
-        {{
-          govukTaskList({
-            "idPrefix": section.slug,
-            "items": rows
-          })
-        }}
-      {% endif %}
-    {% else %}
-      <p class="govuk-body">This collection has no sections.</p>
-    {% endfor %}
+          {{
+            govukTaskList({
+              "idPrefix": section.slug,
+              "items": rows
+            })
+          }}
+        {% endif %}
+      {% else %}
+        <p class="govuk-body">This collection has no sections.</p>
+      {% endfor %}
+    </div>
   </div>
-</div>
 {% endblock content %}

--- a/app/developers/templates/developers/list_collections.html
+++ b/app/developers/templates/developers/list_collections.html
@@ -28,45 +28,49 @@
   </h1>
   <p class="govuk-body">View the information that has been provided by users for a schema.</p>
 
-
   {% set rows=[] %}
   {# collections is probably a list of collection helpers? to be decided #}
   {% for collection in collections %}
     {% set link_to_collection %}
-      <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('developers.manage_collection', collection_id=collection.id)}}">{{ collection.id | string | truncate(11) }}</a>
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('developers.manage_collection', collection_id=collection.id) }}">{{ collection.id | string | truncate(11) }}</a>
     {% endset %}
-    {% do rows.append([
-      {
-        "html": link_to_collection,
-      }, {
-        "html": status(collection.status, statuses)
-      }, {
-        "text": collection.created_by_email
-      }, {
-        "text": format_date_short(collection.created_at_utc)
-      }
-    ]) %}
-
+    {%
+      do rows.append([
+        {
+          "html": link_to_collection,
+        }, {
+          "html": status(collection.status, statuses)
+        }, {
+          "text": collection.created_by_email
+        }, {
+          "text": format_date_short(collection.created_at_utc)
+        }
+      ])
+    %}
   {% else %}
     {% set no_collections_text %}
-    <span><i>No collections found for this schema</i></span>
+      <span><i>No collections found for this schema</i></span>
     {% endset %}
-    {% do rows.append([
-      {
-        "html": no_collections_text,
-        "colspan": 4
-      }
-    ]) %}
+    {%
+      do rows.append([
+        {
+          "html": no_collections_text,
+          "colspan": 4
+        }
+      ])
+    %}
   {% endfor %}
 
-  {{ govukTable({
-    "captionClasses": "govuk-table__caption--m",
-    "head": [
-      { "text": "Collection" },
-      { "text": "" },
-      { "text": "Started by" },
-      { "text": "Created" }
-    ],
-    "rows": rows
-  }) }}
+  {{
+    govukTable({
+      "captionClasses": "govuk-table__caption--m",
+      "head": [
+        { "text": "Collection" },
+        { "text": "" },
+        { "text": "Started by" },
+        { "text": "Created" }
+      ],
+      "rows": rows
+    })
+  }}
 {% endblock content %}

--- a/app/developers/templates/developers/manage_collection.html
+++ b/app/developers/templates/developers/manage_collection.html
@@ -23,11 +23,11 @@
 
 {% block content %}
   <div class="app-aligned-header-tag">
-  <h1 class="govuk-heading-l">
-    <span class="govuk-caption-l">{{ collection_helper.id | string | truncate(11) }}</span>
-    Collection
-  </h1>
-  {{ status(collection_helper.status, statuses)}}
+    <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l">{{ collection_helper.id | string | truncate(11) }}</span>
+      Collection
+    </h1>
+    {{ status(collection_helper.status, statuses) }}
   </div>
 
   {% for section in collection_helper.get_ordered_visible_sections() %}
@@ -40,20 +40,23 @@
         {# the answer is a well formed, validated pydantic thing we could access any of the properties #}
         {# of for the templates use - we'll probably generally just want the interface of that model to tell #}
         {# us what to put when we need a single line text representation #}
-        {% do rows.append({
-          "key": {
-            "text": question.text
-          },
-          "value": {
-            "text": collection_helper.get_answer_for_question(question.id).root or "(Not answered)"
-          }
-        }) %}
+        {%
+          do rows.append({
+            "key": {
+              "text": question.text
+            },
+            "value": {
+              "text": collection_helper.get_answer_for_question(question.id).root or "(Not answered)"
+            }
+          })
+        %}
 
-        {{ govukSummaryList({
-          "rows": rows
-        })}}
+        {{
+          govukSummaryList({
+            "rows": rows
+          })
+        }}
       {% endfor %}
     {% endfor %}
   {% endfor %}
-
 {% endblock content %}

--- a/app/developers/templates/developers/manage_form.html
+++ b/app/developers/templates/developers/manage_form.html
@@ -6,29 +6,35 @@
 {% extends "deliver_grant_funding/manage_grant_base.html" %}
 
 {% block pageTitle %}
-    {{ schema.name }}
-    - {{ grant.name }} - MHCLG Funding Service
+  {{ schema.name }}
+  - {{ grant.name }} - MHCLG Funding Service
 {% endblock pageTitle %}
 
 {% set active_sub_navigation_tab = "grant_developers" %}
 {% block beforeContent %}
-    {{ govukBackLink({
+  {{
+    govukBackLink({
         "text": "Back",
         "href": back_link_href
-    }) }}
+    })
+  }}
 {% endblock beforeContent %}
 
 {% block content %}
-<h1 class="govuk-heading-l">
+  <h1 class="govuk-heading-l">
     <span class="govuk-caption-l">{{ section.title }}</span>
     {{ form.title }}
-</h1>
-{% set question_text %}
-{% trans count=form.questions | length %}{{ count }} question{% pluralize %}{{ count }}
-    questions{% endtrans %}{% endset %}
-<div class="govuk-grid-row">
+  </h1>
+  {% set question_text %}
+    {% trans count=form.questions | length %}
+      {{ count }}
+      question{% pluralize %}{{ count }} questions
+    {% endtrans %}
+  {% endset %}
+  <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-5">
-        {{ govukSummaryList({
+      {{
+        govukSummaryList({
           "rows": [{
               "key": {"text": "Title"},
               "value":{"text": form.title},
@@ -42,17 +48,18 @@
                   ]
               }
         }]
-        }) }}
+        })
+      }}
     </div>
-</div>
-<div class="govuk-grid-row">
+  </div>
+  <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
+      <h2 class="govuk-heading-m">Questions</h2>
 
-        <h2 class="govuk-heading-m">Questions</h2>
-
-        {% set table_rows = [] %}
-        {% for question in form.questions %}
-            {% do table_rows.append({
+      {% set table_rows = [] %}
+      {% for question in form.questions %}
+        {%
+          do table_rows.append({
           "text": question.text,
           "actions":[
           {"text":"Move up",
@@ -65,29 +72,27 @@
                    section_id = section.id, form_id=form.id, question_id=question.id),
                   "text": "Manage","post":false}
           ]
-                  }) %}
-        {% endfor %}
+                  })
+        %}
+      {% endfor %}
 
-        {% if form.questions %}
-            <p class="govuk-body">This form has {{ question_text }}.</p>
-            {{ moveUpDownTable(table_rows) }}
-            {{ govukButton({
-        "text": "Add question",
-        "classes": "govuk-button--secondary",
-        "href": url_for("developers.choose_question_type", grant_id=grant.id, schema_id=schema.id, section_id=section.id, form_id=form.id),
-    }) }}
-
-
-        {% else %}
-
-            <p class="govuk-body">
-                This form has no questions, you can
-                <a class="govuk-link govuk-link--no-visited-state"
-                   href="{{ url_for('developers.choose_question_type', grant_id=grant.id, schema_id=schema.id, section_id=section.id, form_id=form.id) }}">add
-                    a question</a>
-                .
-            </p>
-        {% endif %}
-        {% endblock content %}
+      {% if form.questions %}
+        <p class="govuk-body">This form has {{ question_text }}.</p>
+        {{ moveUpDownTable(table_rows) }}
+        {{
+          govukButton({
+              "text": "Add question",
+              "classes": "govuk-button--secondary",
+              "href": url_for("developers.choose_question_type", grant_id=grant.id, schema_id=schema.id, section_id=section.id, form_id=form.id),
+          })
+        }}
+      {% else %}
+        <p class="govuk-body">
+          This form has no questions, you can
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('developers.choose_question_type', grant_id=grant.id, schema_id=schema.id, section_id=section.id, form_id=form.id) }}">add a question</a>
+          .
+        </p>
+      {% endif %}
     </div>
-</div>
+  </div>
+{% endblock content %}

--- a/app/developers/templates/developers/manage_schema.html
+++ b/app/developers/templates/developers/manage_schema.html
@@ -35,9 +35,10 @@
   {% endset %}
   {% set collections_text %}
     {% trans count=schema.collections | length %}
-      {{ count }} preview collection
-      {% pluralize %}
-      {{ count }} preview collections
+      {{ count }}
+      preview collection {% pluralize %}
+      {{ count }}
+      preview collections
     {% endtrans %}
   {% endset %}
   <div class="govuk-grid-row">

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
         "govuk-frontend": "5.9.0"
       },
       "devDependencies": {
+        "prettier": "^3.5.3",
+        "prettier-plugin-jinja-template": "^2.1.0",
         "sass": "1.89.1",
         "vite": "6.3.5",
         "vite-plugin-static-copy": "2.3.1"
@@ -1473,6 +1475,32 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-jinja-template": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-jinja-template/-/prettier-plugin-jinja-template-2.1.0.tgz",
+      "integrity": "sha512-mzoCp2Oy9BDSug80fw3B3J4n4KQj1hRvoQOL1akqcDKBb5nvYxrik9zUEDs4AEJ6nK7QDTGoH0y9rx7AlnQ78Q==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "prettier": "^3.0.0"
       }
     },
     "node_modules/queue-microtask": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   },
   "devDependencies": {
     "sass": "1.89.1",
+    "prettier": "^3.5.3",
+    "prettier-plugin-jinja-template": "^2.1.0",
     "vite": "6.3.5",
     "vite-plugin-static-copy": "2.3.1"
   }

--- a/stubs/sso/templates/sso/sso_login.html
+++ b/stubs/sso/templates/sso/sso_login.html
@@ -8,8 +8,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="theme-color" content="#0b0c0c" />
     {# We're pointing at the vite server used for local development here #}
-      <link rel="stylesheet" href="{{ vite_asset('app/assets/main.scss') }}" type="text/css" />
-      <script type="module" src="{{ vite_asset('app/assets/main.js') }}"></script>
+    <link rel="stylesheet" href="{{ vite_asset('app/assets/main.scss') }}" type="text/css" />
+    <script type="module" src="{{ vite_asset('app/assets/main.js') }}"></script>
   </head>
 
   <body class="govuk-template__body">


### PR DESCRIPTION
This commit adds the prettier formatter to the node package manager
dependencies. This configuration for formatting jinja templates is the
only one we've found so far that feels like it does a consistent job.

As we're not yet convinced this commit doesn't include it in pre-commit
or CI breaking checks but just makes it available to developers to use
if they're working on templates and would like opinions.

This can be run with:
```
make format-html
```