### PR TITLE
FSPT-438 Submit collection backend

### DIFF
--- a/app/common/data/types.py
+++ b/app/common/data/types.py
@@ -40,3 +40,4 @@ class CollectionStatusEnum(enum.StrEnum):
 
 class MetadataEventKey(enum.StrEnum):
     FORM_RUNNER_FORM_COMPLETED = "Form completed"
+    COLLECTION_SUBMITTED = "Collection submitted"

--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -57,13 +57,15 @@ class CollectionHelper:
 
     @property
     def status(self) -> str:
+        submitted = MetadataEventKey.COLLECTION_SUBMITTED in [x.event_key for x in self.collection.collection_metadata]
+
         form_statuses = set(
             [
                 self.get_status_for_form(form)
                 for form in chain.from_iterable(section.forms for section in self.schema.sections)
             ]
         )
-        if {CollectionStatusEnum.COMPLETED} == form_statuses:
+        if {CollectionStatusEnum.COMPLETED} == form_statuses and submitted:
             return CollectionStatusEnum.COMPLETED
         elif {CollectionStatusEnum.NOT_STARTED} == form_statuses:
             return CollectionStatusEnum.NOT_STARTED
@@ -173,6 +175,23 @@ class CollectionHelper:
         question = self.get_question(question_id)
         data = _form_data_to_question_type(question, form)
         interfaces.collections.update_collection_data(self.collection, question, data)
+
+    def submit_collection(self, user: "User") -> None:
+        collection_complete = self.status == CollectionStatusEnum.COMPLETED
+        if collection_complete:
+            return
+
+        # TODO: is there a nice way to remove this duplication with the status check?
+        form_statuses = set(
+            [
+                self.get_status_for_form(form)
+                for form in chain.from_iterable(section.forms for section in self.schema.sections)
+            ]
+        )
+        if {CollectionStatusEnum.COMPLETED} == form_statuses:
+            interfaces.collections.add_collection_metadata(self.collection, MetadataEventKey.COLLECTION_SUBMITTED, user)
+        else:
+            raise ValueError(f"Could not submit collection id={self.id} because not all forms are complete.")
 
     def toggle_form_completed(self, form: "Form", user: "User", is_complete: bool) -> None:
         form_complete = self.get_status_for_form(form) == CollectionStatusEnum.COMPLETED

--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -127,7 +127,7 @@ class CollectionHelper:
     def get_status_for_form(self, form: "Form") -> str:
         all_questions_answered, answers = self.get_all_questions_answered_for_form(form)
         marked_as_complete = MetadataEventKey.FORM_RUNNER_FORM_COMPLETED in [
-            x.event_key for x in self.collection.collection_metadata
+            x.event_key for x in self.collection.collection_metadata if x.form and x.form.id == form.id
         ]
         if form.questions and all_questions_answered and marked_as_complete:
             return CollectionStatusEnum.COMPLETED

--- a/tests/integration/common/helpers/test_collections.py
+++ b/tests/integration/common/helpers/test_collections.py
@@ -33,8 +33,10 @@ class TestCollectionHelper:
     class TestStatuses:
         def test_form_status_based_on_questions(self, db_session, factories):
             form = factories.form.build()
+            form_two = factories.form.build(section=form.section)
             question_one = factories.question.build(form=form)
             question_two = factories.question.build(form=form)
+            question_three = factories.question.build(form=form_two)
 
             collection = factories.collection.build(collection_schema=form.section.collection_schema)
             helper = CollectionHelper(collection)
@@ -56,6 +58,12 @@ class TestCollectionHelper:
             helper.toggle_form_completed(form, collection.created_by, True)
 
             assert helper.get_status_for_form(form) == CollectionStatusEnum.COMPLETED
+
+            # make sure the second form is unaffected by the first forms status
+            helper.submit_answer_for_question(
+                question_three.id, build_question_form(question_three)(question="User submitted data")
+            )
+            assert helper.get_status_for_form(form_two) == CollectionStatusEnum.IN_PROGRESS
 
         def test_form_status_with_no_questions(self, db_session, factories):
             form = factories.form.build()


### PR DESCRIPTION
Extends the collection status to only move to complete if a collection
has been submitted.

This will be plugged into a HTTP form that will submit collections in
a future commit.

(Note no preview collections will move to collect until the next story is in)