### PR TITLE
BAU: Allow @test.communities email domain

### DIFF
--- a/app/common/auth/decorators.py
+++ b/app/common/auth/decorators.py
@@ -1,7 +1,7 @@
 import functools
 from typing import Callable, cast
 
-from flask import abort, redirect, request, session, url_for
+from flask import abort, current_app, redirect, request, session, url_for
 from flask.typing import ResponseReturnValue
 from flask_login import current_user
 
@@ -29,7 +29,8 @@ def mhclg_login_required[**P](
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> ResponseReturnValue:
         # This decorator is itself wrapped by `login_required`, so we know that `current_user` exists and is
         # not an anonymous user (ie a user is definitely logged-in) if we get here.
-        if not cast(User, current_user).email.endswith("@communities.gov.uk"):
+        internal_domains = current_app.config["INTERNAL_DOMAINS"]
+        if not cast(User, current_user).email.endswith(internal_domains):
             abort(403)
 
         return func(*args, **kwargs)

--- a/app/common/auth/forms.py
+++ b/app/common/auth/forms.py
@@ -1,3 +1,4 @@
+from flask import current_app
 from flask_wtf import FlaskForm
 from govuk_frontend_wtf.wtforms_widgets import GovSubmitInput, GovTextInput
 from wtforms import StringField, SubmitField
@@ -6,8 +7,9 @@ from wtforms.validators import DataRequired, Email, ValidationError
 
 def validate_communities_gov_uk_email(form: FlaskForm, field: StringField) -> None:
     if field.data and "@" in field.data:
-        if not field.data.endswith("@communities.gov.uk"):
-            raise ValidationError("Email address must end with @communities.gov.uk")
+        internal_domains = current_app.config["INTERNAL_DOMAINS"]
+        if not field.data.endswith(internal_domains):
+            raise ValidationError(f"Email address must end with {' or '.join(internal_domains)}")
 
 
 class SignInForm(FlaskForm):

--- a/app/config/__init__.py
+++ b/app/config/__init__.py
@@ -244,6 +244,9 @@ class _SharedConfig(_BaseConfig):
     # https://docs.microsoft.com/en-us/graph/permissions-reference
     MS_GRAPH_PERMISSIONS_SCOPE: list[str] = ["User.ReadBasic.All"]
 
+    # Internal Domains
+    INTERNAL_DOMAINS: tuple[str, ...] = ("@communities.gov.uk", "@test.communities.gov.uk")
+
     @property
     def IS_PRODUCTION(self) -> bool:
         return self.FLASK_ENV == Environment.PROD
@@ -344,6 +347,9 @@ class ProdConfig(_SharedConfig):
     """
     Overrides / default configuration for our deployed 'prod' environment
     """
+
+    # Internal Domains
+    INTERNAL_DOMAINS: tuple[str, ...] = ("@communities.gov.uk",)
 
     # Flask app
     FLASK_ENV: Environment = Environment.PROD

--- a/stubs/sso/__init__.py
+++ b/stubs/sso/__init__.py
@@ -26,6 +26,7 @@ from stubs.sso.forms import SSOSignInForm
 
 app = Flask(__name__)
 app.config["SECRET_KEY"] = "dummy-value"  # pragma: allowlist secret
+app.config["INTERNAL_DOMAINS"] = ("@communities.gov.uk", "@test.communities.gov.uk")
 
 app.jinja_loader = ChoiceLoader(
     [

--- a/stubs/sso/forms.py
+++ b/stubs/sso/forms.py
@@ -1,3 +1,4 @@
+from flask import current_app
 from flask_wtf import FlaskForm
 from govuk_frontend_wtf.wtforms_widgets import GovSubmitInput, GovTextInput
 from wtforms import StringField, SubmitField
@@ -6,8 +7,9 @@ from wtforms.validators import DataRequired, Email, ValidationError
 
 def validate_communities_gov_uk_email(form: FlaskForm, field: StringField) -> None:
     if field.data and "@" in field.data:
-        if not field.data.endswith("@communities.gov.uk"):
-            raise ValidationError("Email address must end with @communities.gov.uk")
+        internal_domains = current_app.config["INTERNAL_DOMAINS"]
+        if not field.data.endswith(internal_domains):
+            raise ValidationError(f"Email address must end with {' or '.join(internal_domains)}")
 
 
 class SSOSignInForm(FlaskForm):

--- a/tests/integration/common/auth/test_auth.py
+++ b/tests/integration/common/auth/test_auth.py
@@ -28,7 +28,7 @@ class TestSignInView:
         response = client.post(url_for("auth.request_a_link_to_sign_in"), data={"email_address": "test@example.com"})
         assert response.status_code == 200
         soup = BeautifulSoup(response.data, "html.parser")
-        assert page_has_error(soup, "Email address must end with @communities.gov.uk")
+        assert page_has_error(soup, "Email address must end with @communities.gov.uk or @test.communities.gov.uk")
 
     def test_post_valid_email(self, anonymous_client, mock_notification_service_calls):
         response = anonymous_client.post(
@@ -63,7 +63,7 @@ class TestSignInView:
 
         response = anonymous_client.post(
             url_for("auth.request_a_link_to_sign_in"),
-            data={"email_address": "test@communities.gov.uk"},
+            data={"email_address": "test@test.communities.gov.uk"},
             follow_redirects=True,
         )
         assert response.status_code == 200


### PR DESCRIPTION
Now we've implemented SSO, people will be signing in with their `@test.communities.gov.uk` accounts through SSO. As we're only using the test key currently, this PR updates our form validation and route wrapper to allow logins with both `@communities` and `@test.communities` emails.

For consistency this has also now been applied to the magic link sign-in page, which previously validated to only allow `@communities` emails as well. It's likely we'll drop this validation in future once the platform is more built out, as this sign-in route will be the one that's open to and used by most external users, but for now internal users can continue to sign in with both methods.

Adding it as config in the main app and SSO stub seems slightly duplicative but as the SSO stub is only used locally and for locally-run end to end tests this seems like an ok compromise, and allows us to override the `INTERNAL_DOMAINS` variable for prod and not allow `test.communities` accounts.