### PR TITLE
FSPT-401: Run migrations conditionally on head file changing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,23 +82,20 @@ jobs:
           echo "ecr_image_location=$ECR_IMAGE_LOCATION" >> $GITHUB_OUTPUT
 
       - name: checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-      - name: Set up Python
-        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5
+      - name: check if changeset includes migrations
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: changes
         with:
-          python-version: 3.13.3
+          filters: |
+            alembic-head:
+              - 'app/common/data/migrations/.current-alembic-head'
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
-        with:
-          enable-cache: true
 
-      - name: install dependencies
-        run: uv sync
       - name: Run Database Migrations
-        run: |
-          uv run scripts/run-ad-hoc-task.py --command "flask db upgrade"
+        if: steps.changes.outputs.alembic-head == 'true'
+        uses: ./.github/workflows/run-database-migrations
 
       - name: Deploy image to AppRunner
         id: deploy

--- a/.github/workflows/run-database-migrations/action.yml
+++ b/.github/workflows/run-database-migrations/action.yml
@@ -1,0 +1,23 @@
+name: 'Run Database Migrations'
+description: 'Composite Action to run Database Migration script'
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.13.3
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+      with:
+        enable-cache: true
+
+    - name: Install dependencies
+      shell: bash
+      run: uv sync
+
+    - name: Run Database Migrations
+      shell: bash
+      run: |
+        uv run scripts/run-ad-hoc-task.py --command "flask db upgrade"

--- a/.github/workflows/run_db_migrations.yml
+++ b/.github/workflows/run_db_migrations.yml
@@ -9,9 +9,13 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: "AWS environment to run migrations in."
-        type: string
+        description:  Which AWS Account to use
+        type: choice
         required: true
+        options:
+        - dev
+        - test
+        - prod
 
 jobs:
   run_migrations:

--- a/.github/workflows/run_db_migrations.yml
+++ b/.github/workflows/run_db_migrations.yml
@@ -1,0 +1,37 @@
+name: Run Database Migrations
+
+
+permissions:
+  contents: read  # This is required for actions/checkout
+  id-token: write  # This is required for authenticating with aws
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "AWS environment to run migrations in."
+        type: string
+        required: true
+
+jobs:
+  run_migrations:
+    environment: ${{ inputs.environment }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Get current date
+        shell: bash
+        id: currentdatetime
+        run: echo "datetime=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_OUTPUT
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
+        with:
+            role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/GithubCopilotDeploy
+            role-session-name: "funding-service_deploy_${{ inputs.environment }}_${{ steps.currentdatetime.outputs.datetime }}"
+            aws-region: eu-west-2
+
+      - name: Run Database Migrations
+        uses: ./.github/workflows/run-database-migrations

--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,13 @@
       "matchManagers": ["docker-compose", "github-actions"],
       "allowedVersions": "<17",
       "description": "If updating to a new major version, update testcontainers in tests/integration/conftest"
+    },
+    {
+      "groupName": "Paths filter GitHub action",
+      "matchPackageNames": ["dorny/paths-filter"],
+      "matchManagers": ["github-actions"],
+      "enabled": false,
+      "description": "Disable updates to 3rd party GitHub action to reduce security risk"
     }
   ]
 }


### PR DESCRIPTION
This makes database migrations run conditionally in the main pipeline only if `.current-alembic-head` is in the changeset.

It also adds a standalone workflow for edge cases where we need to force migrations to run in other circumstances.

Note this is modelled as a [composite action](https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-composite-action) to allow steps to be shared without a wholesale refactor of the main workflow.

I have tested this on the branch e.g.

https://github.com/communitiesuk/funding-service/actions/runs/14855949610 - standalone action 
https://github.com/communitiesuk/funding-service/actions/runs/14856870735 - main pipeline