### PR TITLE
Add "test submission" implementation and signage

### DIFF
--- a/app/assets/main.scss
+++ b/app/assets/main.scss
@@ -150,3 +150,20 @@ $app-destructive-link-active-colour: $govuk-text-colour;
         width: 50%;
     }
 }
+
+
+.app-test-data-banner {
+    text-align: center;
+    border-top: 5px solid #f47738;
+    z-index: 10;
+}
+
+.app-test-data-banner__tag {
+    position: relative;
+    display: inline-block;
+    padding: 2px;
+    padding-right: 8px;
+    padding-left: 8px;
+    background-color: #f47738;
+    color: white;
+}

--- a/app/assets/main.scss
+++ b/app/assets/main.scss
@@ -151,7 +151,6 @@ $app-destructive-link-active-colour: $govuk-text-colour;
     }
 }
 
-
 .app-test-data-banner {
     text-align: center;
     border-top: 5px solid #f47738;

--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -17,7 +17,7 @@ from app.common.data.models import (
     SubmissionEvent,
 )
 from app.common.data.models_user import User
-from app.common.data.types import QuestionDataType, SubmissionEventKey, SubmissionStatusEnum
+from app.common.data.types import QuestionDataType, SubmissionEventKey, SubmissionModeEnum, SubmissionStatusEnum
 from app.common.utils import slugify
 from app.extensions import db
 
@@ -99,10 +99,11 @@ def get_submission(submission_id: UUID, with_full_schema: bool = False) -> Submi
     return db.session.get_one(Submission, submission_id, options=options, populate_existing=bool(options))
 
 
-def create_submission(*, collection: Collection, created_by: User) -> Submission:
+def create_submission(*, collection: Collection, created_by: User, mode: SubmissionModeEnum) -> Submission:
     submission = Submission(
         collection=collection,
         created_by=created_by,
+        mode=mode,
         data={},
         status=SubmissionStatusEnum.NOT_STARTED,
     )

--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-002_adding_name_column
+003_add_mode_to_submission_table

--- a/app/common/data/migrations/versions/003_add_mode_to_submission_table.py
+++ b/app/common/data/migrations/versions/003_add_mode_to_submission_table.py
@@ -1,0 +1,36 @@
+"""add mode column to submission table
+
+Revision ID: 003_add_mode_to_submission_table
+Revises: 002_adding_name_column
+Create Date: 2025-06-11 08:53:52.299045
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "003_add_mode_to_submission_table"
+down_revision = "002_adding_name_column"
+branch_labels = None
+depends_on = None
+
+submission_mode_enum = sa.Enum("TEST", "LIVE", name="submission_mode_enum")
+
+
+def upgrade() -> None:
+    submission_mode_enum.create(op.get_bind())
+
+    with op.batch_alter_table("submission", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("mode", submission_mode_enum, nullable=True))
+
+    op.execute("UPDATE submission SET mode = 'TEST' WHERE mode IS NULL;")
+
+    with op.batch_alter_table("submission", schema=None) as batch_op:
+        batch_op.alter_column("mode", nullable=False, existing_nullable=True)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("submission", schema=None) as batch_op:
+        batch_op.drop_column("mode")
+
+    submission_mode_enum.drop(op.get_bind())

--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -13,7 +13,13 @@ from sqlalchemy_json import mutable_json_type
 
 from app.common.data.base import BaseModel, CIStr
 from app.common.data.models_user import User
-from app.common.data.types import QuestionDataType, SubmissionEventKey, SubmissionStatusEnum, json_scalars
+from app.common.data.types import (
+    QuestionDataType,
+    SubmissionEventKey,
+    SubmissionModeEnum,
+    SubmissionStatusEnum,
+    json_scalars,
+)
 
 if TYPE_CHECKING:
     from app.common.data.models_user import UserRole
@@ -109,6 +115,9 @@ class Submission(BaseModel):
     __tablename__ = "submission"
 
     data: Mapped[json_scalars] = mapped_column(mutable_json_type(dbtype=JSONB, nested=True))  # type: ignore[no-untyped-call]
+    mode: Mapped[SubmissionModeEnum] = mapped_column(
+        SqlEnum(SubmissionModeEnum, name="submission_mode_enum", validate_strings=True)
+    )
     status: Mapped[SubmissionStatusEnum] = mapped_column(
         SqlEnum(SubmissionStatusEnum, name="submission_status_enum", validate_strings=True)
     )

--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -90,7 +90,8 @@ class Collection(BaseModel):
     created_by_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("user.id"))
     created_by: Mapped[User] = relationship("User")
 
-    submissions: Mapped[list["Submission"]] = relationship(
+    # NOTE: Don't use this relationship directly; use either `test_submissions` or `live_submissions`.
+    _submissions: Mapped[list["Submission"]] = relationship(
         "Submission",
         lazy=True,
         order_by="Submission.created_at_utc",
@@ -109,6 +110,14 @@ class Collection(BaseModel):
     )
 
     __table_args__ = (UniqueConstraint("name", "grant_id", "version", name="uq_collection_name_version_grant_id"),)
+
+    @property
+    def test_submissions(self) -> list["Submission"]:
+        return list(submission for submission in self._submissions if submission.mode == SubmissionModeEnum.TEST)
+
+    @property
+    def live_submissions(self) -> list["Submission"]:
+        return list(submission for submission in self._submissions if submission.mode == SubmissionModeEnum.LIVE)
 
 
 class Submission(BaseModel):

--- a/app/common/data/types.py
+++ b/app/common/data/types.py
@@ -32,6 +32,11 @@ class QuestionDataType(enum.StrEnum):
         raise ValueError(f"Cannot coerce {value} to QuestionDataType")
 
 
+class SubmissionModeEnum(enum.StrEnum):
+    TEST = "test"
+    LIVE = "live"
+
+
 class SubmissionStatusEnum(enum.StrEnum):
     NOT_STARTED = "Not started"
     IN_PROGRESS = "In progress"

--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -10,7 +10,7 @@ from app.common.collections.forms import DynamicQuestionForm
 from app.common.data import interfaces
 from app.common.data.interfaces.collections import get_submission
 from app.common.data.models_user import User
-from app.common.data.types import QuestionDataType, SubmissionEventKey, SubmissionStatusEnum
+from app.common.data.types import QuestionDataType, SubmissionEventKey, SubmissionModeEnum, SubmissionStatusEnum
 
 if TYPE_CHECKING:
     from app.common.data.models import Form, Grant, Question, Section, Submission
@@ -79,6 +79,14 @@ class SubmissionHelper:
     @property
     def is_completed(self) -> bool:
         return self.status == SubmissionStatusEnum.COMPLETED
+
+    @property
+    def is_test(self) -> bool:
+        return self.submission.mode == SubmissionModeEnum.TEST
+
+    @property
+    def is_live(self) -> bool:
+        return self.submission.mode == SubmissionModeEnum.LIVE
 
     @property
     def created_by_email(self) -> str:

--- a/app/common/templates/common/partials/mhclg-test-banner.html
+++ b/app/common/templates/common/partials/mhclg-test-banner.html
@@ -1,0 +1,7 @@
+{% macro mhclgTestBanner(label) %}
+  <div class="app-test-data-banner govuk-body govuk-!-margin-bottom-0">
+    <div class="app-test-data-banner__tag">
+      <strong>{{ label }}</strong>
+    </div>
+  </div>
+{% endmacro %}

--- a/app/developers/forms.py
+++ b/app/developers/forms.py
@@ -8,7 +8,7 @@ from wtforms.validators import DataRequired, Optional
 
 
 class PreviewCollectionForm(FlaskForm):
-    submit = SubmitField("Preview this collection", widget=GovSubmitInput())
+    submit = SubmitField("Test this collection", widget=GovSubmitInput())
 
 
 class CheckYourAnswersForm(FlaskForm):

--- a/app/developers/routes.py
+++ b/app/developers/routes.py
@@ -38,7 +38,7 @@ from app.common.data.interfaces.temporary import (
     delete_section,
     delete_submissions_created_by_user,
 )
-from app.common.data.types import QuestionDataType, SubmissionStatusEnum
+from app.common.data.types import QuestionDataType, SubmissionModeEnum, SubmissionStatusEnum
 from app.common.helpers.collections import SubmissionHelper
 from app.deliver_grant_funding.forms import (
     CollectionForm,
@@ -112,7 +112,7 @@ def manage_collection(grant_id: UUID, collection_id: UUID) -> ResponseReturnValu
     if form.validate_on_submit() and form.submit.data:
         user = interfaces.user.get_current_user()
         delete_submissions_created_by_user(grant_id=collection.grant_id, created_by_id=user.id)
-        submission = create_submission(collection=collection, created_by=user)
+        submission = create_submission(collection=collection, created_by=user, mode=SubmissionModeEnum.TEST)
         return redirect(url_for("developers.submission_tasklist", submission_id=submission.id))
 
     return render_template(

--- a/app/developers/templates/developers/ask_a_question.html
+++ b/app/developers/templates/developers/ask_a_question.html
@@ -3,6 +3,7 @@
 {% from "govuk_frontend_jinja/components/tag/macro.html" import govukTag %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "govuk_frontend_jinja/components/task-list/macro.html" import govukTaskList %}
+{% from "common/partials/mhclg-test-banner.html" import mhclgTestBanner %}
 {% extends "developers/access_grant_funding_base.html" %}
 
 {% block pageTitle %}
@@ -11,6 +12,10 @@
 {% endblock pageTitle %}
 
 {% block beforeContent %}
+  {% if submission_helper.is_test %}
+    {{ mhclgTestBanner("Test submission") }}
+  {% endif %}
+
   {{ govukBackLink({ "text": "Back", "href": back_link }) }}
 {% endblock beforeContent %}
 

--- a/app/developers/templates/developers/check_your_answers.html
+++ b/app/developers/templates/developers/check_your_answers.html
@@ -2,6 +2,7 @@
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "govuk_frontend_jinja/components/radios/macro.html" import govukRadios %}
+{% from "common/partials/mhclg-test-banner.html" import mhclgTestBanner %}
 {% extends "developers/access_grant_funding_base.html" %}
 
 {% block pageTitle %}
@@ -9,6 +10,9 @@
 {% endblock pageTitle %}
 
 {% block beforeContent %}
+  {% if submission_helper.is_test %}
+    {{ mhclgTestBanner("Test submission") }}
+  {% endif %}
   {{
     govukBackLink({
         "text": "Back",

--- a/app/developers/templates/developers/collection_submit_confirmation.html
+++ b/app/developers/templates/developers/collection_submit_confirmation.html
@@ -1,9 +1,16 @@
 {% from "govuk_frontend_jinja/components/panel/macro.html" import govukPanel %}
+{% from "common/partials/mhclg-test-banner.html" import mhclgTestBanner %}
 {% extends "developers/access_grant_funding_base.html" %}
 
 {% block pageTitle %}
   Submission submitted {{ submission_helper.name }} - MHCLG Funding Service
 {% endblock pageTitle %}
+
+{% block beforeContent %}
+  {% if submission_helper.is_test %}
+    {{ mhclgTestBanner("Test submission") }}
+  {% endif %}
+{% endblock beforeContent %}
 
 {% block content %}
   <div class="govuk-grid-row">

--- a/app/developers/templates/developers/collection_tasklist.html
+++ b/app/developers/templates/developers/collection_tasklist.html
@@ -3,6 +3,7 @@
 {% from "govuk_frontend_jinja/components/tag/macro.html" import govukTag %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "govuk_frontend_jinja/components/task-list/macro.html" import govukTaskList %}
+{% from "common/partials/mhclg-test-banner.html" import mhclgTestBanner %}
 {% from "common/macros/status.html" import status %}
 {% extends "developers/access_grant_funding_base.html" %}
 
@@ -12,13 +13,8 @@
 
 {% block beforeContent %}
   {% if submission_helper.is_test %}
-    <div class="test-data-banner govuk-body govuk-!-margin-bottom-2">
-      <div class="test-data-banner__tag">
-        <strong>Test submission</strong>
-      </div>
-    </div>
+    {{ mhclgTestBanner("Test submission") }}
   {% endif %}
-
   {{
     govukBackLink({
         "text": "Back",

--- a/app/developers/templates/developers/collection_tasklist.html
+++ b/app/developers/templates/developers/collection_tasklist.html
@@ -11,6 +11,14 @@
 {% endblock pageTitle %}
 
 {% block beforeContent %}
+  {% if submission_helper.is_test %}
+    <div class="test-data-banner govuk-body govuk-!-margin-bottom-2">
+      <div class="test-data-banner__tag">
+        <strong>Test submission</strong>
+      </div>
+    </div>
+  {% endif %}
+
   {{
     govukBackLink({
         "text": "Back",

--- a/app/developers/templates/developers/list_submissions.html
+++ b/app/developers/templates/developers/list_submissions.html
@@ -12,6 +12,14 @@
 {% set active_item_identifier = "developers" %}
 
 {% block beforeContent %}
+  {% if is_test_mode %}
+    <div class="test-data-banner govuk-body govuk-!-margin-bottom-0">
+      <div class="test-data-banner__tag">
+        <strong>Test submissions</strong>
+      </div>
+    </div>
+  {% endif %}
+
   {{
     govukBackLink({
         "text": "Back",

--- a/app/developers/templates/developers/list_submissions.html
+++ b/app/developers/templates/developers/list_submissions.html
@@ -2,6 +2,7 @@
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "govuk_frontend_jinja/components/table/macro.html" import govukTable %}
+{% from "common/partials/mhclg-test-banner.html" import mhclgTestBanner %}
 {% from "common/macros/status.html" import status %}
 {% extends "deliver_grant_funding/base.html" %}
 
@@ -13,11 +14,7 @@
 
 {% block beforeContent %}
   {% if is_test_mode %}
-    <div class="test-data-banner govuk-body govuk-!-margin-bottom-0">
-      <div class="test-data-banner__tag">
-        <strong>Test submissions</strong>
-      </div>
-    </div>
+    {{ mhclgTestBanner("Test submissions") }}
   {% endif %}
 
   {{

--- a/app/developers/templates/developers/manage_collection.html
+++ b/app/developers/templates/developers/manage_collection.html
@@ -44,11 +44,11 @@
         {% endtrans %}
       {% endset %}
       {% set submissions_text %}
-        {% trans count=collection.submissions | length %}
+        {% trans count=collection.test_submissions | length %}
           {{ count }}
-          preview submission {% pluralize %}
+          test submission {% pluralize %}
           {{ count }}
-          preview submissions
+          test submissions
         {% endtrans %}
       {% endset %}
 
@@ -84,7 +84,7 @@
               "actions": {
                   "items": [
                       {
-                        "href": url_for("developers.list_submissions_for_collection", collection_id=collection.id),
+                        "href": url_for("developers.list_submissions_for_collection", collection_id=collection.id, submission_mode=submission_mode.TEST),
                         "text": "View",
                         "classes": "govuk-link govuk-link--no-visited-state"
                       }

--- a/app/developers/templates/developers/manage_collection.html
+++ b/app/developers/templates/developers/manage_collection.html
@@ -84,7 +84,7 @@
               "actions": {
                   "items": [
                       {
-                        "href": url_for("developers.list_submissions_for_collection", collection_id=collection.id, submission_mode=submission_mode.TEST),
+                        "href": url_for("developers.list_submissions_for_collection", collection_id=collection.id, submission_mode=submission_mode_enum.TEST),
                         "text": "View",
                         "classes": "govuk-link govuk-link--no-visited-state"
                       }

--- a/app/developers/templates/developers/manage_submission.html
+++ b/app/developers/templates/developers/manage_submission.html
@@ -2,6 +2,7 @@
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "govuk_frontend_jinja/components/table/macro.html" import govukTable %}
+{% from "common/partials/mhclg-test-banner.html" import mhclgTestBanner %}
 {% from "common/macros/status.html" import status %}
 {% extends "deliver_grant_funding/base.html" %}
 
@@ -13,11 +14,7 @@
 
 {% block beforeContent %}
   {% if submission_helper.is_test %}
-    <div class="test-data-banner govuk-body govuk-!-margin-bottom-0">
-      <div class="test-data-banner__tag">
-        <strong>Test submission</strong>
-      </div>
-    </div>
+    {{ mhclgTestBanner("Test submission") }}
   {% endif %}
 
   {{

--- a/app/developers/templates/developers/manage_submission.html
+++ b/app/developers/templates/developers/manage_submission.html
@@ -12,6 +12,14 @@
 {% set active_item_identifier = "developers" %}
 
 {% block beforeContent %}
+  {% if submission_helper.is_test %}
+    <div class="test-data-banner govuk-body govuk-!-margin-bottom-0">
+      <div class="test-data-banner__tag">
+        <strong>Test submission</strong>
+      </div>
+    </div>
+  {% endif %}
+
   {{
     govukBackLink({
         "text": "Back",

--- a/tests/e2e/developer_pages.py
+++ b/tests/e2e/developer_pages.py
@@ -94,7 +94,7 @@ class CollectionDetailPage(GrantDevelopersBasePage):
         )
         self.collection_name = collection_name
         self.manage_sections_link = self.page.get_by_role("link", name="manage sections")
-        self.preview_collection_button = self.page.get_by_role("button", name="Preview this collection")
+        self.preview_collection_button = self.page.get_by_role("button", name="Test this collection")
         self.summary_row_submissions = page.locator("div.govuk-summary-list__row").filter(
             has=page.get_by_text("Submissions")
         )

--- a/tests/e2e/test_developer_journey.py
+++ b/tests/e2e/test_developer_journey.py
@@ -163,7 +163,7 @@ def test_create_and_preview_collection(
     collection_detail_page = navigate_to_collection_detail_page(page, domain, new_grant_name, new_collection_name)
 
     # View the collection
-    expect(collection_detail_page.summary_row_submissions.get_by_text("1 preview submission")).to_be_visible()
+    expect(collection_detail_page.summary_row_submissions.get_by_text("1 test submission")).to_be_visible()
     collections_list_page = collection_detail_page.click_view_submissions()
 
     view_collection_page = collections_list_page.click_on_submission(collection_reference=collection_reference)

--- a/tests/integration/common/data/test_models.py
+++ b/tests/integration/common/data/test_models.py
@@ -1,0 +1,12 @@
+from app.common.data.types import SubmissionModeEnum
+
+
+class TestSubmissionModel:
+    def test_test_submission_property_only_includes_test_submissions(self, factories):
+        # what a test name
+        collection = factories.collection.create()
+        test_submission = factories.submission.create(collection=collection, mode=SubmissionModeEnum.TEST)
+        live_submission = factories.submission.create(collection=collection, mode=SubmissionModeEnum.LIVE)
+
+        assert collection.test_submissions == [test_submission]
+        assert collection.live_submissions == [live_submission]

--- a/tests/models.py
+++ b/tests/models.py
@@ -26,7 +26,7 @@ from app.common.data.models import (
     SubmissionEvent,
 )
 from app.common.data.models_user import User, UserRole
-from app.common.data.types import QuestionDataType, SubmissionEventKey, SubmissionStatusEnum
+from app.common.data.types import QuestionDataType, SubmissionEventKey, SubmissionModeEnum, SubmissionStatusEnum
 from app.extensions import db
 
 
@@ -129,6 +129,7 @@ class _SubmissionFactory(factory.alchemy.SQLAlchemyModelFactory):
         sqlalchemy_session_persistence = "commit"
 
     id = factory.LazyFunction(uuid4)
+    mode = SubmissionModeEnum.TEST
     data = factory.LazyFunction(dict)
     status = SubmissionStatusEnum.NOT_STARTED
 


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FSPT-537

## Description
As a platform, we want to be able to test a number of our core entities and features on the system before they are finished or ready to go fully live. In order to support this, we'll be considering the states of various entities like a grant, a collection, and a submission.

This PR considers some of the states for a submission: `test` and `live`. A `test` submission is one that contains fake data and is used to support (mainly) two user groups: form designers and grant team members. A `live` submission will only be used to collect real data, mainly from one user group: grant applicants/recipients.

Form designers will spend a lot of time building out the specific questions and defining the data that we want to collect from users. We want to optimise for that journey by letting them very quickly iterate on a form, and validate the changes they're making to that form.

We expect rant team members to care more about the end-to-end journey that their grant applicants/recipients will see, rather than seeing the collection questions independent of the service context.

These changes will support both user groups, but we don't have any pages yet that allow you to see the full end-to-end journey, so this mostly focuses on showing the form-designer use-case. We want to make it very clear to all users when they are working with test data vs live data, and so will want to apply a prominent banner/signage that shows when they're in some manner of "test" mode. The designs for this are still being worked on, so we're adding some temporary indicative examples here and locking it within the "developers" (WIP) tab. Expect final designs on user-facing domains to be different; what is important here is the underlying technical changes that support test vs live submissions.

## Show it

| Page | Screenshot | 
|---|---|
| List (test) submissions | ![image](https://github.com/user-attachments/assets/e7ba076d-6137-44e9-8984-91a027d22296) |
| List (live) submissions | ![image](https://github.com/user-attachments/assets/7f21a2a9-14e3-41a4-81c3-664be3b402b0) |
| View (test) submission | ![image](https://github.com/user-attachments/assets/ee8b2d7b-b3a9-4d59-86c2-2df174cfc782) |
| Test submission tasklist | ![image](https://github.com/user-attachments/assets/1c533ca8-abaa-4543-86fd-7bbb13c30ed4) |
| Test submission question page | ![image](https://github.com/user-attachments/assets/51b0622e-10c1-4ed6-bea7-4ec3566f21e3) |
| Test submission check-your-answers page | ![image](https://github.com/user-attachments/assets/fb96c896-5660-4115-9d18-84a81a6b5a7e) |
| Test submission confirmation page | ![image](https://github.com/user-attachments/assets/a7126d0c-c617-4886-8f08-7af46083a002) |

## Misc notes
* For form designers, we might just want to redirect from the "submit" button back to some sensible page in the form design journey, rather than showing a submission confirmation page. The confirmation page feels more like "end to end journey" than "validating my form changes are good".
* The orange test banner/signage looks a bit grim right next to the MHCLG colour bar or service navigation component; goal was to keep the added height to a minimum while still having a prominent+obvious signal.