### PR TITLE
BAU Tweak developer pages for consistency

### DIFF
--- a/app/assets/main.scss
+++ b/app/assets/main.scss
@@ -142,3 +142,11 @@ $app-destructive-link-active-colour: $govuk-text-colour;
     margin-left: auto;
   }
 }
+
+.app-tasklist-builder {
+    // extends the existing - want to think this through more
+    .govuk-summary-list__key {
+        font-weight: normal;
+        width: 50%;
+    }
+}

--- a/app/common/templates/common/macros/move-up-down-table.html
+++ b/app/common/templates/common/macros/move-up-down-table.html
@@ -1,9 +1,17 @@
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
+{# todo: I think all of this can be accomplished by overriding some design system classes #}
+{#       which would allow us to use the standard summary list macro with a few style changes #}
 {% macro moveUpDownTable(table_rows) %}
   <dl class="govuk-summary-list app-move-up-down-table">
     {% for row in table_rows %}
       <div class="govuk-summary-list__row app-move-up-down-table__row">
-        <dt class="govuk-summary-list__value">{{ row.text }}</dt>
+        <dt class="govuk-summary-list__value">
+          {% if row.text %}
+            {{ row.text }}
+          {% else %}
+            {{ row.html | safe }}
+          {% endif %}
+        </dt>
         <dd class="govuk-summary-list__actions app-move-up-down-table__actions">
           <ul class="govuk-summary-list__actions-list">
             {% for action in row.actions %}

--- a/app/developers/routes.py
+++ b/app/developers/routes.py
@@ -270,12 +270,6 @@ def move_form(
 @auto_commit_after_request
 def manage_form(grant_id: UUID, collection_id: UUID, section_id: UUID, form_id: UUID) -> ResponseReturnValue:
     form = get_form_by_id(form_id)
-    back_link = url_for(
-        f"developers.{request.args.get('back_link')}",
-        grant_id=grant_id,
-        collection_id=collection_id,
-        section_id=section_id,
-    )
 
     confirm_deletion_form = ConfirmDeletionForm()
     if (
@@ -295,7 +289,6 @@ def manage_form(grant_id: UUID, collection_id: UUID, section_id: UUID, form_id: 
         section=form.section,
         collection=form.section.collection,
         form=form,
-        back_link_href=back_link,
         confirm_deletion_form=confirm_deletion_form if "delete" in request.args else None,
     )
 

--- a/app/developers/routes.py
+++ b/app/developers/routes.py
@@ -334,6 +334,7 @@ def edit_section(grant_id: UUID, collection_id: UUID, section_id: UUID) -> Respo
     )
 
 
+# TODO: having this method do both selecting the type and adding the form feels like too much
 @developers_blueprint.route(
     "/grants/<uuid:grant_id>/collections/<uuid:collection_id>/sections/<uuid:section_id>/forms/add",
     methods=["GET", "POST"],

--- a/app/developers/templates/developers/add_section.html
+++ b/app/developers/templates/developers/add_section.html
@@ -11,7 +11,7 @@
   {{
     govukBackLink({
         "text": "Back",
-        "href": url_for("developers.manage_collection", grant_id = grant.id, collection_id=collection.id)
+        "href": url_for("developers.list_sections", grant_id = grant.id, collection_id=collection.id)
     })
   }}
 {% endblock beforeContent %}

--- a/app/developers/templates/developers/edit_question.html
+++ b/app/developers/templates/developers/edit_question.html
@@ -1,7 +1,6 @@
 {% extends "deliver_grant_funding/base.html" %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
-{% from "govuk_frontend_jinja/components/inset-text/macro.html" import govukInsetText %}
 {% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
 
 {% block pageTitle %}
@@ -36,20 +35,11 @@
 
       <h1 class="govuk-heading-l">Edit question</h1>
       <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-          {{
-            govukSummaryList({
-              "rows": [{
-                  "key": {"text": "Question type"},
-                  "value":{"text": question.data_type},
-            }]
-            })
-          }}
-          {{
-            govukInsetText({
-             "text": "You cannot change the type of a question once it has been created. If you need to change the type of a question, you will need to delete the question and create a new one.",
-            })
-          }}
+        <div class="govuk-grid-column-two-thirds">
+          <dl class="govuk-body govuk-!-margin-bottom-6">
+            <dt class="govuk-body govuk-!-margin-bottom-1">Question type</dt>
+            <dd class="govuk-summary-list__value">{{ question.data_type }}</dd>
+          </dl>
         </div>
       </div>
       <div class="govuk-grid-row">

--- a/app/developers/templates/developers/edit_section.html
+++ b/app/developers/templates/developers/edit_section.html
@@ -18,9 +18,13 @@
 {% endblock %}
 
 {% block content %}
-  <form method="post" novalidate>
-    {{ form.csrf_token }}
-    {{ form.title (params={"label": {"isPageHeading": true, "classes": "govuk-label--l" }})}}
-    {{ form.submit }}
-  </form>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form method="post" novalidate>
+        {{ form.csrf_token }}
+        {{ form.title (params={"label": {"isPageHeading": true, "classes": "govuk-label--l" }})}}
+        {{ form.submit }}
+      </form>
+    </div>
+  </div>
 {% endblock %}

--- a/app/developers/templates/developers/list_schemas.html
+++ b/app/developers/templates/developers/list_schemas.html
@@ -33,37 +33,34 @@
         %}
       {% endfor %}
       {% if not grant.collections %}
-        <p class="govuk-body">
-          This grant has no collections, you can
-          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('developers.setup_collection', grant_id = grant.id) }}">add a collection</a>
-          .
-        </p>
+        <p class="govuk-body">This grant has no collections.</p>
       {% else %}
         {{
           govukTable({
-          "captionClasses": "govuk-table__caption--m",
-          "head": [
-            {
-              "text": "Description"
-            },
-            {
-              "text": "Added by"
-            },
-            {
-              "text": "Added on"
-            }
-          ],
-                "rows": rows
-                })
-        }}
-        {{
-          govukButton({
-          "text": "Add collection",
-          "classes": "govuk-button--secondary",
-          "href": url_for("developers.setup_collection", grant_id = grant.id)
+            "captionClasses": "govuk-table__caption--m",
+            "head": [
+              {
+                "text": "Description"
+              },
+              {
+                "text": "Added by"
+              },
+              {
+                "text": "Added on"
+              }
+            ],
+            "rows": rows
           })
         }}
       {% endif %}
+
+      {{
+        govukButton({
+        "text": "Add collection",
+        "classes": "govuk-button--secondary",
+        "href": url_for("developers.setup_collection", grant_id = grant.id)
+        })
+      }}
     </div>
   </div>
 {% endblock content %}

--- a/app/developers/templates/developers/list_sections.html
+++ b/app/developers/templates/developers/list_sections.html
@@ -19,58 +19,59 @@
 {% endblock beforeContent %}
 
 {% block content %}
-  <h1 class="govuk-heading-l">
-    <span class="govuk-caption-l">{{ collection.name }}</span>
-    Sections
-  </h1>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l">{{ collection.name }}</span>
+        Sections
+      </h1>
 
-  {% set sections_text %}
-    {% trans count=collection.sections | length %}
-      {{ count }}
-      section {% pluralize %}
-      {{ count }}
-      sections
-    {% endtrans %}
-  {% endset %}
-  {% if not collection.sections %}
-    <p class="govuk-body">
-      This collection has no sections, you can
-      <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('developers.add_section', grant_id = grant.id, collection_id=collection.id) }}">add a section</a>
-      .
-    </p>
-  {% else %}
-    <p class="govuk-body">This collection has {{ sections_text }}</p>
+      {% set sections_text %}
+        {% trans count=collection.sections | length %}
+          {{ count }}
+          section {% pluralize %}
+          {{ count }}
+          sections
+        {% endtrans %}
+      {% endset %}
+      {% if not collection.sections %}
+        <p class="govuk-body">This collection has no sections.</p>
+      {% else %}
+        <p class="govuk-body">This collection has {{ sections_text }}</p>
 
-    {% set section_rows = [] %}
-    {% set table_rows = [] %}
-    {% for section in collection.sections %}
-      {%
-        do table_rows.append({
-        "text": section.title,
-        "actions":[
-        {"text":"Move up",
-            "href":url_for('developers.move_section', grant_id = grant.id, collection_id=collection.id,
-                   section_id = section.id, direction = 'up'),"disabled":(loop.index <= 1), "post":true},
-                   {"href":url_for('developers.move_section', grant_id = grant.id, collection_id=collection.id,
-                   section_id = section.id, direction = 'down') ,
-                "text": "Move down","disabled":(loop.index >= collection.sections | length), "post":true},
-                {"href":url_for('developers.manage_section', grant_id = grant.id, collection_id=collection.id,
-                   section_id = section.id),
-                "text": "Manage","post":false}
-        ]
-                })
-      %}
-    {% endfor %}
+        {% set section_rows = [] %}
+        {% set table_rows = [] %}
+        {% for section in collection.sections %}
+          {%
+            do table_rows.append({
+            "text": section.title,
+            "actions":[
+            {"text":"Move up",
+                "href":url_for('developers.move_section', grant_id = grant.id, collection_id=collection.id,
+                      section_id = section.id, direction = 'up'),"disabled":(loop.index <= 1), "post":true},
+                      {"href":url_for('developers.move_section', grant_id = grant.id, collection_id=collection.id,
+                      section_id = section.id, direction = 'down') ,
+                    "text": "Move down","disabled":(loop.index >= collection.sections | length), "post":true},
+                    {"href":url_for('developers.manage_section', grant_id = grant.id, collection_id=collection.id,
+                      section_id = section.id),
+                    "text": "Manage","post":false}
+            ]
+                    })
+          %}
+        {% endfor %}
 
-    {% if collection.sections %}
-      {{ moveUpDownTable(table_rows) }}
-    {% endif %}
-    {{
-      govukButton({
-      "text": "Add a section",
-      "classes": "govuk-button--secondary",
-      "href": url_for("developers.add_section", grant_id = grant.id, collection_id=collection.id)
-      })
-    }}
-  {% endif %}
+        {% if collection.sections %}
+          {{ moveUpDownTable(table_rows) }}
+        {% endif %}
+      {% endif %}
+
+      {{
+        govukButton({
+        "text": "Add a section",
+        "classes": "govuk-button--secondary",
+        "href": url_for("developers.add_section", grant_id = grant.id, collection_id=collection.id)
+        })
+      }}
+    </div>
+  </div>
 {% endblock content %}

--- a/app/developers/templates/developers/list_sections.html
+++ b/app/developers/templates/developers/list_sections.html
@@ -44,19 +44,22 @@
         {% for section in collection.sections %}
           {%
             do table_rows.append({
-            "text": section.title,
-            "actions":[
-            {"text":"Move up",
-                "href":url_for('developers.move_section', grant_id = grant.id, collection_id=collection.id,
-                      section_id = section.id, direction = 'up'),"disabled":(loop.index <= 1), "post":true},
-                      {"href":url_for('developers.move_section', grant_id = grant.id, collection_id=collection.id,
-                      section_id = section.id, direction = 'down') ,
-                    "text": "Move down","disabled":(loop.index >= collection.sections | length), "post":true},
-                    {"href":url_for('developers.manage_section', grant_id = grant.id, collection_id=collection.id,
-                      section_id = section.id),
-                    "text": "Manage","post":false}
-            ]
-                    })
+              "text": section.title,
+              "actions":[{
+                "text":"Move up",
+                "href": url_for('developers.move_section', grant_id = grant.id, collection_id=collection.id, section_id = section.id, direction = 'up'),"disabled":(loop.index <= 1),
+                "post": True
+              }, {
+                "text": "Move down",
+                "href": url_for('developers.move_section', grant_id = grant.id, collection_id=collection.id, section_id = section.id, direction = 'down'),
+                "disabled":(loop.index >= collection.sections | length),
+                "post": True
+              }, {
+                "href": url_for('developers.manage_section', grant_id = grant.id, collection_id=collection.id, section_id = section.id),
+                "text": "Manage",
+                "post": False
+              }]
+            })
           %}
         {% endfor %}
 

