### PR TITLE
BAU: Fix `form.is_completed` error

### DIFF
--- a/app/developers/routes.py
+++ b/app/developers/routes.py
@@ -661,7 +661,7 @@ def ask_a_question(collection_id: UUID, question_id: UUID) -> ResponseReturnValu
     form = build_question_form(question)(question=answer.root if answer else None)
 
     if collection_helper.is_completed:
-        if form.is_completed():
+        if form.is_submitted():
             # TODO: Add an error flash message?
             pass
         return redirect(url_for("developers.check_your_answers", collection_id=collection_id, form_id=question.form_id))


### PR DESCRIPTION
Spotted this behaviour if you try grab a URL from a collection question while it's still being filled out and try to go to that URL after it's been submitted - you should see the read-only 'check your answers' view for that question but we were getting an AttributeError, as a wtform `is_submitted` was incorrectly an `is_completed`.