### PR TITLE
FSPT-551: Redirect SSO users to original destination

### DIFF
--- a/app/common/auth/__init__.py
+++ b/app/common/auth/__init__.py
@@ -100,6 +100,7 @@ def sso_get_token() -> ResponseReturnValue:
     sso_user = result["id_token_claims"]
 
     user = get_or_create_user(email_address=sso_user["preferred_username"])
+    redirect_to_path = sanitise_redirect_url(session.pop("next", url_for("index")))
 
     if "FSD_ADMIN" in sso_user.get("roles", []):
         add_user_role(user_id=user.id, role=RoleEnum.ADMIN)
@@ -113,7 +114,7 @@ def sso_get_token() -> ResponseReturnValue:
     if not login_user(user):
         abort(400)
 
-    return redirect(sso_user.get("next", url_for("deliver_grant_funding.list_grants")))
+    return redirect(redirect_to_path)
 
 
 @auth_blueprint.get("/sign-out")


### PR DESCRIPTION
With the Magic Link journey we were capturing the `session["next"]` value and redirecting users back to that path when they had successfully authenticated. We hadn't implemented this for SSO so all users would be sent to the default Grant List view on successful authentication, regardless of if they were trying to nagivate to a different page on the service.

This updates that behaviour to bring it inline with magic links.