--- a/app/developers/templates/developers/manage_form.html
+++ b/app/developers/templates/developers/manage_form.html
@@ -16,7 +16,7 @@
   {{
     govukBackLink({
         "text": "Back",
-        "href": url_for("developers.manage_schema", grant_id = grant.id, schema_id= schema.id)
+        "href": url_for("developers.manage_collection", grant_id = grant.id, collection_id= collection.id)
     })
   }}
 {% endblock beforeContent %}
@@ -107,9 +107,7 @@
   <div class="govuk-grid-row govuk-!-margin-top-7">
     <div class="govuk-grid-column-two-thirds">
       <p class="govuk-body">
-        <a class="govuk-link app-link--destructive" href="{{ url_for('developers.manage_form', grant_id=grant.id, collection_id=collection.id, section_id=section.id, form_id=form.id, back_link=request.args.get('back_link'), delete='') }}">
-          Delete this form
-        </a>
+        <a class="govuk-link app-link--destructive" href="{{ url_for('developers.manage_form', grant_id=grant.id, collection_id=collection.id, section_id=section.id, form_id=form.id, delete='') }}">Delete this form</a>
       </p>
     </div>
   </div>

--- a/app/developers/templates/developers/manage_form.html
+++ b/app/developers/templates/developers/manage_form.html
@@ -16,7 +16,7 @@
   {{
     govukBackLink({
         "text": "Back",
-        "href": back_link_href
+        "href": url_for("developers.manage_schema", grant_id = grant.id, schema_id= schema.id)
     })
   }}
 {% endblock beforeContent %}
