### PR TITLE
FSPT-477 pullpreview sso stub implementation

### DIFF
--- a/.pullpreview/Caddyfile.template
+++ b/.pullpreview/Caddyfile.template
@@ -5,3 +5,7 @@ ${PULLPREVIEW_PUBLIC_DNS}:443 {
 
     reverse_proxy web:8080
 }
+
+sso.${PULLPREVIEW_PUBLIC_DNS}:443 {
+    reverse_proxy sso:8080
+}

--- a/app/config.py
+++ b/app/config.py
@@ -336,7 +336,7 @@ class PullPreviewConfig(_SharedConfig):
     AZURE_AD_CLIENT_ID: str = "00000000-0000-0000-0000-000000000000"
     AZURE_AD_CLIENT_SECRET: str = "incorrect_value"
     AZURE_AD_TENANT_ID: str = "00000000-0000-0000-0000-000000000000"
-    AZURE_AD_BASE_URL: str = "https://sso.communities.gov.localhost:4005/"
+    AZURE_AD_BASE_URL: str = os.getenv("AZURE_AD_BASE_URL", "https://sso.communities.gov.localhost:4005/")
 
     # Talisman security settings
     TALISMAN_CONTENT_SECURITY_POLICY: dict[str, list[str]] = make_development_csp()

--- a/docker-compose.pullpreview.yml
+++ b/docker-compose.pullpreview.yml
@@ -72,6 +72,28 @@ services:
     networks:
       - ofs
 
+  sso:
+    build: .
+    volumes:
+      - .:/app
+      - /app/node_modules
+      - '/app/.venv' # Don't overwrite this directory with local .venv because uv links won't translate in the container
+    ports:
+      - "8080" # application
+    stdin_open: true
+    tty: true
+    command: >
+      bash -c "
+      gunicorn wsgi_sso_stub:app
+      "
+    environment:
+      FLASK_APP: "stubs.sso"
+      WERKZEUG_DEBUG_PIN: off
+    networks:
+      ofs:
+        aliases:
+          - sso.${PULLPREVIEW_PUBLIC_DNS}
+
 volumes:
   postgres_data:
 

--- a/docker-compose.pullpreview.yml
+++ b/docker-compose.pullpreview.yml
@@ -91,6 +91,7 @@ services:
     environment:
       FLASK_APP: "stubs.sso"
       WERKZEUG_DEBUG_PIN: off
+      FLASK_ENV: pullpreview
     networks:
       ofs:
         aliases:

--- a/docker-compose.pullpreview.yml
+++ b/docker-compose.pullpreview.yml
@@ -44,6 +44,8 @@ services:
         gunicorn wsgi:app
       "
     env_file: .env
+    extra_hosts:
+      - "sso.${PULLPREVIEW_PUBLIC_DNS}:host-gateway"
     environment:
       FLASK_ENV: pullpreview
       DATABASE_HOST: "db"
@@ -53,6 +55,7 @@ services:
       SECRET_KEY: unsafe  # pragma: allowlist secret
       SERVER_NAME: ${PULLPREVIEW_PUBLIC_DNS}
       DEBUG_TB_ENABLED: true
