### PR TITLE
FSPT-441 Preview Schema end to end tests

### DIFF
--- a/app/developers/templates/developers/check_your_answers.html
+++ b/app/developers/templates/developers/check_your_answers.html
@@ -27,10 +27,13 @@
       {% for question in collection_helper.get_ordered_visible_questions_for_form(schema_form) %}
         {% set answer = collection_helper.get_answer_for_question(question.id) %}
         {% if answer is not none %}
+          {% set value_html %}
+            <span data-testid="answer-{{ question.text }}">{{ answer.root }}</span>
+          {% endset %}
           {%
             do rows.append({
               "key": {"text": question.text},
-              "value": {"text": answer.root},
+              "value": {"html": value_html},
               "actions": {"items": [{"href": url_for('developers.ask_a_question', collection_id=collection_helper.collection.id, question_id=question.id, source=back_link_source_enum.CHECK_YOUR_ANSWERS.value), "text": "Change", "visuallyHiddenText": question.name}]},
             })
           %}

--- a/app/developers/templates/developers/collection_tasklist.html
+++ b/app/developers/templates/developers/collection_tasklist.html
@@ -30,7 +30,7 @@
       {# NOTE: Should we have this as a custom component or macro-ize it? #}
       <dl class="app-metadata govuk-!-margin-bottom-7">
         <dt class="app-metadata__key">Status:</dt>
-        <dd class="app-metadata__value">{{ status(collection_helper.status, statuses) }}</dd>
+        <dd class="app-metadata__value" data-testid="collection-status">{{ status(collection_helper.status, statuses) }}</dd>
       </dl>
 
       {% for section in collection_helper.get_ordered_visible_sections() %}

--- a/tests/e2e/developer_pages.py
+++ b/tests/e2e/developer_pages.py
@@ -80,6 +80,7 @@ class AddSchemaPage(GrantDevelopersBasePage):
 class SchemaDetailPage(GrantDevelopersBasePage):
     schema_name: str
     add_section_link: Locator
+    preview_collection_button: Locator
 
     def __init__(self, page: Page, domain: str, grant_name: str, schema_name: str) -> None:
         super().__init__(
@@ -87,6 +88,7 @@ class SchemaDetailPage(GrantDevelopersBasePage):
         )
         self.schema_name = schema_name
         self.add_section_link = self.page.get_by_role("link", name="add a section")
+        self.preview_collection_button = self.page.get_by_role("button", name="Preview this collection")
 
     def check_section_exists(self, section_title: str) -> None:
         expect(self.page.get_by_role("link", name=section_title)).to_be_visible()
@@ -96,6 +98,12 @@ class SchemaDetailPage(GrantDevelopersBasePage):
         add_section_page = AddSectionPage(self.page, self.domain, grant_name=self.grant_name)
         expect(add_section_page.heading).to_be_visible()
         return add_section_page
+
+    def click_preview_collection(self) -> TasklistPage:
+        self.preview_collection_button.click()
+        tasklist_page = TasklistPage(self.page, self.domain, grant_name=self.grant_name, schema_name=self.schema_name)
+        expect(tasklist_page.heading).to_be_visible()
+        return tasklist_page
 
 
 class SectionsListPage(GrantDevelopersBasePage):
@@ -362,3 +370,22 @@ class AddFormDetailsPage(GrantDevelopersBasePage):
         )
         expect(section_details_page.heading).to_be_visible()
         return section_details_page
+
+
+class TasklistPage(GrantDevelopersBasePage):
+    schema_name: str
+
+    def __init__(
+        self,
+        page: Page,
+        domain: str,
+        grant_name: str,
+        schema_name: str,
+    ) -> None:
+        super().__init__(
+            page,
+            domain,
+            grant_name=grant_name,
+            heading=page.get_by_role("heading", name=f"{schema_name} Collection"),
+        )
+        self.schema_name = schema_name

