### PR TITLE
Make Deliver base template inherit from common base and rationalise

### DIFF
--- a/app/common/templates/common/base.html
+++ b/app/common/templates/common/base.html
@@ -1,3 +1,4 @@
+{% extends "govuk_frontend_jinja/template.html" %}
 {% from "common/partials/mhclg-header.html" import mhclgHeader %}
 {% from "govuk_frontend_jinja/components/phase-banner/macro.html" import govukPhaseBanner %}
 {% from "govuk_frontend_jinja/components/footer/macro.html" import govukFooter %}
@@ -5,7 +6,6 @@
 
 {% set assetPath = vite_asset('assets') %}
 {% set cspNonce = csp_nonce() %}
-{% extends "govuk_frontend_jinja/template.html" %}
 
 {% block head %}
   {% if config["ASSETS_VITE_LIVE_ENABLED"] %}
@@ -16,14 +16,13 @@
 
 {% block header %}
   {{
-    mhclgHeader({
-        "productName": "MHCLG Funding Service",
-        "homepageUrl":  url_for("index") ,
-        "classes": "govuk-header--full-width-border app-!-no-wrap",
-        "navigation": [{ "text": ("Sign out"), "href": url_for('auth.sign_out') }] if current_user.is_authenticated else [],
-        "navigationClasses": "govuk-header__navigation--end",
+    mhclgHeader(
+      params={
+        "homepageUrl": url_for("index"),
         "assetPath": assetPath
-    })
+      },
+      currentUser=current_user,
+    )
   }}
 {% endblock header %}
 

--- a/app/common/templates/common/partials/mhclg-header.html
+++ b/app/common/templates/common/partials/mhclg-header.html
@@ -1,14 +1,18 @@
-{% macro mhclgHeader(params) %}
+{% macro mhclgHeader(params, currentUser) %}
   {% from "govuk_frontend_jinja/macros/attributes.html" import govukAttributes %}
 
   {%- set menuButtonText = params.menuButtonText if params.menuButtonText else 'Menu' -%}
+  {%- set _productName = params.productName if params.productName else 'MHCLG Funding Service' -%}
+  {%- set _classes = params.classes if params.classes else 'govuk-header--full-width-border app-!-no-wrap' -%}
+  {%- set _navigation = params.navigation if params.navigation else [{ "text": ("Sign out"), "href": url_for('auth.sign_out') }] if currentUser and currentUser.is_authenticated else [] -%}
+  {%- set _navigationClasses = params.navigationClasses if params.navigationClasses else 'govuk-header__navigation--end' -%}
 
 
   {%- set _hmgInsignia %}
     <img src="{{ params.assetPath }}/images/mhclg-crest.png" alt="MHCLG Crest" width="32" height="32" style="color: white; filter: brightness(0) invert(1);" nonce="{{ csp_nonce() }}" />
   {% endset -%}
 
-  <header class="govuk-header {% if params.classes %}{{ params.classes }}{% endif %}" data-module="govuk-header" {{- govukAttributes(params.attributes) }}>
+  <header class="govuk-header {% if _classes %}{{ _classes }}{% endif %}" data-module="govuk-header" {{- govukAttributes(params.attributes) }}>
     <div class="govuk-header__container {{ params.containerClasses | default("govuk-width-container", true) }}">
       <div class="govuk-header__logo govuk-!-margin-bottom-1">
         <a href="{{ params.homepageUrl | default("/", true) }}" class="govuk-header__link govuk-header__link--homepage">
@@ -19,12 +23,12 @@
         We use a single compound path for the logo to prevent subpixel rounding
         shifting different elements unevenly relative to one another. #}
           {{ _hmgInsignia | safe | trim | indent(8) }}
-          {% if (params.productName) %}
-            <span class="govuk-header__product-name">{{ params.productName }}</span>
+          {% if (_productName) %}
+            <span class="govuk-header__product-name">{{ _productName }}</span>
           {% endif %}
         </a>
       </div>
-      {% if params.serviceName or params.navigation | length %}
+      {% if params.serviceName or _navigation | length %}
         <div class="govuk-header__content">
           {% if params.serviceName %}
             {% if params.serviceUrl %}
@@ -33,14 +37,14 @@
               <span class="govuk-header__service-name">{{ params.serviceName }}</span>
             {% endif %}
           {% endif %}
