### PR TITLE
Rename 'collections' to 'schemas' in the scaffolding

### DIFF
--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -23,7 +23,7 @@ def create_collection_schema(*, name: str, user: User, grant: Grant, version: in
     return schema
 
 
-def get_collection_schema(collection_id: UUID4, version: int | None = None) -> CollectionSchema:
+def get_collection_schema(schema_id: UUID4, version: int | None = None) -> CollectionSchema:
     """Get a collection schema by ID and optionally version.
 
     If you do not pass a version, it will retrieve the latest version (ie highest version number).
@@ -33,28 +33,28 @@ def get_collection_schema(collection_id: UUID4, version: int | None = None) -> C
     if version is None:
         return db.session.scalars(
             select(CollectionSchema)
-            .where(CollectionSchema.id == collection_id)
+            .where(CollectionSchema.id == schema_id)
             .order_by(CollectionSchema.version.desc())
             .limit(1)
         ).one()
 
-    return db.session.get_one(CollectionSchema, [collection_id, version])
+    return db.session.get_one(CollectionSchema, [schema_id, version])
 
 
-def update_collection_schema(collection: CollectionSchema, *, name: str) -> CollectionSchema:
-    collection.name = name
-    collection.slug = slugify(name)
+def update_collection_schema(schema: CollectionSchema, *, name: str) -> CollectionSchema:
+    schema.name = name
+    schema.slug = slugify(name)
     try:
         db.session.flush()
     except IntegrityError as e:
         db.session.rollback()
         raise DuplicateValueError(e) from e
-    return collection
+    return schema
 
 
-def create_section(*, title: str, collection_schema: CollectionSchema) -> Section:
-    section = Section(title=title, collection_schema_id=collection_schema.id, slug=slugify(title))
-    collection_schema.sections.append(section)
+def create_section(*, title: str, schema: CollectionSchema) -> Section:
+    section = Section(title=title, collection_schema_id=schema.id, slug=slugify(title))
+    schema.sections.append(section)
     db.session.add(section)
     try:
         db.session.flush()

--- a/app/deliver_grant_funding/forms.py
+++ b/app/deliver_grant_funding/forms.py
@@ -21,10 +21,10 @@ class GrantForm(FlaskForm):
     submit = SubmitField(widget=GovSubmitInput())
 
 
-class CollectionForm(FlaskForm):
+class SchemaForm(FlaskForm):
     name = StringField(
-        "What is the name of the collection?",
-        validators=[DataRequired("Enter a collection name")],
+        "What is the name of the schema?",
+        validators=[DataRequired("Enter a schema name")],
         filters=[strip_string_if_not_empty],
         widget=GovTextInput(),
     )

--- a/app/deliver_grant_funding/routes.py
+++ b/app/deliver_grant_funding/routes.py
@@ -32,11 +32,11 @@ from app.common.data.interfaces.collections import (
 from app.common.data.interfaces.exceptions import DuplicateValueError
 from app.common.data.models import QuestionDataType, User
 from app.deliver_grant_funding.forms import (
-    CollectionForm,
     FormForm,
     GrantForm,
     QuestionForm,
     QuestionTypeForm,
+    SchemaForm,
     SectionForm,
 )
 from app.extensions import auto_commit_after_request
@@ -105,118 +105,112 @@ def grant_developers(grant_id: UUID4) -> str:
     return render_template("deliver_grant_funding/developers/grant_developers.html", grant=grant)
 
 
-@deliver_grant_funding_blueprint.route("/grants/<uuid:grant_id>/developers/collections", methods=["GET"])
+@deliver_grant_funding_blueprint.route("/grants/<uuid:grant_id>/developers/schemas", methods=["GET"])
 @mhclg_login_required
-def grant_developers_collections(grant_id: UUID4) -> str:
+def grant_developers_schemas(grant_id: UUID4) -> str:
     grant = interfaces.grants.get_grant(grant_id)
-    return render_template("deliver_grant_funding/developers/list_collections.html", grant=grant)
+    return render_template("deliver_grant_funding/developers/list_schemas.html", grant=grant)
 
 
-@deliver_grant_funding_blueprint.route("/grants/<uuid:grant_id>/developers/collections/set-up", methods=["GET", "POST"])
+@deliver_grant_funding_blueprint.route("/grants/<uuid:grant_id>/developers/schemas/set-up", methods=["GET", "POST"])
 @mhclg_login_required
 @auto_commit_after_request
-def setup_collection(grant_id: UUID4) -> ResponseReturnValue:
+def setup_schema(grant_id: UUID4) -> ResponseReturnValue:
     grant = interfaces.grants.get_grant(grant_id)
-    form = CollectionForm()
+    form = SchemaForm()
     if form.validate_on_submit():
         try:
             assert form.name.data is not None
             create_collection_schema(name=form.name.data, user=cast(User, current_user), grant=grant)
-            return redirect(url_for("deliver_grant_funding.grant_developers_collections", grant_id=grant_id))
+            return redirect(url_for("deliver_grant_funding.grant_developers_schemas", grant_id=grant_id))
         except DuplicateValueError as e:
             field_with_error: Field = getattr(form, e.field_name)
             field_with_error.errors.append(f"{field_with_error.name.capitalize()} already in use")  # type:ignore[attr-defined]
-    return render_template("deliver_grant_funding/developers/add_collection.html", grant=grant, form=form)
+    return render_template("deliver_grant_funding/developers/add_schema.html", grant=grant, form=form)
 
 
 @deliver_grant_funding_blueprint.route(
-    "/grants/<uuid:grant_id>/developers/collections/<uuid:collection_id>", methods=["GET", "POST"]
+    "/grants/<uuid:grant_id>/developers/schemas/<uuid:schema_id>", methods=["GET", "POST"]
 )
 @mhclg_login_required
 @auto_commit_after_request
-def manage_collection(grant_id: UUID4, collection_id: UUID4) -> ResponseReturnValue:
-    collection = get_collection_schema(collection_id)  # TODO: handle collection versioning; this just grabs latest.
-    return render_template(
-        "deliver_grant_funding/developers/manage_collection.html", grant=collection.grant, collection=collection
-    )
+def manage_schema(grant_id: UUID4, schema_id: UUID4) -> ResponseReturnValue:
+    schema = get_collection_schema(schema_id)  # TODO: handle collection versioning; this just grabs latest.
+    return render_template("deliver_grant_funding/developers/manage_schema.html", grant=schema.grant, schema=schema)
 
 
 @deliver_grant_funding_blueprint.route(
-    "/grants/<uuid:grant_id>/developers/collections/<uuid:collection_id>/edit", methods=["GET", "POST"]
+    "/grants/<uuid:grant_id>/developers/schemas/<uuid:schema_id>/edit", methods=["GET", "POST"]
 )
 @mhclg_login_required
 @auto_commit_after_request
-def edit_collection(grant_id: UUID4, collection_id: UUID4) -> ResponseReturnValue:
-    collection = get_collection_schema(collection_id)  # TODO: handle collection versioning; this just grabs latest.
-    form = CollectionForm(obj=collection)
+def edit_schema(grant_id: UUID4, schema_id: UUID4) -> ResponseReturnValue:
+    schema = get_collection_schema(schema_id)  # TODO: handle collection versioning; this just grabs latest.
+    form = SchemaForm(obj=schema)
     if form.validate_on_submit():
         try:
             assert form.name.data is not None
-            update_collection_schema(name=form.name.data, collection=collection)
-            return redirect(
-                url_for("deliver_grant_funding.manage_collection", grant_id=grant_id, collection_id=collection_id)
-            )
+            update_collection_schema(name=form.name.data, schema=schema)
+            return redirect(url_for("deliver_grant_funding.manage_schema", grant_id=grant_id, schema_id=schema_id))
         except DuplicateValueError as e:
             field_with_error: Field = getattr(form, e.field_name)
             field_with_error.errors.append(f"{field_with_error.name.capitalize()} already in use")  # type:ignore[attr-defined]
 
     return render_template(
-        "deliver_grant_funding/developers/edit_collection.html",
-        grant=collection.grant,
-        collection=collection,
+        "deliver_grant_funding/developers/edit_schema.html",
+        grant=schema.grant,
+        schema=schema,
         form=form,
     )
 
 
 @deliver_grant_funding_blueprint.route(
-    "/grants/<uuid:grant_id>/developers/collections/<uuid:collection_id>/sections/add", methods=["GET", "POST"]
+    "/grants/<uuid:grant_id>/developers/schemas/<uuid:schema_id>/sections/add", methods=["GET", "POST"]
 )
 @mhclg_login_required
 @auto_commit_after_request
-def add_section(grant_id: UUID4, collection_id: UUID4) -> ResponseReturnValue:
-    collection = get_collection_schema(collection_id)  # TODO: handle collection versioning; this just grabs latest.
+def add_section(grant_id: UUID4, schema_id: UUID4) -> ResponseReturnValue:
+    collection = get_collection_schema(schema_id)  # TODO: handle collection versioning; this just grabs latest.
     form = SectionForm()
     if form.validate_on_submit():
         try:
             assert form.title.data is not None
             create_section(
                 title=form.title.data,
-                collection_schema=collection,
+                schema=collection,
             )
-            return redirect(
-                url_for("deliver_grant_funding.list_sections", grant_id=grant_id, collection_id=collection_id)
-            )
+            return redirect(url_for("deliver_grant_funding.list_sections", grant_id=grant_id, schema_id=schema_id))
         except DuplicateValueError as e:
             field_with_error: Field = getattr(form, e.field_name)
             field_with_error.errors.append(f"{field_with_error.name.capitalize()} already in use")  # type:ignore[attr-defined]
     return render_template(
-        "deliver_grant_funding/developers/add_section.html", grant=collection.grant, collection=collection, form=form
+        "deliver_grant_funding/developers/add_section.html", grant=collection.grant, schema=collection, form=form
     )
 
 
 @deliver_grant_funding_blueprint.route(
-    "/grants/<uuid:grant_id>/developers/collections/<uuid:collection_id>/sections/", methods=["GET"]
+    "/grants/<uuid:grant_id>/developers/schemas/<uuid:schema_id>/sections/", methods=["GET"]
 )
 @mhclg_login_required
 def list_sections(
     grant_id: UUID4,
-    collection_id: UUID4,
+    schema_id: UUID4,
 ) -> ResponseReturnValue:
-    collection_schema = get_collection_schema(collection_id)
+    collection_schema = get_collection_schema(schema_id)
     return render_template(
         "deliver_grant_funding/developers/list_sections.html",
         grant=collection_schema.grant,
-        collection=collection_schema,
+        schema=collection_schema,
     )
 
 
 @deliver_grant_funding_blueprint.route(
-    "/grants/<uuid:grant_id>/developers/collections/<uuid:collection_id>/sections/<uuid:section_id>/move/<string:direction>",
+    "/grants/<uuid:grant_id>/developers/schemas/<uuid:schema_id>/sections/<uuid:section_id>/move/<string:direction>",
     methods=["POST"],
 )
 @mhclg_login_required
 @auto_commit_after_request
-def move_section(grant_id: UUID4, collection_id: UUID4, section_id: UUID4, direction: str) -> ResponseReturnValue:
+def move_section(grant_id: UUID4, schema_id: UUID4, section_id: UUID4, direction: str) -> ResponseReturnValue:
     section = get_section_by_id(section_id)
 
     if direction == "up":
@@ -226,36 +220,36 @@ def move_section(grant_id: UUID4, collection_id: UUID4, section_id: UUID4, direc
     else:
         abort(400)
 
-    return redirect(url_for("deliver_grant_funding.list_sections", grant_id=grant_id, collection_id=collection_id))
+    return redirect(url_for("deliver_grant_funding.list_sections", grant_id=grant_id, schema_id=schema_id))
 
 
 @deliver_grant_funding_blueprint.route(
-    "/grants/<uuid:grant_id>/developers/collections/<uuid:collection_id>/sections/<uuid:section_id>/manage",
+    "/grants/<uuid:grant_id>/developers/schemas/<uuid:schema_id>/sections/<uuid:section_id>/manage",
     methods=["GET"],
 )
 @mhclg_login_required
 def manage_section(
     grant_id: UUID4,
-    collection_id: UUID4,
+    schema_id: UUID4,
     section_id: UUID4,
 ) -> ResponseReturnValue:
     section = get_section_by_id(section_id)
     return render_template(
         "deliver_grant_funding/developers/manage_section.html",
         grant=section.collection_schema.grant,
-        collection=section.collection_schema,
+        schema=section.collection_schema,
         section=section,
     )
 
 
 @deliver_grant_funding_blueprint.route(
-    "/grants/<uuid:grant_id>/developers/collections/<uuid:collection_id>/sections/<uuid:section_id>/forms/<uuid:form_id>/move/<string:direction>",
+    "/grants/<uuid:grant_id>/developers/schemas/<uuid:schema_id>/sections/<uuid:section_id>/forms/<uuid:form_id>/move/<string:direction>",
     methods=["POST"],
 )
 @mhclg_login_required
 @auto_commit_after_request
 def move_form(
-    grant_id: UUID4, collection_id: UUID4, section_id: UUID4, form_id: UUID4, direction: str
+    grant_id: UUID4, schema_id: UUID4, section_id: UUID4, form_id: UUID4, direction: str
 ) -> ResponseReturnValue:
     form = get_form_by_id(form_id)
 
@@ -270,42 +264,42 @@ def move_form(
         url_for(
             "deliver_grant_funding.manage_section",
             grant_id=grant_id,
-            collection_id=collection_id,
+            schema_id=schema_id,
             section_id=section_id,
         )
     )
 
 
 @deliver_grant_funding_blueprint.route(
-    "/grants/<uuid:grant_id>/developers/collections/<uuid:collection_id>/sections/<uuid:section_id>/forms/<uuid:form_id>/manage",
+    "/grants/<uuid:grant_id>/developers/schemas/<uuid:schema_id>/sections/<uuid:section_id>/forms/<uuid:form_id>/manage",
     methods=["GET"],
 )
 @mhclg_login_required
-def manage_form(grant_id: UUID4, collection_id: UUID4, section_id: UUID4, form_id: UUID4) -> ResponseReturnValue:
+def manage_form(grant_id: UUID4, schema_id: UUID4, section_id: UUID4, form_id: UUID4) -> ResponseReturnValue:
     form = get_form_by_id(form_id)
 
     return render_template(
         "deliver_grant_funding/developers/manage_form.html",
         grant=form.section.collection_schema.grant,
         section=form.section,
-        collection=form.section.collection_schema,
+        schema=form.section.collection_schema,
         form=form,
         back_link_href=url_for(
             f"deliver_grant_funding.{request.args.get('back_link')}",
             grant_id=grant_id,
-            collection_id=collection_id,
+            schema_id=schema_id,
             section_id=section_id,
         ),
     )
 
 
 @deliver_grant_funding_blueprint.route(
-    "/grants/<uuid:grant_id>/developers/collections/<uuid:collection_id>/sections/<uuid:section_id>/edit",
+    "/grants/<uuid:grant_id>/developers/schemas/<uuid:schema_id>/sections/<uuid:section_id>/edit",
     methods=["GET", "POST"],
 )
 @mhclg_login_required
 @auto_commit_after_request
-def edit_section(grant_id: UUID4, collection_id: UUID4, section_id: UUID4) -> ResponseReturnValue:
+def edit_section(grant_id: UUID4, schema_id: UUID4, section_id: UUID4) -> ResponseReturnValue:
     section = get_section_by_id(section_id)
     form = SectionForm(obj=section)
     if form.validate_on_submit():
@@ -316,7 +310,7 @@ def edit_section(grant_id: UUID4, collection_id: UUID4, section_id: UUID4) -> Re
                 url_for(
                     "deliver_grant_funding.manage_section",
                     grant_id=grant_id,
-                    collection_id=collection_id,
+                    schema_id=schema_id,
                     section_id=section_id,
                 )
             )
@@ -327,26 +321,26 @@ def edit_section(grant_id: UUID4, collection_id: UUID4, section_id: UUID4) -> Re
     return render_template(
         "deliver_grant_funding/developers/edit_section.html",
         grant=section.collection_schema.grant,
-        collection=section.collection_schema,
+        schema=section.collection_schema,
         section=section,
         form=form,
     )
 
 
 @deliver_grant_funding_blueprint.route(
-    "/grants/<uuid:grant_id>/developers/collections/<uuid:collection_id>/sections/<uuid:section_id>/forms/add",
+    "/grants/<uuid:grant_id>/developers/schemas/<uuid:schema_id>/sections/<uuid:section_id>/forms/add",
     methods=["GET", "POST"],
 )
 @mhclg_login_required
 @auto_commit_after_request
-def add_form(grant_id: UUID4, collection_id: UUID4, section_id: UUID4) -> ResponseReturnValue:
+def add_form(grant_id: UUID4, schema_id: UUID4, section_id: UUID4) -> ResponseReturnValue:
     section = get_section_by_id(section_id)
     form_type = request.args.get("form_type", None)
     if not form_type:
         return render_template(
             "deliver_grant_funding/developers/select_form_type.html",
             grant=section.collection_schema.grant,
-            collection=section.collection_schema,
+            schema=section.collection_schema,
             section=section,
         )
 
@@ -359,7 +353,7 @@ def add_form(grant_id: UUID4, collection_id: UUID4, section_id: UUID4) -> Respon
                 url_for(
                     "deliver_grant_funding.manage_section",
                     grant_id=grant_id,
-                    collection_id=collection_id,
+                    schema_id=schema_id,
                     section_id=section_id,
                 )
             )
@@ -369,7 +363,7 @@ def add_form(grant_id: UUID4, collection_id: UUID4, section_id: UUID4) -> Respon
     return render_template(
         "deliver_grant_funding/developers/add_form.html",
         grant=section.collection_schema.grant,
-        collection=section.collection_schema,
+        schema=section.collection_schema,
         section=section,
         form_type=form_type,
         form=form,
@@ -377,12 +371,12 @@ def add_form(grant_id: UUID4, collection_id: UUID4, section_id: UUID4) -> Respon
 
 
 @deliver_grant_funding_blueprint.route(
-    "/grants/<uuid:grant_id>/developers/collections/<uuid:collection_id>/sections/<uuid:section_id>/forms/<uuid:form_id>/edit",
+    "/grants/<uuid:grant_id>/developers/schemas/<uuid:schema_id>/sections/<uuid:section_id>/forms/<uuid:form_id>/edit",
     methods=["GET", "POST"],
 )
 @mhclg_login_required
 @auto_commit_after_request
-def edit_form(grant_id: UUID4, collection_id: UUID4, section_id: UUID4, form_id: UUID4) -> ResponseReturnValue:
+def edit_form(grant_id: UUID4, schema_id: UUID4, section_id: UUID4, form_id: UUID4) -> ResponseReturnValue:
     db_form = get_form_by_id(form_id)
     wt_form = FormForm(obj=db_form)
     if wt_form.validate_on_submit():
@@ -393,7 +387,7 @@ def edit_form(grant_id: UUID4, collection_id: UUID4, section_id: UUID4, form_id:
                 url_for(
                     "deliver_grant_funding.manage_form",
                     grant_id=grant_id,
-                    collection_id=collection_id,
+                    schema_id=schema_id,
                     section_id=section_id,
                     form_id=form_id,
                     back_link="manage_section",
@@ -406,7 +400,7 @@ def edit_form(grant_id: UUID4, collection_id: UUID4, section_id: UUID4, form_id:
     return render_template(
         "deliver_grant_funding/developers/edit_form.html",
         grant=db_form.section.collection_schema.grant,
-        collection=db_form.section.collection_schema,
+        schema=db_form.section.collection_schema,
         section=db_form.section,
         db_form=db_form,
         form=wt_form,
@@ -414,13 +408,11 @@ def edit_form(grant_id: UUID4, collection_id: UUID4, section_id: UUID4, form_id:
 
 
 @deliver_grant_funding_blueprint.route(
-    "/grants/<uuid:grant_id>/developers/collections/<uuid:collection_id>/sections/<uuid:section_id>/forms/<uuid:form_id>/questions/add/choose-type",
+    "/grants/<uuid:grant_id>/developers/schemas/<uuid:schema_id>/sections/<uuid:section_id>/forms/<uuid:form_id>/questions/add/choose-type",
     methods=["GET", "POST"],
 )
 @mhclg_login_required
-def choose_question_type(
-    grant_id: UUID4, collection_id: UUID4, section_id: UUID4, form_id: UUID4
-) -> ResponseReturnValue:
+def choose_question_type(grant_id: UUID4, schema_id: UUID4, section_id: UUID4, form_id: UUID4) -> ResponseReturnValue:
     db_form = get_form_by_id(form_id)
     wt_form = QuestionTypeForm(question_data_type=request.args.get("question_data_type", None))
     if wt_form.validate_on_submit():
@@ -429,7 +421,7 @@ def choose_question_type(
             url_for(
                 "deliver_grant_funding.add_question",
                 grant_id=grant_id,
-                collection_id=collection_id,
+                schema_id=schema_id,
                 section_id=section_id,
                 form_id=form_id,
                 question_data_type=question_data_type,
@@ -438,7 +430,7 @@ def choose_question_type(
     return render_template(
         "deliver_grant_funding/developers/choose_question_type.html",
         grant=db_form.section.collection_schema.grant,
-        collection=db_form.section.collection_schema,
+        schema=db_form.section.collection_schema,
         section=db_form.section,
         db_form=db_form,
         form=wt_form,
@@ -446,12 +438,12 @@ def choose_question_type(
 
 
 @deliver_grant_funding_blueprint.route(
-    "/grants/<uuid:grant_id>/developers/collections/<uuid:collection_id>/sections/<uuid:section_id>/forms/<uuid:form_id>/questions/add",
+    "/grants/<uuid:grant_id>/developers/schemas/<uuid:schema_id>/sections/<uuid:section_id>/forms/<uuid:form_id>/questions/add",
     methods=["GET", "POST"],
 )
 @mhclg_login_required
 @auto_commit_after_request
-def add_question(grant_id: UUID4, collection_id: UUID4, section_id: UUID4, form_id: UUID4) -> ResponseReturnValue:
+def add_question(grant_id: UUID4, schema_id: UUID4, section_id: UUID4, form_id: UUID4) -> ResponseReturnValue:
     form = get_form_by_id(form_id)
     question_data_type_arg = request.args.get("question_data_type", QuestionDataType.TEXT_SINGLE_LINE.name)
     question_data_type_enum = QuestionDataType.coerce(question_data_type_arg)
@@ -473,7 +465,7 @@ def add_question(grant_id: UUID4, collection_id: UUID4, section_id: UUID4, form_
                 url_for(
                     "deliver_grant_funding.manage_form",
                     grant_id=grant_id,
-                    collection_id=collection_id,
+                    schema_id=schema_id,
                     section_id=section_id,
                     form_id=form_id,
                     back_link="manage_section",
@@ -486,7 +478,7 @@ def add_question(grant_id: UUID4, collection_id: UUID4, section_id: UUID4, form_
     return render_template(
         "deliver_grant_funding/developers/add_question.html",
         grant=form.section.collection_schema.grant,
-        collection=form.section.collection_schema,
+        schema=form.section.collection_schema,
         section=form.section,
         db_form=form,
         chosen_question_data_type=question_data_type_enum,
@@ -495,13 +487,13 @@ def add_question(grant_id: UUID4, collection_id: UUID4, section_id: UUID4, form_
 
 
 @deliver_grant_funding_blueprint.route(
-    "/grants/<uuid:grant_id>/developers/collections/<uuid:collection_id>/sections/<uuid:section_id>/forms/<uuid:form_id>/questions/<uuid:question_id>/move/<string:direction>",
+    "/grants/<uuid:grant_id>/developers/schemas/<uuid:schema_id>/sections/<uuid:section_id>/forms/<uuid:form_id>/questions/<uuid:question_id>/move/<string:direction>",
     methods=["POST"],
 )
 @mhclg_login_required
 @auto_commit_after_request
 def move_question(
-    grant_id: UUID4, collection_id: UUID4, section_id: UUID4, form_id: UUID4, question_id: UUID4, direction: str
+    grant_id: UUID4, schema_id: UUID4, section_id: UUID4, form_id: UUID4, question_id: UUID4, direction: str
 ) -> ResponseReturnValue:
     question = get_question_by_id(question_id=question_id)
 
@@ -516,7 +508,7 @@ def move_question(
         url_for(
             "deliver_grant_funding.manage_form",
             grant_id=grant_id,
-            collection_id=collection_id,
+            schema_id=schema_id,
             section_id=section_id,
             form_id=form_id,
             back_link="manage_section",
@@ -525,13 +517,13 @@ def move_question(
 
 
 @deliver_grant_funding_blueprint.route(
-    "/grants/<uuid:grant_id>/developers/collections/<uuid:collection_id>/sections/<uuid:section_id>/forms/<uuid:form_id>/questions/<uuid:question_id>/edit",
+    "/grants/<uuid:grant_id>/developers/schemas/<uuid:schema_id>/sections/<uuid:section_id>/forms/<uuid:form_id>/questions/<uuid:question_id>/edit",
     methods=["GET", "POST"],
 )
 @mhclg_login_required
 @auto_commit_after_request
 def edit_question(
-    grant_id: UUID4, collection_id: UUID4, section_id: UUID4, form_id: UUID4, question_id: UUID4
+    grant_id: UUID4, schema_id: UUID4, section_id: UUID4, form_id: UUID4, question_id: UUID4
 ) -> ResponseReturnValue:
     question = get_question_by_id(question_id=question_id)
     wt_form = QuestionForm(obj=question)
@@ -545,7 +537,7 @@ def edit_question(
                 url_for(
                     "deliver_grant_funding.manage_form",
                     grant_id=grant_id,
-                    collection_id=collection_id,
+                    schema_id=schema_id,
                     section_id=section_id,
                     form_id=form_id,
                     back_link="manage_section",
@@ -558,7 +550,7 @@ def edit_question(
     return render_template(
         "deliver_grant_funding/developers/edit_question.html",
         grant=question.form.section.collection_schema.grant,
-        collection=question.form.section.collection_schema,
+        schema=question.form.section.collection_schema,
         section=question.form.section,
         db_form=question.form,
         question=question,

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/developers/add_form.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/developers/add_form.html
@@ -13,7 +13,7 @@
   {{
     govukBackLink({
         "text": "Back",
-        "href": url_for("deliver_grant_funding.add_form", grant_id = grant.id, collection_id = collection.id, section_id=section.id)
+        "href": url_for("deliver_grant_funding.add_form", grant_id = grant.id, schema_id=schema.id, section_id=section.id)
     })
   }}
 {% endblock beforeContent %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/developers/add_question.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/developers/add_question.html
@@ -12,7 +12,7 @@
   {{
     govukBackLink({
         "text": "Back",
-        "href": url_for("deliver_grant_funding.choose_question_type", grant_id = grant.id, collection_id = collection.id, section_id=section.id, form_id=db_form.id, question_data_type=chosen_question_data_type.name, back_link="manage_section")
+        "href": url_for("deliver_grant_funding.choose_question_type", grant_id = grant.id, schema_id=schema.id, section_id=section.id, form_id=db_form.id, question_data_type=chosen_question_data_type.name, back_link="manage_section")
     })
   }}
 {% endblock beforeContent %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/developers/add_schema.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/developers/add_schema.html
@@ -12,7 +12,7 @@
   {{
     govukBackLink({
         "text": "Back",
-        "href": url_for("deliver_grant_funding.grant_developers_collections", grant_id = grant.id)
+        "href": url_for("deliver_grant_funding.grant_developers_schemas", grant_id = grant.id)
     })
   }}
 {% endblock beforeContent %}
@@ -28,7 +28,7 @@
         }}
         {{
           form.submit(params={
-              "text": "Set up collection"
+              "text": "Set up schema"
           })
         }}
       </form>

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/developers/add_section.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/developers/add_section.html
@@ -3,7 +3,7 @@
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block pageTitle %}
-  Add a section - {{ collection.name }} - MHCLG Funding Service
+  Add a section - {{ schema.name }} - MHCLG Funding Service
 {% endblock pageTitle %}
 
 {% set active_sub_navigation_tab = "grant_developers" %}
@@ -12,7 +12,7 @@
   {{
     govukBackLink({
         "text": "Back",
-        "href": url_for("deliver_grant_funding.manage_collection", grant_id = grant.id, collection_id = collection.id)
+        "href": url_for("deliver_grant_funding.manage_schema", grant_id = grant.id, schema_id=schema.id)
     })
   }}
 {% endblock beforeContent %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/developers/choose_question_type.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/developers/choose_question_type.html
@@ -14,7 +14,7 @@
   {{
     govukBackLink({
         "text": "Back",
-        "href": url_for("deliver_grant_funding.manage_form", grant_id = grant.id, collection_id = collection.id, section_id=section.id, form_id=db_form.id, back_link="manage_section")
+        "href": url_for("deliver_grant_funding.manage_form", grant_id = grant.id, schema_id=schema.id, section_id=section.id, form_id=db_form.id, back_link="manage_section")
     })
   }}
 {% endblock beforeContent %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/developers/edit_form.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/developers/edit_form.html
@@ -12,7 +12,7 @@
   {{
     govukBackLink({
         "text": "Back",
-        "href": url_for("deliver_grant_funding.manage_form", grant_id = grant.id, collection_id = collection.id, section_id=section.id, form_id=db_form.id, back_link="manage_section")
+        "href": url_for("deliver_grant_funding.manage_form", grant_id = grant.id, schema_id=schema.id, section_id=section.id, form_id=db_form.id, back_link="manage_section")
     })
   }}
 {% endblock beforeContent %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/developers/edit_question.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/developers/edit_question.html
@@ -14,7 +14,7 @@
   {{
     govukBackLink({
         "text": "Back",
-        "href": url_for("deliver_grant_funding.manage_form", grant_id = grant.id, collection_id = collection.id, section_id=section.id, form_id=db_form.id, back_link="manage_section")
+        "href": url_for("deliver_grant_funding.manage_form", grant_id = grant.id, schema_id=schema.id, section_id=section.id, form_id=db_form.id, back_link="manage_section")
     })
   }}
 {% endblock beforeContent %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/developers/edit_schema.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/developers/edit_schema.html
@@ -12,7 +12,7 @@
   {{
     govukBackLink({
       "text": "Back",
-      "href": url_for("deliver_grant_funding.manage_collection", grant_id=grant.id, collection_id = collection.id)
+      "href": url_for("deliver_grant_funding.manage_schema", grant_id=grant.id, schema_id=schema.id)
     })
   }}
 {% endblock %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/developers/edit_section.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/developers/edit_section.html
@@ -12,7 +12,7 @@
   {{
     govukBackLink({
       "text": "Back",
-      "href": url_for("deliver_grant_funding.manage_section", grant_id=grant.id, collection_id = collection.id, section_id = section.id)
+      "href": url_for("deliver_grant_funding.manage_section", grant_id=grant.id, schema_id=schema.id, section_id = section.id)
     })
   }}
 {% endblock %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/developers/grant_developers.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/developers/grant_developers.html
@@ -23,14 +23,15 @@
   <hr class="govuk-section-break govuk-section-break--visible" />
   {{
     govukSummaryList({
-        "rows": [{
+        "rows": [
+        {
             "key": {
-                "text": "Collections",
+                "text": "Schemas",
                 "classes": "govuk-!-padding-top-4 govuk-!-padding-bottom-4"
             },
-            "value": { "text": ( grant.collection_schemas | length | string ) + " preview collections" },
+            "value": { "text": ( grant.collection_schemas | length | string ) + " preview schemas" },
             "actions": {
-                "items": [{ "text": "Manage", "href": url_for('deliver_grant_funding.grant_developers_collections', grant_id = grant.id), "classes": "govuk-link--no-visited-state" }]
+                "items": [{ "text": "Manage", "href": url_for('deliver_grant_funding.grant_developers_schemas', grant_id = grant.id), "classes": "govuk-link--no-visited-state" }]
             },
         }]
     })

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/developers/list_schemas.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/developers/list_schemas.html
@@ -4,7 +4,7 @@
 {% extends "deliver_grant_funding/manage_grant_base.html" %}
 
 {% block pageTitle %}
-  Collections - {{ grant.name }} - MHCLG Funding Service
+  Schemas - {{ grant.name }} - MHCLG Funding Service
 {% endblock pageTitle %}
 
 {% set active_sub_navigation_tab = "grant_developers" %}
@@ -13,24 +13,24 @@
   <div class="app-body__watermark" aria-hidden="true">Developers</div>
   <h1 class="govuk-heading-l">
     <span class="govuk-caption-l">{{ grant.name }}</span>
-    Collections
+    Schemas
   </h1>
-  <p class="govuk-body">Use preview collections to try out the tools to set up, collect and review information from users.</p>
+  <p class="govuk-body">Use preview schemas to try out the tools to set up, collect and review information from users.</p>
 
-  <h2 class="govuk-heading-m">Collections</h2>
+  <h2 class="govuk-heading-m">Schemas</h2>
 
   {% set rows=[] %}
-  {% for collection in grant.collection_schemas %}
+  {% for schema in grant.collection_schemas %}
     {%
       do rows.append([{
-      "html": "<a class='govuk-link govuk-link--no-visited-state' href='" + url_for("deliver_grant_funding.manage_collection", grant_id = grant.id, collection_id = collection.id) + "'>" + collection.name + "</a>",
-      }, {"text": collection.created_by.email}, {"text": format_date(collection.created_at_utc)}])
+      "html": "<a class='govuk-link govuk-link--no-visited-state' href='" + url_for("deliver_grant_funding.manage_schema", grant_id = grant.id, schema_id=schema.id) + "'>" + schema.name + "</a>",
+      }, {"text": schema.created_by.email}, {"text": format_date(schema.created_at_utc)}])
     %}
   {% endfor %}
   {% if not grant.collection_schemas %}
     <p class="govuk-body">
-      This grant has no collections, you can
-      <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.setup_collection', grant_id = grant.id) }}">add a collection</a>
+      This grant has no schemas, you can
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.setup_schema', grant_id = grant.id) }}">add a schema</a>
       .
     </p>
   {% else %}
@@ -53,9 +53,9 @@
     }}
     {{
       govukButton({
-      "text": "Add collection",
+      "text": "Add schema",
       "classes": "govuk-button--secondary",
-      "href": url_for("deliver_grant_funding.setup_collection", grant_id = grant.id)
+      "href": url_for("deliver_grant_funding.setup_schema", grant_id = grant.id)
       })
     }}
   {% endif %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/developers/list_sections.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/developers/list_sections.html
@@ -4,7 +4,7 @@
 {% extends "deliver_grant_funding/manage_grant_base.html" %}
 
 {% block pageTitle %}
-  {{ collection.name }}
+  {{ schema.name }}
   - {{ grant.name }} - MHCLG Funding Service
 {% endblock pageTitle %}
 
@@ -13,7 +13,7 @@
   {{
     govukBackLink({
         "text": "Back",
-        "href": url_for("deliver_grant_funding.manage_collection", grant_id = grant.id, collection_id= collection.id)
+        "href": url_for("deliver_grant_funding.manage_schema", grant_id = grant.id, schema_id= schema.id)
     })
   }}
 {% endblock beforeContent %}
@@ -21,41 +21,41 @@
 {% block content %}
   <div class="app-body__watermark" aria-hidden="true">Scaffolding</div>
   <h1 class="govuk-heading-l">
-    <span class="govuk-caption-l">{{ collection.name }}</span>
+    <span class="govuk-caption-l">{{ schema.name }}</span>
     Sections
   </h1>
 
   {% set sections_text %}
-    {% trans count=collection.sections | length %}
+    {% trans count=schema.sections | length %}
       {{ count }}
       section {% pluralize %}
       {{ count }}
       sections
     {% endtrans %}
   {% endset %}
-  {% if not collection.sections %}
+  {% if not schema.sections %}
     <p class="govuk-body">
-      This collection has no sections, you can
-      <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.add_section', grant_id = grant.id, collection_id = collection.id) }}">add a section</a>
+      This schema has no sections, you can
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.add_section', grant_id = grant.id, schema_id=schema.id) }}">add a section</a>
       .
     </p>
   {% else %}
-    <p class="govuk-body">This collection has {{ sections_text }}</p>
+    <p class="govuk-body">This schema has {{ sections_text }}</p>
 
     {% set section_rows = [] %}
     {% set table_rows = [] %}
-    {% for section in collection.sections %}
+    {% for section in schema.sections %}
       {%
         do table_rows.append({
         "text": section.title,
         "actions":[
         {"text":"Move up",
-            "href":url_for('deliver_grant_funding.move_section', grant_id = grant.id, collection_id = collection.id,
+            "href":url_for('deliver_grant_funding.move_section', grant_id = grant.id, schema_id=schema.id,
                    section_id = section.id, direction = 'up'),"disabled":(loop.index <= 1), "post":true},
-                   {"href":url_for('deliver_grant_funding.move_section', grant_id = grant.id, collection_id = collection.id,
+                   {"href":url_for('deliver_grant_funding.move_section', grant_id = grant.id, schema_id=schema.id,
                    section_id = section.id, direction = 'down') ,
-                "text": "Move down","disabled":(loop.index >= collection.sections | length), "post":true},
-                {"href":url_for('deliver_grant_funding.manage_section', grant_id = grant.id, collection_id = collection.id,
+                "text": "Move down","disabled":(loop.index >= schema.sections | length), "post":true},
+                {"href":url_for('deliver_grant_funding.manage_section', grant_id = grant.id, schema_id=schema.id,
                    section_id = section.id),
                 "text": "Manage","post":false}
         ]
@@ -63,14 +63,14 @@
       %}
     {% endfor %}
 
-    {% if collection.sections %}
+    {% if schema.sections %}
       {{ moveUpDownTable(table_rows) }}
     {% endif %}
     {{
       govukButton({
       "text": "Add a section",
       "classes": "govuk-button--secondary",
-      "href": url_for("deliver_grant_funding.add_section", grant_id = grant.id, collection_id = collection.id)
+      "href": url_for("deliver_grant_funding.add_section", grant_id = grant.id, schema_id=schema.id)
       })
     }}
   {% endif %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/developers/manage_form.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/developers/manage_form.html
@@ -6,7 +6,7 @@
 {% extends "deliver_grant_funding/manage_grant_base.html" %}
 
 {% block pageTitle %}
-    {{ collection.name }}
+    {{ schema.name }}
     - {{ grant.name }} - MHCLG Funding Service
 {% endblock pageTitle %}
 
@@ -36,7 +36,7 @@
               "actions": {
                   "items": [
                       {
-                        "href": url_for("deliver_grant_funding.edit_form", grant_id = grant.id, collection_id = collection.id, section_id = section.id, form_id = form.id),
+                        "href": url_for("deliver_grant_funding.edit_form", grant_id = grant.id, schema_id = schema.id, section_id = section.id, form_id = form.id),
                         "text": "Change",
                         "classes": "govuk-link govuk-link--no-visited-state"
                       }
@@ -57,12 +57,12 @@
           "text": question.text,
           "actions":[
           {"text":"Move up",
-              "href":url_for('deliver_grant_funding.move_question', grant_id = grant.id, collection_id = collection.id,
+              "href":url_for('deliver_grant_funding.move_question', grant_id = grant.id, schema_id = schema.id,
                      section_id = section.id, form_id=form.id, question_id=question.id, direction = 'up'),"disabled":(loop.index <= 1), "post":true},
-                     {"href":url_for('deliver_grant_funding.move_question', grant_id = grant.id, collection_id = collection.id,
+                     {"href":url_for('deliver_grant_funding.move_question', grant_id = grant.id, schema_id = schema.id,
                      section_id = section.id, form_id=form.id, question_id=question.id, direction = 'down') ,"post":true,
                   "text": "Move down","disabled":(loop.index >= form.questions | length)},
-                  {"href":url_for('deliver_grant_funding.edit_question', grant_id = grant.id, collection_id = collection.id,
+                  {"href":url_for('deliver_grant_funding.edit_question', grant_id = grant.id, schema_id = schema.id,
                    section_id = section.id, form_id=form.id, question_id=question.id),
                   "text": "Manage","post":false}
           ]
@@ -75,7 +75,7 @@
             {{ govukButton({
         "text": "Add question",
         "classes": "govuk-button--secondary",
-        "href": url_for("deliver_grant_funding.choose_question_type", grant_id=grant.id, collection_id=collection.id, section_id=section.id, form_id=form.id),
+        "href": url_for("deliver_grant_funding.choose_question_type", grant_id=grant.id, schema_id=schema.id, section_id=section.id, form_id=form.id),
     }) }}
 
 
@@ -84,7 +84,7 @@
             <p class="govuk-body">
                 This form has no questions, you can
                 <a class="govuk-link govuk-link--no-visited-state"
-                   href="{{ url_for('deliver_grant_funding.choose_question_type', grant_id=grant.id, collection_id=collection.id, section_id=section.id, form_id=form.id) }}">add
+                   href="{{ url_for('deliver_grant_funding.choose_question_type', grant_id=grant.id, schema_id=schema.id, section_id=section.id, form_id=form.id) }}">add
                     a question</a>
                 .
             </p>

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/developers/manage_schema.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/developers/manage_schema.html
@@ -5,7 +5,7 @@
 {% extends "deliver_grant_funding/manage_grant_base.html" %}
 
 {% block pageTitle %}
-  {{ collection.name }}
+  {{ schema.name }}
   - {{ grant.name }} - MHCLG Funding Service
 {% endblock pageTitle %}
 
@@ -14,7 +14,7 @@
   {{
     govukBackLink({
         "text": "Back",
-        "href": url_for("deliver_grant_funding.grant_developers_collections", grant_id = grant.id)
+        "href": url_for("deliver_grant_funding.grant_developers_schemas", grant_id = grant.id)
     })
   }}
 {% endblock beforeContent %}
@@ -23,10 +23,10 @@
   <div class="app-body__watermark" aria-hidden="true">Developers</div>
   <h1 class="govuk-heading-l">
     <span class="govuk-caption-l">{{ grant.name }}</span>
-    {{ collection.name }}
+    {{ schema.name }}
   </h1>
   {% set sections_text %}
-    {% trans count=collection.sections | length %}
+    {% trans count=schema.sections | length %}
       {{ count }}
       section {% pluralize %}
       {{ count }}
@@ -39,11 +39,11 @@
         govukSummaryList({
           "rows": [{
               "key": {"text": "Name"},
-              "value":{"text": collection.name},
+              "value":{"text": schema.name},
               "actions": {
                   "items": [
                       {
-                        "href": url_for("deliver_grant_funding.edit_collection", grant_id = grant.id, collection_id = collection.id),
+                        "href": url_for("deliver_grant_funding.edit_schema", grant_id = grant.id, schema_id=schema.id),
                         "text": "Change",
                         "classes": "govuk-link govuk-link--no-visited-state"
                       }
@@ -55,7 +55,7 @@
               "actions": {
                   "items": [
                       {
-                        "href": url_for("deliver_grant_funding.list_sections", grant_id = grant.id, collection_id = collection.id),
+                        "href": url_for("deliver_grant_funding.list_sections", grant_id = grant.id, schema_id=schema.id),
                         "text": "Manage",
                         "classes": "govuk-link govuk-link--no-visited-state"
                       }
@@ -65,10 +65,10 @@
         })
       }}
 
-      {% if not collection.sections %}
+      {% if not schema.sections %}
         <p class="govuk-body">
-          This collection has no sections, you can
-          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.add_section', grant_id = grant.id, collection_id = collection.id) }}">add a section</a>
+          This schema has no sections, you can
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.add_section', grant_id = grant.id, schema_id=schema.id) }}">add a section</a>
           .
         </p>
       {% endif %}
@@ -76,13 +76,13 @@
   </div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      {% for section in collection.sections %}
+      {% for section in schema.sections %}
         <h2 class="govuk-heading-m">{{ section.title }}</h2>
 
         {% if not section.forms %}
           <p class="govuk-body">
             This section has no forms, you can
-            <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.add_form', grant_id = grant.id, collection_id = collection.id, section_id=section.id) }}">add a form</a>
+            <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.add_form', grant_id = grant.id, schema_id=schema.id, section_id=section.id) }}">add a form</a>
             .
           </p>
         {% endif %}
@@ -105,7 +105,7 @@
                 "status": {
                   "text": question_text
                 },
-              "href": url_for("deliver_grant_funding.manage_form", grant_id = grant.id, collection_id = collection.id, section_id = section.id, form_id=form.id, back_link="manage_collection")
+              "href": url_for("deliver_grant_funding.manage_form", grant_id = grant.id, schema_id=schema.id, section_id = section.id, form_id=form.id, back_link="manage_schema")
             })
           %}
         {% endfor %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/developers/manage_section.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/developers/manage_section.html
@@ -6,7 +6,7 @@
 
 {% block pageTitle %}
   {{ section.title }}
-  - {{ collection.name }} - MHCLG Funding Service
+  - {{ schema.name }} - MHCLG Funding Service
 {% endblock pageTitle %}
 
 {% set active_sub_navigation_tab = "grant_developers" %}
@@ -14,7 +14,7 @@
   {{
     govukBackLink({
         "text": "Back",
-        "href": url_for("deliver_grant_funding.manage_collection", grant_id = grant.id, collection_id=collection.id)
+        "href": url_for("deliver_grant_funding.manage_schema", grant_id = grant.id, schema_id=schema.id)
     })
   }}
 {% endblock beforeContent %}
@@ -22,7 +22,7 @@
 {% block content %}
   <div class="app-body__watermark" aria-hidden="true">Scaffolding</div>
   <h1 class="govuk-heading-l">
-    <span class="govuk-caption-l">{{ collection.name }}</span>
+    <span class="govuk-caption-l">{{ schema.name }}</span>
     {{ section.title }}
   </h1>
   <div class="govuk-grid-row">
@@ -35,7 +35,7 @@
         "actions": {
         "items": [
         {
-        "href": url_for("deliver_grant_funding.edit_section", grant_id = grant.id, collection_id = collection.id, section_id = section.id),
+        "href": url_for("deliver_grant_funding.edit_section", grant_id = grant.id, schema_id = schema.id, section_id = section.id),
         "text": "Change",
         "classes": "govuk-link--no-visited-state"
         }
@@ -57,7 +57,7 @@
       {% if not section.forms %}
         <p class="govuk-body">
           This section has no forms, you can
-          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.add_form', grant_id = grant.id, collection_id = collection.id, section_id=section.id) }}">add a form</a>
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.add_form', grant_id = grant.id, schema_id=schema.id, section_id=section.id) }}">add a form</a>
           .
         </p>
       {% else %}
@@ -71,12 +71,12 @@
           "text": form.title,
           "actions":[
           {"text":"Move up",
-              "href":url_for('deliver_grant_funding.move_form', grant_id = grant.id, collection_id = collection.id,
+              "href":url_for('deliver_grant_funding.move_form', grant_id = grant.id, schema_id=schema.id,
                      section_id = section.id, form_id=form.id, direction = 'up'),"disabled":(loop.index <= 1), "post":true},
-                     {"href":url_for('deliver_grant_funding.move_form', grant_id = grant.id, collection_id = collection.id,
+                     {"href":url_for('deliver_grant_funding.move_form', grant_id = grant.id, schema_id=schema.id,
                      section_id = section.id, form_id=form.id, direction = 'down') ,"post":true,
                   "text": "Move down","disabled":(loop.index >= section.forms | length)},
-                  {"href":url_for('deliver_grant_funding.manage_form', grant_id = grant.id, collection_id = collection.id,
+                  {"href":url_for('deliver_grant_funding.manage_form', grant_id = grant.id, schema_id=schema.id,
                      section_id = section.id, form_id=form.id, back_link="manage_section"),
                   "text": "Manage","post":false}
           ]
@@ -90,7 +90,7 @@
           govukButton({
           "text": "Add a form",
           "classes": "govuk-button--secondary",
-          "href": url_for("deliver_grant_funding.add_form", grant_id = grant.id, collection_id = collection.id, section_id=section.id)
+          "href": url_for("deliver_grant_funding.add_form", grant_id = grant.id, schema_id=schema.id, section_id=section.id)
           })
         }}
       {% endif %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/developers/select_form_type.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/developers/select_form_type.html
@@ -14,7 +14,7 @@
   {{
     govukBackLink({
         "text": "Back",
-        "href": url_for("deliver_grant_funding.manage_section", grant_id = grant.id, collection_id = collection.id, section_id=section.id)
+        "href": url_for("deliver_grant_funding.manage_section", grant_id = grant.id, schema_id=schema.id, section_id=section.id)
     })
   }}
 {% endblock beforeContent %}
@@ -51,7 +51,7 @@
         govukButton({
         "text": "Continue",
         "classes": "govuk-button--secondary",
-        "href": url_for("deliver_grant_funding.add_form", grant_id = grant.id, collection_id = collection.id, section_id=section.id, form_type="empty")
+        "href": url_for("deliver_grant_funding.add_form", grant_id = grant.id, schema_id=schema.id, section_id=section.id, form_type="empty")
         })
       }}
     </div>

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -23,7 +23,7 @@ from app.common.data.models import CollectionSchema, QuestionDataType
 
 def test_get_collection(db_session, factories):
     cs = factories.collection_schema.create()
-    from_db = get_collection_schema(collection_id=cs.id)
+    from_db = get_collection_schema(schema_id=cs.id)
     assert from_db is not None
 
 
@@ -31,8 +31,8 @@ def test_get_collection_version(db_session, factories):
     cs = factories.collection_schema.create()
     _ = factories.collection_schema.create(id=cs.id, version=2)
 
-    from_db = get_collection_schema(collection_id=cs.id, version=1)
-    from_db_v2 = get_collection_schema(collection_id=cs.id, version=2)
+    from_db = get_collection_schema(schema_id=cs.id, version=1)
+    from_db_v2 = get_collection_schema(schema_id=cs.id, version=2)
     assert from_db.version == 1
     assert from_db_v2.version == 2
 
@@ -43,7 +43,7 @@ def test_get_collection_version_latest_by_default(db_session, factories):
     _ = factories.collection_schema.create(id=cs.id, version=3)
     _ = factories.collection_schema.create(id=cs.id, version=4)
 
-    from_db = get_collection_schema(collection_id=cs.id)
+    from_db = get_collection_schema(schema_id=cs.id)
     assert from_db.version == 4
 
 
@@ -93,7 +93,7 @@ def test_get_section(db_session, factories):
 
 def test_create_section(db_session, factories):
     cs = factories.collection_schema.create()
-    section = create_section(title="test_section", collection_schema=cs)
+    section = create_section(title="test_section", schema=cs)
     assert section
 
     from_db = get_section_by_id(section.id)
@@ -102,33 +102,33 @@ def test_create_section(db_session, factories):
     assert from_db.title == section.title
     assert from_db.order == 0
 
-    section = create_section(title="test_section_2", collection_schema=cs)
+    section = create_section(title="test_section_2", schema=cs)
 
 
 def test_section_ordering(db_session, factories):
     cs = factories.collection_schema.create()
-    section = create_section(title="test_section_1", collection_schema=cs)
+    section = create_section(title="test_section_1", schema=cs)
     assert section
     assert section.order == 0
 
-    section2 = create_section(title="test_section_2", collection_schema=cs)
+    section2 = create_section(title="test_section_2", schema=cs)
     assert section2
     assert section2.order == 1
 
 
 def test_section_name_unique_in_collection(db_session, factories):
     cs = factories.collection_schema.create()
-    section = create_section(title="test_section", collection_schema=cs)
+    section = create_section(title="test_section", schema=cs)
     assert section
 
     with pytest.raises(DuplicateValueError):
-        create_section(title="test_section", collection_schema=cs)
+        create_section(title="test_section", schema=cs)
 
 
 def test_move_section_up_down(db_session, factories):
     cs = factories.collection_schema.create()
-    section1 = create_section(title="test_section_1", collection_schema=cs)
-    section2 = create_section(title="test_section_2", collection_schema=cs)
+    section1 = create_section(title="test_section_1", schema=cs)
+    section2 = create_section(title="test_section_2", schema=cs)
     assert section1
     assert section2
 


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FSPT-437

We're about to let developers start collecting data on a collection schema, and I think that calling the schemas 'collections' is a bit backwards. This patch renames those to 'schemas', and then the actual instance of a user submitting data can be called a 'collection'.

Note: these words don't matter too much at the moment, just for while we're scaffolding.