### PR TITLE
Remove redundant env var

### DIFF
--- a/docker-compose.pullpreview.yml
+++ b/docker-compose.pullpreview.yml
@@ -46,7 +46,6 @@ services:
     env_file: .env
     environment:
       FLASK_ENV: pullpreview
-      FLASK_PORT: 8080
       DATABASE_HOST: "db"
       DATABASE_PORT: 5432
       DATABASE_NAME: "postgres"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,6 @@ services:
     env_file: .env
     environment:
       FLASK_ENV: local
-      FLASK_PORT: 8080
       DATABASE_HOST: "db"
       DATABASE_PORT: 5432
       DATABASE_NAME: "postgres"


### PR DESCRIPTION
The actual env var is FLASK_RUN_PORT; this has never worked. The port is correct because we also pass `--port` to the flask run command.