### PR TITLE
BAU Forms aren't complete if there are no questions

### DIFF
--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -103,7 +103,7 @@ class CollectionHelper:
         # there's likely a slicker interface for this helper but just brute forcing it for now
         visible_questions = self.get_ordered_visible_questions_for_form(form)
         answers = [answer for q in visible_questions if (answer := self.get_answer_for_question(q.id)) is not None]
-        if len(visible_questions) == len(answers):
+        if visible_questions and len(visible_questions) == len(answers):
             return CollectionStatusEnum.COMPLETED
         elif answers:
             return CollectionStatusEnum.IN_PROGRESS

--- a/tests/integration/common/helpers/test_collections.py
+++ b/tests/integration/common/helpers/test_collections.py
@@ -292,6 +292,12 @@ class TestCollectionHelper:
 
             assert helper.get_status_for_form(form) == CollectionStatusEnum.COMPLETED
 
+        def test_form_status_with_no_questions(self, db_session, factories):
+            form = factories.form.build()
+            collection = factories.collection.build(collection_schema=form.section.collection_schema)
+            helper = CollectionHelper(collection)
+            assert helper.get_status_for_form(form) == CollectionStatusEnum.NOT_STARTED
+
         def test_collection_status_based_on_forms(self, db_session, factories):
             question = factories.question.build()
             form_two = factories.form.build(section=question.form.section)


### PR DESCRIPTION
We currently allow you to preview a schema at any time, in the future we might want to put in some rules that make sure its sensibly configured before you can preview but for now its a bit confusing to see "Completed" on a form/ collection when you haven't answered any questions (in the case there aren't any!)

Appropriately set this as "Not started" as no answers have been provided by the user.