### PR TITLE
User model tweaks

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, Optional
 
 from flask import Flask, Response, redirect, render_template, url_for
 from flask.typing import ResponseReturnValue
@@ -9,7 +9,6 @@ from sqlalchemy.exc import NoResultFound
 
 from app import logging
 from app.common.data import interfaces
-from app.common.data.models_user import User
 from app.common.filters import format_date, format_date_range, format_date_short, format_datetime, format_datetime_range
 from app.config import get_settings
 from app.extensions import (
@@ -25,6 +24,9 @@ from app.extensions import (
 )
 from app.monkeypatch import patch_sqlalchemy_lite_async
 from app.sentry import init_sentry
+
+if TYPE_CHECKING:
+    from app.common.data.models_user import User
 
 init_sentry()
 
@@ -70,7 +72,7 @@ def create_app() -> Flask:
     record_sqlalchemy_queries.init_app(app, db)
 
     @login_manager.user_loader  # type: ignore[misc]
-    def load_user(user_id: str) -> User | None:
+    def load_user(user_id: str) -> Optional["User"]:
         return interfaces.user.get_user(user_id)
 
     # This section is needed for url_for("foo", _external=True) to

--- a/app/common/auth/__init__.py
+++ b/app/common/auth/__init__.py
@@ -99,7 +99,7 @@ def sso_get_token() -> ResponseReturnValue:
 
     sso_user = result["id_token_claims"]
 
-    user = get_or_create_user(email_address=sso_user["preferred_username"])
+    user = get_or_create_user(email_address=sso_user["preferred_username"], name=sso_user["name"])
     redirect_to_path = sanitise_redirect_url(session.pop("next", url_for("index")))
 
     if "FSD_ADMIN" in sso_user.get("roles", []):

--- a/app/common/data/interfaces/user.py
+++ b/app/common/data/interfaces/user.py
@@ -33,10 +33,14 @@ def get_or_create_user(email_address: str, name: Optional[str] = None) -> User:
     # This feels like it should be a `on_conflict_do_nothing`, except in that case the DB won't return any rows
     # So we use `on_conflict_do_update` with a noop change, so that this upsert will always return the User regardless
     # of if its doing an insert or an 'update'.
+    on_conflict_set = {"email": email_address}
+    if name:  # doesn't let us remove the name, but that doesn't feel like a super valid usecase, so ignoring for now.
+        on_conflict_set["name"] = name
+
     user = db.session.scalars(
         postgresql_upsert(User)
         .values(email=email_address, name=name)
-        .on_conflict_do_update(index_elements=["email"], set_={"email": email_address, "name": name})
+        .on_conflict_do_update(index_elements=["email"], set_=on_conflict_set)
         .returning(User),
         execution_options={"populate_existing": True},
     ).one()

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_team/grant_user_list.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_team/grant_user_list.html
@@ -42,7 +42,7 @@
 
   {% set table_pending_signin_rows = namespace(items=[]) %}
   {% if grant.users %}
-    {% for user in grant.users if not user.is_logged_in %}
+    {% for user in grant.users if not user.has_logged_in %}
       {%
         set table_pending_signin_rows.items = table_pending_signin_rows.items + [[
           {"text": user.email},
@@ -72,7 +72,7 @@
   {% set table_rows = namespace(items=[]) %}
 
   {% if grant.users %}
-    {% for user in grant.users if user.is_logged_in %}
+    {% for user in grant.users if user.has_logged_in %}
       {%
         set table_rows.items = table_rows.items + [[
           {"text": user.name},

--- a/tests/integration/common/data/interfaces/test_user.py
+++ b/tests/integration/common/data/interfaces/test_user.py
@@ -39,13 +39,24 @@ class TestGetOrCreateUser:
         assert user.email == "test@communities.gov.uk"
 
     def test_get_existing_user(self, db_session, factories):
-        factories.user.create(email="test@communities.gov.uk")
+        factories.user.create(email="test@communities.gov.uk", name="My Name")
         assert db_session.scalar(select(func.count()).select_from(User)) == 1
 
         user = interfaces.user.get_or_create_user(email_address="test@communities.gov.uk")
 
         assert db_session.scalar(select(func.count()).select_from(User)) == 1
         assert user.email == "test@communities.gov.uk"
+        assert user.name == "My Name"
+
+    def test_get_existing_user_can_set_name(self, db_session, factories):
+        factories.user.create(email="test@communities.gov.uk", name="My Name")
+        assert db_session.scalar(select(func.count()).select_from(User)) == 1
+
+        user = interfaces.user.get_or_create_user(email_address="test@communities.gov.uk", name="My NewName")
+
+        assert db_session.scalar(select(func.count()).select_from(User)) == 1
+        assert user.email == "test@communities.gov.uk"
+        assert user.name == "My NewName"
 
 
 class TestAddUserRole:

--- a/tests/models.py
+++ b/tests/models.py
@@ -51,6 +51,7 @@ class _UserFactory(factory.alchemy.SQLAlchemyModelFactory):
         sqlalchemy_session_persistence = "commit"
 
     id = factory.LazyFunction(uuid4)
+    name = factory.Faker("name")
     email = factory.Faker("email")
 
 

--- a/tests/unit/app/deliver_grant_funding/test_forms.py
+++ b/tests/unit/app/deliver_grant_funding/test_forms.py
@@ -5,9 +5,8 @@ from flask import Flask, request
 from wtforms import Form, StringField
 from wtforms.validators import ValidationError
 
-from app import User
 from app.common.data.models import Grant
-from app.common.data.models_user import UserRole
+from app.common.data.models_user import User, UserRole
 from app.common.data.types import RoleEnum
 from app.deliver_grant_funding.forms import GrantAddUserForm, GrantGGISForm, UniqueGrantName
 


### PR DESCRIPTION
Noticed a few issues while scanning over the user code again this morning.

* The name `is_logged_in` implies that a user is _actively_ logged in, but really we only care about "have they ever logged in". So renames to `has_logged_in`. Ideally this would be a stronger check that "do they have a name" (which is also only true for SSO users, not magic link users). We should consider either:
  * A field modelling "last logged in at" or similar.
  * Whether we create user entries before the user logs in, ie use some kind of invite system.
* `get_or_create_user` was updated to take a `name` argument:
  * we didn't add test coverage for this
  * we didn't update the user factory
  * we didn't update users of this function to pass it in (ie SSO user create/update). This in particular would mean that the name attribute never got set on SSO users.
  * the implementation was such that, if a previous call to `get_or_create_user` had set the name field, and then you only wanted to update another field (eg the email - unlikely, but still), then the `name` would be set to None. There was no logic to do partial updates and preserve the existing data.