### PR TITLE
Increase test run duration in CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,7 +191,8 @@ markers = [
     "e2e: Run E2E (browser) tests using playwright",
     "authenticate_as: Email address to use for `authenticated_client` (integration) and `authenticated_browser` (e2e)",
     "skip_in_environments: Environment in which this end to end test should be run",
-    "freeze_time: Mock all calls to now() in code or database to return the specified date/time"
+    "freeze_time: Mock all calls to now() in code or database to return the specified date/time",
+    "fail_if_takes_longer_than_ms: Fail integration tests if they take longer than this amount of time, in milliseconds. Defaults to 250ms. Override this only in clearly-defined, exception circumstances. Note: this duration gets doubled when tests run in CI (eg GitHub Actions)."
 ]
 
 filterwarnings = [


### PR DESCRIPTION
We've seen some of our "slower" tests start to flake in GitHub Actions. In CI the tests run a lot slower than locally for us, so we'll add a very gross override that allows tests to take "twice as long" as we otherwise let them run locally by default.

If we start hitting up against this some more, we should be happy to consider whether this check is very valuable at all.

For exceptional circumstances, there's now also a marker that lets you increase (or decrease) the duration for a specific test.