### PR TITLE
FSPT-438 Tasklist frontend for submitting collection

### DIFF
--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-005_collection_metadata
+006_metadata_enum

--- a/app/common/data/migrations/versions/006_metadata_enum.py
+++ b/app/common/data/migrations/versions/006_metadata_enum.py
@@ -1,0 +1,23 @@
+"""extends metadata enum
+
+Revision ID: 006_metadata_enum
+Revises: 005_collection_metadata
+Create Date: 2025-06-04 14:56:07.802724
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "006_metadata_enum"
+down_revision = "005_collection_metadata"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(sa.text("ALTER TYPE metadata_event_key_enum ADD VALUE 'COLLECTION_SUBMITTED'"))
+
+
+def downgrade() -> None:
+    pass

--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -119,14 +119,15 @@ class CollectionHelper:
         """Returns the visible, ordered sections based upon the current state of this collection."""
         return sorted(self.sections, key=lambda s: s.order)
 
-    def get_all_questions_answered_for_form(
+    def get_all_questions_are_answered_for_form(
         self, form: "Form"
     ) -> tuple[bool, list[TextSingleLine | TextMultiLine | Integer]]:
         visible_questions = self.get_ordered_visible_questions_for_form(form)
         answers = [answer for q in visible_questions if (answer := self.get_answer_for_question(q.id)) is not None]
         return len(visible_questions) == len(answers), answers
 
-    def get_all_forms_completed(self) -> bool:
+    @property
+    def all_forms_are_completed(self) -> bool:
         form_statuses = set(
             [
                 self.get_status_for_form(form)
@@ -136,7 +137,7 @@ class CollectionHelper:
         return {CollectionStatusEnum.COMPLETED} == form_statuses
 
     def get_status_for_form(self, form: "Form") -> str:
-        all_questions_answered, answers = self.get_all_questions_answered_for_form(form)
+        all_questions_answered, answers = self.get_all_questions_are_answered_for_form(form)
         marked_as_complete = MetadataEventKey.FORM_RUNNER_FORM_COMPLETED in [
             x.event_key for x in self.collection.collection_metadata if x.form and x.form.id == form.id
         ]
@@ -190,7 +191,7 @@ class CollectionHelper:
         if collection_complete:
             return
 
-        if self.get_all_forms_completed():
+        if self.all_forms_are_completed:
             interfaces.collections.add_collection_metadata(self.collection, MetadataEventKey.COLLECTION_SUBMITTED, user)
         else:
             raise ValueError(f"Could not submit collection id={self.id} because not all forms are complete.")
@@ -201,7 +202,7 @@ class CollectionHelper:
             return
 
         if is_complete:
-            all_questions_answered, _ = self.get_all_questions_answered_for_form(form)
+            all_questions_answered, _ = self.get_all_questions_are_answered_for_form(form)
             if not all_questions_answered:
                 raise ValueError(
                     f"Could not mark form id={form.id} as complete because not all questions have been answered."

--- a/app/developers/forms.py
+++ b/app/developers/forms.py
@@ -29,3 +29,7 @@ class CheckYourAnswersForm(FlaskForm):
 
 class ConfirmDeletionForm(FlaskForm):
     confirm_deletion = SubmitField("Confirm deletion", widget=GovSubmitInput())
+
+
+class SubmitCollectionForm(FlaskForm):
+    submit = SubmitField("Submit collection", widget=GovSubmitInput())

--- a/app/developers/routes.py
+++ b/app/developers/routes.py
@@ -712,7 +712,7 @@ def check_your_answers(collection_id: UUID, form_id: UUID) -> ResponseReturnValu
         )
     )
 
-    all_questions_answered, _ = collection_helper.get_all_questions_answered_for_form(schema_form)
+    all_questions_answered, _ = collection_helper.get_all_questions_are_answered_for_form(schema_form)
     form.set_is_required(all_questions_answered)
 
     if form.validate_on_submit():

--- a/app/developers/routes.py
+++ b/app/developers/routes.py
@@ -48,7 +48,7 @@ from app.deliver_grant_funding.forms import (
     SectionForm,
 )
 from app.developers import developers_blueprint
-from app.developers.forms import CheckYourAnswersForm, ConfirmDeletionForm, PreviewCollectionForm
+from app.developers.forms import CheckYourAnswersForm, ConfirmDeletionForm, PreviewCollectionForm, SubmitCollectionForm
 from app.extensions import auto_commit_after_request
 
 if TYPE_CHECKING:
@@ -607,15 +607,27 @@ def _get_form_runner_link_from_source(
     return None
 
 
-@developers_blueprint.route("/collections/<uuid:collection_id>", methods=["GET"])
+@developers_blueprint.route("/collections/<uuid:collection_id>", methods=["GET", "POST"])
+@auto_commit_after_request
 @platform_admin_role_required
 def collection_tasklist(collection_id: UUID) -> ResponseReturnValue:
     collection_helper = CollectionHelper.load(collection_id)
+    form = SubmitCollectionForm()
+
+    if form.validate_on_submit():
+        try:
+            collection_helper.submit_collection(interfaces.user.get_current_user())
+            # TODO: this will go to a confirmation page
+            return redirect(url_for("developers.collection_tasklist", collection_id=collection_helper.id))
+        except ValueError:
+            form.submit.errors.append("You must complete all forms before submitting the collection")  # type:ignore[attr-defined]
+
     return render_template(
         "developers/collection_tasklist.html",
         collection_helper=collection_helper,
         statuses=CollectionStatusEnum,
         back_link_source_enum=FormRunnerSourceEnum,
+        form=form,
     )
 
 

--- a/app/developers/templates/developers/check_your_answers.html
+++ b/app/developers/templates/developers/check_your_answers.html
@@ -58,7 +58,7 @@
 
       <form method="post" novalidate>
         {{ form.csrf_token }}
-        {% set all_questions_answered, _ = collection_helper.get_all_questions_answered_for_form(schema_form) %}
+        {% set all_questions_answered, _ = collection_helper.get_all_questions_are_answered_for_form(schema_form) %}
         {% if all_questions_answered %}
           {{
             form.section_completed(params={

--- a/app/developers/templates/developers/collection_tasklist.html
+++ b/app/developers/templates/developers/collection_tasklist.html
@@ -77,7 +77,7 @@
   {% if collection_helper.status != statuses.COMPLETED %}
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        {% if not collection_helper.get_all_forms_completed() %}
+        {% if not collection_helper.all_forms_are_completed %}
           <p class="govuk-body">You must complete all sections before you can submit the collection.</p>
         {% endif %}
         <form method="post" novalidate>
@@ -85,7 +85,7 @@
 
           {{
             form.submit(params={
-              "disabled": not collection_helper.get_all_forms_completed()
+              "disabled": not collection_helper.all_forms_are_completed
             })
           }}
         </form>

--- a/app/developers/templates/developers/collection_tasklist.html
+++ b/app/developers/templates/developers/collection_tasklist.html
@@ -74,4 +74,22 @@
       {% endfor %}
     </div>
   </div>
+  {% if collection_helper.status != statuses.COMPLETED %}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        {% if not collection_helper.get_all_forms_completed() %}
+          <p class="govuk-body">You must complete all sections before you can submit the collection.</p>
+        {% endif %}
+        <form method="post" novalidate>
+          {{ form.csrf_token }}
+
+          {{
+            form.submit(params={
+              "disabled": not collection_helper.get_all_forms_completed()
+            })
+          }}
+        </form>
+      </div>
+    </div>
+  {% endif %}
 {% endblock content %}


### PR DESCRIPTION
Depends on https://github.com/communitiesuk/funding-service/pull/253

Adds a submit collection button to move it through to "Complete".

Tweaks the helper method for checking a collection form status so that
it can be used by the template.

The confirmation page and view only data will be added in a separate
commit.

Page showing the tasklist before all forms have been completed (submit not clickable and some text shown):
<img width="1289" alt="Screenshot 2025-06-04 at 15 50 21" src="https://github.com/user-attachments/assets/13e02ee8-0f0b-46ed-aa7c-aaf2a3383723" />

Page showing the tasklist when all forms have been completed (submit is now clickable):
<img width="1289" alt="Screenshot 2025-06-04 at 15 48 39" src="https://github.com/user-attachments/assets/24bc8175-cd03-48e1-adec-9294db59af0c" />


Page showing the tasklist when all completed (note these commits don't add the confirmation page or the a view only mode for the forms)
<img width="1289" alt="Screenshot 2025-06-04 at 15 49 23" src="https://github.com/user-attachments/assets/f540a59d-2dc4-4b55-811c-3fb3d11dc2c0" />

Edge case: if there's a race condition with another user changing questions or marking forms as not yet ready before you press submit the submission will not be allowed and it will be handled
<img width="1289" alt="Screenshot 2025-06-04 at 15 49 13" src="https://github.com/user-attachments/assets/56ef7e5f-e3ac-4f9b-b4a3-b8feaafdce5a" />
