### PR TITLE
Fixing the E2E deploy pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,10 @@ on:
         required: true
       TEMP_SLACK_CHANNEL_ID:
         required: true
+      SERVICE_ACCOUNT_USERNAME:
+          required: true
+      SERVICE_ACCOUNT_PASSWORD:
+          required: true
 
 jobs:
   deploy:

--- a/.github/workflows/run_e2e_tests_docker_compose.yml
+++ b/.github/workflows/run_e2e_tests_docker_compose.yml
@@ -55,9 +55,7 @@ jobs:
       - name: Setup certs
         run: |
           sudo apt-get update && sudo apt-get install -y mkcert libnss3-tools
-          mkdir -p certs
-          CAROOT=certs mkcert -install
-          CAROOT=certs mkcert -cert-file certs/cert.pem -key-file certs/key.pem "*.communities.gov.localhost"
+          make certs
           echo "GOVUK_NOTIFY_API_KEY=$PULLPREVIEW_GOVUK_NOTIFY_API_KEY" >> .env
           echo "GOVUK_NOTIFY_DISABLE=False" >> .env
           echo "127.0.0.1       sso.communities.gov.localhost funding.communities.gov.localhost" | sudo tee -a /etc/hosts


### PR DESCRIPTION
- The workflow file for `build_deploy_e2e_pipeline` was invalid after merging https://github.com/communitiesuk/funding-service/pull/308
- This PR fixes that, and also addresses the suggestion for the e2e docker compose workflow to us `make certs` for setting up the certs so we only maintain that code in one place.