+      AZURE_AD_BASE_URL: https://sso.${PULLPREVIEW_PUBLIC_DNS}/
       # Removes the ConfigPanel, which could show sensitive configuration.
       DEBUG_TB_PANELS: |
         [

--- a/docker-compose.pullpreview.yml
+++ b/docker-compose.pullpreview.yml
@@ -79,7 +79,6 @@ services:
     build: .
     volumes:
       - .:/app
-      - /app/node_modules
       - '/app/.venv' # Don't overwrite this directory with local .venv because uv links won't translate in the container
     ports:
       - "8080" # application

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,7 @@ services:
     environment:
       FLASK_APP: "stubs.sso:create_sso_stub_app"
       WERKZEUG_DEBUG_PIN: off
+      ASSETS_VITE_LIVE_ENABLED: true
     networks:
       ofs:
         aliases:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,7 @@ services:
       uv run flask run --host 0.0.0.0 --port 4005 --debug --cert=/app/certs/cert.pem --key=/app/certs/key.pem
       "
     environment:
-      FLASK_APP: "stubs.sso"
+      FLASK_APP: "stubs.sso:create_sso_stub_app"
       WERKZEUG_DEBUG_PIN: off
     networks:
       ofs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,7 @@ services:
       FLASK_APP: "stubs.sso:create_sso_stub_app"
       WERKZEUG_DEBUG_PIN: off
       ASSETS_VITE_LIVE_ENABLED: true
+      FLASK_ENV: local
     networks:
       ofs:
         aliases:

--- a/stubs/sso/__init__.py
+++ b/stubs/sso/__init__.py
@@ -18,140 +18,146 @@ import time
 import uuid
 from urllib.parse import urlencode
 
-from flask import Flask, redirect, render_template, request
+from flask import Flask, jsonify, redirect, render_template, request
 from govuk_frontend_wtf.main import WTFormsHelpers
 from jinja2 import ChoiceLoader, PackageLoader, PrefixLoader
 
 from stubs.sso.forms import SSOSignInForm
 
-app = Flask(__name__)
-app.config["SECRET_KEY"] = "dummy-value"  # pragma: allowlist secret
-app.config["INTERNAL_DOMAINS"] = ("@communities.gov.uk", "@test.communities.gov.uk")
 
-app.jinja_loader = ChoiceLoader(
-    [
-        PackageLoader("stubs.sso"),
-        PrefixLoader({"govuk_frontend_jinja": PackageLoader("govuk_frontend_jinja")}),
-        PrefixLoader({"govuk_frontend_wtf": PackageLoader("govuk_frontend_wtf")}),
-    ]
-)
+def create_sso_stub_app() -> Flask:
+    app = Flask(__name__)
+    app.config["SECRET_KEY"] = "dummy-value"  # pragma: allowlist secret
+    app.config["INTERNAL_DOMAINS"] = ("@communities.gov.uk", "@test.communities.gov.uk")
 
-WTFormsHelpers(app)
+    app.jinja_loader = ChoiceLoader(
+        [
+            PackageLoader("stubs.sso"),
+            PrefixLoader({"govuk_frontend_jinja": PackageLoader("govuk_frontend_jinja")}),
+            PrefixLoader({"govuk_frontend_wtf": PackageLoader("govuk_frontend_wtf")}),
+        ]
+    )
 
-dummy_nonce = ""
-email_address = ""
+    WTFormsHelpers(app)
 
-dummy_client_info = {"uid": str(uuid.uuid4()), "utid": str(uuid.uuid4())}
-json_dummy_client_info = json.dumps(dummy_client_info)
-base_64_str_client_info = base64.b64encode(json_dummy_client_info.encode()).decode()
+    dummy_nonce = ""  # noqa: F841
+    email_address = ""  # noqa: F841
 
+    dummy_client_info = {"uid": str(uuid.uuid4()), "utid": str(uuid.uuid4())}
+    json_dummy_client_info = json.dumps(dummy_client_info)
+    base_64_str_client_info = base64.b64encode(json_dummy_client_info.encode()).decode()  # noqa: F841
 
-@app.route("/<tenant>/oauth2/v2.0/authorize", methods=["GET", "POST"])
-def oauth_redirect(tenant):
-    global dummy_nonce, base_64_str_client_info, email_address
+    @app.route("/<tenant>/oauth2/v2.0/authorize", methods=["GET", "POST"])
+    def oauth_redirect(tenant):
+        global dummy_nonce, base_64_str_client_info, email_address
 
-    form = SSOSignInForm()
-    if form.validate_on_submit():
-        dummy_nonce = request.args["nonce"]
-        email_address = form.email_address.data
-        data = urlencode(
-            {
-                "code": "dummy value",
-                "client_info": base_64_str_client_info,
-                "state": request.args["state"],
-                "session_state": uuid.uuid4(),
-            }
-        )
-        return redirect(request.args["redirect_uri"] + "?" + data)
-    return render_template("sso/sso_login.html", form=form)
+        form = SSOSignInForm()
+        if form.validate_on_submit():
+            dummy_nonce = request.args["nonce"]
+            email_address = form.email_address.data
+            data = urlencode(
+                {
+                    "code": "dummy value",
+                    "client_info": base_64_str_client_info,
+                    "state": request.args["state"],
+                    "session_state": uuid.uuid4(),
+                }
+            )
+            return redirect(request.args["redirect_uri"] + "?" + data)
+        return render_template("sso/sso_login.html", form=form)
 
+    @app.route("/<tenant>/v2.0/.well-known/openid-configuration")
+    def openid_configuration(tenant):
+        # There are a number of URIs in this dict which we haven't defined in the stub server (eg. jwks_uri,
+        # userinfo_endpoint etc.) which don't get used as part of this journey. If we remove these from the payload
+        # it seems to break the server so they need to be there even if they're not used.
+        return {
+            "token_endpoint": f"https://{request.host}/{tenant}/oauth2/v2.0/token",
+            "token_endpoint_auth_methods_supported": ["client_secret_post", "private_key_jwt", "client_secret_basic"],
+            "jwks_uri": f"https://{request.host}/{tenant}/discovery/v2.0/keys",  # Not used
+            "response_modes_supported": ["query", "fragment", "form_post"],
+            "subject_types_supported": ["pairwise"],
+            "id_token_signing_alg_values_supported": ["RS256"],
+            "response_types_supported": ["code", "id_token", "code id_token", "id_token token"],
+            "scopes_supported": ["openid", "profile", "email", "offline_access"],
+            "issuer": f"https://{request.host}/{tenant}/v2.0",  # Not used
+            "request_uri_parameter_supported": False,
+            "userinfo_endpoint": f"https://{request.host}/oidc/userinfo",  # Not used
+            "authorization_endpoint": f"https://{request.host}/{tenant}/oauth2/v2.0/authorize",
+            "device_authorization_endpoint": f"https://{request.host}/{tenant}/oauth2/v2.0/devicecode",  # Not used
+            "http_logout_supported": True,
+            "frontchannel_logout_supported": True,
+            "end_session_endpoint": f"https://{request.host}/{tenant}/oauth2/v2.0/logout",  # Not used
+            "claims_supported": [
+                "sub",
+                "iss",
+                "cloud_instance_name",
+                "cloud_instance_host_name",
+                "cloud_graph_host_name",
+                "msgraph_host",
+                "aud",
+                "exp",
+                "iat",
+                "auth_time",
+                "acr",
+                "nonce",
+                "preferred_username",
+                "name",
+                "tid",
+                "ver",
+                "at_hash",
+                "c_hash",
+                "email",
+            ],
+            "kerberos_endpoint": f"https://{request.host}/{tenant}/kerberos",  # Not used
+            "tenant_region_scope": "EU",
+            "cloud_instance_name": request.host,
+            # These are dummy values
+            "cloud_graph_host_name": "graph.mhclg.localhost",
+            "msgraph_host": "graph.mhclg.localhost",
+            "rbac_url": "https://pas.mhclg.localhost",
+        }
 
-@app.route("/<tenant>/v2.0/.well-known/openid-configuration")
-def openid_configuration(tenant):
-    # There are a number of URIs in this dict which we haven't defined in the stub server (eg. jwks_uri,
-    # userinfo_endpoint etc.) which don't get used as part of this journey. If we remove these from the payload
-    # it seems to break the server so they need to be there even if they're not used.
-    return {
-        "token_endpoint": f"https://{request.host}/{tenant}/oauth2/v2.0/token",
-        "token_endpoint_auth_methods_supported": ["client_secret_post", "private_key_jwt", "client_secret_basic"],
-        "jwks_uri": f"https://{request.host}/{tenant}/discovery/v2.0/keys",  # Not used
-        "response_modes_supported": ["query", "fragment", "form_post"],
-        "subject_types_supported": ["pairwise"],
-        "id_token_signing_alg_values_supported": ["RS256"],
-        "response_types_supported": ["code", "id_token", "code id_token", "id_token token"],
-        "scopes_supported": ["openid", "profile", "email", "offline_access"],
-        "issuer": f"https://{request.host}/{tenant}/v2.0",  # Not used
-        "request_uri_parameter_supported": False,
-        "userinfo_endpoint": f"https://{request.host}/oidc/userinfo",  # Not used
-        "authorization_endpoint": f"https://{request.host}/{tenant}/oauth2/v2.0/authorize",
-        "device_authorization_endpoint": f"https://{request.host}/{tenant}/oauth2/v2.0/devicecode",  # Not used
-        "http_logout_supported": True,
-        "frontchannel_logout_supported": True,
-        "end_session_endpoint": f"https://{request.host}/{tenant}/oauth2/v2.0/logout",  # Not used
-        "claims_supported": [
-            "sub",
-            "iss",
-            "cloud_instance_name",
-            "cloud_instance_host_name",
-            "cloud_graph_host_name",
-            "msgraph_host",
-            "aud",
-            "exp",
-            "iat",
-            "auth_time",
-            "acr",
-            "nonce",
-            "preferred_username",
-            "name",
-            "tid",
-            "ver",
-            "at_hash",
-            "c_hash",
-            "email",
-        ],
-        "kerberos_endpoint": f"https://{request.host}/{tenant}/kerberos",  # Not used
-        "tenant_region_scope": "EU",
-        "cloud_instance_name": request.host,
-        # These are dummy values
-        "cloud_graph_host_name": "graph.mhclg.localhost",
-        "msgraph_host": "graph.mhclg.localhost",
-        "rbac_url": "https://pas.mhclg.localhost",
-    }
+    @app.route("/<tenant>/oauth2/v2.0/token", methods=["GET", "POST"])
+    def token_endpoint(tenant):
+        global dummy_nonce, base_64_str_client_info, email_address
 
+        # We've replaced a lot of the values in this dictionary with empty strings
+        # as they won't be referenced anywhere else
+        # The only ones that are needed are the global variables, roles and timestamps.
+        # For more info on these look at the docs https://learn.microsoft.com/en-us/entra/identity-platform/id-token-claims-reference
+        return {
+            "token_type": "Bearer",
+            "scope": "User.Read User.ReadBasic.All profile openid email",
+            "expires_in": 3980,
+            "ext_expires_in": 3980,
+            "access_token": "",
+            "refresh_token": "",
+            "client_info": base_64_str_client_info,
+            "id_token_claims": {
+                "aud": "",
+                "iss": "",
+                "iat": int(time.time()),
+                "nbf": int(time.time()),
+                "exp": int(time.time() + 60 * 60),
+                "idp": "",
+                "name": "Dev Developer",
+                "nonce": dummy_nonce,
+                "oid": "",
+                "preferred_username": email_address,
+                "rh": "",
+                "roles": ["FSD_ADMIN"],
+                "sid": "",
+                "sub": "",
+                "tid": "",
+                "uti": "",
+                "ver": "2.0",
+            },
+            "token_source": "identity_provider",
+        }
 
-@app.route("/<tenant>/oauth2/v2.0/token", methods=["GET", "POST"])
-def token_endpoint(tenant):
-    global dummy_nonce, base_64_str_client_info, email_address
+    @app.route("/health", methods=["GET"])
+    def health_endpoint():
+        return jsonify(status="ok", message="Stub server running"), 200
 
-    # We've replaced a lot of the values in this dictionary with empty strings as they won't be referenced anywhere else
-    # The only ones that are needed are the global variables, roles and timestamps.
-    # For more info on these look at the docs https://learn.microsoft.com/en-us/entra/identity-platform/id-token-claims-reference
-    return {
-        "token_type": "Bearer",
-        "scope": "User.Read User.ReadBasic.All profile openid email",
-        "expires_in": 3980,
-        "ext_expires_in": 3980,
-        "access_token": "",
-        "refresh_token": "",
-        "client_info": base_64_str_client_info,
-        "id_token_claims": {
-            "aud": "",
-            "iss": "",
-            "iat": int(time.time()),
-            "nbf": int(time.time()),
-            "exp": int(time.time() + 60 * 60),
-            "idp": "",
-            "name": "Dev Developer",
-            "nonce": dummy_nonce,
-            "oid": "",
-            "preferred_username": email_address,
-            "rh": "",
-            "roles": ["FSD_ADMIN"],
-            "sid": "",
-            "sub": "",
-            "tid": "",
-            "uti": "",
-            "ver": "2.0",
-        },
-        "token_source": "identity_provider",
-    }
+    return app

--- a/stubs/sso/__init__.py
+++ b/stubs/sso/__init__.py
@@ -39,6 +39,7 @@ def create_sso_stub_app() -> Flask:
     app.config["SECRET_KEY"] = "dummy-value"  # pragma: allowlist secret
     app.config["INTERNAL_DOMAINS"] = ("@communities.gov.uk", "@test.communities.gov.uk")
     app.config["ASSETS_VITE_LIVE_ENABLED"] = os.environ.get("ASSETS_VITE_LIVE_ENABLED", False)
+    app.config["FLASK_ENV"] = os.environ.get("FLASK_ENV", "local")
     app.config["ASSETS_VITE_BASE_URL"] = os.environ.get("ASSETS_VITE_BASE_URL", "http://localhost:5173")
 
     app.jinja_loader = ChoiceLoader(

--- a/stubs/sso/templates/sso/sso_login.html
+++ b/stubs/sso/templates/sso/sso_login.html
@@ -8,12 +8,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="theme-color" content="#0b0c0c" />
     {# We're pointing at the vite server used for local development here #}
-    <link rel="icon" sizes="48x48" href="http://localhost:5173/static/assets/images/favicon.ico" />
-    <link rel="icon" sizes="any" href="http://localhost:5173/static/assets/images/favicon.svg" type="image/svg+xml" />
-    <link rel="mask-icon" href="http://localhost:5173/static/assets/images/govuk-icon-mask.svg" color="#0b0c0c" />
-    <link rel="apple-touch-icon" href="http://localhost:5173/static/assets/images/govuk-icon-180.png" />
-    <link rel="manifest" href="http://localhost:5173/static/assets/manifest.json" />
-    <link rel="stylesheet" href="http://localhost:5173/static/app/assets/main.scss" />
+      <link rel="stylesheet" href="{{ vite_asset('app/assets/main.scss') }}" type="text/css" />
+      <script type="module" src="{{ vite_asset('app/assets/main.js') }}"></script>
   </head>
 
   <body class="govuk-template__body">

--- a/wsgi_sso_stub.py
+++ b/wsgi_sso_stub.py
@@ -1,0 +1,10 @@
+from gevent import monkey
+
+from stubs.sso import create_sso_stub_app
+
+monkey.patch_all()
+
+app = create_sso_stub_app()
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
**Ticket : https://mhclgdigital.atlassian.net/browse/FSPT-477**

Following are the implementation steps that I have followed 

1. First I have converted the sso stub app into a another gunicorn service because this sso service if going to pretend like Microsoft login so to do that we have to have this SSO service as a separate service that is the reason behind this change

2. Adding some Network configuration in to the pull preview and in the caddy service I have implemented a subdomain and from this subdomain it will reverse proxy the requests into the correct containers if it has sso.<> then goes to sso stub server here I have added the `AZURE_AD_BASE_URL: https://sso.${PULLPREVIEW_PUBLIC_DNS}/` as a env since for given pullpreview has a different url

Also 

`extra_hosts`: This allows to define additional hostname-to-IP mappings for the container.
`host-gateway`: This tells Docker to resolve the hostname to the IP address of the host machine's gateway. This is particularly useful when you want a container to access services running on the host.

So this will mimic the Microsoft login behaviour 

3. SSO should have some static css, js files with this change it enables to get the static content for the sso service  