### PR TITLE
FSPT-521 Show grant list page based on the user roll platform admin or member

### DIFF
--- a/app/assets/main.scss
+++ b/app/assets/main.scss
@@ -88,3 +88,7 @@ body.govuk-template__body:has(div.app-body__watermark) {
     align-items: anchor-center;
     gap: 0.5em;
 }
+
+.color-black {
+    color: black;
+}

--- a/app/assets/main.scss
+++ b/app/assets/main.scss
@@ -88,7 +88,3 @@ body.govuk-template__body:has(div.app-body__watermark) {
     align-items: anchor-center;
     gap: 0.5em;
 }
-
-.color-black {
-    color: black;
-}

--- a/app/common/data/interfaces/grants.py
+++ b/app/common/data/interfaces/grants.py
@@ -1,7 +1,6 @@
-from typing import Sequence, Tuple, cast
+from typing import Sequence
 from uuid import UUID
 
-from flask_login import current_user
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
@@ -21,17 +20,16 @@ def grant_name_exists(name: str) -> bool:
     return grant is not None
 
 
-def get_all_grants_by_user() -> Tuple[Sequence[Grant], bool]:
-    user = cast(User, current_user)
+def get_all_grants_by_user(user: User) -> Sequence[Grant]:
     if user.is_platform_admin:
         statement = select(Grant).order_by(Grant.name)
-        return db.session.scalars(statement).all(), user.is_platform_admin
+        return db.session.scalars(statement).all()
     else:
         grant_ids = [role.grant_id for role in user.roles]
         if not grant_ids:
-            return [], user.is_platform_admin
+            return []
         statement = select(Grant).where(Grant.id.in_(grant_ids)).order_by(Grant.name)
-        return db.session.scalars(statement).all(), user.is_platform_admin
+        return db.session.scalars(statement).all()
 
 
 def get_all_grants() -> Sequence[Grant]:

--- a/app/common/data/interfaces/grants.py
+++ b/app/common/data/interfaces/grants.py
@@ -22,7 +22,7 @@ def grant_name_exists(name: str) -> bool:
 
 
 def get_all_grants_by_user() -> Sequence[Grant]:
-    user: User = cast(User, current_user)
+    user = cast(User, current_user)
     if user.is_platform_admin:
         statement = select(Grant).order_by(Grant.name)
         return db.session.scalars(statement).all()

--- a/app/common/data/interfaces/grants.py
+++ b/app/common/data/interfaces/grants.py
@@ -1,4 +1,4 @@
-from typing import Sequence, cast
+from typing import Sequence, Tuple, cast
 from uuid import UUID
 
 from flask_login import current_user
@@ -21,17 +21,17 @@ def grant_name_exists(name: str) -> bool:
     return grant is not None
 
 
-def get_all_grants_by_user() -> Sequence[Grant]:
+def get_all_grants_by_user() -> Tuple[Sequence[Grant], bool]:
     user = cast(User, current_user)
     if user.is_platform_admin:
         statement = select(Grant).order_by(Grant.name)
-        return db.session.scalars(statement).all()
+        return db.session.scalars(statement).all(), user.is_platform_admin
     else:
         grant_ids = [role.grant_id for role in user.roles]
         if not grant_ids:
-            return []
+            return [], user.is_platform_admin
         statement = select(Grant).where(Grant.id.in_(grant_ids)).order_by(Grant.name)
-        return db.session.scalars(statement).all()
+        return db.session.scalars(statement).all(), user.is_platform_admin
 
 
 def get_all_grants() -> Sequence[Grant]:

--- a/app/common/data/interfaces/user.py
+++ b/app/common/data/interfaces/user.py
@@ -1,5 +1,7 @@
 import uuid
+from typing import cast
 
+from flask_login import current_user
 from sqlalchemy.dialects.postgresql import insert as postgresql_upsert
 from sqlalchemy.exc import IntegrityError
 
@@ -11,6 +13,11 @@ from app.extensions import db
 
 def get_user(id_: str | uuid.UUID) -> User | None:
     return db.session.get(User, id_)
+
+
+def get_current_user() -> User:
+    user = cast(User, current_user)
+    return user
 
 
 def get_or_create_user(email_address: str) -> User:

--- a/app/deliver_grant_funding/routes.py
+++ b/app/deliver_grant_funding/routes.py
@@ -128,8 +128,8 @@ def grant_setup_contact() -> ResponseReturnValue:
 @mhclg_login_required
 def list_grants() -> Response | str:
     grants = interfaces.grants.get_all_grants_by_user()