--- a/tests/e2e/developer_pages.py
+++ b/tests/e2e/developer_pages.py
@@ -397,11 +397,9 @@ class TasklistPage(GrantDevelopersBasePage):
     def click_on_form(self, form_name: str) -> None:
         self.page.get_by_role("link", name=form_name).click()
 
-    def click_submit_collection(self) -> TasklistPage:
+    def click_submit_collection(self) -> None:
         self.submit_button.click()
-        tasklist_page = TasklistPage(self.page, self.domain, self.grant_name, self.schema_name)
-        expect(tasklist_page.heading).to_be_visible()
-        return tasklist_page
+        expect(self.page.get_by_role("heading", name="Collection submitted")).to_be_visible()
 
 
 class QuestionPage(GrantDevelopersBasePage):

--- a/tests/e2e/developer_pages.py
+++ b/tests/e2e/developer_pages.py
@@ -389,3 +389,64 @@ class TasklistPage(GrantDevelopersBasePage):
             heading=page.get_by_role("heading", name=f"{schema_name} Collection"),
         )
         self.schema_name = schema_name
+
+    def click_on_form(self, form_name: str) -> None:
+        self.page.get_by_role("link", name=form_name).click()
+
+
+class QuestionPage(GrantDevelopersBasePage):
+    continue_button: Locator
+    question_name: str
+
+    def __init__(
+        self,
+        page: Page,
+        domain: str,
+        grant_name: str,
+        question_name: str,
+    ) -> None:
+        super().__init__(
+            page,
+            domain,
+            grant_name=grant_name,
+            heading=page.get_by_role("heading", name=question_name),
+        )
+        self.question_name = question_name
+        self.continue_button = page.get_by_role("button", name="Continue")
+
+    def respond_to_question(self, answer: str) -> None:
+        self.page.get_by_role("textbox", name=self.question_name).fill(answer)
+
+    def click_continue(
+        self,
+    ) -> None:
+        self.continue_button.click()
+
+
+class CheckYourAnswersPage(GrantDevelopersBasePage):
+    save_and_continue_button: Locator
+    mark_as_complete_yes: Locator
+
+    def __init__(
+        self,
+        page: Page,
+        domain: str,
+        grant_name: str,
+    ) -> None:
+        super().__init__(
+            page,
+            domain,
+            grant_name=grant_name,
+            heading=page.get_by_role("heading", name="Check your answers"),
+        )
+        self.save_and_continue_button = page.get_by_role("button", name="Save and continue")
+        self.mark_as_complete_yes = page.get_by_role("radio", name="Yes, I’ve completed this section")
+
+    def click_mark_as_complete_yes(self) -> None:
+        self.mark_as_complete_yes.click()
+
+    def click_save_and_continue(self, schema_name: str) -> TasklistPage:
+        self.save_and_continue_button.click()
+        task_list_page = TasklistPage(self.page, self.domain, self.grant_name, schema_name=schema_name)
+        expect(task_list_page.heading).to_be_visible()
+        return task_list_page

--- a/tests/e2e/developer_pages.py
+++ b/tests/e2e/developer_pages.py
@@ -374,6 +374,8 @@ class AddFormDetailsPage(GrantDevelopersBasePage):
 
 class TasklistPage(GrantDevelopersBasePage):
     schema_name: str
+    collection_status_box: Locator
+    submit_button: Locator
 
     def __init__(
         self,
@@ -389,9 +391,17 @@ class TasklistPage(GrantDevelopersBasePage):
             heading=page.get_by_role("heading", name=f"{schema_name} Collection"),
         )
         self.schema_name = schema_name
+        self.collection_status_box = page.get_by_test_id("collection-status")
+        self.submit_button = page.get_by_role("button", name="Submit collection")
 
     def click_on_form(self, form_name: str) -> None:
         self.page.get_by_role("link", name=form_name).click()
