### PR TITLE
FSPT-402 - Watermark

### DIFF
--- a/app/assets/main.scss
+++ b/app/assets/main.scss
@@ -6,39 +6,39 @@ $govuk-assets-path: "/static/assets/";
 @import "../../node_modules/govuk-frontend/dist/govuk";
 
 .app-\!-no-wrap {
-  white-space: nowrap;
+    white-space: nowrap;
 }
 
 // this class will only be applied if GOV.UK Frontend Jinja has set the `.js-enabled` class meaning
 // it could execute JavaScript
 .js-enabled .app-js-hidden {
-  display: none;
+    display: none;
 }
 
 .fs-nav-item > a {
-  display: block;
-  padding: 7px 0;
-  width: 100%;
+    display: block;
+    padding: 7px 0;
+    width: 100%;
 }
 
 // Makes the content of this div display behind the other elements on the page, like a watermark
-div.fs-watermark {
-  transform: rotate(331deg);
-  font-size: 10em;
-  color: rgba(0, 0, 0, 0.22);
-  position: absolute;
-  padding-left: 1%;
-  padding-top: 5%;
-  font-family: GDS Transport, arial, sans-serif;
-  z-index: -1;
+.app-body__watermark {
+    transform: rotate(331deg);
+    font-size: 10em;
+    color: rgba(0, 0, 0, 0.22);
+    position: absolute;
+    padding-left: 1%;
+    padding-top: 5%;
+    font-family: GDS Transport, arial, sans-serif;
+    z-index: -1;
 }
 
 // Needed to make the watermark above visible
-body.govuk-template__body:has(div.fs-watermark) {
-  background-color: rgba(255, 255, 255, 0.5);
+body.govuk-template__body:has(div.app-body__watermark) {
+    background-color: rgba(255, 255, 255, 0.5);
 }
 
 // Needed to make the watermark above visible
-.govuk-template:has(div.fs-watermark) {
-  background-color: rgba(255, 255, 255, 0.5);
+.govuk-template:has(div.app-body__watermark) {
+    background-color: rgba(255, 255, 255, 0.5);
 }

--- a/app/assets/main.scss
+++ b/app/assets/main.scss
@@ -25,7 +25,7 @@ $govuk-assets-path: "/static/assets/";
 div.fs-watermark {
   transform: rotate(331deg);
   font-size: 10em;
-  color: rgba(0, 0, 0, 0.08);
+  color: rgba(0, 0, 0, 0.22);
   position: absolute;
   padding-left: 1%;
   padding-top: 5%;

--- a/app/assets/main.scss
+++ b/app/assets/main.scss
@@ -6,17 +6,39 @@ $govuk-assets-path: "/static/assets/";
 @import "../../node_modules/govuk-frontend/dist/govuk";
 
 .app-\!-no-wrap {
-    white-space: nowrap;
+  white-space: nowrap;
 }
 
 // this class will only be applied if GOV.UK Frontend Jinja has set the `.js-enabled` class meaning
 // it could execute JavaScript
 .js-enabled .app-js-hidden {
-    display: none;
+  display: none;
 }
 
-.fs-nav-item>a {
-    display: block;
-    padding: 7px 0;
-    width: 100%;
+.fs-nav-item > a {
+  display: block;
+  padding: 7px 0;
+  width: 100%;
+}
+
+// Makes the content of this div display behind the other elements on the page, like a watermark
+div.fs-watermark {
+  transform: rotate(331deg);
+  font-size: 10em;
+  color: rgba(0, 0, 0, 0.08);
+  position: absolute;
+  padding-left: 1%;
+  padding-top: 5%;
+  font-family: GDS Transport, arial, sans-serif;
+  z-index: -1;
+}
+
+// Needed to make the watermark above visible
+body.govuk-template__body:has(div.fs-watermark) {
+  background-color: rgba(255, 255, 255, 0.5);
+}
+
+// Needed to make the watermark above visible
+.govuk-template:has(div.fs-watermark) {
+  background-color: rgba(255, 255, 255, 0.5);
 }

--- a/app/platform/templates/platform/developers/collection_details.html
+++ b/app/platform/templates/platform/developers/collection_details.html
@@ -17,7 +17,7 @@
 {% endblock beforeContent %}
 
 {% block content %}
-    <div class="fs-watermark">Developers</div>
+    <div class="app-body__watermark" aria-hidden="true">Developers</div>
     <h1 class="govuk-heading-l">
         {{ collection.name }}
     </h1>

--- a/app/platform/templates/platform/developers/collection_details.html
+++ b/app/platform/templates/platform/developers/collection_details.html
@@ -17,6 +17,7 @@
 {% endblock beforeContent %}
 
 {% block content %}
+    <div class="fs-watermark">Developers</div>
     <h1 class="govuk-heading-l">
         {{ collection.name }}
     </h1>

--- a/app/platform/templates/platform/developers/collections_list.html
+++ b/app/platform/templates/platform/developers/collections_list.html
@@ -11,6 +11,7 @@
 {% set active_sub_navigation_tab = "grant_developers" %}
 
 {% block content %}
+    <div class="fs-watermark">Developers</div>
     <h1 class="govuk-heading-l">
         <span class="govuk-caption-l">{{ grant.name }}</span>
         Collections

--- a/app/platform/templates/platform/developers/collections_list.html
+++ b/app/platform/templates/platform/developers/collections_list.html
@@ -11,7 +11,7 @@
 {% set active_sub_navigation_tab = "grant_developers" %}
 
 {% block content %}
-    <div class="fs-watermark">Developers</div>
+    <div class="app-body__watermark" aria-hidden="true">Developers</div>
     <h1 class="govuk-heading-l">
         <span class="govuk-caption-l">{{ grant.name }}</span>
         Collections

--- a/app/platform/templates/platform/developers/create_collection.html
+++ b/app/platform/templates/platform/developers/create_collection.html
@@ -18,7 +18,7 @@
 {% endblock beforeContent %}
 
 {% block content %}
-    <div class="fs-watermark">Developers</div>
+    <div class="app-body__watermark" aria-hidden="true">Developers</div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             <h1 class="govuk-heading-l">Set up a new collection</h1>

--- a/app/platform/templates/platform/developers/create_collection.html
+++ b/app/platform/templates/platform/developers/create_collection.html
@@ -18,6 +18,7 @@
 {% endblock beforeContent %}
 
 {% block content %}
+    <div class="fs-watermark">Developers</div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             <h1 class="govuk-heading-l">Set up a new collection</h1>

--- a/app/platform/templates/platform/developers/edit_collection.html
+++ b/app/platform/templates/platform/developers/edit_collection.html
@@ -17,7 +17,7 @@
 {% endblock %}
 
 {% block content %}
-    <div class="fs-watermark">Developers</div>
+    <div class="app-body__watermark" aria-hidden="true">Developers</div>
     <h1 class="govuk-heading-l">
         Edit collection details
     </h1>

--- a/app/platform/templates/platform/developers/edit_collection.html
+++ b/app/platform/templates/platform/developers/edit_collection.html
@@ -17,6 +17,7 @@
 {% endblock %}
 
 {% block content %}
+    <div class="fs-watermark">Developers</div>
     <h1 class="govuk-heading-l">
         Edit collection details
     </h1>

--- a/app/platform/templates/platform/developers/grant_developers.html
+++ b/app/platform/templates/platform/developers/grant_developers.html
@@ -11,7 +11,7 @@
 
 
 {% block content %}
-    <div class="fs-watermark">Developers</div>
+    <div class="app-body__watermark" aria-hidden="true">Developers</div>
     <h1 class="govuk-heading-l">
         <span class="govuk-caption-l">{{ grant.name }}</span>
         Developers

--- a/app/platform/templates/platform/developers/grant_developers.html
+++ b/app/platform/templates/platform/developers/grant_developers.html
@@ -9,7 +9,9 @@
 
 {% set active_sub_navigation_tab = "grant_developers" %}
 
+
 {% block content %}
+    <div class="fs-watermark">Developers</div>
     <h1 class="govuk-heading-l">
         <span class="govuk-caption-l">{{ grant.name }}</span>
         Developers


### PR DESCRIPTION
Adds CSS to make a `div` behave as a watermark. This allows us to visually differentiate screens if we need to. Some example use cases for this are:
- Developers - for screens that won't be in the real use journey and are just developer facing while we work on the platform
- Scaffolding - for screens that allow us to see a user journey playing out, before the data model and/or journey design is complete

This PR also implements this 'developers' watermark on the relevant existing pages.