@@ -92,20 +92,16 @@
       {% if form.questions %}
         <p class="govuk-body">This form has {% trans count=form.questions | length %}{{ count }} question{% pluralize %}{{ count }} questions{% endtrans %}.</p>
         {{ moveUpDownTable(table_rows) }}
-        {{
-          govukButton({
-              "text": "Add question",
-              "classes": "govuk-button--secondary",
-              "href": url_for("developers.choose_question_type", grant_id=grant.id, collection_id=collection.id, section_id=section.id, form_id=form.id),
-          })
-        }}
       {% else %}
-        <p class="govuk-body">
-          This form has no questions, you can
-          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('developers.choose_question_type', grant_id=grant.id, collection_id=collection.id, section_id=section.id, form_id=form.id) }}">add a question</a>
-          .
-        </p>
+        <p class="govuk-body">This form has no questions.</p>
       {% endif %}
+      {{
+        govukButton({
+            "text": "Add question",
+            "classes": "govuk-button--secondary",
+            "href": url_for("developers.choose_question_type", grant_id=grant.id, collection_id=collection.id, section_id=section.id, form_id=form.id),
+        })
+      }}
     </div>
   </div>
   <div class="govuk-grid-row govuk-!-margin-top-7">

--- a/app/developers/templates/developers/manage_form.html
+++ b/app/developers/templates/developers/manage_form.html
@@ -90,7 +90,7 @@
       {% endfor %}
 
       {% if form.questions %}