-    if not grants:
-        return redirect(url_for("deliver_grant_funding.grant_setup_intro"))
+    # TODO if the user is a MEMBER and does not have any grant we need to handle that but if you are a
+    #  ADMIN then should be able to see grants or empty page with create grant feature
     if len(grants) == 1:
         return redirect(url_for("deliver_grant_funding.view_grant", grant_id=grants[0].id))
     return render_template("deliver_grant_funding/grant_list.html", grants=grants)

--- a/app/deliver_grant_funding/routes.py
+++ b/app/deliver_grant_funding/routes.py
@@ -127,10 +127,11 @@ def grant_setup_contact() -> ResponseReturnValue:
 @deliver_grant_funding_blueprint.route("/grants", methods=["GET"])
 @mhclg_login_required
 def list_grants() -> Response | str:
-    grants, is_platform_admin = interfaces.grants.get_all_grants_by_user()
+    user = interfaces.user.get_current_user()
+    grants = interfaces.grants.get_all_grants_by_user(user=user)
     # TODO if the user is a MEMBER and does not have any grant we need to handle that but if you are a
     #  ADMIN then should be able to see grants or empty page with create grant feature
-    if len(grants) == 1 and not is_platform_admin:
+    if len(grants) == 1 and not user.is_platform_admin:
         return redirect(url_for("deliver_grant_funding.view_grant", grant_id=grants[0].id))
     return render_template("deliver_grant_funding/grant_list.html", grants=grants)
 

--- a/app/deliver_grant_funding/routes.py
+++ b/app/deliver_grant_funding/routes.py
@@ -126,8 +126,12 @@ def grant_setup_contact() -> ResponseReturnValue:
 
 @deliver_grant_funding_blueprint.route("/grants", methods=["GET"])
 @mhclg_login_required
-def list_grants() -> str:
-    grants = interfaces.grants.get_all_grants()
+def list_grants() -> Response | str:
+    grants = interfaces.grants.get_all_grants_by_user()
+    if not grants:
+        return redirect(url_for("deliver_grant_funding.grant_setup_intro"))
+    if len(grants) == 1:
+        return redirect(url_for("deliver_grant_funding.view_grant", grant_id=grants[0].id))
     return render_template("deliver_grant_funding/grant_list.html", grants=grants)
 
 

--- a/app/deliver_grant_funding/routes.py
+++ b/app/deliver_grant_funding/routes.py
@@ -127,10 +127,10 @@ def grant_setup_contact() -> ResponseReturnValue:
 @deliver_grant_funding_blueprint.route("/grants", methods=["GET"])
 @mhclg_login_required
 def list_grants() -> Response | str:
-    grants = interfaces.grants.get_all_grants_by_user()
+    grants, is_platform_admin = interfaces.grants.get_all_grants_by_user()
     # TODO if the user is a MEMBER and does not have any grant we need to handle that but if you are a
     #  ADMIN then should be able to see grants or empty page with create grant feature
-    if len(grants) == 1:
+    if len(grants) == 1 and not is_platform_admin:
         return redirect(url_for("deliver_grant_funding.view_grant", grant_id=grants[0].id))
     return render_template("deliver_grant_funding/grant_list.html", grants=grants)
 

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_list.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_list.html
@@ -3,47 +3,52 @@
 {% from "govuk_frontend_jinja/components/table/macro.html" import govukTable %}
 
 {% block pageTitle %}
-    Grants - MHCLG Funding Service
+  Grants - MHCLG Funding Service
 {% endblock pageTitle %}
 
 {% set active_item_identifier = "grants" %}
 
 {% block content %}
-<div class="govuk-grid-row">
+  <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l">Grants</h1>
-        {{ govukButton({
+      <h1 class="govuk-heading-l">Grants</h1>
+      {{
+        govukButton({
            "text": "Set up a grant",
            "href": url_for("deliver_grant_funding.grant_setup_intro")
-        }) }}
+        })
+      }}
     </div>
-</div>
-<div class="govuk-grid-row">
+  </div>
+  <div class="govuk-grid-row">
     {% if grants %}
