### PR TITLE
Link the MHCLG header (logo + product name) to 'list grants' page

### DIFF
--- a/app/common/templates/common/base.html
+++ b/app/common/templates/common/base.html
@@ -17,7 +17,7 @@
   {{
     mhclgHeader({
         "productName": "MHCLG Funding Service",
-        "homepageUrl": "#",
+        "homepageUrl": url_for("deliver_grant_funding.list_grants"),
         "classes": "govuk-header--full-width-border app-!-no-wrap",
         "navigation": [{ "text": ("Sign out"), "href": url_for('auth.sign_out') }] if current_user.is_authenticated else [],
         "navigationClasses": "govuk-header__navigation--end",


### PR DESCRIPTION
Currently the MHCLG header (logo + product name) doesn't link anywhere: we use a placeholder href value of "#" that just adds a hash to the end of the URL.

This change links the header to the "list grants" page.