-        <p class="govuk-body">This form has {{ question_text }}.</p>
+        <p class="govuk-body">This form has {% trans count=form.questions | length %}{{ count }} question{% pluralize %}{{ count }} questions{% endtrans %}.</p>
         {{ moveUpDownTable(table_rows) }}
         {{
           govukButton({

--- a/app/developers/templates/developers/manage_form.html
+++ b/app/developers/templates/developers/manage_form.html
@@ -71,21 +71,25 @@
 
       {% set table_rows = [] %}
       {% for question in form.questions %}
+        {% set question_link %}
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('developers.edit_question', grant_id = grant.id, collection_id = collection.id, section_id = section.id, form_id=form.id, question_id=question.id) }}">
+            {{ question.text }}
+          </a>
+        {% endset %}
         {%
           do table_rows.append({
-          "text": question.text,
-          "actions":[
-          {"text":"Move up",
-              "href":url_for('developers.move_question', grant_id = grant.id, collection_id = collection.id,
-                     section_id = section.id, form_id=form.id, question_id=question.id, direction = 'up'),"disabled":(loop.index <= 1), "post":true},
-                     {"href":url_for('developers.move_question', grant_id = grant.id, collection_id = collection.id,
-                     section_id = section.id, form_id=form.id, question_id=question.id, direction = 'down') ,"post":true,
-                  "text": "Move down","disabled":(loop.index >= form.questions | length)},
-                  {"href":url_for('developers.edit_question', grant_id = grant.id, collection_id = collection.id,
-                   section_id = section.id, form_id=form.id, question_id=question.id),
-                  "text": "Manage","post":false}
-          ]
-                  })
+            "html": question_link,
+            "actions":[{
+                "text":"Move up",
+                "href": url_for('developers.move_question', grant_id = grant.id, collection_id = collection.id, section_id = section.id, form_id=form.id, question_id=question.id, direction = 'up'),"disabled":(loop.index <= 1),
+                "post": True
+              }, {
+                "href": url_for('developers.move_question', grant_id = grant.id, collection_id = collection.id, section_id = section.id, form_id=form.id, question_id=question.id, direction = 'down'),
+                "post": True,
+                "text": "Move down","disabled":(loop.index >= form.questions | length)
+              }
+            ]
+          })
         %}
       {% endfor %}
 

