### PR TITLE
Centralise and standardise page titles

### DIFF
--- a/app/common/templates/common/auth/check_email.html
+++ b/app/common/templates/common/auth/check_email.html
@@ -1,9 +1,7 @@
 {% extends "common/base.html" %}
 {% from "govuk_frontend_jinja/components/inset-text/macro.html" import govukInsetText %}
 
-{% block pageTitle %}
-  Check your email - MHCLG Funding Service
-{% endblock pageTitle %}
+{% block pageTitle %}Check your email - {{ super() }}{% endblock pageTitle %}
 
 {% block content %}
   <div class="govuk-grid-row">

--- a/app/common/templates/common/auth/claim_magic_link.html
+++ b/app/common/templates/common/auth/claim_magic_link.html
@@ -1,8 +1,6 @@
 {% extends "common/base.html" %}
 
-{% block pageTitle %}
-  Sign in - MHCLG Funding Service
-{% endblock pageTitle %}
+{% block pageTitle %}Sign in - {{ super() }}{% endblock pageTitle %}
 
 {% block content %}
   <div class="govuk-grid-row">

--- a/app/common/templates/common/auth/mhclg-user-not-authorised.html
+++ b/app/common/templates/common/auth/mhclg-user-not-authorised.html
@@ -1,8 +1,6 @@
 {% extends "common/base.html" %}
 
-{% block pageTitle %}
-  Access denied - MHCLG Funding Service
-{% endblock pageTitle %}
+{% block pageTitle %}Access denied - {{ super() }}{% endblock pageTitle %}
 
 {% block content %}
   <div class="govuk-grid-row">

--- a/app/common/templates/common/auth/sign_in_magic_link.html
+++ b/app/common/templates/common/auth/sign_in_magic_link.html
@@ -1,9 +1,7 @@
 {% extends "common/base.html" %}
 {% from "govuk_frontend_jinja/components/inset-text/macro.html" import govukInsetText %}
 
-{% block pageTitle %}
-  Request a link to sign in - MHCLG Funding Service
-{% endblock pageTitle %}
+{% block pageTitle %}Request a link to sign in - {{ super() }}{% endblock pageTitle %}
 
 {% block content %}
   <div class="govuk-grid-row">

