### PR TITLE
FSPT-409 identify auto commit from test

### DIFF
--- a/app/extensions/record_sqlalchemy_queries.py
+++ b/app/extensions/record_sqlalchemy_queries.py
@@ -105,6 +105,11 @@ class RecordSqlalchemyQueriesExtension:
         else:
             location = "<unknown>"
 
+        # Ignore SAVEPOINT-related queries
+        statement = context.statement.strip().upper()
+        if statement.startswith("SAVEPOINT"):
+            return
+
         g._recorded_sqlalchemy_queries.append(
             QueryInfo(
                 statement=context.statement,

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -109,7 +109,7 @@ def test_get_collection_with_full_schema(db_session, factories, track_sql_querie
     # * Load the sections
     # * Load the forms
     # * Load the question
-    assert len(queries) == 5
+    assert len(queries) == 4
 
     # Iterate over all the related models; check that no further SQL queries are emitted. The count is just a noop.
     count = 0

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -109,7 +109,7 @@ def test_get_collection_with_full_schema(db_session, factories, track_sql_querie
     # * Load the sections
     # * Load the forms
     # * Load the question
-    assert len(queries) == 4
+    assert len(queries) == 5
 
     # Iterate over all the related models; check that no further SQL queries are emitted. The count is just a noop.
     count = 0

--- a/tests/integration/deliver_grant_funding/test_routes.py
+++ b/tests/integration/deliver_grant_funding/test_routes.py
@@ -23,7 +23,7 @@ def test_list_grants(app, authenticated_client, factories, templates_rendered, t
     assert len(templates_rendered[0][1]["grants"]) == 5
     soup = BeautifulSoup(result.data, "html.parser")
     assert soup.h1.text == "My grants"
-    assert len(queries) == 2  # 1) select grants, 2) rollback
+    assert len(queries) == 4  # 2) select grants, 3) rollback
 
 
 @pytest.mark.authenticate_as("test@google.com")

--- a/tests/integration/deliver_grant_funding/test_routes.py
+++ b/tests/integration/deliver_grant_funding/test_routes.py
@@ -23,7 +23,7 @@ def test_list_grants(app, authenticated_client, factories, templates_rendered, t
     assert len(templates_rendered[0][1]["grants"]) == 5
     soup = BeautifulSoup(result.data, "html.parser")
     assert soup.h1.text == "My grants"
-    assert len(queries) == 4  # 2) select grants, 3) rollback
+    assert len(queries) == 3  # 1) select grant, 2) rollback
 
 
 @pytest.mark.authenticate_as("test@google.com")

--- a/tests/integration/models.py
+++ b/tests/integration/models.py
@@ -33,7 +33,7 @@ class _GrantFactory(factory.alchemy.SQLAlchemyModelFactory):
     class Meta:
         model = Grant
         sqlalchemy_session_factory = lambda: db.session  # noqa: E731
-        sqlalchemy_session_persistence = "flush"
+        sqlalchemy_session_persistence = "commit"
 
     id = factory.LazyFunction(uuid4)
     name = factory.Sequence(lambda n: "Grant %d" % n)
@@ -43,7 +43,7 @@ class _UserFactory(factory.alchemy.SQLAlchemyModelFactory):
     class Meta:
         model = User
         sqlalchemy_session_factory = lambda: db.session  # noqa: E731
-        sqlalchemy_session_persistence = "flush"
+        sqlalchemy_session_persistence = "commit"
 
     id = factory.LazyFunction(uuid4)
     email = factory.Faker("email")
@@ -62,7 +62,7 @@ class _UserRoleFactory(factory.alchemy.SQLAlchemyModelFactory):
     class Meta:
         model = UserRole
         sqlalchemy_session_factory = lambda: db.session  # noqa: E731
-        sqlalchemy_session_persistence = "flush"
+        sqlalchemy_session_persistence = "commit"
 
     id = factory.LazyFunction(uuid4)
     user_id = factory.LazyAttribute(lambda o: o.user.id)
@@ -88,7 +88,7 @@ class _MagicLinkFactory(factory.alchemy.SQLAlchemyModelFactory):
     class Meta:
         model = MagicLink
         sqlalchemy_session_factory = lambda: db.session  # noqa: E731
-        sqlalchemy_session_persistence = "flush"
+        sqlalchemy_session_persistence = "commit"
 
     id = factory.LazyFunction(uuid4)
     code = factory.LazyFunction(lambda: secrets.token_urlsafe(12))
@@ -103,7 +103,7 @@ class _CollectionSchemaFactory(factory.alchemy.SQLAlchemyModelFactory):
     class Meta:
         model = CollectionSchema
         sqlalchemy_session_factory = lambda: db.session  # noqa: E731
-        sqlalchemy_session_persistence = "flush"
+        sqlalchemy_session_persistence = "commit"
 
     id = factory.LazyFunction(uuid4)
     name = factory.Sequence(lambda n: "Collection %d" % n)
@@ -120,7 +120,7 @@ class _CollectionFactory(factory.alchemy.SQLAlchemyModelFactory):
     class Meta:
         model = Collection
         sqlalchemy_session_factory = lambda: db.session  # noqa: E731
-        sqlalchemy_session_persistence = "flush"
+        sqlalchemy_session_persistence = "commit"
 
     id = factory.LazyFunction(uuid4)
     data = factory.LazyFunction(dict)
@@ -138,7 +138,7 @@ class _SectionFactory(factory.alchemy.SQLAlchemyModelFactory):
     class Meta:
         model = Section
         sqlalchemy_session_factory = lambda: db.session  # noqa: E731
-        sqlalchemy_session_persistence = "flush"
+        sqlalchemy_session_persistence = "commit"
 
     id = factory.LazyFunction(uuid4)
     title = factory.Sequence(lambda n: "Section %d" % n)
@@ -153,7 +153,7 @@ class _FormFactory(factory.alchemy.SQLAlchemyModelFactory):
     class Meta:
         model = Form
         sqlalchemy_session_factory = lambda: db.session  # noqa: E731
-        sqlalchemy_session_persistence = "flush"
+        sqlalchemy_session_persistence = "commit"
 
     id = factory.LazyFunction(uuid4)
     title = factory.Sequence(lambda n: "Form %d" % n)
@@ -168,7 +168,7 @@ class _QuestionFactory(factory.alchemy.SQLAlchemyModelFactory):
     class Meta:
         model = Question
         sqlalchemy_session_factory = lambda: db.session  # noqa: E731
-        sqlalchemy_session_persistence = "flush"
+        sqlalchemy_session_persistence = "commit"
 
     id = factory.LazyFunction(uuid4)
     text = factory.Sequence(lambda n: "Question %d" % n)


### PR DESCRIPTION
**Ticket: https://mhclgdigital.atlassian.net/browse/FSPT-409**

###In this PR we try to achieve following 

1. if there is a `POST` `PATCH` 'DELETE' endpoint which is missing the  `@auto_commit_after_request` and then this endpoint needs to update the db but since it is not committing it violates the data base integrity here we detect wether session is clean or not during the end of request (clean means is data saved to the db or not)
2. also this helps us to check miss use of 'GET' endpoint so in these we should not do any create, update, delete and if detects there is a uncommitted change that means a miss use 
3. This change is event driven & according to the sqlalchemy that is the best way to identify wether that is committed or not [Documentation](https://docs.sqlalchemy.org/en/20/orm/events.html#sqlalchemy.orm.SessionEvents.before_flush)

### How to test 

Remove the annotation in one of the POST endpoint & test and the annotation is `@auto_commit_after_request` 

### Screen shots 

After removing the annotation
![image](https://github.com/user-attachments/assets/a1e2c084-3463-4e2a-b8d5-26d73beb5e6e)
