### PR TITLE
BAU: Fix `updated_at` behaviour

### DIFF
--- a/app/common/data/base.py
+++ b/app/common/data/base.py
@@ -26,4 +26,4 @@ class BaseModel(DeclarativeBase):
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, sort_order=-100, default=uuid.uuid4)
     created_at: Mapped[datetime] = mapped_column(server_default=func.now(), sort_order=-99)
-    updated_at: Mapped[datetime] = mapped_column(server_default=func.now(), server_onupdate=func.now(), sort_order=-98)
+    updated_at: Mapped[datetime] = mapped_column(server_default=func.now(), onupdate=func.now(), sort_order=-98)


### PR DESCRIPTION
We're using `server_onupdate` for our `updated_at` column in the base model to catch timestamps when rows in our database are updated.

However this doesn't seem to be firing and all our `updated_at` columns in tables that inherit from the base model are still set at the same time as `created_at`, even after updates.

The reason for this seems to be that `server_onupdate` doesn't automatically trigger when row is updated, and instead needs explicit instruction to update that column during an UPDATE operation eg. with a trigger (see [SQLALchemy docs](https://docs.sqlalchemy.org/en/20/core/metadata.html#sqlalchemy.schema.Column.params.server_onupdate)).

Switching to just using `onupdate` allows SQLAlchemy to handle this behaviour when an entity is updated through the ORM, but `func.now` is calculated by the db so is still the kind of behaviour we want.

Nit: Is using `served_default` and not `server_onupdate` an annoying/potentially bad inconsistency? Do we just set that to `default` instead of `server_default` for consistency? 