--- a/app/common/templates/common/auth/sign_in_sso.html
+++ b/app/common/templates/common/auth/sign_in_sso.html
@@ -2,9 +2,7 @@
 {% from "govuk_frontend_jinja/components/inset-text/macro.html" import govukInsetText %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 
-{% block pageTitle %}
-  Deliver grant funding - MHCLG Funding Service
-{% endblock pageTitle %}
+{% block pageTitle %}Deliver grant funding - {{ super() }}{% endblock pageTitle %}
 
 {% block content %}
   <div class="govuk-grid-row">

--- a/app/common/templates/common/base.html
+++ b/app/common/templates/common/base.html
@@ -7,6 +7,8 @@
 {% set assetPath = vite_asset('assets') %}
 {% set cspNonce = csp_nonce() %}
 
+{% block pageTitle %}MHCLG Funding Service{% endblock pageTitle %}
+
 {% block head %}
   {% if config["ASSETS_VITE_LIVE_ENABLED"] %}
     <script type="module" src="{{ vite_asset('@vite/client') }}"></script>

--- a/app/common/templates/common/errors/403.html
+++ b/app/common/templates/common/errors/403.html
@@ -1,8 +1,6 @@
 {% extends "common/base.html" %}
 
-{% block pageTitle %}
-  You do not have permission to access this page
-{% endblock pageTitle %}
+{% block pageTitle %}You do not have permission to access this page - {{ super() }}{% endblock pageTitle %}
 
 {% block content %}
   <div class="govuk-grid-row">

--- a/app/common/templates/common/errors/404.html
+++ b/app/common/templates/common/errors/404.html
@@ -1,8 +1,6 @@
 {% extends "common/base.html" %}
 
-{% block pageTitle %}
-  Page not found
-{% endblock pageTitle %}
+{% block pageTitle %}Page not found - {{ super() }}{% endblock pageTitle %}
 
 {% block content %}
   <div class="govuk-grid-row">

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/base.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/base.html
@@ -8,10 +8,7 @@
 {% set nav_items = nav_items or [] %}
 {% set right_nav_items = right_nav_items or [] %}
 
-{% block pageTitle %}
-  {{ page_title }}
-  - MHCLG Funding Service
-{% endblock pageTitle %}
+{% block pageTitle %}{{ page_title }} - {{ super() }}{% endblock pageTitle %}
 
 {% block header %}
   {{

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_details.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_details.html
@@ -1,10 +1,7 @@
 {% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
 {% extends "deliver_grant_funding/grant_base.html" %}
 
-{% block pageTitle %}
-  Grant details - {{ grant.name }} - MHCLG Funding Service
-{% endblock pageTitle %}
-
+{% set page_title = "Grant details - " ~ grant.name %}
 {% set active_item_identifier = "details" %}
 
 {% block content %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_list.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_list.html
@@ -2,10 +2,7 @@
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/table/macro.html" import govukTable %}
 
-{% block pageTitle %}
-  Grants - MHCLG Funding Service
-{% endblock pageTitle %}
-
+{% set page_title = "Grants" %}
 {% set active_item_identifier = "grants" %}
 
 {% block content %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_setup/initial_flow/check_your_answers.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_setup/initial_flow/check_your_answers.html
@@ -1,8 +1,7 @@
 {% extends "deliver_grant_funding/base.html" %}
 {% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
 
-{% block pageTitle %}Check your answers{% endblock %}
-
+{% set page_title = "Check your answers" %}
 {% set active_item_identifier = "grants" %}
 
 {% block content %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_setup/initial_flow/confirmation.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_setup/initial_flow/confirmation.html
@@ -1,10 +1,6 @@
 {% extends "deliver_grant_funding/base.html" %}
 
-{% block pageTitle %}
-  {{ grant.name }}
-  added
-{% endblock %}
-
+{% set page_title = grant.name ~ " added" %}
 {% set active_item_identifier = "grants" %}
 
 {% block content %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_setup/initial_flow/intro.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_setup/initial_flow/intro.html
@@ -1,10 +1,7 @@
 {% extends "deliver_grant_funding/base.html" %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
-{% block pageTitle %}
-  Add a grant - MHCLG Funding Service
-{% endblock pageTitle %}
-
+{% set page_title = "Add a grant" %}
 {% set active_item_identifier = "grants" %}
 
 {% block beforeContent %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_team/grant_user_add.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_team/grant_user_add.html
@@ -2,10 +2,7 @@
 {% from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
-{% block pageTitle %}
-  Add grant team member - MHCLG Funding Service
-{% endblock pageTitle %}
-
+{% set page_title = "Add grant team member" %}
 {% set active_item_identifier = "grant_team" %}
 
 {% block beforeContent %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_team/grant_user_list.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_team/grant_user_list.html
@@ -3,10 +3,7 @@
 {% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 
-{% block pageTitle %}
-  Grant team - {{ grant.name }} - MHCLG Funding Service
-{% endblock pageTitle %}
-
+{% set page_title = "Grant team - " ~ grant.name %}
 {% set active_item_identifier = "grant_team" %}
 
 {% block content %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_view.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_view.html
@@ -1,10 +1,6 @@
 {% extends "deliver_grant_funding/grant_base.html" %}
 
-{% block pageTitle %}
-  {{ grant.name }}
-  - MHCLG Funding Service
-{% endblock pageTitle %}
-
+{% set page_title = grant.name %}
 {% set active_item_identifier = "grants" %}
 
 {% block content %}

--- a/app/developers/templates/developers/access_grant_funding_base.html
+++ b/app/developers/templates/developers/access_grant_funding_base.html
@@ -5,6 +5,8 @@
 {% set active_item_identifier = "grants" %}
 {% set cspNonce = csp_nonce() %}
 
+{% block pageTitle %}{{ page_title }} - {{ super() }}{% endblock pageTitle %}
+
 {#
 common/base.html embeds "Deliver grant funding" in the service navigation. That doesn't feel right here, so this just removes it.
 

--- a/app/developers/templates/developers/add_collection.html
+++ b/app/developers/templates/developers/add_collection.html
@@ -1,10 +1,7 @@
 {% extends "deliver_grant_funding/grant_base.html" %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
-{% block pageTitle %}
-  Setup a new collection - {{ grant.name }} - MHCLG Funding Service
-{% endblock pageTitle %}
-
+{% set page_title = "Setup a new collection - " ~ grant.name %}
 {% set active_item_identifier = "developers" %}
 
 {% block beforeContent %}

--- a/app/developers/templates/developers/add_form.html
+++ b/app/developers/templates/developers/add_form.html
@@ -2,10 +2,7 @@
 {% from "govuk_frontend_jinja/components/input/macro.html" import govukInput %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
-{% block pageTitle %}
-  Add a form - {{ section.title }} - MHCLG Funding Service
-{% endblock pageTitle %}
-
+{% set page_title = "Add a form - " ~ section.title %}
 {% set active_item_identifier = "developers" %}
 
 {% block beforeContent %}

--- a/app/developers/templates/developers/add_question.html
+++ b/app/developers/templates/developers/add_question.html
@@ -1,10 +1,7 @@
 {% extends "deliver_grant_funding/grant_base.html" %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
-{% block pageTitle %}
-  Add a question - {{ db_form.title }} - MHCLG Funding Service
-{% endblock pageTitle %}
-
+{% set page_title = "Add a question - " ~ db_form.title %}
 {% set active_item_identifier = "developers" %}
 
 {% block beforeContent %}

--- a/app/developers/templates/developers/add_section.html
+++ b/app/developers/templates/developers/add_section.html
@@ -1,10 +1,7 @@
 {% extends "deliver_grant_funding/grant_base.html" %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
-{% block pageTitle %}
-  Add a section - {{ collection.name }} - MHCLG Funding Service
-{% endblock pageTitle %}
-
+{% set page_title = "Add a section - " ~ collection.name %}
 {% set active_item_identifier = "developers" %}
 
 {% block beforeContent %}

--- a/app/developers/templates/developers/ask_a_question.html
+++ b/app/developers/templates/developers/ask_a_question.html
@@ -6,10 +6,7 @@
 {% from "common/partials/mhclg-test-banner.html" import mhclgTestBanner %}
 {% extends "developers/access_grant_funding_base.html" %}
 
-{% block pageTitle %}
-  {{ question.text }}
-  - MHCLG Funding Service
-{% endblock pageTitle %}
+{% set page_title = question.text ~ " - " ~ question.form.title %}
 
 {% block beforeContent %}
   {% if submission_helper.is_test %}

--- a/app/developers/templates/developers/check_your_answers.html
+++ b/app/developers/templates/developers/check_your_answers.html
@@ -5,9 +5,7 @@
 {% from "common/partials/mhclg-test-banner.html" import mhclgTestBanner %}
 {% extends "developers/access_grant_funding_base.html" %}
 
-{% block pageTitle %}
-  Check your answers - MHCLG Funding Service
-{% endblock pageTitle %}
+{% set page_title = "Check your answers - " ~ collection_form.title %}
 
 {% block beforeContent %}
   {% if submission_helper.is_test %}

--- a/app/developers/templates/developers/choose_question_type.html
+++ b/app/developers/templates/developers/choose_question_type.html
@@ -3,10 +3,7 @@
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/radios/macro.html" import govukRadios %}
 
-{% block pageTitle %}
-  Add a question - {{ form.title }} - MHCLG Funding Service
-{% endblock pageTitle %}
-
+{% set page_title = "Add a question - " ~ form.title %}
 {% set active_item_identifier = "developers" %}
 
 {% block beforeContent %}

--- a/app/developers/templates/developers/collection_submit_confirmation.html
+++ b/app/developers/templates/developers/collection_submit_confirmation.html
@@ -2,9 +2,7 @@
 {% from "common/partials/mhclg-test-banner.html" import mhclgTestBanner %}
 {% extends "developers/access_grant_funding_base.html" %}
 
-{% block pageTitle %}
-  Submission submitted {{ submission_helper.name }} - MHCLG Funding Service
-{% endblock pageTitle %}
+{% set page_title = "Submission submitted - " ~ submission_helper.name %}
 
 {% block beforeContent %}
   {% if submission_helper.is_test %}

--- a/app/developers/templates/developers/collection_tasklist.html
+++ b/app/developers/templates/developers/collection_tasklist.html
@@ -7,9 +7,7 @@
 {% from "common/macros/status.html" import status %}
 {% extends "developers/access_grant_funding_base.html" %}
 
-{% block pageTitle %}
-  Collection for {{ submission_helper.name }} - MHCLG Funding Service
-{% endblock pageTitle %}
+{% set page_title = "Collection for " ~ submission_helper.name %}
 
 {% block beforeContent %}
   {% if submission_helper.is_test %}

--- a/app/developers/templates/developers/edit_collection.html
+++ b/app/developers/templates/developers/edit_collection.html
@@ -2,10 +2,7 @@
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% extends "deliver_grant_funding/grant_base.html" %}
 
-{% block pageTitle %}
-  Edit collection - MHCLG Funding Service
-{% endblock pageTitle %}
-
+{% set page_title = "Edit collection - " ~ grant.name %}
 {% set active_item_identifier = "developers" %}
 
 {% block beforeContent %}

--- a/app/developers/templates/developers/edit_form.html
+++ b/app/developers/templates/developers/edit_form.html
@@ -1,10 +1,7 @@
 {% extends "deliver_grant_funding/grant_base.html" %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
-{% block pageTitle %}
-  Edit form - {{ section.title }} - MHCLG Funding Service
-{% endblock pageTitle %}
-
+{% set page_title = "Edit form - " ~ section.title %}
 {% set active_item_identifier = "developers" %}
 
 {% block beforeContent %}

--- a/app/developers/templates/developers/edit_question.html
+++ b/app/developers/templates/developers/edit_question.html
@@ -3,10 +3,7 @@
 {% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
 {% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
 
-{% block pageTitle %}
-  Edit question - {{ db_form.title }} - MHCLG Funding Service
-{% endblock pageTitle %}
-
+{% set page_title = "Edit question - " ~ db_form.title %}
 {% set active_item_identifier = "developers" %}
 
 {% block beforeContent %}

--- a/app/developers/templates/developers/edit_section.html
+++ b/app/developers/templates/developers/edit_section.html
@@ -2,10 +2,7 @@
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% extends "deliver_grant_funding/grant_base.html" %}
 
-{% block pageTitle %}
-  Edit section - MHCLG Funding Service
-{% endblock pageTitle %}
-
+{% set page_title = "Edit section - " ~ collection.name %}
 {% set active_item_identifier = "developers" %}
 
 {% block beforeContent %}

--- a/app/developers/templates/developers/grant_developers.html
+++ b/app/developers/templates/developers/grant_developers.html
@@ -2,10 +2,7 @@
 {% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
 {% from "govuk_frontend_jinja/components/phase-banner/macro.html" import govukPhaseBanner %}
 
-{% block pageTitle %}
-  Developers - {{ grant.name }} - MHCLG Funding Service
-{% endblock pageTitle %}
-
+{% set page_title = "Developers - " ~ grant.name %}
 {% set active_item_identifier = "developers" %}
 
 {% block content %}

--- a/app/developers/templates/developers/list_collections.html
+++ b/app/developers/templates/developers/list_collections.html
@@ -3,10 +3,7 @@
 {% from "govuk_frontend_jinja/components/table/macro.html" import govukTable %}
 {% extends "deliver_grant_funding/grant_base.html" %}
 
-{% block pageTitle %}
-  Collections - {{ grant.name }} - MHCLG Funding Service
-{% endblock pageTitle %}
-
+{% set page_title = "Collections - " ~ grant.name %}
 {% set active_item_identifier = "developers" %}
 
 {% block content %}

--- a/app/developers/templates/developers/list_sections.html
+++ b/app/developers/templates/developers/list_sections.html
@@ -3,12 +3,9 @@
 {% from "common/macros/move-up-down-table.html" import moveUpDownTable %}
 {% extends "deliver_grant_funding/grant_base.html" %}
 
-{% block pageTitle %}
-  {{ collection.name }}
-  - {{ grant.name }} - MHCLG Funding Service
-{% endblock pageTitle %}
-
+{% set page_title = collection.name ~ " - " ~ grant.name %}
 {% set active_item_identifier = "developers" %}
+
 {% block beforeContent %}
   {{
     govukBackLink({

--- a/app/developers/templates/developers/list_submissions.html
+++ b/app/developers/templates/developers/list_submissions.html
@@ -6,10 +6,7 @@
 {% from "common/macros/status.html" import status %}
 {% extends "deliver_grant_funding/grant_base.html" %}
 
-{% block pageTitle %}
-  Submissions - {{ collection.name }} - MHCLG Funding Service
-{% endblock pageTitle %}
-
+{% set page_title = "Submissions - " ~ collection.name %}
 {% set active_item_identifier = "developers" %}
 
 {% block beforeContent %}

--- a/app/developers/templates/developers/manage_collection.html
+++ b/app/developers/templates/developers/manage_collection.html
@@ -4,10 +4,7 @@
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% extends "deliver_grant_funding/grant_base.html" %}
 
-{% block pageTitle %}
-  {{ collection.name }}
-  - {{ grant.name }} - MHCLG Funding Service
-{% endblock pageTitle %}
+{% set page_title = collection.name ~ " - " ~ grant.name %}
 
 {% set active_item_identifier = "developers" %}
 {% block beforeContent %}

--- a/app/developers/templates/developers/manage_form.html
+++ b/app/developers/templates/developers/manage_form.html
@@ -6,12 +6,9 @@
 {% from "common/macros/move-up-down-table.html" import moveUpDownTable %}
 {% extends "deliver_grant_funding/grant_base.html" %}
 
-{% block pageTitle %}
-  {{ collection.name }}
-  - {{ grant.name }} - MHCLG Funding Service
-{% endblock pageTitle %}
-
+{% set page_title = collection.name ~ " - " ~ grant.name %}
 {% set active_item_identifier = "developers" %}
+
 {% block beforeContent %}
   {{
     govukBackLink({

--- a/app/developers/templates/developers/manage_section.html
+++ b/app/developers/templates/developers/manage_section.html
@@ -5,12 +5,9 @@
 {% from "common/macros/move-up-down-table.html" import moveUpDownTable %}
 {% extends "deliver_grant_funding/grant_base.html" %}
 
-{% block pageTitle %}
-  {{ section.title }}
-  - {{ collection.name }} - MHCLG Funding Service
-{% endblock pageTitle %}
-
+{% set page_title = section.title ~ " - " ~ collection.name %}
 {% set active_item_identifier = "developers" %}
+
 {% block beforeContent %}
   {{
     govukBackLink({

--- a/app/developers/templates/developers/manage_submission.html
+++ b/app/developers/templates/developers/manage_submission.html
@@ -6,10 +6,7 @@
 {% from "common/macros/status.html" import status %}
 {% extends "deliver_grant_funding/grant_base.html" %}
 
-{% block pageTitle %}
-  Collection - {{ collection.name }} - MHCLG Funding Service
-{% endblock pageTitle %}
-
+{% set page_title = "Collection - " ~ collection.name %}
 {% set active_item_identifier = "developers" %}
 
 {% block beforeContent %}

--- a/app/developers/templates/developers/select_form_type.html
+++ b/app/developers/templates/developers/select_form_type.html
@@ -3,10 +3,7 @@
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/radios/macro.html" import govukRadios %}
 
-{% block pageTitle %}
-  Add a form - {{ section.title }} - MHCLG Funding Service
-{% endblock pageTitle %}
-
+{% set page_title = "Add a form - " ~ section.title %}
 {% set active_item_identifier = "developers" %}
 
 {% block beforeContent %}


### PR DESCRIPTION
Establish page titles in the base templates and extend these in sub-templates. The most derived template can just set its fragment in `page_title` and it will be injected into the standard format correctly, ensuring that "MHCLG Funding Service" is always part of the page title.