### PR TITLE
FSPT-520 List collections

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -9,7 +9,7 @@ from jinja2 import ChoiceLoader, PackageLoader, PrefixLoader
 from app import logging
 from app.common.data import interfaces
 from app.common.data.models_user import User
-from app.common.filters import format_date, format_date_range, format_datetime, format_datetime_range
+from app.common.filters import format_date, format_date_range, format_date_short, format_datetime, format_datetime_range
 from app.config import get_settings
 from app.extensions import (
     auto_commit_after_request,
@@ -90,6 +90,7 @@ def create_app() -> Flask:
     def _formatters() -> dict[str, Any]:
         return dict(
             format_date=format_date,
+            format_date_short=format_date_short,
             format_datetime=format_datetime,
             format_date_range=format_date_range,
             format_datetime_range=format_datetime_range,

--- a/app/common/filters.py
+++ b/app/common/filters.py
@@ -9,6 +9,14 @@ def format_date(value: date | datetime) -> str:
     return value.strftime("%A %-d %B %-Y")
 
 
+def format_date_short(value: date | datetime) -> str:
+    """Format a date or datetime as follows:
+
+    > 16 May 2025
+    """
+    return value.strftime("%-d %B %-Y")
+
+
 def format_datetime(value: datetime) -> str:
     """Format a datetime as follows:
 

--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import datetime
 from itertools import chain
 from typing import TYPE_CHECKING, Optional
 from uuid import UUID
@@ -67,6 +68,18 @@ class CollectionHelper:
             return CollectionStatusEnum.NOT_STARTED
         else:
             return CollectionStatusEnum.IN_PROGRESS
+
+    @property
+    def created_by_email(self) -> str:
+        return self.collection.created_by.email
+
+    @property
+    def created_at_utc(self) -> datetime:
+        return self.collection.created_at_utc
+
+    @property
+    def id(self) -> UUID:
+        return self.collection.id
 
     def get_section(self, section_id: uuid.UUID) -> "Section":
         try:

--- a/app/developers/routes.py
+++ b/app/developers/routes.py
@@ -559,12 +559,15 @@ def ask_a_question(collection_id: UUID, question_id: UUID) -> ResponseReturnValu
 @developers_blueprint.route("/schemas/<uuid:schema_id>/collections", methods=["GET"])
 @platform_admin_role_required
 def list_collections_for_schema(schema_id: UUID) -> ResponseReturnValue:
-    schema = interfaces.collections.get_collection_schema(schema_id)
+    schema = interfaces.collections.get_collection_schema(schema_id, with_full_schema=True)
+
+    collections = [CollectionHelper(collection) for collection in schema.collections]
 
     return render_template(
         "developers/list_collections.html",
         back_link=url_for("developers.manage_schema", schema_id=schema.id, grant_id=schema.grant.id),
         grant=schema.grant,
         schema=schema,
-        collections=schema.collections,
+        collections=collections,
+        statuses=CollectionStatusEnum,
     )

--- a/app/developers/routes.py
+++ b/app/developers/routes.py
@@ -554,3 +554,17 @@ def ask_a_question(collection_id: UUID, question_id: UUID) -> ResponseReturnValu
         question=question,
         question_types=QuestionDataType,
     )
+
+
+@developers_blueprint.route("/schemas/<uuid:schema_id>/collections", methods=["GET"])
+@platform_admin_role_required
+def list_collections_for_schema(schema_id: UUID) -> ResponseReturnValue:
+    schema = interfaces.collections.get_collection_schema(schema_id)
+
+    return render_template(
+        "developers/list_collections.html",
+        back_link=url_for("developers.manage_schema", schema_id=schema.id, grant_id=schema.grant.id),
+        grant=schema.grant,
+        schema=schema,
+        collections=schema.collections,
+    )

--- a/app/developers/templates/developers/list_collections.html
+++ b/app/developers/templates/developers/list_collections.html
@@ -1,0 +1,68 @@
+{% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
+{% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/table/macro.html" import govukTable %}
+{% extends "deliver_grant_funding/manage_grant_base.html" %}
+
+{% block pageTitle %}
+  Collections - {{ schema.name }} - MHCLG Funding Service
+{% endblock pageTitle %}
+
+{% set active_sub_navigation_tab = "grant_developers" %}
+
+{% block beforeContent %}
+  {{
+    govukBackLink({
+        "text": "Back",
+        "href": back_link,
+        "classes": "govuk-!-margin-bottom-7"
+    })
+  }}
+{% endblock beforeContent %}
+
+{% block content %}
+  <h1 class="govuk-heading-l">
+    <span class="govuk-caption-l">{{ schema.name }}</span>
+    Collections
+  </h1>
+  <p class="govuk-body">View the information that has been provided by users for a schema.</p>
+
+
+  {% set rows=[] %}
+  {# collections is probably a list of collection helpers? to be decided #}
+  {% for collection in collections %}
+    {% set link_to_collection %}
+      <a class="govuk-link govuk-link--no-visited-state" href="#">{{ collection.id | string | truncate(11) }}</a>
+    {% endset %}
+    {% do rows.append([
+      {
+        "html": link_to_collection,
+      }, {
+        "text": collection.created_by.email
+      }, {
+        "text": format_date(collection.created_at_utc)
+      }
+    ]) %}
+
+  {% else %}
+    {% set no_collections_text %}
+    <span><i>No collections found for this schema</i></span>
+    {% endset %}
+    {% do rows.append([
+      {
+        "html": no_collections_text,
+        "colspan": 3
+      }
+    ]) %}
+  {% endfor %}
+
+  {{ govukTable({
+    "captionClasses": "govuk-table__caption--m",
+    "head": [
+      { "text": "Collection" },
+      { "text": "Started by" },
+      { "text": "Created" }
+    ],
+    "rows": rows
+  }) }}
+{% endblock content %}

--- a/app/developers/templates/developers/list_collections.html
+++ b/app/developers/templates/developers/list_collections.html
@@ -2,6 +2,7 @@
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "govuk_frontend_jinja/components/table/macro.html" import govukTable %}
+{% from "common/macros/status.html" import status %}
 {% extends "deliver_grant_funding/manage_grant_base.html" %}
 
 {% block pageTitle %}
@@ -38,9 +39,11 @@
       {
         "html": link_to_collection,
       }, {
-        "text": collection.created_by.email
+        "html": status(collection.status, statuses)
       }, {
-        "text": format_date(collection.created_at_utc)
+        "text": collection.created_by_email
+      }, {
+        "text": format_date_short(collection.created_at_utc)
       }
     ]) %}
 
@@ -51,7 +54,7 @@
     {% do rows.append([
       {
         "html": no_collections_text,
-        "colspan": 3
+        "colspan": 4
       }
     ]) %}
   {% endfor %}
@@ -60,6 +63,7 @@
     "captionClasses": "govuk-table__caption--m",
     "head": [
       { "text": "Collection" },
+      { "text": "" },
       { "text": "Started by" },
       { "text": "Created" }
     ],

--- a/app/developers/templates/developers/manage_schema.html
+++ b/app/developers/templates/developers/manage_schema.html
@@ -32,8 +32,15 @@
       sections
     {% endtrans %}
   {% endset %}
+  {% set collections_text %}
+    {% trans count=schema.collections | length %}
+      {{ count }} preview collection
+      {% pluralize %}
+      {{ count }} preview collections
+    {% endtrans %}
+  {% endset %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-5">
+    <div class="govuk-grid-column-two-thirds">
       {{
         govukSummaryList({
           "rows": [{
@@ -60,6 +67,18 @@
                       }
                   ]
               }
+        }, {
+              "key": {"text": "Collections"},
+              "value":{"text": collections_text },
+              "actions": {
+                  "items": [
+                      {
+                        "href": url_for("developers.list_collections_for_schema", schema_id=schema.id),
+                        "text": "View",
+                        "classes": "govuk-link govuk-link--no-visited-state"
+                      }
+                  ]
+              }
         }]
         })
       }}
@@ -74,7 +93,15 @@
     </div>
   </div>
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full govuk-!-margin-bottom-5">
+    <div class="govuk-grid-column-full">
+      <form method="post" novalidate>
+        {{ form.csrf_token }}
+        {{ form.submit(params={"classes": "govuk-button--secondary"}) }}
+      </form>
+    </div>
+  </div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full govuk-!-margin-top-5">
       {% for section in schema.sections %}
         <h2 class="govuk-heading-m">{{ section.title }}</h2>
 
@@ -116,14 +143,6 @@
           })
         }}
       {% endfor %}
-    </div>
-  </div>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      <form method="post" novalidate>
-        {{ form.csrf_token }}
-        {{ form.submit(params={"classes": "govuk-button--secondary"}) }}
-      </form>
     </div>
   </div>
 {% endblock content %}

--- a/app/developers/templates/developers/manage_schema.html
+++ b/app/developers/templates/developers/manage_schema.html
@@ -14,7 +14,8 @@
   {{
     govukBackLink({
         "text": "Back",
-        "href": url_for("developers.grant_developers_schemas", grant_id = grant.id)
+        "href": url_for("developers.grant_developers_schemas", grant_id = grant.id),
+        "classes": "govuk-!-margin-bottom-7"
     })
   }}
 {% endblock beforeContent %}


### PR DESCRIPTION
Adds a page to list collections for a given schema, this is hooked up to
the manage a schema (building a tasklist) page.

For now it just uses the collections that are fetched and back
referenced from the collection schema - I think the ORM should only be
fetching the collection schema once for any number of collections which
is nice but should be validated (otherwise thats a very expensive
query!). We might need to revisit that if we want to limit or paginate
the number of collections we're returning.

Link from schema management to collections preview
<img width="1265" alt="Screenshot 2025-05-30 at 16 58 29" src="https://github.com/user-attachments/assets/a76bf554-a00f-4ebd-aa46-bc5265237743" />

Empty collections page
<img width="1265" alt="Screenshot 2025-05-30 at 16 58 32" src="https://github.com/user-attachments/assets/842b2ad2-01c0-43ff-8b18-1428f4417cec" />

A preview collection exists
<img width="1265" alt="Screenshot 2025-05-30 at 16 58 48" src="https://github.com/user-attachments/assets/68512179-6a88-4ff3-9298-c9a8db9caeeb" />