-          {% if params.navigation | length %}
-            <nav aria-label="{{ params.navigationLabel | default(menuButtonText, true) }}" class="govuk-header__navigation {% if params.navigationClasses %}{{ params.navigationClasses }}{% endif %}">
+          {% if _navigation | length %}
+            <nav aria-label="{{ params.navigationLabel | default(menuButtonText, true) }}" class="govuk-header__navigation {% if _navigationClasses %}{{ _navigationClasses }}{% endif %}">
               {# <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" {%- if params.menuButtonLabel and params.menuButtonLabel != menuButtonText %} aria-label="{{ params.menuButtonLabel }}"{% endif %} hidden>
           {{ menuButtonText }}
         </button> #}
 
               <ul class="govuk-header__navigation-list">
-                {% for item in params.navigation %}
+                {% for item in _navigation %}
                   {% if item.text or item.html %}
                     <li class="govuk-header__navigation-item {% if item.active %}govuk-header__navigation-item--active{% endif %}">
                       {% if item.href %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/base.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/base.html
@@ -1,38 +1,27 @@
+{% extends "common/base.html" %}
 {% from "common/partials/mhclg-header.html" import mhclgHeader %}
 {% from "govuk_frontend_jinja/components/phase-banner/macro.html" import govukPhaseBanner %}
 {% from "govuk_frontend_jinja/components/footer/macro.html" import govukFooter %}
 {% from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary %}
 {% from "common/partials/navigation.html" import deliverGrantFundingServiceNavigation %}
 
-{% set assetPath = vite_asset('assets') %}
-{% set cspNonce = csp_nonce() %}
-{% extends "govuk_frontend_jinja/template.html" %}
+{% set nav_items = nav_items or [] %}
+{% set right_nav_items = right_nav_items or [] %}
 
 {% block pageTitle %}
   {{ page_title }}
   - MHCLG Funding Service
 {% endblock pageTitle %}
 
-{% block head %}
-  {% if config["ASSETS_VITE_LIVE_ENABLED"] %}
-    <script type="module" src="{{ vite_asset('@vite/client') }}"></script>
-  {% endif %}
-  <link rel="stylesheet" href="{{ vite_asset('app/assets/main.scss') }}" type="text/css" />
-{% endblock head %}
-
-{% set nav_items = nav_items or [] %}
-{% set right_nav_items = right_nav_items or [] %}
-
 {% block header %}
   {{
-    mhclgHeader({
-        "productName": "MHCLG Funding Service",
+    mhclgHeader(
+      params={
         "homepageUrl": url_for("deliver_grant_funding.list_grants"),
-        "classes": "govuk-header--full-width-border app-!-no-wrap",
-        "navigation": [{ "text": ("Sign out"), "href": url_for('auth.sign_out') }] if current_user.is_authenticated else [],
-        "navigationClasses": "govuk-header__navigation--end",
         "assetPath": assetPath
-    })
+      },
+      currentUser=current_user,
+    )
   }}
   {{ deliverGrantFundingServiceNavigation(nav_items, right_nav_items) }}
 {% endblock header %}
@@ -62,20 +51,3 @@
     </div>
   </div>
 {% endblock %}
-
-{% block bodyEnd %}
-  <script type="module" src="{{ vite_asset('app/assets/main.js') }}"></script>
-{% endblock %}
-
-{% block footer %}
-  {{
-    govukFooter({
-        "meta": {
-            "items": [
-                { "href": "#", "text": ("Cookies") },
-                { "href": "#", "text": ("Accessibility statement") }
-            ]
-        }
-    })
-  }}
-{% endblock footer %}

--- a/app/developers/templates/developers/access_grant_funding_base.html
+++ b/app/developers/templates/developers/access_grant_funding_base.html
@@ -12,14 +12,13 @@ This is only OK because we're in the `developers` package and nothing here shoul
 #}
 {% block header %}
   {{
-    mhclgHeader({
-        "productName": "MHCLG Funding Service",
+    mhclgHeader(
+      params={
         "homepageUrl": "#",
-        "classes": "govuk-header--full-width-border app-!-no-wrap",
-        "navigation": [{ "text": ("Sign out"), "href": url_for('auth.sign_out') }] if current_user.is_authenticated else [],
-        "navigationClasses": "govuk-header__navigation--end",
         "assetPath": assetPath
-    })
+      },
+      currentUser=current_user,
+    )
   }}
 {% endblock header %}
 

--- a/stubs/sso/templates/sso/sso_login.html
+++ b/stubs/sso/templates/sso/sso_login.html
@@ -27,12 +27,13 @@
     </script>
     <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
     {{
-      mhclgHeader({
-          "productName": "MHCLG Funding Service",
+      mhclgHeader(
+        params={
           "homepageUrl": "#",
-          "classes": "govuk-header--full-width-border app-!-no-wrap",
           "assetPath": assetPath
-      })
+        },
+        currentUser=current_user,
+      )
     }}
     <div class="govuk-width-container">
       <main class="govuk-main-wrapper" id="main-content">


### PR DESCRIPTION
Currently the Deliver Grant Funding base Jinja template (`deliver_grant_funding/base.html`) extends the base `govuk_frontend_jinja` template directly despite sharing many similarities with the repo-specific common base template (`common/base.html`) (which also extends the `govuk_frontend_jinja` template).

We should have the Deliver Grant Funding base template extend the common base template instead, remove any newly-redundant bits in the Deliver Grant Funding base template, and then rationalise.