### PR TITLE
FSPT-438 Submit collection confirmation page

### DIFF
--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -108,6 +108,12 @@ class Collection(BaseModel):
         SqlEnum(CollectionStatusEnum, name="collection_status_enum", validate_strings=True)
     )
 
+    # TODO: generated and persisted human readable references for submissions
+    #       these will likely want to fit the domain need
+    @property
+    def reference(self) -> str:
+        return str(self.id)[:8]
+
     created_by_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("user.id"))
     created_by: Mapped[User] = relationship("User", back_populates="collections")
 

--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -56,6 +56,10 @@ class CollectionHelper:
         return self.schema.name
 
     @property
+    def reference(self) -> str:
+        return self.collection.reference
+
+    @property
     def status(self) -> str:
         submitted = MetadataEventKey.COLLECTION_SUBMITTED in [x.event_key for x in self.collection.collection_metadata]
 

--- a/app/developers/routes.py
+++ b/app/developers/routes.py
@@ -617,8 +617,7 @@ def collection_tasklist(collection_id: UUID) -> ResponseReturnValue:
     if form.validate_on_submit():
         try:
             collection_helper.submit_collection(interfaces.user.get_current_user())
-            # TODO: this will go to a confirmation page
-            return redirect(url_for("developers.collection_tasklist", collection_id=collection_helper.id))
+            return redirect(url_for("developers.collection_confirmation", collection_id=collection_helper.id))
         except ValueError:
             form.submit.errors.append("You must complete all forms before submitting the collection")  # type:ignore[attr-defined]
 
@@ -628,6 +627,21 @@ def collection_tasklist(collection_id: UUID) -> ResponseReturnValue:
         statuses=CollectionStatusEnum,
         back_link_source_enum=FormRunnerSourceEnum,
         form=form,
+    )
+
+
+@developers_blueprint.route("/collections/<uuid:collection_id>/confirmation", methods=["GET", "POST"])
+@auto_commit_after_request
+@platform_admin_role_required
+def collection_confirmation(collection_id: UUID) -> ResponseReturnValue:
+    collection_helper = CollectionHelper.load(collection_id)
+
+    # only show this if it has actually been submitted - for now you can get to this page anytime
+
+    return render_template(
+        "developers/collection_submit_confirmation.html",
+        collection_helper=collection_helper,
+        statuses=CollectionStatusEnum,
     )
 
 

--- a/app/developers/routes.py
+++ b/app/developers/routes.py
@@ -636,7 +636,7 @@ def collection_tasklist(collection_id: UUID) -> ResponseReturnValue:
 def collection_confirmation(collection_id: UUID) -> ResponseReturnValue:
     collection_helper = CollectionHelper.load(collection_id)
 
-    # only show this if it has actually been submitted - for now you can get to this page anytime
+    # TODO: only show this if it has actually been submitted - for now you can get to this page anytime
 
     return render_template(
         "developers/collection_submit_confirmation.html",

--- a/app/developers/templates/developers/collection_submit_confirmation.html
+++ b/app/developers/templates/developers/collection_submit_confirmation.html
@@ -12,7 +12,7 @@
       {% set reference_html %}
         Your reference number
         <br />
-        <strong>{{ reference }}</strong>
+        <strong>{{ collection_helper.collection.reference }}</strong>
       {% endset %}
       {{
         govukPanel({
@@ -21,8 +21,8 @@
         })
       }}
 
-      {# <p class="govuk-body">We have sent you a confirmation email.</p> #}
-      <p class="govuk-body">We do not currently send a confirmation email.</p>
+      {# TODO: send a confirmation email using Notify #}
+      <p class="govuk-body">We have sent you a confirmation email.</p>
 
       <h2 class="govuk-heading-m">What happens next</h2>
 

--- a/app/developers/templates/developers/collection_submit_confirmation.html
+++ b/app/developers/templates/developers/collection_submit_confirmation.html
@@ -1,9 +1,8 @@
 {% from "govuk_frontend_jinja/components/panel/macro.html" import govukPanel %}
-{% from "common/macros/status.html" import status %}
 {% extends "developers/access_grant_funding_base.html" %}
 
 {% block pageTitle %}
-  Submitted {{ collection_helper.name }} - MHCLG Funding Service
+  Collection submitted {{ collection_helper.name }} - MHCLG Funding Service
 {% endblock pageTitle %}
 
 {% block content %}
@@ -22,7 +21,8 @@
         })
       }}
 
