### PR TITLE
Use the app fixture, remove unneeded context

### DIFF
--- a/tests/integration/common/auth/test_decorators.py
+++ b/tests/integration/common/auth/test_decorators.py
@@ -19,19 +19,17 @@ class TestLoginRequired:
 
         user = factories.user.create(email="test@anything.com")
 
-        with app.test_client(), app.test_request_context("/"):
-            login_user(user)
-            response = test_login_required()
-            assert response == "OK"
+        login_user(user)
+        response = test_login_required()
+        assert response == "OK"
 
     def test_anonymous_user_gets_redirect(self, app):
         @login_required
         def test_login_required():
             return "OK"
 
-        with app.test_client(), app.test_request_context("/"):
-            response = test_login_required()
-            assert response.status_code == 302
+        response = test_login_required()
+        assert response.status_code == 302
 
 
 class TestMHCLGLoginRequired:
@@ -42,10 +40,9 @@ class TestMHCLGLoginRequired:
 
         user = factories.user.create(email="test@communities.gov.uk")
 
-        with app.test_client(), app.test_request_context("/"):
-            login_user(user)
-            response = test_login_required()
-            assert response == "OK"
+        login_user(user)
+        response = test_login_required()
+        assert response == "OK"
 
     def test_non_mhclg_user_is_forbidden(self, app, factories):
         @mhclg_login_required
@@ -54,7 +51,7 @@ class TestMHCLGLoginRequired:
 
         user = factories.user.create(email="test@anything.com")
 
-        with app.test_client(), app.test_request_context("/"), pytest.raises(Forbidden):
+        with pytest.raises(Forbidden):
             login_user(user)
             test_login_required()
 
@@ -63,9 +60,8 @@ class TestMHCLGLoginRequired:
         def test_login_required():
             return "OK"
 
-        with app.test_client(), app.test_request_context("/"):
-            response = test_login_required()
-            assert response.status_code == 302
+        response = test_login_required()
+        assert response.status_code == 302
 
 
 class TestPlatformAdminRoleRequired:
@@ -77,10 +73,9 @@ class TestPlatformAdminRoleRequired:
         user = factories.user.create(email="test@communities.gov.uk")
         factories.user_role.create(user_id=user.id, user=user, role=RoleEnum.ADMIN)
 
-        with app.test_client(), app.test_request_context("/"):
-            login_user(user)
-            response = test_login_required()
-            assert response == "OK"
+        login_user(user)
+        response = test_login_required()
+        assert response == "OK"
 
     def test_non_platform_admin_is_forbidden(self, app, factories):
         @platform_admin_role_required
@@ -89,7 +84,7 @@ class TestPlatformAdminRoleRequired:
 
         user = factories.user.create(email="test@communities.gov.uk")
 
-        with app.test_client(), app.test_request_context("/"), pytest.raises(Forbidden):
+        with pytest.raises(Forbidden):
             login_user(user)
             test_login_required()
 
@@ -98,9 +93,8 @@ class TestPlatformAdminRoleRequired:
         def test_login_required():
             return "OK"
 
-        with app.test_client(), app.test_request_context("/"):
-            response = test_login_required()
-            assert response.status_code == 302
+        response = test_login_required()
+        assert response.status_code == 302
 
 
 class TestRedirectIfAuthenticated:
@@ -111,10 +105,9 @@ class TestRedirectIfAuthenticated:
 
         user = factories.user.create(email="test@communities.gov.uk")
 
-        with app.test_client(), app.test_request_context("/"):
-            login_user(user)
-            response = test_authenticated_redirect()
-            assert response.status_code == 302
+        login_user(user)
+        response = test_authenticated_redirect()
+        assert response.status_code == 302
 
     def test_external_authenticated_user_gets_403(self, app, factories):
         @redirect_if_authenticated
@@ -123,7 +116,7 @@ class TestRedirectIfAuthenticated:
 
         user = factories.user.create(email="test@anything.com")
 
-        with app.test_client(), app.test_request_context("/"), pytest.raises(InternalServerError):
+        with pytest.raises(InternalServerError):
             login_user(user)
             test_authenticated_redirect()
 
@@ -132,6 +125,5 @@ class TestRedirectIfAuthenticated:
         def test_authenticated_redirect():
             return "OK"
 
