### PR TITLE
Make test factories flush on create

### DIFF
--- a/tests/integration/models.py
+++ b/tests/integration/models.py
@@ -22,6 +22,7 @@ class _GrantFactory(factory.alchemy.SQLAlchemyModelFactory):
     class Meta:
         model = Grant
         sqlalchemy_session_factory = lambda: db.session  # noqa: E731
+        sqlalchemy_session_persistence = "flush"
 
     id = factory.LazyFunction(uuid4)
     name = factory.Sequence(lambda n: "Grant %d" % n)
@@ -31,6 +32,7 @@ class _UserFactory(factory.alchemy.SQLAlchemyModelFactory):
     class Meta:
         model = User
         sqlalchemy_session_factory = lambda: db.session  # noqa: E731
+        sqlalchemy_session_persistence = "flush"
 
     id = factory.LazyFunction(uuid4)
     email = factory.Faker("email")
@@ -40,6 +42,7 @@ class _MagicLinkFactory(factory.alchemy.SQLAlchemyModelFactory):
     class Meta:
         model = MagicLink
         sqlalchemy_session_factory = lambda: db.session  # noqa: E731
+        sqlalchemy_session_persistence = "flush"
 
     id = factory.LazyFunction(uuid4)
     code = factory.LazyFunction(lambda: secrets.token_urlsafe(12))
@@ -54,6 +57,7 @@ class _CollectionSchemaFactory(factory.alchemy.SQLAlchemyModelFactory):
     class Meta:
         model = CollectionSchema
         sqlalchemy_session_factory = lambda: db.session  # noqa: E731
+        sqlalchemy_session_persistence = "flush"
 
     id = factory.LazyFunction(uuid4)
     name = factory.Sequence(lambda n: "Collection %d" % n)
@@ -70,6 +74,7 @@ class _SectionFactory(factory.alchemy.SQLAlchemyModelFactory):
     class Meta:
         model = Section
         sqlalchemy_session_factory = lambda: db.session  # noqa: E731
+        sqlalchemy_session_persistence = "flush"
 
     id = factory.LazyFunction(uuid4)
     title = factory.Sequence(lambda n: "Section %d" % n)
@@ -84,6 +89,7 @@ class _FormFactory(factory.alchemy.SQLAlchemyModelFactory):
     class Meta:
         model = Form
         sqlalchemy_session_factory = lambda: db.session  # noqa: E731
+        sqlalchemy_session_persistence = "flush"
 
     id = factory.LazyFunction(uuid4)
     title = factory.Sequence(lambda n: "Form %d" % n)


### PR DESCRIPTION
When trying to use our Factory Boy factory `create` calls to trigger an Integrity Error we realised that the create calls weren't actually flushing or committing to the test DB, but just creating and adding the entity ephemerally in the session. This is the default behaviour [see docs](https://factoryboy.readthedocs.io/en/stable/orms.html#factory.alchemy.SQLAlchemyOptions.sqlalchemy_session_persistence)

When we call the `create` method with our factories this should perform a session flush, to differentiate it from the `build` method (when explicit adding and flushing/committing) is needed.

This sets the `sqlalchemy_session_persistence` to `flush` for all our factories, which should be our default going forward, so when we call `create` we know the object is created and a session flush is performed.