--- a/app/developers/templates/developers/manage_schema.html
+++ b/app/developers/templates/developers/manage_schema.html
@@ -2,7 +2,6 @@
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
-{% from "govuk_frontend_jinja/components/task-list/macro.html" import govukTaskList %}
 {% extends "deliver_grant_funding/base.html" %}
 
 {% block pageTitle %}
@@ -119,8 +118,8 @@
         {% if not section.forms %}
           <p class="govuk-body">
             This section has no forms, you can
-            <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('developers.add_form', grant_id = grant.id, collection_id=collection.id, section_id=section.id) }}">add a form</a>
-            .
+            <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('developers.manage_section', grant_id = grant.id, collection_id=collection.id, section_id=section.id) }}">manage this section</a>
+            to add a form.
           </p>
         {% endif %}
 
@@ -134,23 +133,27 @@
               questions
             {% endtrans %}
           {% endset %}
+          {% set form_link %}
+            <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('developers.manage_form', grant_id = grant.id, schema_id=schema.id, section_id = section.id, form_id=form.id, back_link='manage_schema') }}">
+              {{ form.title }}
+            </a>
+          {% endset %}
           {%
             do rows.append({
-                  "title": {
-                    "text": form.title,
-                  },
-                "status": {
+                "key": {
+                  "html": form_link,
+                },
+                "value": {
                   "text": question_text
                 },
-              "href": url_for("developers.manage_form", grant_id = grant.id, collection_id=collection.id, section_id = section.id, form_id=form.id, back_link="manage_collection")
             })
           %}
         {% endfor %}
 
         {{
-          govukTaskList({
-            "idPrefix": section.slug,
-            "items": rows
+          govukSummaryList({
+            "rows": rows,
+            "classes": "app-tasklist-builder"
           })
         }}
       {% endfor %}

--- a/app/developers/templates/developers/manage_schema.html
+++ b/app/developers/templates/developers/manage_schema.html
@@ -36,7 +36,6 @@
       {% endif %}
 
       <h1 class="govuk-heading-l">
-        <span class="govuk-caption-l">{{ grant.name }}</span>
         {{ collection.name }}
       </h1>
       {% set sections_text %}

--- a/app/developers/templates/developers/manage_schema.html
+++ b/app/developers/templates/developers/manage_schema.html
@@ -34,9 +34,7 @@
         {{ govukNotificationBanner(params={"role": "alert", "titleText": "Warning", "classes": "app-notification-banner--destructive", "html": banner_html}) }}
       {% endif %}
 
-      <h1 class="govuk-heading-l">
-        {{ collection.name }}
-      </h1>
+      <h1 class="govuk-heading-l">{{ collection.name }}</h1>
       {% set sections_text %}
         {% trans count=collection.sections | length %}
           {{ count }}
@@ -96,14 +94,6 @@
         })
       }}
 