-      <p class="govuk-body">We have sent you a confirmation email.</p>
+      {# <p class="govuk-body">We have sent you a confirmation email.</p> #}
+      <p class="govuk-body">We do not currently send a confirmation email.</p>
 
       <h2 class="govuk-heading-m">What happens next</h2>
 

--- a/app/developers/templates/developers/collection_submit_confirmation.html
+++ b/app/developers/templates/developers/collection_submit_confirmation.html
@@ -1,0 +1,30 @@
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/panel/macro.html" import govukPanel %}
+{% from "common/macros/status.html" import status %}
+{% extends "developers/access_grant_funding_base.html" %}
+
+{% block pageTitle %}
+  Submitted {{ collection_helper.name }} - MHCLG Funding Service
+{% endblock pageTitle %}
+
+{% block beforeContent %}
+  {{
+    govukBackLink({
+        "text": "Back",
+        "href": url_for("developers.manage_schema", grant_id=collection_helper.grant.id, schema_id=collection_helper.schema.id)
+    })
+  }}
+{% endblock beforeContent %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{
+        govukPanel({
+          "titleText": "Collection submitted",
+          "text": "There are no reference numbers"
+        })
+      }}
+    </div>
+  </div>
+{% endblock content %}

--- a/app/developers/templates/developers/collection_submit_confirmation.html
+++ b/app/developers/templates/developers/collection_submit_confirmation.html
@@ -1,4 +1,3 @@
-{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "govuk_frontend_jinja/components/panel/macro.html" import govukPanel %}
 {% from "common/macros/status.html" import status %}
 {% extends "developers/access_grant_funding_base.html" %}
@@ -7,24 +6,33 @@
   Submitted {{ collection_helper.name }} - MHCLG Funding Service
 {% endblock pageTitle %}
 
-{% block beforeContent %}
-  {{
-    govukBackLink({
-        "text": "Back",
-        "href": url_for("developers.manage_schema", grant_id=collection_helper.grant.id, schema_id=collection_helper.schema.id)
-    })
-  }}
-{% endblock beforeContent %}
-
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      {% set reference = collection_helper.id | string | truncate(8, True, "") %}
+      {% set reference_html %}
+        Your reference number
+        <br />
+        <strong>{{ reference }}</strong>
+      {% endset %}
       {{
         govukPanel({
           "titleText": "Collection submitted",
-          "text": "There are no reference numbers"
+          "html": reference_html
         })
       }}
+
+      <p class="govuk-body">We have sent you a confirmation email.</p>
+
+      <h2 class="govuk-heading-m">What happens next</h2>
+
+      <p class="govuk-body">We will review your collection and ask if we need more information.</p>
+
+      <p class="govuk-body">
+        You can
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('developers.collection_tasklist', collection_id=collection_helper.id) }}">view your submission</a>
+        at any time.
+      </p>
     </div>
   </div>
 {% endblock content %}

--- a/app/developers/templates/developers/list_collections.html
+++ b/app/developers/templates/developers/list_collections.html
@@ -31,7 +31,7 @@
   {# collections is probably a list of collection helpers? to be decided #}
   {% for collection in collections %}
     {% set link_to_collection %}
-      <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('developers.manage_collection', collection_id=collection.id) }}">{{ collection.id | string | truncate(11) }}</a>
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('developers.manage_collection', collection_id=collection.id) }}">{{ collection.reference }}</a>
     {% endset %}
     {%
       do rows.append([

--- a/app/developers/templates/developers/manage_collection.html
+++ b/app/developers/templates/developers/manage_collection.html
@@ -23,7 +23,7 @@
 {% block content %}
   <div class="app-aligned-header-tag">
     <h1 class="govuk-heading-l">
-      <span class="govuk-caption-l">{{ collection_helper.id | string | truncate(11) }}</span>
+      <span class="govuk-caption-l">{{ collection_helper.reference }}</span>
       Collection
     </h1>
     {{ status(collection_helper.status, statuses) }}


### PR DESCRIPTION
Adds a confirmation page after a preview collection has been submitted.

The confirmation page will be loadable by the user if they refresh or navigate away and return. If for some reason they arrive at it prematurely before completing all forms an integrity check will send them back to the tasklist.

Video showing an incomplete submission through to complete: 

https://github.com/user-attachments/assets/4c8cfe50-b021-450d-b0eb-545c42a4ce84

Page showing the confirmation page after a submission has been completed:
<img width="1399" alt="Screenshot 2025-06-06 at 01 08 03" src="https://github.com/user-attachments/assets/e763fb54-977a-41dd-9e3f-eda3785410e4" />
