### PR TITLE
Disable slow test failures in CI

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -149,7 +149,7 @@ def _integration_test_timeout(request: FixtureRequest) -> None:
     These tests may talk over the network (eg to the DB), so we need to make some allowance for that, but they should
     still be able to be fairly fast.
     """
-    request.node.add_marker(pytest.mark.fail_slow("250ms"))
+    request.node.add_marker(pytest.mark.fail_slow("250ms", enabled="CI" not in os.environ))
 
 
 @pytest.fixture(scope="function", autouse=True)


### PR DESCRIPTION
We're seeing this pop off a lot in github actions at the moment. This feels maybe suboptimal - but maybe better than turning it off altogether, or loosening it up temporarily and then forgetting to tighten it back up.