-    {% set table_rows = namespace(items=[]) %}
-    {% for grant in grants %}
-    {% set grant_detail_link %}
-    <a class='govuk-link govuk-link--no-visited-state'
-       href={{ url_for("deliver_grant_funding.view_grant", grant_id=grant.id) }}>{{ grant.name }}</a>
-    {% endset %}
-    {% set table_rows.items = table_rows.items + [
-                [{"html": grant_detail_link},
-                 {"text": grant.ggis_number},
-                 {"text": grant.primary_contact_email}]
-            ] %}
-    {% endfor %}
-    <div class="govuk-grid-column-full">
-        {{ govukTable({
-                    "captionClasses": "govuk-table__caption--m",
-                    "firstCellIsHeader": false,
-                    "head": [{"text": "Grant"}, {"text": "GGIS number"}, {"text": "Email"}],
-                    "rows": table_rows.items
-                }) }}
-    </div>
+      {% set table_rows = namespace(items=[]) %}
+      {% for grant in grants %}
+        {% set grant_detail_link %}
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for("deliver_grant_funding.view_grant", grant_id=grant.id) }}">{{ grant.name }}</a>
+        {% endset %}
+        {%
+          set table_rows.items = table_rows.items + [
+              [{"html": grant_detail_link},
+               {"text": grant.ggis_number or ''},
+               {"text": grant.primary_contact_email}]
+          ]
+        %}
+      {% endfor %}
+      <div class="govuk-grid-column-full">
+        {{
+          govukTable({
+              "captionClasses": "govuk-table__caption--m",
+              "firstCellIsHeader": false,
+              "head": [{"text": "Grant"}, {"text": "GGIS number"}, {"text": "Email"}],
+              "rows": table_rows.items
+          })
+        }}
+      </div>
     {% else %}
-    <div class="govuk-grid-column-full">
+      <div class="govuk-grid-column-full">
         <p class="govuk-body">No grants available at the moment.</p>
-    </div>
+      </div>
     {% endif %}
