### PR TITLE
Fix header and assets on SSO stub server

### DIFF
--- a/stubs/sso/__init__.py
+++ b/stubs/sso/__init__.py
@@ -45,10 +45,13 @@ def create_sso_stub_app() -> Flask:
     app.jinja_loader = ChoiceLoader(
         [
             PackageLoader("stubs.sso"),
+            PackageLoader("app.common"),
             PrefixLoader({"govuk_frontend_jinja": PackageLoader("govuk_frontend_jinja")}),
             PrefixLoader({"govuk_frontend_wtf": PackageLoader("govuk_frontend_wtf")}),
         ]
     )
+
+    app.add_template_global(lambda *a, **k: None, "csp_nonce")
 
     WTFormsHelpers(app)
 

--- a/stubs/sso/templates/sso/sso_login.html
+++ b/stubs/sso/templates/sso/sso_login.html
@@ -1,15 +1,24 @@
 {% from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary %}
+{% from "common/partials/mhclg-header.html" import mhclgHeader %}
+
+{% set assetPath = vite_asset('assets') %}
 
 <!doctype html>
 <html lang="en" class="govuk-template">
   <head>
     <meta charset="utf-8" />
-    <title>MHCLG Funding Service - local development SSO stub server</title>
+    <title>Local SSO Stub Login - MHCLG Funding Service</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="theme-color" content="#0b0c0c" />
     {# We're pointing at the vite server used for local development here #}
     <link rel="stylesheet" href="{{ vite_asset('app/assets/main.scss') }}" type="text/css" />
     <script type="module" src="{{ vite_asset('app/assets/main.js') }}"></script>
+    <link rel="icon" sizes="48x48" href="{{ assetPath | default('/assets', true) }}/images/favicon.ico" />
+    <link rel="icon" sizes="any" href="{{ assetPath | default('/assets', true) }}/images/favicon.svg" type="image/svg+xml" />
+    <link rel="mask-icon" href="{{ assetPath | default('/assets', true) }}/images/govuk-icon-mask.svg" color="{{ themeColor | default('#0b0c0c') }}" />
+    {#- Hardcoded value of $govuk-black #}
+    <link rel="apple-touch-icon" href="{{ assetPath | default('/assets', true) }}/images/govuk-icon-180.png" />
+    <link rel="manifest" href="{{ assetPath | default('/assets', true) }}/manifest.json" />
   </head>
 
   <body class="govuk-template__body">
@@ -17,31 +26,14 @@
       document.body.className += " js-enabled" + ("noModule" in HTMLScriptElement.prototype ? " govuk-frontend-supported" : "");
     </script>
     <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-    <header class="govuk-header" data-module="govuk-header">
-      <div class="govuk-header__container govuk-width-container">
-        <div class="govuk-header__logo">
-          <a href="/" class="govuk-header__link govuk-header__link--homepage">
-            <svg focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 296 60" height="30" width="148" fill="currentcolor" class="govuk-header__logotype" aria-label="GOV.UK">
-              <title>GOV.UK</title>
-              <g>
-                <circle cx="20" cy="17.6" r="3.7" />
-                <circle cx="10.2" cy="23.5" r="3.7" />
-                <circle cx="3.7" cy="33.2" r="3.7" />
-                <circle cx="31.7" cy="30.6" r="3.7" />
-                <circle cx="43.3" cy="17.6" r="3.7" />
-                <circle cx="53.2" cy="23.5" r="3.7" />
-                <circle cx="59.7" cy="33.2" r="3.7" />
-                <circle cx="31.7" cy="30.6" r="3.7" />
-                <path
-                  d="M33.1,9.8c.2-.1.3-.3.5-.5l4.6,2.4v-6.8l-4.6,1.5c-.1-.2-.3-.3-.5-.5l1.9-5.9h-6.7l1.9,5.9c-.2.1-.3.3-.5.5l-4.6-1.5v6.8l4.6-2.4c.1.2.3.3.5.5l-2.6,8c-.9,2.8,1.2,5.7,4.1,5.7h0c3,0,5.1-2.9,4.1-5.7l-2.6-8ZM37,37.9s-3.4,3.8-4.1,6.1c2.2,0,4.2-.5,6.4-2.8l-.7,8.5c-2-2.8-4.4-4.1-5.7-3.8.1,3.1.5,6.7,5.8,7.2,3.7.3,6.7-1.5,7-3.8.4-2.6-2-4.3-3.7-1.6-1.4-4.5,2.4-6.1,4.9-3.2-1.9-4.5-1.8-7.7,2.4-10.9,3,4,2.6,7.3-1.2,11.1,2.4-1.3,6.2,0,4,4.6-1.2-2.8-3.7-2.2-4.2.2-.3,1.7.7,3.7,3,4.2,1.9.3,4.7-.9,7-5.9-1.3,0-2.4.7-3.9,1.7l2.4-8c.6,2.3,1.4,3.7,2.2,4.5.6-1.6.5-2.8,0-5.3l5,1.8c-2.6,3.6-5.2,8.7-7.3,17.5-7.4-1.1-15.7-1.7-24.5-1.7h0c-8.8,0-17.1.6-24.5,1.7-2.1-8.9-4.7-13.9-7.3-17.5l5-1.8c-.5,2.5-.6,3.7,0,5.3.8-.8,1.6-2.3,2.2-4.5l2.4,8c-1.5-1-2.6-1.7-3.9-1.7,2.3,5,5.2,6.2,7,5.9,2.3-.4,3.3-2.4,3-4.2-.5-2.4-3-3.1-4.2-.2-2.2-4.6,1.6-6,4-4.6-3.7-3.7-4.2-7.1-1.2-11.1,4.2,3.2,4.3,6.4,2.4,10.9,2.5-2.8,6.3-1.3,4.9,3.2-1.8-2.7-4.1-1-3.7,1.6.3,2.3,3.3,4.1,7,3.8,5.4-.5,5.7-4.2,5.8-7.2-1.3-.2-3.7,1-5.7,3.8l-.7-8.5c2.2,2.3,4.2,2.7,6.4,2.8-.7-2.3-4.1-6.1-4.1-6.1h10.6,0Z" />
-              </g>
-              <path
-                d="M88.6,33.2c0,1.8.2,3.4.6,5s1.2,3,2,4.4c1,1.2,2,2.2,3.4,3s3,1.2,5,1.2,3.4-.2,4.6-.8,2.2-1.4,3-2.2,1.2-1.8,1.6-3c.2-1,.4-2,.4-3v-.4h-10.6v-6.4h18.8v23h-7.4v-5c-.6.8-1.2,1.6-2,2.2-.8.6-1.6,1.2-2.6,1.8-1,.4-2,.8-3.2,1.2s-2.4.4-3.6.4c-3,0-5.8-.6-8-1.6-2.4-1.2-4.4-2.6-6-4.6s-2.8-4.2-3.6-6.8c-.6-2.8-1-5.6-1-8.6s.4-5.8,1.4-8.4,2.2-4.8,4-6.8,3.8-3.4,6.2-4.6c2.4-1.2,5.2-1.6,8.2-1.6s3.8.2,5.6.6c1.8.4,3.4,1.2,4.8,2s2.8,1.8,3.8,3c1.2,1.2,2,2.6,2.8,4l-7.4,4.2c-.4-.8-1-1.8-1.6-2.4-.6-.8-1.2-1.4-2-2s-1.6-1-2.6-1.4-2.2-.4-3.4-.4c-2,0-3.6.4-5,1.2-1.4.8-2.6,1.8-3.4,3-1,1.2-1.6,2.8-2,4.4-.6,1.6-.8,3.8-.8,5.4ZM161.4,24.6c-.8-2.6-2.2-4.8-4-6.8s-3.8-3.4-6.2-4.6c-2.4-1.2-5.2-1.6-8.4-1.6s-5.8.6-8.4,1.6c-2.2,1.2-4.4,2.8-6,4.6-1.8,2-3,4.2-4,6.8-.8,2.6-1.4,5.4-1.4,8.4s.4,5.8,1.4,8.4c.8,2.6,2.2,4.8,4,6.8s3.8,3.4,6.2,4.6c2.4,1.2,5.2,1.6,8.4,1.6s5.8-.6,8.4-1.6c2.4-1.2,4.6-2.6,6.2-4.6,1.8-2,3-4.2,4-6.8.8-2.6,1.4-5.4,1.4-8.4-.2-3-.6-5.8-1.6-8.4h0ZM154,33.2c0,2-.2,3.8-.8,5.4-.4,1.6-1.2,3.2-2.2,4.4s-2.2,2.2-3.4,2.8c-1.4.6-3,1-4.8,1s-3.4-.4-4.8-1-2.6-1.6-3.4-2.8c-1-1.2-1.6-2.6-2.2-4.4-.4-1.6-.8-3.4-.8-5.4v-.2c0-2,.2-3.8.8-5.4.4-1.6,1.2-3.2,2.2-4.4,1-1.2,2.2-2.2,3.4-2.8,1.4-.6,3-1,4.8-1s3.4.4,4.8,1,2.6,1.6,3.4,2.8c1,1.2,1.6,2.6,2.2,4.4.4,1.6.8,3.4.8,5.4v.2ZM177.8,54l-11.8-42h9.4l8,31.4h.2l8-31.4h9.4l-11.8,42h-11.4,0ZM235.4,46.7c1.2,0,2.4-.2,3.4-.6,1-.4,2-.8,2.8-1.6s1.4-1.6,1.8-2.8c.4-1.2.6-2.4.6-4V11.8h8.2v27.2c0,2.4-.4,4.4-1.2,6.2s-2,3.4-3.6,4.8c-1.4,1.4-3.2,2.4-5.4,3-2,.8-4.4,1-6.8,1s-4.8-.4-6.8-1c-2-.8-3.8-1.8-5.4-3-1.6-1.4-2.6-3-3.6-4.8-.8-1.8-1.2-4-1.2-6.2V11.7h8.4v26c0,1.6.2,2.8.6,4,.4,1.2,1,2,1.8,2.8s1.6,1.2,2.8,1.6c1.2.4,2.2.6,3.6.6h0ZM261.4,11.9h8.4v18.2l14.8-18.2h10.4l-14.4,16.8,15.4,25.2h-9.8l-11-18.8-5.4,6v12.8h-8.4V11.9h0ZM206.2,44.2c-3,0-5.4,2.4-5.4,5.4s2.4,5.4,5.4,5.4,5.4-2.4,5.4-5.4-2.4-5.4-5.4-5.4Z" />
-            </svg>
-          </a>
-        </div>
-      </div>
-    </header>
+    {{
+      mhclgHeader({
+          "productName": "MHCLG Funding Service",
+          "homepageUrl": "#",
+          "classes": "govuk-header--full-width-border app-!-no-wrap",
+          "assetPath": assetPath
+      })
+    }}
     <div class="govuk-width-container">
       <main class="govuk-main-wrapper" id="main-content">
         <div class="govuk-grid-row">


### PR DESCRIPTION
- Make border underneath header full width
- Switch from GOV.UK -> MHCLG Funding Service.
- Fix favicon and asset fetching.

## Before
<img width="1057" alt="image" src="https://github.com/user-attachments/assets/c84ef001-1889-45e4-bbb7-b323c1507038" />


## After
<img width="1146" alt="image" src="https://github.com/user-attachments/assets/f37721c5-ab0b-4649-a67a-8ee4936a0d71" />
