### PR TITLE
FSPT-561: Evaluate (python-like) expressions

### DIFF
--- a/app/common/expressions/__init__.py
+++ b/app/common/expressions/__init__.py
@@ -1,0 +1,101 @@
+import ast
+import uuid
+from typing import Any
+
+import simpleeval
+
+from app.common.data.models import Expression
+
+
+class BaseExpressionError(Exception):
+    pass
+
+
+class UndefinedVariableInExpression(BaseExpressionError):
+    pass
+
+
+class DisallowedExpression(BaseExpressionError):
+    pass
+
+
+class InvalidEvaluationResult(BaseExpressionError):
+    pass
+
+
+def _evaluate_expression_with_context(
+    expression: Expression, context: dict[str, str | int | float | bool | None] | None = None
+) -> Any:
+    """
+    The base evaluator to use for handling all expressions.
+
+    This parses arbitrary Python-language text into an Abstract Syntax Tree (AST) and then evaluates the result of
+    that expression. Parsing arbitrary Python is extremely dangerous so we heavily restrict the AST nodes that we
+    are willing to handle, to (hopefully) close off the attack surface to any malicious behaviour.
+
+    The addition of any new AST nodes should be well-tested and intentional consideration should be given to any
+    ways of exploit or misuse.
+    """
+    expr_context = expression.context or {}
+    context = context or {}
+
+    if context_overlap := set(expr_context).intersection(set(context)):
+        raise ValueError(
+            f"Cannot safely evaluate with overlapping contexts. "
+            f"The following keys exist in both the expression.context and additional context: {context_overlap}."
+        )
+
+    merged_context = {**expr_context, **context}
+
+    # May want EvalWithCompoundTypes at some point, but for now simple+very limited is OK.
+    evaluator = simpleeval.SimpleEval(names=merged_context)  # type: ignore[no-untyped-call]
+
+    # Remove all nodes except those we explicitly allowlist
+    evaluator.nodes = {
+        ast_expr: ast_fn
+        for ast_expr, ast_fn in evaluator.nodes.items()
+        if ast_expr
+        in {
+            ast.UnaryOp,
+            ast.Expr,
+            ast.Name,
+            ast.BinOp,
+            ast.BoolOp,
+            ast.Compare,
+            ast.Subscript,
+            ast.Attribute,
+            ast.Index,
+            ast.Slice,
+            ast.Constant,
+            ast.Call,
+        }
+    }
+
+    try:
+        result = evaluator.eval(expression.statement)  # type: ignore[no-untyped-call]
+    except simpleeval.NameNotDefined as e:
+        raise UndefinedVariableInExpression(e.message) from e
+    except (simpleeval.FeatureNotAvailable, simpleeval.FunctionNotDefined) as e:
+        raise DisallowedExpression("Expression is using unsafe/unsupported features") from e
+
+    return result
+
+
+# todo: interpolate an expression (eg for injecting dynamic data into question text, error messages, etc)
+def interpolate(expression: Expression, context: dict[str, str | int | float | bool | None] | None = None) -> Any: ...
+
+
+def evaluate(expression: Expression, context: dict[str, str | int | float | bool | None] | None = None) -> bool:
+    result = _evaluate_expression_with_context(expression, context)
+
+    # do we want these to evalaute to non-bool types like int/str ever?
+    if not isinstance(result, bool):
+        raise InvalidEvaluationResult(f"Result of evaluating {expression=} was {result=}; expected a boolean.")
+
+    return result
+
+
+def mangle_question_id_for_context(question_id: uuid.UUID) -> str:
+    # todo: work out how to refer to questions in an expressions-compatible way without doing this mangling
+    #       in all of the places. It's not nice.
+    return "q_" + question_id.hex

--- a/app/common/expressions/managed.py
+++ b/app/common/expressions/managed.py
@@ -4,6 +4,8 @@ from uuid import UUID
 
 from pydantic import BaseModel
 
+from app.common.expressions import mangle_question_id_for_context
+
 # Define any "managed" expressions that can be applied to common conditions or validations
 # that are built through the UI. These will be used alongside custom expressions
 