+
+    def click_submit_collection(self) -> TasklistPage:
+        self.submit_button.click()
+        tasklist_page = TasklistPage(self.page, self.domain, self.grant_name, self.schema_name)
+        expect(tasklist_page.heading).to_be_visible()
+        return tasklist_page
 
 
 class QuestionPage(GrantDevelopersBasePage):

--- a/tests/e2e/test_developer_journey.py
+++ b/tests/e2e/test_developer_journey.py
@@ -144,8 +144,4 @@ def test_create_and_preview_schema(
         tasklist_page.collection_status_box.filter(has=tasklist_page.page.get_by_text("In progress"))
     ).to_be_visible()
     expect(tasklist_page.submit_button).to_be_enabled()
-    tasklist_page = tasklist_page.click_submit_collection()
-
-    # Check the collection status is now completed
-    expect(tasklist_page.collection_status_box.filter(has=tasklist_page.page.get_by_text("Completed"))).to_be_visible()
-    expect(tasklist_page.submit_button).not_to_be_visible()
+    tasklist_page.click_submit_collection()

--- a/tests/e2e/test_developer_journey.py
+++ b/tests/e2e/test_developer_journey.py
@@ -110,6 +110,10 @@ def test_create_and_preview_schema(
 
     # Check the tasklist has loaded
     expect(tasklist_page.page.get_by_role("heading", name=new_section_name)).to_be_visible()
+    expect(
+        tasklist_page.collection_status_box.filter(has=tasklist_page.page.get_by_text("Not started"))
+    ).to_be_visible()
+    expect(tasklist_page.submit_button).to_be_disabled()
     expect(tasklist_page.page.get_by_role("link", name=form_name)).to_be_visible()
 
     # Complete the first form
@@ -133,4 +137,15 @@ def test_create_and_preview_schema(
     expect(check_your_answers.page.get_by_text("Have you completed this section?", exact=True)).to_be_visible()
 
     check_your_answers.click_mark_as_complete_yes()
-    task_list_page = check_your_answers.click_save_and_continue(schema_name=new_schema_name)
+    tasklist_page = check_your_answers.click_save_and_continue(schema_name=new_schema_name)
+
+    # Submit the collection
+    expect(
+        tasklist_page.collection_status_box.filter(has=tasklist_page.page.get_by_text("In progress"))
+    ).to_be_visible()
+    expect(tasklist_page.submit_button).to_be_enabled()
+    tasklist_page = tasklist_page.click_submit_collection()
+
+    # Check the collection status is now completed
+    expect(tasklist_page.collection_status_box.filter(has=tasklist_page.page.get_by_text("Completed"))).to_be_visible()
+    expect(tasklist_page.submit_button).not_to_be_visible()

--- a/tests/e2e/test_developer_journey.py
+++ b/tests/e2e/test_developer_journey.py
@@ -7,38 +7,7 @@ from app.common.data.types import QuestionDataType
 from tests.e2e.config import EndToEndTestSecrets
 from tests.e2e.dataclasses import E2ETestUser
 from tests.e2e.developer_pages import ManageFormPage
-from tests.e2e.pages import AllGrantsPage, GrantDashboardPage
-
-
-def create_grant(new_grant_name: str, page: Page, domain: str) -> GrantDashboardPage:
-    """
-    Split this out as a separate function for now while we decide if we want this test to create the grant it uses,
-    or whether we go with a different option
-    (See notes in ticket FSPT-441)
-    :param new_grant_name: name of grant to create
-    :param page: page object from Playwright
-    :param domain: domain to use for the test
-    :return: Grant dashboard page object for the newly created grant
-    """
-    all_grants_page = AllGrantsPage(page, domain)
-    all_grants_page.navigate()
-
-    # Set up new grant
-    grant_intro_page = all_grants_page.click_set_up_a_grant()
-    grant_ggis_page = grant_intro_page.click_continue()
-    grant_ggis_page.select_yes()
-    grant_ggis_page.fill_ggis_number()
-    grant_name_page = grant_ggis_page.click_save_and_continue()
-    grant_name_page.fill_name(new_grant_name)
-    grant_description_page = grant_name_page.click_save_and_continue()
-    grant_description_page.fill_description()
-    grant_contact_page = grant_description_page.click_save_and_continue()
-    grant_contact_page.fill_contact_name()
-    grant_contact_page.fill_contact_email()
-    grant_check_your_answers_page = grant_contact_page.click_save_and_continue()
-    grant_confirmation_page = grant_check_your_answers_page.click_add_grant()
-    grant_dashboard_page = grant_confirmation_page.click_continue()
-    return grant_dashboard_page
+from tests.e2e.pages import AllGrantsPage
 
 
 def create_question(
@@ -63,14 +32,25 @@ def create_question(
 def test_create_and_preview_schema(
     page: Page, domain: str, e2e_test_secrets: EndToEndTestSecrets, authenticated_browser_sso: E2ETestUser
 ):
-    # TODO - FSPT-441: Decide if we want to create the grant in this test or not.
-    new_grant_name = f"E2E create_schema_grant {uuid.uuid4()}"
-    grant_dashboard_page = create_grant(new_grant_name, page, domain)
-    #
-    # # Go to Grant Dashboard
-    # all_grants_page = AllGrantsPage(page, domain)
-    # all_grants_page.navigate()
-    # grant_dashboard_page = all_grants_page.click_grant(new_grant_name)
+    new_grant_name = f"E2E developer_grant {uuid.uuid4()}"
+    all_grants_page = AllGrantsPage(page, domain)
+    all_grants_page.navigate()
+
+    # Set up new grant
+    grant_intro_page = all_grants_page.click_set_up_a_grant()
+    grant_ggis_page = grant_intro_page.click_continue()
+    grant_ggis_page.select_yes()
+    grant_ggis_page.fill_ggis_number()
+    grant_name_page = grant_ggis_page.click_save_and_continue()
+    grant_name_page.fill_name(new_grant_name)
+    grant_description_page = grant_name_page.click_save_and_continue()
+    grant_description_page.fill_description()
+    grant_contact_page = grant_description_page.click_save_and_continue()
+    grant_contact_page.fill_contact_name()
+    grant_contact_page.fill_contact_email()
+    grant_check_your_answers_page = grant_contact_page.click_save_and_continue()
+    grant_confirmation_page = grant_check_your_answers_page.click_add_grant()
+    grant_dashboard_page = grant_confirmation_page.click_continue()
 
     # Go to developers tab
     developers_page = grant_dashboard_page.click_developers(new_grant_name)
@@ -106,3 +86,12 @@ def test_create_and_preview_schema(
     create_question(QuestionDataType.TEXT_SINGLE_LINE.value, manage_form_page)
     create_question(QuestionDataType.TEXT_MULTI_LINE.value, manage_form_page)
     create_question(QuestionDataType.INTEGER.value, manage_form_page)
+
+    # Preview the form
+    all_grants_page = AllGrantsPage(page, domain)
+    all_grants_page.navigate()
+    grant_dashboard_page = all_grants_page.click_grant(new_grant_name)
+    developers_page = grant_dashboard_page.click_developers(new_grant_name)
+    list_schemas_page = developers_page.click_manage_schemas(grant_name=new_grant_name)
+    schema_detail_page = list_schemas_page.click_on_schema(grant_name=new_grant_name, schema_name=new_schema_name)
+    schema_detail_page.click_preview_collection()


### PR DESCRIPTION
Builds on the existing 'create a schema' test and previews that schema.
- Completes each question added during create a schema, and stores the answers given
- Checks the 'check your answers' page shows the correct answer for each question
- Submits the collection.

Also adds test ids to the html for the following elements:
- Collection status on the tasklist page
- Answer value on check your answers