### PR TITLE
BAU: Do safe lookup on roles

### DIFF
--- a/app/common/auth/__init__.py
+++ b/app/common/auth/__init__.py
@@ -101,7 +101,7 @@ def sso_get_token() -> ResponseReturnValue:
 
     user = get_or_create_user(email_address=sso_user["preferred_username"])
 
-    if "FSD_ADMIN" in sso_user["roles"]:
+    if "FSD_ADMIN" in sso_user.get("roles", []):
         add_user_role(user_id=user.id, role=RoleEnum.ADMIN)
     else:  # TODO: also allow to log in if they're a member of a grant.
         return render_template(

--- a/tests/integration/common/auth/test_auth.py
+++ b/tests/integration/common/auth/test_auth.py
@@ -187,6 +187,18 @@ class TestSSOGetTokenView:
         assert response.status_code == 403
         assert "https://mhclgdigital.atlassian.net/servicedesk/customer/portal/5" in response.text
 
+    def test_get_without_any_roles_should_403(self, app, anonymous_client):
+        with patch("app.common.auth.build_msal_app") as mock_build_msap_app:
+            # Partially mock the expected return value; just enough for the test.
+            mock_build_msap_app.return_value.acquire_token_by_auth_code_flow.return_value = {
+                "id_token_claims": {"preferred_username": "test@test.communities.gov.uk"}
+            }
+
+            response = anonymous_client.get(url_for("auth.sso_get_token"))
+
+        assert response.status_code == 403
+        assert "https://mhclgdigital.atlassian.net/servicedesk/customer/portal/5" in response.text
+
 
 class TestAuthenticatedUserRedirect:
     def test_magic_link_get(self, authenticated_client):


### PR DESCRIPTION
If the user has not been assigned any roles then the `roles` key is not present. In this case we want a 403 rather than throwing an exception as before