@@ -41,5 +43,6 @@ class GreaterThan(BaseExpression):
 
     @property
     def expression(self) -> str:
-        # todo: are UUIDs parsable by the expression parser/ language
-        return f"(( {self.question_id} )) > {self.minimum_value}"
+        # todo: do you refer to the question by ID or slugs - pros and cons - discuss - by the end of the epic
+        qid = mangle_question_id_for_context(self.question_id)
+        return f"{qid} > {self.minimum_value}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "msal==1.32.3",
     "gunicorn[gevent]==23.0.0",
     "sqlalchemy-json==0.7.0",
+    "simpleeval>=1.0.3",
 ]
 
 [dependency-groups]
@@ -177,7 +178,7 @@ module = ["factory"]
 implicit_reexport = true
 
 [[tool.mypy.overrides]]
-module = ["sqlalchemy_json"]
+module = ["sqlalchemy_json", "simpleeval"]
 follow_untyped_imports = true
 
 [tool.pytest.ini_options]

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -27,6 +27,7 @@ from app.common.data.interfaces.collections import (
 from app.common.data.interfaces.exceptions import DuplicateValueError
 from app.common.data.models import Collection
 from app.common.data.types import ExpressionType, QuestionDataType, SubmissionEventKey
+from app.common.expressions import mangle_question_id_for_context
 from app.common.expressions.managed import GreaterThan
 from app.common.helpers.collections import TextSingleLine
 
@@ -429,7 +430,9 @@ def test_add_expression(db_session, factories):
 
     assert len(from_db.expressions) == 1
     assert from_db.expressions[0].type == ExpressionType.CONDITION
-    assert from_db.expressions[0].statement == f"(( {question.id} )) > 3000"
+
+    qid = mangle_question_id_for_context(question.id)
+    assert from_db.expressions[0].statement == f"{qid} > 3000"
 
     # check the serialised context lines up with the values in the managed expression
     assert from_db.expressions[0].context["key"] == "Greater than"
@@ -446,7 +449,8 @@ def test_update_expression(db_session, factories):
 
     update_question_expression(question.expressions[0], updated_expression)
 
-    assert question.expressions[0].statement == f"(( {question.id} )) > 5000"
+    qid = mangle_question_id_for_context(question.id)
+    assert question.expressions[0].statement == f"{qid} > 5000"
 
 
 def test_remove_expression(db_session, factories):

--- a/tests/integration/common/expressions/test_init.py
+++ b/tests/integration/common/expressions/test_init.py
@@ -1,0 +1,19 @@
+from app.common.data.interfaces.collections import add_question_condition
+from app.common.expressions import evaluate, mangle_question_id_for_context
+from app.common.expressions.managed import GreaterThan
+
+
+class TestEvaluatingManagedExpressions:
+    def test_greater_than(self, factories):
+        user = factories.user.create()
+        question = factories.question.create()
+        managed_expression = GreaterThan(minimum_value=3000, question_id=question.id)
+        add_question_condition(question, user, managed_expression)
+
+        expr = question.expressions[0]
+
+        # todo: find a smooth way of doing this
+        question_id_for_context = mangle_question_id_for_context(question.id)
+        assert evaluate(expr, {question_id_for_context: 500}) is False
+        assert evaluate(expr, {question_id_for_context: 3000}) is False
+        assert evaluate(expr, {question_id_for_context: 3001}) is True

--- a/tests/unit/common/test_expressions.py
+++ b/tests/unit/common/test_expressions.py
@@ -1,0 +1,103 @@
+from unittest.mock import Mock
+
+import pytest
+
+from app.common.data.models import Expression
+from app.common.expressions import (
+    DisallowedExpression,
+    InvalidEvaluationResult,
+    UndefinedVariableInExpression,
+    _evaluate_expression_with_context,
+    evaluate,
+)
+
+
+class TestInternalEvaluateExpressionWithContext:
+    @pytest.mark.parametrize(
+        "expression, expected_result",
+        (
+            # ast.UnaryOp
+            (Expression(statement="not 1"), False),
+            # ast.Expr / ast.Constant
+            (Expression(statement="1"), 1),
+            # ast.Name
+            (Expression(statement="variable", context={"variable": True}), True),
+            # ast.BinOp
+            (Expression(statement="1 + 1"), 2),
+            (Expression(statement="1 - 1"), 0),
+            (Expression(statement="1 * 2"), 2),
+            (Expression(statement="10 / 2"), 5),
+            # ast.BoolOp
+            (Expression(statement="0 or 1"), True),
+            (Expression(statement="0 and 1"), False),
+            # ast.Compare
+            (Expression(statement="10 > 1"), True),
+            (Expression(statement="10 == 1"), False),
+            (Expression(statement="10 <= 1"), False),
+            (Expression(statement="True"), True),
+            (Expression(statement="False"), False),
+            # ast.Subscript
+            (Expression(statement="variable[0]", context={"variable": [1, 2, 3]}), 1),
+            # ast.Attribute
+            (Expression(statement="variable.value", context={"variable": Mock(value="potato")}), "potato"),
+        ),
+    )
+    def test_allowed_expressions(self, expression, expected_result):
+        assert _evaluate_expression_with_context(expression, {}) == expected_result
+
+    @pytest.mark.parametrize(
+        "expression",
+        (
+            (Expression(statement="import os")),
+            (Expression(statement="raise Exception")),  # ast.Keyword
+            (Expression(statement="eval('1')")),
+            (Expression(statement="input('hi')")),
+            (Expression(statement="print('hi')")),
+            (Expression(statement="exec('1')")),
+            (Expression(statement="compile('1')")),
+            (Expression(statement="__import__('os')")),
+            (Expression(statement="getattr()")),
+            (Expression(statement="setattr()")),
+            (Expression(statement="delattr()")),
+            (Expression(statement="hasattr()")),
+            (Expression(statement="memoryview()")),
+            (Expression(statement="bytearray()")),
+            (Expression(statement="open()")),
+            (Expression(statement="vars()")),
+            (Expression(statement="dir()")),
+            (Expression(statement="globals()")),
+            (Expression(statement="locals()")),
+            (Expression(statement="a = 1")),  # ast.Assign
+            (Expression(statement="a += 1", context={"a": 1})),  # ast.AugAssign
+            (Expression(statement="1 if True else 2")),  # ast.IfExp
+            (Expression(statement="f'hi'")),  # ast.JoinedStr
+            (Expression(statement="f'{var}'", context={"var": 1})),  # ast.JoinedStr
+        ),
+    )
+    def test_disallowed_expressions(self, expression):
+        with pytest.raises(DisallowedExpression):
+            _evaluate_expression_with_context(expression, {})
+
+    def test_unknown_variable(self):
+        with pytest.raises(UndefinedVariableInExpression):
+            expression = Expression(statement="blah")
+            _evaluate_expression_with_context(expression, {})
+
+    def test_overlapping_contexts(self):
+        expression = Expression(statement="answer == 1", context={"answer": 1})
+        with pytest.raises(ValueError) as e:
+            _evaluate_expression_with_context(expression, {"answer": 2})
+
+        assert "Cannot safely evaluate with overlapping contexts" in str(e.value)
+
+
+class TestEvaluate:
+    def test_ok_with_boolean_result(self):
+        assert evaluate(Expression(statement="True is False")) is False
+
+    def test_additional_context(self):
+        assert evaluate(Expression(statement="answer == 1"), context={"answer": 1}) is True
+
+    def test_raise_on_non_boolean_result(self):
+        with pytest.raises(InvalidEvaluationResult):
+            evaluate(Expression(statement="1"))

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -20,7 +20,7 @@ def _unit_test_timeout(request: FixtureRequest) -> None:
     These tests should not need to do anything over the network and are likely to make use of mocking to keep the
     amount of code under test fairly tight, so this should not be hard to meet.
     """
-    request.node.add_marker(pytest.mark.fail_slow("1ms"))
+    request.node.add_marker(pytest.mark.fail_slow("10ms"))
 
 
 @pytest.fixture(scope="session")

--- a/uv.lock
+++ b/uv.lock
@@ -524,6 +524,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "python-json-logger" },
     { name = "sentry-sdk" },
+    { name = "simpleeval" },
     { name = "sqlalchemy" },
     { name = "sqlalchemy-json" },
     { name = "wtforms", extra = ["email"] },
@@ -580,6 +581,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = "==2.9.1" },
     { name = "python-json-logger", specifier = "==3.3.0" },
     { name = "sentry-sdk", specifier = "==2.29.1" },
+    { name = "simpleeval", specifier = ">=1.0.3" },
     { name = "sqlalchemy", specifier = "==2.0.41" },
     { name = "sqlalchemy-json", specifier = "==0.7.0" },
     { name = "wtforms", extras = ["email"], specifier = "==3.2.1" },
@@ -1404,6 +1406,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/95/32/0cc40fe41fd2adb80a2f388987f4f8db3c866c69e33e0b4c8b093fdf700e/setuptools-80.4.0.tar.gz", hash = "sha256:5a78f61820bc088c8e4add52932ae6b8cf423da2aff268c23f813cfbb13b4006", size = 1315008, upload-time = "2025-05-09T20:42:27.972Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/93/dba5ed08c2e31ec7cdc2ce75705a484ef0be1a2fecac8a58272489349de8/setuptools-80.4.0-py3-none-any.whl", hash = "sha256:6cdc8cb9a7d590b237dbe4493614a9b75d0559b888047c1f67d49ba50fc3edb2", size = 1200812, upload-time = "2025-05-09T20:42:25.325Z" },
+]
+
+[[package]]
+name = "simpleeval"
+version = "1.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/6f/15be211749430f52f2c8f0c69158a6fc961c03aac93fa28d44d1a6f5ebc7/simpleeval-1.0.3.tar.gz", hash = "sha256:67bbf246040ac3b57c29cf048657b9cf31d4e7b9d6659684daa08ca8f1e45829", size = 24358, upload-time = "2024-11-02T10:29:46.912Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/e9/e58082fbb8cecbb6fb4133033c40cc50c248b1a331582be3a0f39138d65b/simpleeval-1.0.3-py3-none-any.whl", hash = "sha256:e3bdbb8c82c26297c9a153902d0fd1858a6c3774bf53ff4f134788c3f2035c38", size = 15762, upload-time = "2024-11-02T10:29:45.706Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FSPT-561

We're starting to bring in the idea of validation and conditional
routing to the form builder/runner. We need to be able to describe how
these rules work and want a simple, powerful, and flexible system that
will let us do straight-forward and complex evaluations. These might
vary from things like "is the answer bigger than 100", to "if the answer
to question A was X, then this answer must be lower than the sum of all
their previous reported spending".

We feel like it's possible to have a single unified system under the
hood that can handle all of validation, conditional question behaviour,
and injecting values into text (eg questions and error messages) and
think it would be simpler to manage and maintain than doing anything too
unique for each of those features.

The idea here is to allow writing (a subset of) Python statements and
evaluating those. Traditionally this was done with `eval()` but there
are many and varied security concerns with doing this. Using Python-like
language should simplify learning how to write expressions (at least for
developers), but as this will handle untrusted user input we need to be
extremely cautious in our approach so as not to create huge security
vulnerabilities. It absolutely must be impossible for expressions to
result in arbitrary code execution.

We use a library called `simpleeval` which takes an expression and
converts it to the abstract syntax tree (AST) and then manually
processes that tree. We can easily add or remove nodes that we want to
be allowable in expressions, which should provide a good level of
protection against dangerous operations, as long as we configure the
allowlist of nodes correctly.

With this system, an expression might look like any of these:

`answer < 100`
`answer == "hello"`

In the future we might be able to do more interesting things like:
`answer <= grant.allocated_funding`
`answer <= question_a.answer`
`answer <= sum(forecasted_spends)`

With this expression system we're able to define the context available
to the expression (eg the set of variables/functions that can be used).
This allows us to expose some data/context to the expression, such as
the question's answer, or answers to all other questions, or information
about the grant they're providing data for.

But a lot of this is left as an extension exercise for the future.