### PR TITLE
FSPT-503 Persist submitted question data

### DIFF
--- a/app/common/collections/forms.py
+++ b/app/common/collections/forms.py
@@ -1,5 +1,3 @@
-from typing import cast
-
 from flask_wtf import FlaskForm
 from govuk_frontend_wtf.wtforms_widgets import GovSubmitInput, GovTextArea, GovTextInput
 from wtforms.fields.numeric import IntegerField
@@ -22,7 +20,7 @@ class DynamicQuestionForm(FlaskForm):
     submit: SubmitField
 
 
-def build_question_form(question: Question) -> DynamicQuestionForm:
+def build_question_form(question: Question) -> type[DynamicQuestionForm]:
     # NOTE: Keep the fields+types in sync with the class of the same name above.
     class _DynamicQuestionForm(FlaskForm):  # noqa
         question: _accepted_fields
@@ -49,4 +47,4 @@ def build_question_form(question: Question) -> DynamicQuestionForm:
 
     _DynamicQuestionForm.question = field
 
-    return cast(DynamicQuestionForm, _DynamicQuestionForm())
+    return _DynamicQuestionForm

--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -64,9 +64,6 @@ def update_collection_schema(schema: CollectionSchema, *, name: str) -> Collecti
 
 
 def update_collection_data(collection: Collection, question: Question, data: BaseModel) -> Collection:
-    # copying the existing data will convince SQLAlchemy that something needs to be updated
-    # this could also be done using the mutability extension which may be more performant
-    # https://docs.sqlalchemy.org/en/20/orm/extensions/mutable.html#module-sqlalchemy.ext.mutable
     collection.data = copy.deepcopy(collection.data)
     collection.data[str(question.id)] = data.model_dump()
     db.session.flush()

--- a/app/common/data/types.py
+++ b/app/common/data/types.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import enum
 from typing import Any, Dict
 
-json_scalars = Dict[str, str | int | float | bool]
+json_scalars = Dict[str, Any]
 
 
 class RoleEnum(str, enum.Enum):

--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -118,7 +118,6 @@ class CollectionHelper:
         serialised_data = self.collection.data.get(str(question_id))
         return _deserialise_question_type(question, serialised_data) if serialised_data else None
 
-    # this likely receives the forms validated data and then maps it
     def submit_answer_for_question(self, question_id: UUID, form: DynamicQuestionForm) -> None:
         question = self.get_question(question_id)
         data = _form_data_to_question_type(question, form)

--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -3,11 +3,20 @@ from itertools import chain
 from typing import TYPE_CHECKING, Optional
 from uuid import UUID
 
+from pydantic import RootModel, TypeAdapter
+
+from app.common.collections.forms import DynamicQuestionForm
+from app.common.data import interfaces
 from app.common.data.interfaces.collections import get_collection
-from app.common.data.types import CollectionStatusEnum
+from app.common.data.types import CollectionStatusEnum, QuestionDataType
 
 if TYPE_CHECKING:
     from app.common.data.models import Collection, Form, Grant, Question, Section
+
+
+TextSingleLine = RootModel[str]
+TextMultiLine = RootModel[str]
+Integer = RootModel[int]
 
 
 class CollectionHelper:
@@ -104,6 +113,17 @@ class CollectionHelper:
 
         raise ValueError(f"Could not find form for question_id={question_id} in collection_schema={self.schema.id}")
 
