### PR TITLE
BAU_bug fixes for the user management: Adding missing member login changes and adding unit tests

### DIFF
--- a/app/common/auth/__init__.py
+++ b/app/common/auth/__init__.py
@@ -108,7 +108,7 @@ def sso_get_token() -> ResponseReturnValue:
         )
         add_user_role(user_id=user.id, role=RoleEnum.ADMIN)
 
-    elif not user or not user.roles:  # TODO: also allow to log in if they're a member of a grant.
+    elif not user or not user.roles:
         return render_template(
             "common/auth/mhclg-user-not-authorised.html", service_desk_url=current_app.config["SERVICE_DESK_URL"]
         ), 403

--- a/app/common/data/interfaces/user.py
+++ b/app/common/data/interfaces/user.py
@@ -3,7 +3,7 @@ from typing import Optional, Sequence, cast
 
 from flask_login import current_user
 from sqlalchemy.dialects.postgresql import insert as postgresql_upsert
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, NoResultFound
 from sqlalchemy.sql.expression import select
 
 from app.common.data.interfaces.exceptions import InvalidUserRoleError
@@ -27,6 +27,13 @@ def get_platform_admin_users() -> Sequence[User]:
         .join(User.roles)
         .where(UserRole.role == RoleEnum.ADMIN, UserRole.grant_id.is_(None), UserRole.organisation_id.is_(None))
     ).all()
+
+
+def get_user_by_email(email_address: str) -> Optional[User]:
+    try:
+        return db.session.execute(select(User).where(User.email == email_address)).scalar_one()
+    except NoResultFound:
+        return None
 
 
 def get_or_create_user(email_address: str, name: Optional[str] = None) -> User:

--- a/app/common/data/interfaces/user.py
+++ b/app/common/data/interfaces/user.py
@@ -3,7 +3,7 @@ from typing import Optional, Sequence, cast
 
 from flask_login import current_user
 from sqlalchemy.dialects.postgresql import insert as postgresql_upsert
-from sqlalchemy.exc import IntegrityError, NoResultFound
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.sql.expression import select
 
 from app.common.data.interfaces.exceptions import InvalidUserRoleError
@@ -30,10 +30,7 @@ def get_platform_admin_users() -> Sequence[User]:
 
 
 def get_user_by_email(email_address: str) -> Optional[User]:
-    try:
-        return db.session.execute(select(User).where(User.email == email_address)).scalar_one()
-    except NoResultFound:
-        return None
+    return db.session.execute(select(User).where(User.email == email_address)).scalar_one_or_none()
 
 
 def get_or_create_user(email_address: str, name: Optional[str] = None) -> User:

--- a/app/deliver_grant_funding/routes.py
+++ b/app/deliver_grant_funding/routes.py
@@ -209,8 +209,6 @@ def add_user_to_grant(grant_id: UUID) -> ResponseReturnValue:
             user = next((user for user in grant.users if user.email == form.user_email.data), None)
             if user is None:
                 created_user = interfaces.user.get_or_create_user(email_address=form.user_email.data)
