### PR TITLE
BAU: Fix entrypoint on local docker runner

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,13 +37,13 @@ services:
       "
     env_file: .env
     environment:
+      FLASK_APP: app/__init__.py
       FLASK_ENV: local
       DATABASE_HOST: "db"
       DATABASE_PORT: 5432
       DATABASE_NAME: "postgres"
       DATABASE_SECRET: '{"username":"postgres","password":"postgres"}'  # pragma:allowlist secret
       REQUESTS_CA_BUNDLE: /etc/ssl/certs/ca-certificates.crt
-      GEVENT_SUPPORT: True
     depends_on:
       - db
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       "
     env_file: .env
     environment:
-      FLASK_APP: app/__init__.py
+      FLASK_APP: app
       FLASK_ENV: local
       DATABASE_HOST: "db"
       DATABASE_PORT: 5432


### PR DESCRIPTION
Flask development server [defaults to `wsgi.py`](https://github.com/pallets/flask/blob/a5f9742398c9429ef84ac8a57b0f3eb418394d9e/src/flask/cli.py#L351) if it exists. Following merge of #162 this meant code in this file was being erroneously executed when running the local development server.

 
This explicitly sets a different entrypoint to avoid erroneously running gevent code which is only used in deployed environments. 