### PR TITLE
Add a 'Check your answers' page at the end of forms

### DIFF
--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -141,6 +141,12 @@ class CollectionHelper:
             return questions[0]
         return None
 
+    def get_last_question_for_form(self, form: "Form") -> Optional["Question"]:
+        questions = self.get_ordered_visible_questions_for_form(form)
+        if questions:
+            return questions[-1]
+        return None
+
     def get_form_for_question(self, question_id: UUID) -> "Form":
         for section in self.schema.sections:
             for form in section.forms:

--- a/app/developers/templates/developers/check_your_answers.html
+++ b/app/developers/templates/developers/check_your_answers.html
@@ -1,0 +1,60 @@
+{% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
+{% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% extends "developers/access_grant_funding_base.html" %}
+
+{% block pageTitle %}
+  Check your answers - MHCLG Funding Service
+{% endblock pageTitle %}
+
+{% block beforeContent %}
+  {{
+    govukBackLink({
+        "text": "Back",
+        "href": back_link,
+    })
+  }}
+{% endblock beforeContent %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l">{{ form.name }}</span>
+    <h1 class="govuk-heading-l">Check your answers</h1>
+
+    {% set rows = [] %}
+    {% for question in collection_helper.get_ordered_visible_questions_for_form(form) %}
+      {% set answer = collection_helper.get_answer_for_question(question.id) %}
+      {% if answer is not none %}
+        {% do rows.append({
+            "key": {"text": question.text},
+            "value": {"text": answer.root},
+            "actions": {"items": [{"href": url_for('developers.ask_a_question', collection_id=collection_helper.collection.id, question_id=question.id, source=back_link_source_enum.CHECK_YOUR_ANSWERS.value), "text": "Change", "visuallyHiddenText": question.name}]},
+          })
+        %}
+      {% else %}
+        {% set valueLink %}
+        <a href="{{ url_for('developers.ask_a_question', collection_id=collection_helper.collection.id, question_id=question.id, source=back_link_source_enum.CHECK_YOUR_ANSWERS.value) }}" class="govuk-link govuk-link--no-visited-state">Enter {{ question.name }}</a>
+        {% endset %}
+        {% do rows.append({
+            "key": {"text": question.text},
+            "value": {"html": valueLink}
+          })
+        %}
+      {% endif %}
+    {% endfor %}
+
+      {{
+        govukSummaryList({
+          "classes": "govuk-!-margin-bottom-9",
+          "rows": rows
+        })
+      }}
+
+    {{ govukButton({
+      "text": "Save and continue",
+      "href": url_for("developers.collection_tasklist", collection_id=collection_helper.collection.id)
+    })}}
+  </div>
+</div>
+{% endblock content %}

--- a/app/developers/templates/developers/collection_tasklist.html
+++ b/app/developers/templates/developers/collection_tasklist.html
@@ -43,6 +43,12 @@
       {% else %}
         {% set rows=[] %}
         {% for form in forms %}
+          {% set linkHref = (
+              url_for("developers.ask_a_question", collection_id=collection_helper.collection.id, question_id=collection_helper.get_first_question_for_form(form).id)
+              if collection_helper.get_status_for_form(form) == statuses.NOT_STARTED else
+              url_for("developers.check_your_answers", collection_id=collection_helper.collection.id, form_id=form.id, source=back_link_source_enum.TASKLIST.value)
+            )
+          %}
           {%
             do rows.append({
                   "title": {
@@ -51,7 +57,7 @@
                 "status": {
                   "html": status(collection_helper.get_status_for_form(form), statuses)
                 },
-              "href": url_for("developers.ask_a_question", collection_id=collection_helper.collection.id, question_id=collection_helper.get_first_question_for_form(form).id)
+              "href": linkHref,
             })
           %}
         {% endfor %}

--- a/tests/integration/common/helpers/test_collections.py
+++ b/tests/integration/common/helpers/test_collections.py
@@ -132,6 +132,30 @@ class TestCollectionHelper:
             helper = CollectionHelper(collection)
             assert helper.get_first_question_for_form(form) is None
 
+
+class TestGetLastQuestionForForm:
+    # TODO: Extend this test suite when we add the business logic that make questions conditional
+
+    def test_at_least_one_question_in_form(self, db_session, factories):
+        form = factories.form.build()
+
+        for x in reversed(range(5)):
+            factories.question.build(form=form, id=uuid.UUID(int=x), order=x)
+
+        collection = factories.collection.build(collection_schema=form.section.collection_schema)
+
+        helper = CollectionHelper(collection)
+        question = helper.get_last_question_for_form(form)
+        assert question.id == uuid.UUID("00000000-0000-0000-0000-000000000004")
+
+    def test_no_visible_questions_in_form(self, db_session, factories):
+        form = factories.form.build()
+
+        collection = factories.collection.build(collection_schema=form.section.collection_schema)
+
+        helper = CollectionHelper(collection)
+        assert helper.get_last_question_for_form(form) is None
+
     class TestGetFormForQuestion:
         def test_question_exists_in_schema_forms(self, db_session, factories):
             section = factories.section.build()


### PR DESCRIPTION
https://mhclgdigital.atlassian.net.mcas.ms/browse/FSPT-436

## Description
This page displays all of the visible questions that users were presented with the answer they provided. They get quick links to change an individual answer.

This also tweaks routing between the tasklist, question pages, and check your answers page.

## Show it
![2025-05-30 17 54 48](https://github.com/user-attachments/assets/41ca10ad-f4b6-4747-ae40-817cdce83ad3)


## Broken backlink journey
-> start on tasklist
-> go to in progress form, check your answers page
-> change an answer for a question that isn't the last one & save
-> click back - you go to the last question on the form, not the tasklist or the question you were just editing.

Maybe we leave this for a proper fix when we make a domain-specific skin, but also - thinking about (nested) backlink journeys now might not be the worst plan.