### PR TITLE
FSPT-438 Fix: helper refactor missed template reference

### DIFF
--- a/app/developers/templates/developers/check_your_answers.html
+++ b/app/developers/templates/developers/check_your_answers.html
@@ -58,7 +58,7 @@
 
       <form method="post" novalidate>
         {{ form.csrf_token }}
-        {% set all_questions_answered, _ = collection_helper.get_all_questions_answered_for_form(schema_form) %}
+        {% set all_questions_answered, _ = collection_helper.get_all_questions_are_answered_for_form(schema_form) %}
         {% if all_questions_answered %}
           {{
             form.section_completed(params={


### PR DESCRIPTION
This should be added to the end to end tests whatever state they're in.