-</div>
+  </div>
 {% endblock content %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_list.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_list.html
@@ -1,27 +1,49 @@
 {% extends "common/base.html" %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
+{% from "govuk_frontend_jinja/components/table/macro.html" import govukTable %}
 
 {% block pageTitle %}
-  Grants - MHCLG Funding Service
+    Grants - MHCLG Funding Service
 {% endblock pageTitle %}
 
 {% set active_item_identifier = "grants" %}
 
 {% block content %}
-  <div class="govuk-grid-row">
+<div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">Grants</h1>
-
-      {{
-        govukButton({
-           "text": "Add a grant",
+        <h1 class="govuk-heading-l">Grants</h1>
+        {{ govukButton({
+           "text": "Set up a grant",
            "href": url_for("deliver_grant_funding.grant_setup_intro")
-        })
-      }}
-
-      {% for grant in grants %}
-        <h2 class="govuk-heading-s"><a href="{{ url_for('deliver_grant_funding.view_grant', grant_id=grant.id) }}" class="govuk-link govuk-link--no-visited-state">{{ grant.name }}</a></h2>
-      {% endfor %}
+        }) }}
     </div>
-  </div>
+</div>
+<div class="govuk-grid-row">
+    {% if grants %}
+    {% set table_rows = namespace(items=[]) %}
+    {% for grant in grants %}
+    {% set grant_detail_link %}
+    <a class='govuk-link govuk-link--no-visited-state'
+       href={{ url_for("deliver_grant_funding.view_grant", grant_id=grant.id) }}>{{ grant.name }}</a>
+    {% endset %}
+    {% set table_rows.items = table_rows.items + [
+                [{"html": grant_detail_link},
+                 {"text": grant.ggis_number},
+                 {"text": grant.primary_contact_email}]
+            ] %}
+    {% endfor %}
+    <div class="govuk-grid-column-full">
+        {{ govukTable({
+                    "captionClasses": "govuk-table__caption--m",
+                    "firstCellIsHeader": false,
+                    "head": [{"text": "Grant"}, {"text": "GGIS number"}, {"text": "Email"}],
+                    "rows": table_rows.items
+                }) }}
+    </div>
+    {% else %}
+    <div class="govuk-grid-column-full">
+        <p class="govuk-body">No grants available at the moment.</p>
+    </div>
+    {% endif %}
+</div>
 {% endblock content %}

--- a/app/extensions/record_sqlalchemy_queries.py
+++ b/app/extensions/record_sqlalchemy_queries.py
@@ -107,7 +107,7 @@ class RecordSqlalchemyQueriesExtension:
 
         # Ignore SAVEPOINT-related queries
         statement = context.statement.strip().upper()
-        if statement.startswith("SAVEPOINT"):
+        if "SAVEPOINT" in statement:
             return
 
         g._recorded_sqlalchemy_queries.append(

--- a/tests/integration/common/data/interfaces/test_grants.py
+++ b/tests/integration/common/data/interfaces/test_grants.py
@@ -1,7 +1,15 @@
 import pytest
 
-from app.common.data.interfaces.grants import DuplicateValueError, create_grant, get_all_grants, get_grant, update_grant
+from app.common.data.interfaces.grants import (
+    DuplicateValueError,
+    create_grant,
+    get_all_grants,
+    get_all_grants_by_user,
+    get_grant,
+    update_grant,
+)
 from app.common.data.models import Grant
+from app.common.data.types import RoleEnum
 
 
 def test_get_grant(factories):
@@ -10,7 +18,23 @@ def test_get_grant(factories):
     assert result is not None
 
 
-def test_get_all_grants(factories):
+def test_get_all_grants_platform_admin(factories):
+    user_obj = factories.user.create(email="testadmin@communities.gov.uk")
+    factories.user_role.create(user=user_obj, role=RoleEnum.ADMIN)
+    factories.grant.create_batch(5)
+    result = get_all_grants_by_user(user_obj)
+    assert len(result) == 5
+
+
+def test_get_all_grants_member(factories):
+    user_member = factories.user.create(email="testmember@communities.gov.uk")
+    grants = factories.grant.create_batch(5)
+    factories.user_role.create(user=user_member, role=RoleEnum.MEMBER, grant=grants[0])
+    result = get_all_grants_by_user(user_member)
+    assert len(result) == 1
+
+
+def test_get_all_grants_by_user(factories):
     factories.grant.create_batch(5)
     result = get_all_grants()
     assert len(result) == 5

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -291,6 +291,23 @@ def authenticated_client(
 
 
 @pytest.fixture()
+def authenticated_member_client(
+    anonymous_client: FlaskClient, factories: _Factories, db_session: Session, request: FixtureRequest
+) -> Generator[FlaskClient, None, None]:
+    email_mark = request.node.get_closest_marker("authenticate_as")
+    email = email_mark.args[0] if email_mark else "test2@communities.gov.uk"
+
+    user = factories.user.create(email=email)
+    grant = factories.grant.create()
+    factories.user_role.create(user_id=user.id, user=user, role=RoleEnum.MEMBER, grant=grant)
+    db_session.commit()
+
+    login_user(user)
+
+    yield anonymous_client
+
+
+@pytest.fixture()
 def authenticated_platform_admin_client(
     anonymous_client: FlaskClient, factories: _Factories, db_session: Session, request: FixtureRequest
 ) -> Generator[FlaskClient, None, None]:

--- a/tests/integration/deliver_grant_funding/test_routes.py
+++ b/tests/integration/deliver_grant_funding/test_routes.py
@@ -59,7 +59,7 @@ def test_list_grants_as_member_with_single_grant(
     assert dashboard_link is not None, "Dashboard link not found"
     settings_link = soup.find("a", string="Settings")
     assert settings_link is not None, "Settings link not found"
-    assert len(queries) == 3
+    assert len(queries) == 2
 
 
 def test_list_grants_as_member_with_multiple_grants(

--- a/tests/integration/deliver_grant_funding/test_routes.py
+++ b/tests/integration/deliver_grant_funding/test_routes.py
@@ -29,6 +29,17 @@ def test_list_grants(app, authenticated_client, factories, templates_rendered, t
     assert result.status_code == 200
     assert len(templates_rendered[0][1]["grants"]) == 5
     soup = BeautifulSoup(result.data, "html.parser")
+
+    button = soup.find("a", string=lambda text: text and "Set up a grant" in text)
+    assert button is not None, "'Set up a grant' button not found"
+
+    headers = soup.find_all("th")
+    header_texts = [th.get_text(strip=True) for th in headers]
+
+    expected_headers = ["Grant", "GGIS number", "Email"]
+    for expected in expected_headers:
+        assert expected in header_texts, f"Header '{expected}' not found in table"
+
     assert soup.h1.text == "Grants"
     assert len(queries) == 3  # 1) select grant, 2) rollback, 3) savepoint
 

--- a/tests/integration/deliver_grant_funding/test_routes.py
+++ b/tests/integration/deliver_grant_funding/test_routes.py
@@ -1,12 +1,15 @@
+from typing import cast
 from uuid import UUID
 
 import pytest
 from bs4 import BeautifulSoup
 from flask import url_for
+from flask_login import current_user
 from sqlalchemy import select
 
+from app import User
 from app.common.data.models import CollectionSchema, Form, Grant, Question, Section
-from app.common.data.types import QuestionDataType
+from app.common.data.types import QuestionDataType, RoleEnum
 from app.deliver_grant_funding.forms import (
     FormForm,
     GrantContactForm,
@@ -22,26 +25,62 @@ from app.deliver_grant_funding.forms import (
 )
 
 
-def test_list_grants(app, authenticated_client, factories, templates_rendered, track_sql_queries):
+def test_list_grants_as_admin(
+    app, authenticated_platform_admin_client, factories, templates_rendered, track_sql_queries
+):
     factories.grant.create_batch(5)
     with track_sql_queries() as queries:
-        result = authenticated_client.get("/grants")
+        result = authenticated_platform_admin_client.get("/grants")
     assert result.status_code == 200
     assert len(templates_rendered[0][1]["grants"]) == 5
     soup = BeautifulSoup(result.data, "html.parser")
-
     button = soup.find("a", string=lambda text: text and "Set up a grant" in text)
     assert button is not None, "'Set up a grant' button not found"
-
     headers = soup.find_all("th")
     header_texts = [th.get_text(strip=True) for th in headers]
-
     expected_headers = ["Grant", "GGIS number", "Email"]
     for expected in expected_headers:
         assert expected in header_texts, f"Header '{expected}' not found in table"
-
     assert soup.h1.text == "Grants"
     assert len(queries) == 3  # 1) select grant, 2) rollback, 3) savepoint
+
+
+def test_list_grants_as_member_with_single_grant(
+    app, authenticated_member_client, factories, templates_rendered, track_sql_queries
+):
+    with track_sql_queries() as queries:
+        result = authenticated_member_client.get("/grants")
+    assert result.status_code == 302
+    redirect_url = result.headers["Location"]
+    final_response = authenticated_member_client.get(redirect_url)
+    assert final_response.status_code == 200
+    soup = BeautifulSoup(final_response.data, "html.parser")
+    dashboard_link = soup.find("a", string="Dashboard")
+    assert dashboard_link is not None, "Dashboard link not found"
+    settings_link = soup.find("a", string="Settings")
+    assert settings_link is not None, "Settings link not found"
+    assert len(queries) == 3
+
+
+def test_list_grants_as_member_with_multiple_grants(
+    app, authenticated_member_client, factories, templates_rendered, track_sql_queries
+):
+    grants = factories.grant.create_batch(5)
+    user: User = cast(User, current_user)
+    for grant in grants:
+        factories.user_role.create(user_id=user.id, user=user, role=RoleEnum.MEMBER, grant=grant)
+
+    result = authenticated_member_client.get("/grants")
+    assert result.status_code == 200
+    soup = BeautifulSoup(result.data, "html.parser")
+    button = soup.find("a", string=lambda text: text and "Set up a grant" in text)
+    assert button is not None, "'Set up a grant' button not found"
+    headers = soup.find_all("th")
+    header_texts = [th.get_text(strip=True) for th in headers]
+    expected_headers = ["Grant", "GGIS number", "Email"]
+    for expected in expected_headers:
+        assert expected in header_texts, f"Header '{expected}' not found in table"
+    assert soup.h1.text == "Grants"
 
 
 @pytest.mark.authenticate_as("test@google.com")


### PR DESCRIPTION
**Ticket : https://mhclgdigital.atlassian.net/browse/FSPT-521**

In the following PR based on the user roll it will show the grants and following are the scenarios that can occur

1. If you have a one record of `ADMIN` in the roles table then we treat them as a `PLATFORM_ADMIN` and they can see all the grants available
2. If you have a one record with `MEMBER` then you should directly go to the grants detail page
3. If you have multiple grants with `MEMBER` then you will go to the grants list table page.

How to test 2 & 3 if you used SSO login remove the `ADMIN` record manually and add some grants & roles as `MEMBER` then you can test 2 and 3 

Grants list page for a `ADMIN` or a `MEMBER` with multiple grants

<img width="777" alt="image" src="https://github.com/user-attachments/assets/55a88480-a8c9-44e9-be63-6333f0aef45e" />