-      {% if not collection.sections %}
-        <p class="govuk-body">
-          This collection has no sections, you can
-          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('developers.add_section', grant_id = grant.id, collection_id=collection.id) }}">add a section</a>
-          .
-        </p>
-      {% endif %}
-
       <form method="post" novalidate>
         {{ form.csrf_token }}
         {{ form.submit(params={"classes": "govuk-button--secondary"}) }}
@@ -134,7 +124,7 @@
             {% endtrans %}
           {% endset %}
           {% set form_link %}
-            <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('developers.manage_form', grant_id = grant.id, schema_id=schema.id, section_id = section.id, form_id=form.id, back_link='manage_schema') }}">
+            <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('developers.manage_form', grant_id = grant.id, collection_id=collection.id, section_id = section.id, form_id=form.id, back_link='manage_schema') }}">
               {{ form.title }}
             </a>
           {% endset %}
@@ -156,6 +146,12 @@
             "classes": "app-tasklist-builder"
           })
         }}
+      {% else %}
+        <p class="govuk-body">
+          This collection has no sections, you can
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('developers.list_sections', grant_id = grant.id, collection_id=collection.id) }}">manage sections</a>
+          to add a section.
+        </p>
       {% endfor %}
 
       <div class="govuk-grid-row govuk-!-margin-top-7">

--- a/app/developers/templates/developers/manage_section.html
+++ b/app/developers/templates/developers/manage_section.html
@@ -15,51 +15,53 @@
   {{
     govukBackLink({
         "text": "Back",
-        "href": url_for("developers.manage_collection", grant_id = grant.id, collection_id=collection.id)
+        "href": url_for("developers.list_sections", grant_id = grant.id, collection_id=collection.id)
     })
   }}
 {% endblock beforeContent %}
 
 {% block content %}
-  {% if confirm_deletion_form %}
-    {% set banner_html %}
-      <p class="govuk-body govuk-!-font-weight-bold">Are you sure you want to delete this section?</p>
-      <form method="post" novalidate>
-        {{ confirm_deletion_form.csrf_token }}
-        {{ confirm_deletion_form.confirm_deletion(params={"classes": "govuk-button--warning govuk-!-margin-bottom-0"}) }}
-      </form>
-    {% endset %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if confirm_deletion_form %}
+        {% set banner_html %}
+          <p class="govuk-body govuk-!-font-weight-bold">Are you sure you want to delete this section?</p>
+          <form method="post" novalidate>
+            {{ confirm_deletion_form.csrf_token }}
+            {{ confirm_deletion_form.confirm_deletion(params={"classes": "govuk-button--warning govuk-!-margin-bottom-0"}) }}
+          </form>
+        {% endset %}
 
-    {{ govukNotificationBanner(params={"role": "alert", "titleText": "Warning", "classes": "app-notification-banner--destructive", "html": banner_html}) }}
-  {% endif %}
+        {{ govukNotificationBanner(params={"role": "alert", "titleText": "Warning", "classes": "app-notification-banner--destructive", "html": banner_html}) }}
+      {% endif %}
 
-  <h1 class="govuk-heading-l">
-    <span class="govuk-caption-l">{{ collection.name }}</span>
-    {{ section.title }}
-  </h1>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l">{{ collection.name }}</span>
+        {{ section.title }}
+      </h1>
+    </div>
+  </div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-5">
       {{
         govukSummaryList({
-        "rows": [{
-        "key": {"text": "Title"},
-        "value":{"text": section.title},
-        "actions": {
-        "items": [
-        {
-        "href": url_for("developers.edit_section", grant_id = grant.id, collection_id = collection.id, section_id = section.id),
-        "text": "Change",
-        "classes": "govuk-link--no-visited-state"
-        }
-        ]
-        }
-        }]
+          "rows": [{
+            "key": {"text": "Title"},
+            "value":{"text": section.title},
+            "actions": {
+              "items": [{
+                "href": url_for("developers.edit_section", grant_id = grant.id, collection_id = collection.id, section_id = section.id),
+                "text": "Change",
+                "classes": "govuk-link--no-visited-state"
+              }]
+            }
+          }]
         })
       }}
     </div>
   </div>
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
+    <div class="govuk-grid-column-two-thirds">
       <h2 class="govuk-heading-m">Forms</h2>
       {% set forms_text %}{% trans count=section.forms | length %}
         {{ count }}
