### PR TITLE
Link MHCLG header to "list grants" page

### DIFF
--- a/app/common/collections/forms.py
+++ b/app/common/collections/forms.py
@@ -1,0 +1,52 @@
+from typing import Protocol, runtime_checkable
+
+from flask_wtf import FlaskForm
+from govuk_frontend_wtf.wtforms_widgets import GovSubmitInput, GovTextArea, GovTextInput
+from wtforms.fields.numeric import IntegerField
+from wtforms.fields.simple import StringField, SubmitField
+
+from app.common.data.models import Question
+from app.common.data.types import QuestionDataType
+
+_accepted_fields = StringField | IntegerField
+
+
+@runtime_checkable
+class QuestionFormProtocol(Protocol):
+    question: _accepted_fields
+    submit: SubmitField
+
+
+# FIXME: Ideally this would do an intersection between FlaskForm and QuestionFormProtocol, but type hinting in
+#        python doesn't currently support this. As of May 2025, it looks like we might be close to some progress on
+#        this in https://github.com/python/typing/issues/213.
+def build_question_form(question: Question) -> FlaskForm:
+    class DynamicQuestionForm(FlaskForm):
+        question: _accepted_fields
+        submit = SubmitField("Continue", widget=GovSubmitInput())
+
+    field: _accepted_fields
+    match question.data_type:
+        case QuestionDataType.TEXT_SINGLE_LINE:
+            field = StringField(label=question.text, description=question.hint or "", widget=GovTextInput())
+        case QuestionDataType.TEXT_MULTI_LINE:
+            field = StringField(
+                label=question.text,
+                description=question.hint or "",
+                widget=GovTextArea(),
+            )
+        case QuestionDataType.INTEGER:
+            field = IntegerField(
+                label=question.text,
+                description=question.hint or "",
+                widget=GovTextInput(),
+            )
+        case _:
+            raise Exception("Unable to generate dynamic form for question type {_}")
+
+    DynamicQuestionForm.question = field
+
+    if not isinstance(DynamicQuestionForm, QuestionFormProtocol):
+        raise RuntimeError("DynamicQuestionForm must implement QuestionFormProtocol")
+
+    return DynamicQuestionForm()

--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -71,6 +71,10 @@ class CollectionSchema(BaseModel):
     created_by_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("user.id"))
     created_by: Mapped[User] = relationship("User")
 
+    collections: Mapped[list["Collection"]] = relationship(
+        "Collection", lazy=True, order_by="Collection.created_at_utc", back_populates="collection_schema"
+    )
+
     sections: Mapped[list["Section"]] = relationship(
         "Section", lazy=True, order_by="Section.order", collection_class=ordering_list("order")
     )

--- a/app/common/templates/common/base.html
+++ b/app/common/templates/common/base.html
@@ -17,7 +17,7 @@
   {{
     mhclgHeader({
         "productName": "MHCLG Funding Service",
-        "homepageUrl": "#",
+        "homepageUrl": url_for("deliver_grant_funding.list_grants"),
         "classes": "govuk-header--full-width-border app-!-no-wrap",
         "navigation": [{ "text": ("Sign out"), "href": url_for('auth.sign_out') }] if current_user.is_authenticated else [],
         "navigationClasses": "govuk-header__navigation--end",

--- a/app/developers/templates/developers/ask_a_question.html
+++ b/app/developers/templates/developers/ask_a_question.html
@@ -1,0 +1,39 @@
+{% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
+{% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
+{% from "govuk_frontend_jinja/components/tag/macro.html" import govukTag %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/task-list/macro.html" import govukTaskList %}
+{% extends "developers/access_grant_funding_base.html" %}
+
+{% block pageTitle %}
+  {{ question.text }} - MHCLG Funding Service
+{% endblock pageTitle %}
+
+{% block beforeContent %}
+  {{
+    govukBackLink({
+        "text": "Back",
+        "href": url_for("developers.manage_schema", grant_id=collection_helper.grant.id, schema_id=collection_helper.schema.id)
+    })
+  }}
+{% endblock beforeContent %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="app-body__watermark" aria-hidden="true">Developers</div>
+
+    <form method="post" novalidate>
+      {{ form.csrf_token }}
+
+      {% if question.data_type == question_types.TEXT_SINGLE_LINE or question.data_type == question_types.TEXT_MULTI_LINE %}
+      {{ form.question(params={"label": {"classes": "govuk-label--l", "isPageHeading": true} }) }}
+      {% elif question.data_type == question_types.INTEGER %}
+      {{ form.question(params={"label": {"classes": "govuk-label--l", "isPageHeading": true}, "inputmode": "numeric", "spellcheck": false }) }}
+      {% endif %}
+
+      {{ form.submit }}
+    </form>
+  </div>
+</div>
+{% endblock content %}

--- a/app/developers/templates/developers/collection_tasklist.html
+++ b/app/developers/templates/developers/collection_tasklist.html
@@ -55,7 +55,7 @@
                     "classes": "govuk-tag govuk-tag--grey"
                   },
                 },
-              "href": "#"
+              "href": url_for("developers.ask_a_question", collection_id=collection_helper.collection.id, question_id=collection_helper.get_first_question_for_form(form).id)
             })
           %}
         {% endfor %}


### PR DESCRIPTION
Currently the MHCLG header (logo + product name) doesn't link anywhere: we use a placeholder href value of "#" that just adds a hash to the end of the URL.

This change links the header to the "list grants" page.