+    def get_answer_for_question(self, question_id: UUID) -> TextSingleLine | TextMultiLine | Integer | None:
+        question = self.get_question(question_id)
+        serialised_data = self.collection.data.get(str(question_id))
+        return _deserialise_question_type(question, serialised_data) if serialised_data else None
+
+    # this likely receives the forms validated data and then maps it
+    def submit_answer_for_question(self, question_id: UUID, form: DynamicQuestionForm) -> None:
+        question = self.get_question(question_id)
+        data = _form_data_to_question_type(question, form)
+        interfaces.collections.update_collection_data(self.collection, question, data)
+
     def get_next_question(self, current_question_id: UUID) -> Optional["Question"]:
         """
         Retrieve the next question that should be shown to the user, or None if this was the last relevant question.
@@ -132,3 +152,34 @@ class CollectionHelper:
                 return next(question_iterator, None)
 
         raise ValueError(f"Could not find a question with id={current_question_id} in schema={self.schema}")
+
+
+def _form_data_to_question_type(
+    question: "Question", form: DynamicQuestionForm
+) -> TextSingleLine | TextMultiLine | Integer:
+    match question.data_type:
+        case QuestionDataType.TEXT_SINGLE_LINE:
+            assert isinstance(form.question.data, str)
+            return TextSingleLine(form.question.data)
+        case QuestionDataType.TEXT_MULTI_LINE:
+            assert isinstance(form.question.data, str)
+            return TextMultiLine(form.question.data)
+        case QuestionDataType.INTEGER:
+            assert isinstance(form.question.data, int)
+            return Integer(form.question.data)
+        case _:
+            raise ValueError(f"Could not parse data for question type={question.data_type}")
+
+
+def _deserialise_question_type(
+    question: "Question", serialised_data: str | int | float | bool
+) -> TextSingleLine | TextMultiLine | Integer:
+    match question.data_type:
+        case QuestionDataType.TEXT_SINGLE_LINE:
+            return TypeAdapter(TextSingleLine).validate_python(serialised_data)
+        case QuestionDataType.TEXT_MULTI_LINE:
+            return TypeAdapter(TextMultiLine).validate_python(serialised_data)
+        case QuestionDataType.INTEGER:
+            return TypeAdapter(Integer).validate_python(serialised_data)
+        case _:
+            raise ValueError(f"Could not deserialise data for question type={question.data_type}")

--- a/app/developers/routes.py
+++ b/app/developers/routes.py
@@ -522,7 +522,7 @@ def ask_a_question(collection_id: UUID, question_id: UUID) -> ResponseReturnValu
     question = collection_helper.get_question(question_id)
     answer = collection_helper.get_answer_for_question(question.id)
 
-    # this method should work as long as data types are a single field any may
+    # this method should work as long as data types are a single field and may
     # need to be revised if we have compound data types
     form = build_question_form(question)(question=answer.root if answer else None)
 

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -16,11 +16,13 @@ from app.common.data.interfaces.collections import (
     move_question_up,
     move_section_down,
     move_section_up,
+    update_collection_data,
     update_question,
 )
 from app.common.data.interfaces.exceptions import DuplicateValueError
 from app.common.data.models import CollectionSchema
 from app.common.data.types import QuestionDataType
+from app.common.helpers.collections import TextSingleLine
 
 
 def test_get_collection_schema(db_session, factories):
@@ -311,3 +313,16 @@ def test_move_question_up_down(db_session, factories):
     assert q1.order == 2
     assert q2.order == 0
     assert q3.order == 1
+
+
+def test_update_collection_data(db_session, factories):
+    form = factories.form.build()
+    question = factories.question.build(form=form)
+    collection = factories.collection.build(collection_schema=form.section.collection_schema)
+
+    assert collection.data.get(str(question.id)) is None
+
+    data = TextSingleLine("User submitted data")
+    updated_collection = update_collection_data(collection, question, data)
+
+    assert updated_collection.data.get(str(question.id)) == "User submitted data"

--- a/tests/integration/common/helpers/test_collections.py
+++ b/tests/integration/common/helpers/test_collections.py
@@ -2,7 +2,9 @@ import uuid
 
 import pytest
 
-from app.common.helpers.collections import CollectionHelper
+from app.common.collections.forms import build_question_form
+from app.common.data.types import QuestionDataType
+from app.common.helpers.collections import CollectionHelper, Integer, TextSingleLine
 from tests.utils import AnyStringMatching
 
 
@@ -243,3 +245,30 @@ class TestCollectionHelper:
                 r"Could not find form for question_id=00000000-0000-0000-0000-000000000009 "
                 r"in collection_schema=[a-z0-9-]+"
             )
+
+    class TestGetAndSubmitAnswerForQuestion:
+        def test_submit_valid_data(self, db_session, factories):
+            section = factories.section.build()
+            form = factories.form.build(section=section)
+            question = factories.question.build(form=form)
+            collection = factories.collection.build(collection_schema=section.collection_schema)
+            helper = CollectionHelper(collection)
+
+            assert helper.get_answer_for_question(question.id) is None
+
+            form = build_question_form(question)(question="User submitted data")
+            helper.submit_answer_for_question(question.id, form)
+
+            assert helper.get_answer_for_question(question.id) == TextSingleLine("User submitted data")
+
+        def test_get_data_maps_type(self, db_session, factories):
+            section = factories.section.build()
+            form = factories.form.build(section=section)
+            question = factories.question.build(form=form, data_type=QuestionDataType.INTEGER)
+            collection = factories.collection.build(collection_schema=section.collection_schema)
+            helper = CollectionHelper(collection)
+
+            form = build_question_form(question)(question=5)
+            helper.submit_answer_for_question(question.id, form)
+
+            assert helper.get_answer_for_question(question.id) == Integer(5)

--- a/tests/unit/app/common/collections/test_forms.py
+++ b/tests/unit/app/common/collections/test_forms.py
@@ -31,7 +31,7 @@ class TestBuildQuestionForm:
     def test_expected_field_types(self, app, data_type, expected_field_type, expected_widget):
         """Feels like a bit of a redundant test that's just reimplementing the function, but ... :shrug:"""
         q = Question(text="Question text", hint="Question hint", data_type=data_type)
-        form = build_question_form(q)
+        form = build_question_form(q)()
 
         assert isinstance(form.question, expected_field_type)
         assert isinstance(form.question.widget, expected_widget)


### PR DESCRIPTION
Add a collections interface method to update the `data` attribute and
store the latest submitted answer from the user.

Note that for now we're just copying the existing data to persuade the
ORM to issue an update on the model, in the future we might want to look
into the SQLAlchemy mutable extension.

This proposes using Pydantic to manage the question data types and give
them a consistent interface. All of the question types we have
right now are primitives so these work with the current method of
building dynamic forms with a single field without any changes.