@@ -67,11 +69,7 @@
       {% endtrans %}{% endset %}
 
       {% if not section.forms %}
-        <p class="govuk-body">
-          This section has no forms, you can
-          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('developers.add_form', grant_id = grant.id, collection_id=collection.id, section_id=section.id) }}">add a form</a>
-          .
-        </p>
+        <p class="govuk-body">This section has no forms.</p>
       {% else %}
         <p class="govuk-body">This section has {{ forms_text }}.</p>
       {% endif %}
@@ -87,10 +85,7 @@
                      section_id = section.id, form_id=form.id, direction = 'up'),"disabled":(loop.index <= 1), "post":true},
                      {"href":url_for('developers.move_form', grant_id = grant.id, collection_id=collection.id,
                      section_id = section.id, form_id=form.id, direction = 'down') ,"post":true,
-                  "text": "Move down","disabled":(loop.index >= section.forms | length)},
-                  {"href":url_for('developers.manage_form', grant_id = grant.id, collection_id=collection.id,
-                     section_id = section.id, form_id=form.id, back_link="manage_section"),
-                  "text": "Manage","post":false}
+                  "text": "Move down","disabled":(loop.index >= section.forms | length)}
           ]
                   })
         %}
@@ -98,14 +93,15 @@
 
       {% if section.forms %}
         {{ moveUpDownTable(table_rows) }}
-        {{
-          govukButton({
-          "text": "Add a form",
-          "classes": "govuk-button--secondary",
-          "href": url_for("developers.add_form", grant_id = grant.id, collection_id=collection.id, section_id=section.id)
-          })
-        }}
       {% endif %}
+
+      {{
+        govukButton({
+        "text": "Add a form",
+        "classes": "govuk-button--secondary",
+        "href": url_for("developers.add_form", grant_id = grant.id, collection_id=collection.id, section_id=section.id)
+        })
+      }}
     </div>
   </div>
   <div class="govuk-grid-row govuk-!-margin-top-7">

--- a/app/developers/templates/developers/manage_section.html
+++ b/app/developers/templates/developers/manage_section.html
@@ -71,6 +71,12 @@
       {% if not section.forms %}
         <p class="govuk-body">This section has no forms.</p>
       {% else %}
+        <p class="govuk-body">
+          You can add and re-order forms. Form questions can be managed from the
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('developers.manage_collection', grant_id=grant.id, collection_id=collection.id) }}">collection tasklist</a>
+          .
+        </p>
+
         <p class="govuk-body">This section has {{ forms_text }}.</p>
       {% endif %}
 

--- a/app/developers/templates/developers/manage_section.html
+++ b/app/developers/templates/developers/manage_section.html
@@ -71,10 +71,10 @@
       {% if not section.forms %}
         <p class="govuk-body">This section has no forms.</p>
       {% else %}
+        <!-- prettier-ignore -->
         <p class="govuk-body">
           You can add and re-order forms. Form questions can be managed from the
-          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('developers.manage_collection', grant_id=grant.id, collection_id=collection.id) }}">collection tasklist</a>
-          .
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('developers.manage_collection', grant_id=grant.id, collection_id=collection.id) }}">collection tasklist</a>.
         </p>
 
         <p class="govuk-body">This section has {{ forms_text }}.</p>
