### PR TITLE
SSO Stub server default email address

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,6 @@ AZURE_AD_CLIENT_ID=example
 AZURE_AD_CLIENT_SECRET=example
 AZURE_AD_TENANT_ID=example
 # AZURE_AD_BASE_URL=https://login.microsoftonline.com/
+
+# If you want to override the default email address for the stub server, set this.
+SSO_STUB_SERVER_DEFAULT_EMAIL=firstname.lastname@communities.gov.uk

--- a/stubs/sso/__init__.py
+++ b/stubs/sso/__init__.py
@@ -62,7 +62,9 @@ def create_sso_stub_app() -> Flask:
     def oauth_redirect(tenant):
         global dummy_nonce, base_64_str_client_info, email_address, is_platform_admin
 
-        form = SSOSignInForm()
+        form = SSOSignInForm(
+            data={"email_address": os.getenv("SSO_STUB_SERVER_DEFAULT_EMAIL", "john.cheese@communities.gov.uk")}
+        )
         if form.validate_on_submit():
             dummy_nonce = request.args["nonce"]
             email_address = form.email_address.data


### PR DESCRIPTION
Save us all a few keypresses each time we need to log in/out.

Add `SSO_STUB_SERVER_DEFAULT_EMAIL` to your `.env` if you want to have a different default value.