### PR TITLE
Don't delete config from current_app

### DIFF
--- a/tests/unit/app/common/forms/test_validators.py
+++ b/tests/unit/app/common/forms/test_validators.py
@@ -1,7 +1,6 @@
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
-from flask import current_app
 from wtforms.validators import ValidationError
 
 from app.common.forms.validators import CommunitiesEmail, WordRange
@@ -101,8 +100,7 @@ class TestCommunitiesEmailValidator:
     def test_case_insensitive_domain_match(self):
         self._call_validator("Staff@Communities.Gov.Uk")
 
-    def test_missing_internal_domains_config(self):
-        with pytest.raises(KeyError):
+    def test_missing_internal_domains_config(self, app):
+        with pytest.raises(KeyError), patch.dict(app.config, {}, clear=True):
             self.field.data = "user@anywhere.com"
-            del current_app.config["INTERNAL_DOMAINS"]
             self.validator(self.form, self.field)

--- a/tests/unit/app/deliver_grant_funding/test_forms.py
+++ b/tests/unit/app/deliver_grant_funding/test_forms.py
@@ -67,7 +67,6 @@ def test_grant_ggis_form_fails_when_yes_selected_and_empty(app: Flask):
 
 
 def test_user_already_in_grant_users(app: Flask):
-    app.config["INTERNAL_DOMAINS"] = ("@communities.gov.uk", "@test.communities.gov.uk")
     user_in_grant = User(email="test.user@communities.gov.uk")
     grant = Grant(name="Test Grant", users=[user_in_grant])
     form = GrantAddUserForm(
@@ -80,7 +79,6 @@ def test_user_already_in_grant_users(app: Flask):
 
 
 def test_user_already_platform_admin(app: Flask):
-    app.config["INTERNAL_DOMAINS"] = ("@communities.gov.uk", "@test.communities.gov.uk")
     platform_admin = User(email="test.admin@communities.gov.uk", roles=[UserRole(role=RoleEnum.ADMIN)])
     grant = Grant(name="Test Grant", users=[])
     form = GrantAddUserForm(


### PR DESCRIPTION
This can leak into other tests; after stopping this we can remove the resetting of INTERNAL_DOMAINS that had to be added elsewhere.

We need to always be careful to not create any side effects from our tests so that they are well isolated from each other.