@@ -84,16 +84,18 @@
       {% for form in section.forms %}
         {%
           do table_rows.append({
-          "text": form.title,
-          "actions":[
-          {"text":"Move up",
-              "href":url_for('developers.move_form', grant_id = grant.id, collection_id=collection.id,
-                     section_id = section.id, form_id=form.id, direction = 'up'),"disabled":(loop.index <= 1), "post":true},
-                     {"href":url_for('developers.move_form', grant_id = grant.id, collection_id=collection.id,
-                     section_id = section.id, form_id=form.id, direction = 'down') ,"post":true,
-                  "text": "Move down","disabled":(loop.index >= section.forms | length)}
-          ]
-                  })
+            "text": form.title,
+            "actions":[{
+              "text":"Move up",
+              "href": url_for('developers.move_form', grant_id = grant.id, collection_id=collection.id, section_id = section.id, form_id=form.id, direction = 'up'),"disabled":(loop.index <= 1),
+              "post": True
+            }, {
+              "text": "Move down",
+              "href": url_for('developers.move_form', grant_id = grant.id, collection_id=collection.id, section_id = section.id, form_id=form.id, direction = 'down'),
+              "post": True,
+              "disabled": (loop.index >= section.forms | length)
+            }]
+          })
         %}
       {% endfor %}
 

--- a/app/developers/templates/developers/select_form_type.html
+++ b/app/developers/templates/developers/select_form_type.html
@@ -48,7 +48,6 @@
       {{
         govukButton({
         "text": "Continue",
-        "classes": "govuk-button--secondary",
         "href": url_for("developers.add_form", grant_id = grant.id, collection_id=collection.id, section_id=section.id, form_type="empty")
         })
       }}

--- a/tests/e2e/developer_pages.py
+++ b/tests/e2e/developer_pages.py
@@ -34,16 +34,16 @@ class GrantDevelopersPage(GrantDevelopersBasePage):
 
 
 class ListCollectionsPage(GrantDevelopersBasePage):
-    add_collection_link: Locator
+    add_collection_button: Locator
 
     def __init__(self, page: Page, domain: str, grant_name: str) -> None:
         super().__init__(
             page, domain, grant_name=grant_name, heading=page.get_by_role("heading", name=f"{grant_name} collections")
         )
-        self.add_collection_link = self.page.get_by_role("link", name="add a collection")
+        self.add_collection_button = self.page.get_by_role("button", name="Add collection")
 
     def click_add_collection(self) -> AddCollectionPage:
-        self.add_collection_link.click()
+        self.add_collection_button.click()
         add_collection_page = AddCollectionPage(self.page, self.domain, grant_name=self.grant_name)
         expect(add_collection_page.heading).to_be_visible()
         return add_collection_page


### PR DESCRIPTION
This proposes some minor tweaks to the developer form building pages to make them consistent and line them up with the original sketches. The journey here will definitely be changed and refined a lot but lets start with something consistent

The main change is separating out the ordering and management of sections into the "Manage" sections pages and keeps all forms/ questions links in the main collection tasklist builder view.

The original intention of that was so that the collection overview/ "tasklist" page was kept clear of many "add" buttons and "move up/ move down" links as well as being the main entry point/ overview for managing forms and questions for your collection (that would be accessed all the time).

The hypothesis being the number of times you need to add/ order sections and forms would be a lot less frequent than adding/ managing questions.

This definitely results in a lot more clicks and possibly some unintuitive separation until you're used to it - we should revise this journey/ design as we need to but lets at least make it fully consistent as a base so that we can then change it intentionally.

This revises the current version where there's a hybrid method of editing a form which is to either click in from the collection detail/ tasklist page or to go through "list sections" -> "manage section" -> "manage form". Just in watching product sign offs I've seen that happen a number of times and it doesn't feel like good repetitive behaviour.

Smaller fixes: 
- make sure we have consistent back link behaviour between all of the pages
- the list/ "Add X" button pattern should be consistent between all pages, this should be that the secondary button to "Add X" is always shown and the page either shows the list of things or some text saying there are none
- headings and caption use should be consistent
- all pages should be 2/3 consistently
- formatting issues
- don't use a "tasklist" HTML component in the case where its not actually a task list to fill out - this could have some very strange effects when using assistive technologies
- make the question text the link in the questions list to visually differentiate it from other up/ down pages
- removes the large "edit question type" disclaimer to try and bring the add and edit question pages closer together - after seeing that for the hundredth time that inset text taking up 1/3 of the page would start to get distracting. I think the "Add question page" showing the question type but not letting it be changed describes this clearly enough - something that would be good to sense check when putting it in front of users!

Updates the end to end tests to understand the tweaked layout.