### PR TITLE
Add flask CLI command to seed a grant

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -126,7 +126,7 @@ def create_app() -> Flask:
     # Attach routes
     from app.common.auth import auth_blueprint
     from app.deliver_grant_funding.routes import deliver_grant_funding_blueprint
-    from app.developers.routes import developers_blueprint
+    from app.developers import developers_blueprint
     from app.healthcheck import healthcheck_blueprint
 
     app.register_blueprint(healthcheck_blueprint)

--- a/app/common/data/interfaces/temporary.py
+++ b/app/common/data/interfaces/temporary.py
@@ -14,6 +14,7 @@ from uuid import UUID
 from app.common.data.models import (
     Collection,
     CollectionSchema,
+    Grant,
 )
 from app.extensions import db
 
@@ -31,4 +32,11 @@ def delete_collections_created_by_user(*, grant_id: UUID, created_by_id: UUID) -
 
     for collection in collections:
         db.session.delete(collection)
+    db.session.flush()
+
+
+def delete_grant(grant_id: UUID) -> None:
+    # Not optimised; do not lift+shift unedited.
+    grant = db.session.query(Grant).where(Grant.id == grant_id).one()
+    db.session.delete(grant)
     db.session.flush()

--- a/app/developers/__init__.py
+++ b/app/developers/__init__.py
@@ -1,0 +1,7 @@
+from flask import Blueprint
+
+developers_blueprint = Blueprint(
+    name="developers", import_name=__name__, url_prefix="/developers", cli_group="developers"
+)
+
+from app.developers import commands, routes  # noqa: E402, F401

--- a/app/developers/commands.py
+++ b/app/developers/commands.py
@@ -1,0 +1,61 @@
+from typing import TYPE_CHECKING, Sequence
+
+import click
+
+from app.common.data import interfaces
+from app.common.data.interfaces.temporary import delete_grant
+from app.common.data.types import QuestionDataType
+from app.developers import developers_blueprint
+
+if TYPE_CHECKING:
+    from app.common.data.models import Grant
+
+
+def _seed_chessboards_in_parks(grants: Sequence["Grant"]) -> None:
+    grant_name = "Chessboards in parks"
+
+    if grant := next((grant for grant in grants if grant.name == grant_name), None):
+        click.echo(f"Grant '{grant_name}' already exists; recreating it.")
+        delete_grant(grant.id)
+
+    from tests.integration.models import (
+        _CollectionSchemaFactory,
+        _FormFactory,
+        _GrantFactory,
+        _QuestionFactory,
+        _SectionFactory,
+    )
+
+    grant = _GrantFactory.create(name=grant_name)
+
+    schema = _CollectionSchemaFactory.create(
+        grant=grant, name="Report on chessboards in parks", slug="report-on-chessboards-in-parks"
+    )
+
+    s = _SectionFactory.create(collection_schema=schema, title="About the park", slug="about-the-park")
+
+    f = _FormFactory.create(section=s, title="Park information")
+
+    _QuestionFactory.create(form=f, text="What is the name of the park?", data_type=QuestionDataType.TEXT_SINGLE_LINE)
+    _QuestionFactory.create(form=f, text="How many chessboards are there?", data_type=QuestionDataType.INTEGER)
+    f = _FormFactory.create(section=s, title="Visitor information")
+    _QuestionFactory.create(
+        form=f, text="How many visitors were there in the last reporting period?", data_type=QuestionDataType.INTEGER
+    )
+
+    s = _SectionFactory.create(collection_schema=schema, title="About the chess", slug="about-the-chess")
+    f = _FormFactory.create(section=s, title="Information about the chess games played")
+    _QuestionFactory.create(
+        form=f,
+        text="Describe the most exciting game played in the last reporting period.",
+        data_type=QuestionDataType.TEXT_MULTI_LINE,
+    )
+
+    click.echo(f"Seeded the ‘{grant_name}’ grant.")
+
+
+@developers_blueprint.cli.command("seed-grants", help="Seed exemplar grants to aid development and testing.")
+def seed_grants() -> None:
+    grants = interfaces.grants.get_all_grants()
+
+    _seed_chessboards_in_parks(grants)

--- a/app/developers/routes.py
+++ b/app/developers/routes.py
@@ -2,7 +2,7 @@ from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Optional
 from uuid import UUID
 
-from flask import Blueprint, abort, redirect, render_template, request, url_for
+from flask import abort, redirect, render_template, request, url_for
 from flask.typing import ResponseReturnValue
 from wtforms import Field
 
@@ -41,13 +41,12 @@ from app.deliver_grant_funding.forms import (
     SchemaForm,
     SectionForm,
 )
+from app.developers import developers_blueprint
 from app.developers.forms import CheckYourAnswersForm, PreviewCollectionForm
 from app.extensions import auto_commit_after_request
 
 if TYPE_CHECKING:
     from app.common.data.models import Collection, Form, Question
-
-developers_blueprint = Blueprint(name="developers", import_name=__name__, url_prefix="/developers")
 
 
 @developers_blueprint.context_processor

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,8 @@ services:
       bash -c "
       cp /app/certs/rootCA.pem /usr/local/share/ca-certificates/rootCA.crt && \
       update-ca-certificates && \
-      uv run flask db upgrade
+      uv run flask db upgrade && \
+      uv run flask developers seed-grants
 
       npm run dev -- --host &
       PYDEVD_DISABLE_FILE_VALIDATION=1 python -m debugpy --listen 0.0.0.0:8081 -m flask run --host 0.0.0.0 --port 8080 --reload --debug --cert=/app/certs/cert.pem --key=/app/certs/key.pem


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FSPT-408

Provide a command that seeds an example grant with a basic collection to streamline testing and development. This should be extended as we add more functionality.

The seeded grant is automatically populated on app startup, including dropping and recreating it. This ensures it's always consistent+updated across all developer machines, but does mean that edits to that grant will be lost. Open to a bit of conversation on which way we think we prefer, but my default is for consistency.