-        with app.test_client(), app.test_request_context("/"):
-            response = test_authenticated_redirect()
-            assert response == "OK"
+        response = test_authenticated_redirect()
+        assert response == "OK"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -190,6 +190,9 @@ def db_session(app: Flask, db: SQLAlchemy) -> Generator[Session, None, None]:
     # sessionmaker configuration to use a connection with a transaction started, and configure FSL to use savepoints
     # for any flushes/commits that happen within the test. When the test finishes, this fixture will do a full rollback,
     # preventing any data leaking beyond the scope of the test.
+    #
+    # NOTE: this fixture is automatically used by all integration tests, and provides both an app context and a test
+    # request context. So you will not need to manually create these within your integration tests.
 
     with app.app_context():
         connection = db.engine.connect()

--- a/tests/unit/app/deliver_grant_funding/test_forms.py
+++ b/tests/unit/app/deliver_grant_funding/test_forms.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 
 import pytest
-from flask import Flask
+from flask import Flask, request
 from wtforms import Form, StringField
 from wtforms.validators import ValidationError
 
@@ -42,38 +42,28 @@ def test_unique_grant_name_fails_when_name_exists():
 
 
 def test_grant_ggis_form_validates_when_no_selected(app: Flask):
-    app.config["SECRET_KEY"] = "test-key"  # pragma: allowlist secret
+    print(request)
+    form = GrantGGISForm(data={"has_ggis": "no", "ggis_number": ""})
 
-    with app.test_request_context():
-        form = GrantGGISForm(data={"has_ggis": "no", "ggis_number": ""})
-
-        # Should return True when "no" is selected and GGIS number can be empty
-        assert form.validate() is True
-        assert len(form.ggis_number.errors) == 0
+    # Should return True when "no" is selected and GGIS number can be empty
+    assert form.validate() is True
+    assert len(form.ggis_number.errors) == 0
 
 
 def test_grant_ggis_form_validates_when_yes_selected_with_ggis_number(app: Flask):
-    app.config["SECRET_KEY"] = "test-key"  # pragma: allowlist secret
+    form = GrantGGISForm(data={"has_ggis": "yes", "ggis_number": "GGIS123456"})
 
-    with app.test_request_context():
-        form = GrantGGISForm(data={"has_ggis": "yes", "ggis_number": "GGIS123456"})
-
-        # Should return True when "yes" is selected and GGIS number is provided
-        assert form.validate() is True
-        assert len(form.ggis_number.errors) == 0
+    # Should return True when "yes" is selected and GGIS number is provided
+    assert form.validate() is True
+    assert len(form.ggis_number.errors) == 0
 
 
 def test_grant_ggis_form_fails_when_yes_selected_and_empty(app: Flask):
-    app = Flask(__name__)
-    app.config["SECRET_KEY"] = "test-key"  # pragma: allowlist secret
-    app.config["WTF_CSRF_ENABLED"] = False  # Disable CSRF for testing
+    form = GrantGGISForm(data={"has_ggis": "yes", "ggis_number": ""})
 
-    with app.test_request_context():
-        form = GrantGGISForm(data={"has_ggis": "yes", "ggis_number": ""})
-
-        # Should return False when "yes" is selected but GGIS number is empty
-        assert form.validate() is False
-        assert "Enter your GGIS reference number" in form.ggis_number.errors
+    # Should return False when "yes" is selected but GGIS number is empty
+    assert form.validate() is False
+    assert "Enter your GGIS reference number" in form.ggis_number.errors
 
 
 def test_user_already_in_grant_users(app: Flask):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -39,6 +39,9 @@ def db_session(app: Flask) -> Generator[None, None, None]:
     # set up the database connection/session with transactional isolation between tests.
     # This blank fixture helps us still provide the ability to use FactoryBoy to build ephemeral instances of our DB
     # models for unit testing.
+    #
+    # NOTE: this fixture is automatically used by all unit tests, and provides both an app context and a test request
+    # context. So you will not need to manually create these within your unit tests.
 
     with app.app_context():
         original_session_property = SQLAlchemy.session


### PR DESCRIPTION
The core app fixture provides a properly-configured Flask instance, so we don't need to set SECRET_KEY manually.

These tests also don't need an explicit test request context - we have a db_session fixture that wraps every test in its own app context, which comes with a test request context as well.