### PR TITLE
FSPT-410: Implement user roles in the database

### DIFF
--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-007_add_section_form
+008_add_userrole_org_tables

--- a/app/common/data/migrations/versions/008_add_userrole_org_tables.py
+++ b/app/common/data/migrations/versions/008_add_userrole_org_tables.py
@@ -1,0 +1,87 @@
+"""Add UserRole table and stub Organisation table
+
+Revision ID: 008_add_userrole_org_tables
+Revises: 007_add_section_form
+Create Date: 2025-05-20 10:32:50.241292
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "008_add_userrole_org_tables"
+down_revision = "007_add_section_form"
+branch_labels = None
+depends_on = None
+
+role_enum = sa.Enum("ADMIN", "MEMBER", "EDITOR", "ASSESSOR", "S151_OFFICER", name="role_enum")
+
+
+def upgrade() -> None:
+    op.create_table(
+        "organisation",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("created_at_utc", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at_utc", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.Column("name", postgresql.CITEXT(), nullable=False),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_organisation")),
+        sa.UniqueConstraint("name", name=op.f("uq_organisation_name")),
+    )
+    op.create_table(
+        "user_role",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("created_at_utc", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at_utc", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("organisation_id", sa.Uuid(), nullable=True),
+        sa.Column("grant_id", sa.Uuid(), nullable=True),
+        sa.Column("role", role_enum, nullable=False),
+        sa.CheckConstraint(
+            "role != 'ASSESSOR' OR (organisation_id IS NULL AND grant_id IS NOT NULL)",
+            name=op.f("ck_user_role_assessor_role_grant_only"),
+        ),
+        sa.CheckConstraint(
+            "role != 'MEMBER' OR NOT (organisation_id IS NULL AND grant_id IS NULL)",
+            name=op.f("ck_user_role_member_role_not_platform"),
+        ),
+        sa.CheckConstraint(
+            "role != 'S151_OFFICER' OR (organisation_id IS NOT NULL AND grant_id IS NULL)",
+            name=op.f("ck_user_role_s151_officer_role_org_only"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["grant_id"], ["grant.id"], name=op.f("fk_user_role_grant_id_grant"), ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["organisation_id"],
+            ["organisation.id"],
+            name=op.f("fk_user_role_organisation_id_organisation"),
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], name=op.f("fk_user_role_user_id_user"), ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_user_role")),
+        sa.UniqueConstraint("user_id", "organisation_id", "grant_id", "role", name="uq_user_org_grant_role"),
+    )
+    with op.batch_alter_table("user_role", schema=None) as batch_op:
+        batch_op.create_index("ix_user_roles_grant_id", ["grant_id"], unique=False)
+        batch_op.create_index("ix_user_roles_organisation_id", ["organisation_id"], unique=False)
+        batch_op.create_index(
+            "ix_user_roles_organisation_id_role_id_grant_id", ["user_id", "organisation_id", "grant_id"], unique=False
+        )
+        batch_op.create_index("ix_user_roles_user_id", ["user_id"], unique=False)
+        batch_op.create_index("ix_user_roles_user_id_grant_id", ["user_id", "grant_id"], unique=False)
+        batch_op.create_index("ix_user_roles_user_id_organisation_id", ["user_id", "organisation_id"], unique=False)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("user_role", schema=None) as batch_op:
+        batch_op.drop_index("ix_user_roles_user_id_organisation_id")
+        batch_op.drop_index("ix_user_roles_user_id_grant_id")
+        batch_op.drop_index("ix_user_roles_user_id")
+        batch_op.drop_index("ix_user_roles_organisation_id_role_id_grant_id")
+        batch_op.drop_index("ix_user_roles_organisation_id")
+        batch_op.drop_index("ix_user_roles_grant_id")
+
+    op.drop_table("user_role")
+    op.drop_table("organisation")
+    op.execute(sa.text("DROP TYPE IF EXISTS role_enum"))

--- a/app/common/data/models/__init__.py
+++ b/app/common/data/models/__init__.py
@@ -5,7 +5,7 @@ from enum import Enum
 
 from pytz import utc
 from sqlalchemy import CheckConstraint, ForeignKey, Index, UniqueConstraint
-from sqlalchemy import Enum as PgEnum
+from sqlalchemy import Enum as SqlEnum
 from sqlalchemy.ext.orderinglist import ordering_list
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -76,7 +76,7 @@ class UserRole(BaseModel):
     )
     grant_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("grant.id", ondelete="CASCADE"), nullable=True)
     role: Mapped[RoleEnum] = mapped_column(
-        PgEnum(
+        SqlEnum(
             RoleEnum,
             name="role_enum",
             validate_strings=True,

--- a/app/common/data/models/__init__.py
+++ b/app/common/data/models/__init__.py
@@ -1,13 +1,25 @@
 import datetime
 import secrets
 import uuid
+from enum import Enum
 
 from pytz import utc
-from sqlalchemy import ForeignKey, Index, UniqueConstraint
+from sqlalchemy import CheckConstraint, ForeignKey, Index, UniqueConstraint
+from sqlalchemy import Enum as PgEnum
 from sqlalchemy.ext.orderinglist import ordering_list
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.common.data.base import BaseModel, CIStr
+
+
+class RoleEnum(str, Enum):
+    ADMIN = (
+        "admin"  # Admin level permissions, combines with null columns in UserRole table to denote level of admin access
+    )
+    MEMBER = "member"  # Basic read level permissions
+    EDITOR = "editor"  # Read/write level permissions
+    ASSESSOR = "assessor"  # Assessor level permissions
+    S151_OFFICER = "s151_officer"  # S151 officer sign-off permissions
 
 
 class Grant(BaseModel):
@@ -16,6 +28,16 @@ class Grant(BaseModel):
     name: Mapped[CIStr] = mapped_column(unique=True)
 
     collection_schemas: Mapped[list["CollectionSchema"]] = relationship("CollectionSchema", lazy=True)
+    roles: Mapped[list["UserRole"]] = relationship("UserRole", back_populates="grant", cascade="all, delete-orphan")
+
+
+class Organisation(BaseModel):
+    __tablename__ = "organisation"
+
+    name: Mapped[CIStr] = mapped_column(unique=True)
+    roles: Mapped[list["UserRole"]] = relationship(
+        "UserRole", back_populates="organisation", cascade="all, delete-orphan"
+    )
 
 
 class User(BaseModel):
@@ -24,6 +46,8 @@ class User(BaseModel):
     email: Mapped[CIStr] = mapped_column(unique=True)
 
     magic_links: Mapped[list["MagicLink"]] = relationship("MagicLink", back_populates="user")
+
+    roles: Mapped[list["UserRole"]] = relationship("UserRole", back_populates="user", cascade="all, delete-orphan")
 
     # Required by Flask-Login; should be provided by UserMixin, except that breaks our type hinting
     # when using this class in SQLAlchemy queries. So we've just lifted the key attributes here directly.
@@ -41,6 +65,50 @@ class User(BaseModel):
 
     def get_id(self) -> str:
         return str(self.id)
+
+
+class UserRole(BaseModel):
+    __tablename__ = "user_role"
+
+    user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("user.id", ondelete="CASCADE"), nullable=False)
+    organisation_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("organisation.id", ondelete="CASCADE"), nullable=True
+    )
+    grant_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("grant.id", ondelete="CASCADE"), nullable=True)
+    role: Mapped[RoleEnum] = mapped_column(
+        PgEnum(
+            RoleEnum,
+            name="role_enum",
+            validate_strings=True,
+        ),
+        nullable=False,
+    )
+
+    user: Mapped[User] = relationship("User", back_populates="roles")
+    organisation: Mapped[Organisation] = relationship("Organisation", back_populates="roles")
+    grant: Mapped[Grant] = relationship("Grant", back_populates="roles")
+
+    __table_args__ = (
+        UniqueConstraint("user_id", "organisation_id", "grant_id", "role", name="uq_user_org_grant_role"),
+        Index("ix_user_roles_user_id", "user_id"),
+        Index("ix_user_roles_organisation_id", "organisation_id"),
+        Index("ix_user_roles_grant_id", "grant_id"),
+        Index("ix_user_roles_user_id_organisation_id", "user_id", "organisation_id"),
+        Index("ix_user_roles_user_id_grant_id", "user_id", "grant_id"),
+        Index("ix_user_roles_organisation_id_role_id_grant_id", "user_id", "organisation_id", "grant_id"),
+        CheckConstraint(
+            "role != 'MEMBER' OR NOT (organisation_id IS NULL AND grant_id IS NULL)",
+            name="member_role_not_platform",
+        ),
+        CheckConstraint(
+            "role != 'S151_OFFICER' OR (organisation_id IS NOT NULL AND grant_id IS NULL)",
+            name="s151_officer_role_org_only",
+        ),
+        CheckConstraint(
+            "role != 'ASSESSOR' OR (organisation_id IS NULL AND grant_id IS NOT NULL)",
+            name="assessor_role_grant_only",
+        ),
+    )
 
 
 class MagicLink(BaseModel):

--- a/tests/integration/common/data/db/test_constraints.py
+++ b/tests/integration/common/data/db/test_constraints.py
@@ -1,0 +1,34 @@
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app.common.data.models import RoleEnum
+
+
+class TestUserRoleConstraints:
+    def test_member_role_not_platform(self, factories):
+        with pytest.raises(IntegrityError) as error:
+            factories.user_role.create(has_grant=False, has_organisation=False, role=RoleEnum.MEMBER)
+        assert (
+            'new row for relation "user_role" violates check constraint "ck_user_role_member_role_not_platform"'
+            in error.value.args[0]
+        )
+
+    @pytest.mark.parametrize("has_organisation, has_grant", [(True, True), (False, True)])
+    def test_s151_officer_role_org_only(self, factories, has_organisation, has_grant):
+        with pytest.raises(IntegrityError) as error:
+            factories.user_role.create(
+                has_organisation=has_organisation, has_grant=has_grant, role=RoleEnum.S151_OFFICER
+            )
+        assert (
+            'new row for relation "user_role" violates check constraint "ck_user_role_s151_officer_role_org_only"'
+            in error.value.args[0]
+        )
+
+    @pytest.mark.parametrize("has_organisation, has_grant", [(True, True), (True, False)])
+    def test_assessor_role_grant_only(self, factories, has_organisation, has_grant):
+        with pytest.raises(IntegrityError) as error:
+            factories.user_role.create(has_organisation=has_organisation, has_grant=has_grant, role=RoleEnum.ASSESSOR)
+        assert (
+            'new row for relation "user_role" violates check constraint "ck_user_role_assessor_role_grant_only"'
+            in error.value.args[0]
+        )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -32,8 +32,10 @@ from tests.integration.models import (
     _FormFactory,
     _GrantFactory,
     _MagicLinkFactory,
+    _OrganisationFactory,
     _SectionFactory,
     _UserFactory,
+    _UserRoleFactory,
 )
 from tests.integration.utils import TimeFreezer
 from tests.types import TTemplatesRendered
@@ -183,7 +185,9 @@ def db_session(app: Flask, db: SQLAlchemy) -> Generator[Session, None, None]:
             connection.close()
 
 
-_Factories = namedtuple("_Factories", ["grant", "user", "magic_link", "collection_schema", "section", "form"])
+_Factories = namedtuple(
+    "_Factories", ["grant", "user", "magic_link", "collection_schema", "section", "form", "organisation", "user_role"]
+)
 
 
 @pytest.fixture(scope="function")
@@ -195,6 +199,8 @@ def factories(db_session: Session) -> _Factories:
         collection_schema=_CollectionSchemaFactory,
         section=_SectionFactory,
         form=_FormFactory,
+        organisation=_OrganisationFactory,
+        user_role=_UserRoleFactory,
     )
 
 


### PR DESCRIPTION
Creates UserRole table for storing a User's roles at all levels. By having nullable columns for Org and Grant Foreign Key references, we can infer the permission level for that user, eg. 
- if they have the `admin` role but org and grant are null, then they are a global/platform admin
- if they have the `admin` role and an org id, then they are an organisation-level admin who would be able to eg. add other users to the organisation
This also means we just have one table to check for roles and permissions rather than splitting it across multiple join tables. 

Creates a stub `role_enum` with some initial broad user roles, an some basic check constraints for now for obvious cases, and a stub Organisation table, which will certainly be extended in the future but means we can have the UserRole table in place.

Adds tests to ensure these constraints are working as expected, which we might want to do later for existing constraints already set up in our tables that we're not explicitly testing elsewhere.