### PR TITLE
Stop non-admin MHCLG users from logging in with SSO

### DIFF
--- a/app/common/auth/__init__.py
+++ b/app/common/auth/__init__.py
@@ -103,6 +103,10 @@ def sso_get_token() -> ResponseReturnValue:
 
     if "FSD_ADMIN" in sso_user["roles"]:
         add_user_role(user_id=user.id, role=RoleEnum.ADMIN)
+    else:  # TODO: also allow to log in if they're a member of a grant.
+        return render_template(
+            "common/auth/mhclg-user-not-authorised.html", service_desk_url=current_app.config["SERVICE_DESK_URL"]
+        ), 403
 
     session.pop("flow", None)
 

--- a/app/common/templates/common/auth/mhclg-user-not-authorised.html
+++ b/app/common/templates/common/auth/mhclg-user-not-authorised.html
@@ -1,0 +1,16 @@
+{% extends "common/base.html" %}
+{% from "govuk_frontend_jinja/components/inset-text/macro.html" import govukInsetText %}
+
+{% block pageTitle %}
+  Access denied - MHCLG Funding Service
+{% endblock pageTitle %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">Access denied</h1>
+      <p class="govuk-body">You do not have permission to log into the Funding Service.</p>
+      <p class="govuk-body">If you think you should have access, please contact us through our <a class="govuk-link govuk-link--no-visited-state" href="{{ service_desk_url }}" target="_blank">support desk</a> if you need help.</p>
+    </div>
+  </div>
+{% endblock content %}


### PR DESCRIPTION
## Description
We currently allow all MHCLG users to log in via SSO, but if they're not in our admin group then they won't have permission to do anything. Rather than designing around the edge cases in design this creates, we will just block them from logging in and direct them to support if needed.

## Show it
<img width="1038" alt="image" src="https://github.com/user-attachments/assets/6619ba82-0b6a-4060-82b2-e1b7e8e59ed5" />

@Kateharries - please feel free to adjust content as you wish when you're back 🙇 