### PR TITLE
BAU - Only show 'Set up a grant' button to platform admin users

### DIFF
--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_list.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_list.html
@@ -12,12 +12,14 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Grants</h1>
-      {{
-        govukButton({
-           "text": "Set up a grant",
-           "href": url_for("deliver_grant_funding.grant_setup_intro")
-        })
-      }}
+      {% if current_user.is_platform_admin %}
+        {{
+          govukButton({
+            "text": "Set up a grant",
+            "href": url_for("deliver_grant_funding.grant_setup_intro")
+          })
+        }}
+      {% endif %}
     </div>
   </div>
   <div class="govuk-grid-row">

--- a/tests/integration/deliver_grant_funding/test_routes.py
+++ b/tests/integration/deliver_grant_funding/test_routes.py
@@ -75,7 +75,7 @@ def test_list_grants_as_member_with_multiple_grants(
     assert result.status_code == 200
     soup = BeautifulSoup(result.data, "html.parser")
     button = soup.find("a", string=lambda text: text and "Set up a grant" in text)
-    assert button is not None, "'Set up a grant' button not found"
+    assert button is None, "'Set up a grant' button found"
     headers = soup.find_all("th")
     header_texts = [th.get_text(strip=True) for th in headers]
     expected_headers = ["Grant", "GGIS number", "Email"]


### PR DESCRIPTION
### Description

Currently the "Set up a grant" button on the "list grants" page is shown to all users - platform admin and non-platform admin users alike. It's a big, green, shiny, highly clickable button at the top of the page. Non-platform admin users with access to multiple grants (users with access to a single grant will get redirected to the dashboard page for that specific grant) can see it. If these users succumb to temptation and click the button, they'll get 403'ed, which feels like a trap.

This PR ensures we only show the "Set up a grant" button on the "list grants" page to the platform admin users who actually have permissions to do grant setup.

### Testing notes

I tried to test this out myself by simply returning `False` from `app.common.data.models_user.User.is_platform_admin`, and while this hides the button, you also get no grants back because `app.common.data.interfaces.grants.get_all_grants_by_user` then reverts to checking for individual user role records, which aren't created by the grant setup flow. So I manually added two (you need more than one to avoid the redirect) user role records to link individual grants to my signed-in user, and returned `False` from `is_platform_admin`, to get this:

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/661c1387-16c7-4138-8e20-a5d7c898af1d" />