-                if created_user is None:
-                    abort(404)
                 interfaces.user.add_user_role(user_id=created_user.id, grant_id=grant_id, role=RoleEnum.MEMBER)
                 notification_service.send_member_confirmation(
                     grant_name=grant.name,

--- a/app/deliver_grant_funding/routes.py
+++ b/app/deliver_grant_funding/routes.py
@@ -209,6 +209,8 @@ def add_user_to_grant(grant_id: UUID) -> ResponseReturnValue:
             user = next((user for user in grant.users if user.email == form.user_email.data), None)
             if user is None:
                 created_user = interfaces.user.get_or_create_user(email_address=form.user_email.data)
+                if created_user is None:
+                    abort(404)
                 interfaces.user.add_user_role(user_id=created_user.id, grant_id=grant_id, role=RoleEnum.MEMBER)
                 notification_service.send_member_confirmation(
                     grant_name=grant.name,

--- a/tests/integration/common/auth/test_auth.py
+++ b/tests/integration/common/auth/test_auth.py
@@ -193,7 +193,7 @@ class TestSSOGetTokenView:
         assert response.status_code == 403
         assert "https://mhclgdigital.atlassian.net/servicedesk/customer/portal/5" in response.text
 
-    def test_get_without_fsd_admin_role_and_with_grant_member_role(self, app, anonymous_client, factories):
+    def test_get_without_fsd_admin_role_and_with_grant_member_role(self, anonymous_client, factories):
         with patch("app.common.auth.build_msal_app") as mock_build_msap_app:
             user = factories.user.create(email="test.member@communities.gov.uk")
             grant = factories.grant.create()
@@ -209,12 +209,11 @@ class TestSSOGetTokenView:
 
             response = anonymous_client.get(url_for("auth.sso_get_token"), follow_redirects=True)
 
-        assert response.status_code == 200
-        soup = BeautifulSoup(response.data, "html.parser")
-        nav_items = [li.get_text(strip=True) for li in soup.find("ul", id="navigation").find_all("li")]
-        assert len({"Home", "Grant details", "Grant team"} - set(nav_items)) == 0
+            assert not interfaces.user.get_current_user().is_platform_admin
 
-    def test_get_without_fsd_admin_role_and_with_no_roles(self, app, anonymous_client):
+        assert response.status_code == 200
+
+    def test_get_without_fsd_admin_role_and_with_no_roles(self, anonymous_client):
         with patch("app.common.auth.build_msal_app") as mock_build_msap_app:
             # Partially mock the expected return value; just enough for the test.
             mock_build_msap_app.return_value.acquire_token_by_auth_code_flow.return_value = {

--- a/tests/integration/common/auth/test_auth.py
+++ b/tests/integration/common/auth/test_auth.py
@@ -9,6 +9,7 @@ from sqlalchemy import select
 from app.common.data import interfaces
 from app.common.data.models import MagicLink
 from app.common.data.models_user import User
+from app.common.data.types import RoleEnum
 from tests.utils import AnyStringMatching, page_has_error
 
 
@@ -191,6 +192,42 @@ class TestSSOGetTokenView:
 
         assert response.status_code == 403
         assert "https://mhclgdigital.atlassian.net/servicedesk/customer/portal/5" in response.text
+
+    def test_get_without_fsd_admin_role_and_with_grant_member_role(self, app, anonymous_client, factories):
+        with patch("app.common.auth.build_msal_app") as mock_build_msap_app:
+            user = factories.user.create(email="test.member@communities.gov.uk")
+            grant = factories.grant.create()
+            factories.user_role.create(user_id=user.id, user=user, role=RoleEnum.MEMBER, grant=grant)
+            # Partially mock the expected return value; just enough for the test.
+            mock_build_msap_app.return_value.acquire_token_by_auth_code_flow.return_value = {
+                "id_token_claims": {
+                    "preferred_username": "test.member@communities.gov.uk",
+                    "name": "SSO User",
+                    "roles": [],
+                }
+            }
+
+            response = anonymous_client.get(url_for("auth.sso_get_token"), follow_redirects=True)
+
+        assert response.status_code == 200
+        soup = BeautifulSoup(response.data, "html.parser")
+        nav_items = [li.get_text(strip=True) for li in soup.find("ul", id="navigation").find_all("li")]
+        assert len({"Home", "Grant details", "Grant team"} - set(nav_items)) == 0
+
+    def test_get_without_fsd_admin_role_and_with_no_roles(self, app, anonymous_client):
+        with patch("app.common.auth.build_msal_app") as mock_build_msap_app:
+            # Partially mock the expected return value; just enough for the test.
+            mock_build_msap_app.return_value.acquire_token_by_auth_code_flow.return_value = {
+                "id_token_claims": {
+                    "preferred_username": "test.member.nodb@communities.gov.uk",
+                    "name": "SSO User",
+                    "roles": [],
+                }
+            }
+
+            response = anonymous_client.get(url_for("auth.sso_get_token"), follow_redirects=True)
+
+        assert response.status_code == 403
 
     def test_get_without_any_roles_should_403(self, app, anonymous_client):
         with patch("app.common.auth.build_msal_app") as mock_build_msap_app:

--- a/tests/integration/common/data/interfaces/test_user.py
+++ b/tests/integration/common/data/interfaces/test_user.py
@@ -29,6 +29,18 @@ class TestGetUser:
             assert RoleEnum.ADMIN in [role.role for role in admin.roles]
 
 
+class GetUserByEmail:
+    def test_get_existing_user(self, db_session, factories):
+        factories.user.create(email="test@communities.gov.uk", name="My Name")
+        assert db_session.scalar(select(func.count()).select_from(User)) == 1
+
+        user = interfaces.user.get_user_by_email(email_address="test@communities.gov.uk")
+
+        assert db_session.scalar(select(func.count()).select_from(User)) == 1
+        assert user.email == "test@communities.gov.uk"
+        assert user.name == "My Name"
+
+
 class TestGetOrCreateUser:
     def test_create_new_user(self, db_session):
         assert db_session.scalar(select(func.count()).select_from(User)) == 0
@@ -47,16 +59,6 @@ class TestGetOrCreateUser:
         assert db_session.scalar(select(func.count()).select_from(User)) == 1
         assert user.email == "test@communities.gov.uk"
         assert user.name == "My Name updated"
-
-    def test_get_existing_user(self, db_session, factories):
-        factories.user.create(email="test@communities.gov.uk", name="My Name")
-        assert db_session.scalar(select(func.count()).select_from(User)) == 1
-
-        user = interfaces.user.get_user_by_email(email_address="test@communities.gov.uk")
-
-        assert db_session.scalar(select(func.count()).select_from(User)) == 1
-        assert user.email == "test@communities.gov.uk"
-        assert user.name == "My Name"
 
     def test_get_existing_user_can_set_name(self, db_session, factories):
         factories.user.create(email="test@communities.gov.uk", name="My Name")

--- a/tests/integration/common/data/interfaces/test_user.py
+++ b/tests/integration/common/data/interfaces/test_user.py
@@ -38,11 +38,21 @@ class TestGetOrCreateUser:
         assert db_session.scalar(select(func.count()).select_from(User)) == 1
         assert user.email == "test@communities.gov.uk"
 
+    def test_get_existing_user_with_update(self, db_session, factories):
+        factories.user.create(email="test@communities.gov.uk", name="My Name")
+        assert db_session.scalar(select(func.count()).select_from(User)) == 1
+
+        user = interfaces.user.get_or_create_user(email_address="test@communities.gov.uk", name="My Name updated")
+
+        assert db_session.scalar(select(func.count()).select_from(User)) == 1
+        assert user.email == "test@communities.gov.uk"
+        assert user.name == "My Name updated"
+
     def test_get_existing_user(self, db_session, factories):
         factories.user.create(email="test@communities.gov.uk", name="My Name")
         assert db_session.scalar(select(func.count()).select_from(User)) == 1
 
-        user = interfaces.user.get_or_create_user(email_address="test@communities.gov.uk")
+        user = interfaces.user.get_user_by_email(email_address="test@communities.gov.uk")
 
         assert db_session.scalar(select(func.count()).select_from(User)) == 1
         assert user.email == "test@communities.gov.uk"


### PR DESCRIPTION
In this PR I am fixing a issue I noticed under this ticket [FSPT-528](https://mhclgdigital.atlassian.net/browse/FSPT-528) some how the change I did was missing in the previous merged PR.

When a user logs in as a MEMBER without an invitation from a platform admin, the system should return a 403 Access Denied error. However, if the user has been invited to the grant by an admin, they should be able to log in successfully without encountering an error. This update includes the necessary fix to implement that functionality.

[FSPT-528]: https://mhclgdigital.atlassian.net/browse/FSPT-528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