### PR TITLE
FSPT-463: Implement AuthorisationHelper for Role-Based Access Control (Platform Admin & Grant Member)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -10,6 +10,7 @@ from sqlalchemy.exc import NoResultFound
 from werkzeug.routing import BaseConverter
 
 from app import logging
+from app.common.auth.authorisation_helper import AuthorisationHelper
 from app.common.data import interfaces
 from app.common.data.types import SubmissionModeEnum
 from app.common.filters import format_date, format_date_range, format_date_short, format_datetime, format_datetime_range
@@ -196,5 +197,6 @@ def create_app() -> Flask:
     # otherwise we don't want the server to continually 304 on assets the browser has
     # should make an intentional decision for when to be setting this
     app.config["SEND_FILE_MAX_AGE_DEFAULT"] = 3600
+    app.add_template_global(AuthorisationHelper, "authorisation_helper")
 
     return app

--- a/app/common/auth/authorisation_helper.py
+++ b/app/common/auth/authorisation_helper.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from app.common.data.models_user import User
 from app.common.data.types import RoleEnum
 
@@ -28,22 +30,34 @@ class AuthorisationHelper:
         return is_grant_admin
 
     @staticmethod
-    def is_grant_member(grant_id: str, user: User) -> bool:
-        is_grant_admin = any(
+    def is_grant_member(grant_id: str | UUID, user: User) -> bool:
+        # TODO account for hierarchical roles
+        # MEMBER_ROLES = [RoleEnum.MEMBER, RoleEnum.ADMIN]
+        # platform admin would have RoleEnum.ADMIN and grant_id would be None so need to change 'any()' call
+        # role.role in MEMBER_ROLES
+        if isinstance(grant_id, str):
+            grant_id = UUID(grant_id)
+        is_grant_member = any(
             role.role == RoleEnum.MEMBER and role.organisation_id is None and role.grant_id == grant_id
             for role in user.roles
         )
-        return is_grant_admin
+        return is_grant_member
 
     @staticmethod
     def has_grant_role(grant_id: str, user: User, role: RoleEnum) -> bool:
-        return bool(
-            next(
-                (
-                    user_role
-                    for user_role in user.roles
-                    if str(user_role.grant_id) == grant_id and user_role.role == role
-                ),
-                None,
-            )
-        )
+        """
+        Will return True if the user has the specified role for the grant, (TODO: or a higher role in the hierarchy).
+        Does not work for platform admin role, as that is not a grant-specific role.
+        :param grant_id:
+        :param user:
+        :param role:
+        :return:
+        """
+        match role:
+            case RoleEnum.ADMIN:
+                return AuthorisationHelper.is_grant_admin(grant_id, user)
+            case RoleEnum.MEMBER:
+                return AuthorisationHelper.is_grant_member(grant_id, user)
+            case _:
+                # If we get to this point, we've put a bad role in the decorator call.
+                raise ValueError(f"Unknown role {role}")

--- a/app/common/auth/authorisation_helper.py
+++ b/app/common/auth/authorisation_helper.py
@@ -1,0 +1,49 @@
+from app.common.data.models_user import User
+from app.common.data.types import RoleEnum
+
+
+class AuthorisationHelper:
+    @staticmethod
+    def has_logged_in(user: User) -> bool:
+        # FIXME: We should have some actual tracking of whether the user has logged in. This could either be a
+        #        field on the model called `last_logged_in_at` or similar, or we could only create entries in the user
+        #        table when the user actually logs in, rather than at invitation-time. Then we could simply trust that
+        #        if a user entry exists, they have definitely logged in.
+        return bool(user.name)
+
+    @staticmethod
+    def is_platform_admin(user: User) -> bool:
+        is_platform_admin = any(
+            role.role == RoleEnum.ADMIN and role.organisation_id is None and role.grant_id is None
+            for role in user.roles
+        )
+        return is_platform_admin
+
+    @staticmethod
+    def is_grant_admin(grant_id: str, user: User) -> bool:
+        is_grant_admin = any(
+            role.role == RoleEnum.ADMIN and role.organisation_id is None and role.grant_id == grant_id
+            for role in user.roles
+        )
+        return is_grant_admin
+
+    @staticmethod
+    def is_grant_member(grant_id: str, user: User) -> bool:
+        is_grant_admin = any(
+            role.role == RoleEnum.MEMBER and role.organisation_id is None and role.grant_id == grant_id
+            for role in user.roles
+        )
+        return is_grant_admin
+
+    @staticmethod
+    def has_grant_role(grant_id: str, user: User, role: RoleEnum) -> bool:
+        return bool(
+            next(
+                (
+                    user_role
+                    for user_role in user.roles
+                    if str(user_role.grant_id) == grant_id and user_role.role == role
+                ),
+                None,
+            )
+        )

--- a/app/common/auth/authorisation_helper.py
+++ b/app/common/auth/authorisation_helper.py
@@ -1,49 +1,38 @@
 from uuid import UUID
 
-from app.common.data import interfaces
 from app.common.data.models_user import User
 from app.common.data.types import GRANT_ROLES_MAPPING, RoleEnum
 
 
 class AuthorisationHelper:
     @staticmethod
-    def has_logged_in(user: User | None = None) -> bool:
+    def has_logged_in(user: User) -> bool:
         # FIXME: We should have some actual tracking of whether the user has logged in. This could either be a
         #        field on the model called `last_logged_in_at` or similar, or we could only create entries in the user
         #        table when the user actually logs in, rather than at invitation-time. Then we could simply trust that
         #        if a user entry exists, they have definitely logged in.
-        if user is None:
-            user = interfaces.user.get_current_user()
         return bool(user.name)
 
     @staticmethod
-    def is_platform_admin(user: User | None = None) -> bool:
-        if user is None:
-            user = interfaces.user.get_current_user()
+    def is_platform_admin(user: User) -> bool:
         return any(
             role.role == RoleEnum.ADMIN and role.organisation_id is None and role.grant_id is None
             for role in user.roles
         )
 
     @staticmethod
-    def is_grant_admin(grant_id: UUID, user: User | None = None) -> bool:
-        if user is None:
-            user = interfaces.user.get_current_user()
-        if AuthorisationHelper.is_platform_admin(user=user):
-            return True
+    def is_grant_admin(grant_id: UUID, user: User) -> bool:
         return any(
             role.role == RoleEnum.ADMIN and role.organisation_id is None and role.grant_id == grant_id
             for role in user.roles
         )
 
     @staticmethod
-    def is_grant_member(grant_id: UUID, user: User | None = None) -> bool:
+    def is_grant_member(grant_id: UUID, user: User) -> bool:
         """
         Determines whether a user has permissions to act as a grant member.
         Platform admin overrides anything else.
         """
-        if user is None:
-            user = interfaces.user.get_current_user()
         if AuthorisationHelper.is_platform_admin(user=user):
             return True
 
@@ -56,13 +45,11 @@ class AuthorisationHelper:
         )
 
     @staticmethod
-    def has_grant_role(grant_id: UUID, role: RoleEnum, user: User | None = None) -> bool:
+    def has_grant_role(grant_id: UUID, role: RoleEnum, user: User) -> bool:
         """
         Will return True if the user has the specified role for the grant.
         Platform admin overrides anything else.
         """
-        if user is None:
-            user = interfaces.user.get_current_user()
         if AuthorisationHelper.is_platform_admin(user=user):
             return True
         match role:

--- a/app/common/auth/decorators.py
+++ b/app/common/auth/decorators.py
@@ -70,7 +70,7 @@ def platform_admin_role_required[**P](
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> ResponseReturnValue:
         # This decorator is itself wrapped by `mhclg_login_required`, so we know that `current_user` exists and is
         # not an anonymous user (ie a user is definitely logged-in) and an MHCLG user if we get here.
-        if not AuthorisationHelper.is_platform_admin():
+        if not AuthorisationHelper.is_platform_admin(user=interfaces.user.get_current_user()):
             abort(403)
 
         return func(*args, **kwargs)
@@ -84,13 +84,14 @@ def has_grant_role[**P](
     def decorator(func: Callable[P, ResponseReturnValue]) -> Callable[P, ResponseReturnValue]:
         @functools.wraps(func)
         def wrapped(*args: P.args, **kwargs: P.kwargs) -> ResponseReturnValue:
-            if AuthorisationHelper.is_platform_admin():
+            user = interfaces.user.get_current_user()
+            if AuthorisationHelper.is_platform_admin(user=user):
                 return func(*args, **kwargs)
 
             if "grant_id" not in kwargs or kwargs["grant_id"] is None:
                 raise ValueError("Grant ID required.")
 
-            if not AuthorisationHelper.has_grant_role(grant_id=UUID(str(kwargs["grant_id"])), role=role):
+            if not AuthorisationHelper.has_grant_role(grant_id=UUID(str(kwargs["grant_id"])), role=role, user=user):
                 abort(403, description="Access denied")
 
             return func(*args, **kwargs)

--- a/app/common/auth/decorators.py
+++ b/app/common/auth/decorators.py
@@ -90,7 +90,6 @@ def has_grant_role[**P](
             if AuthorisationHelper.is_platform_admin(user=current_user):
                 return func(*args, **kwargs)
 
-            # TODO allow the hierarchy in future
             if "grant_id" in kwargs:
                 if not AuthorisationHelper.has_grant_role(
                     grant_id=str(kwargs["grant_id"]), user=current_user, role=role

--- a/app/common/auth/decorators.py
+++ b/app/common/auth/decorators.py
@@ -4,7 +4,9 @@ from typing import Callable
 from flask import abort, current_app, redirect, request, session, url_for
 from flask.typing import ResponseReturnValue
 
-from app.common.data.interfaces.user import get_current_user
+from app.common.auth.authorisation_helper import AuthorisationHelper
+from app.common.data import interfaces
+from app.common.data.types import RoleEnum
 
 
 def login_required[**P](
@@ -12,7 +14,7 @@ def login_required[**P](
 ) -> Callable[P, ResponseReturnValue]:
     @functools.wraps(func)
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> ResponseReturnValue:
-        user = get_current_user()
+        user = interfaces.user.get_current_user()
         if not user.is_authenticated:
             session["next"] = request.full_path
             return redirect(url_for("auth.sso_sign_in"))
@@ -27,7 +29,7 @@ def redirect_if_authenticated[**P](
 ) -> Callable[P, ResponseReturnValue]:
     @functools.wraps(func)
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> ResponseReturnValue:
-        user = get_current_user()
+        user = interfaces.user.get_current_user()
         # TODO: As we add more roles/users to the platform we will want to extend this to redirect appropriately based
         # on the user's role. For now, this covers internal MHCLG users and will hard error for anyone else so that
         # we get a Sentry notification and can get it fixed.
@@ -48,7 +50,7 @@ def mhclg_login_required[**P](
 ) -> Callable[P, ResponseReturnValue]:
     @functools.wraps(func)
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> ResponseReturnValue:
-        user = get_current_user()
+        user = interfaces.user.get_current_user()
         # This decorator is itself wrapped by `login_required`, so we know that `current_user` exists and is
         # not an anonymous user (ie a user is definitely logged-in) if we get here.
         internal_domains = current_app.config["INTERNAL_DOMAINS"]
@@ -67,11 +69,36 @@ def platform_admin_role_required[**P](
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> ResponseReturnValue:
         # This decorator is itself wrapped by `mhclg_login_required`, so we know that `current_user` exists and is
         # not an anonymous user (ie a user is definitely logged-in) and an MHCLG user if we get here.
-        user = get_current_user()
+        user = interfaces.user.get_current_user()
 
-        if not user.is_platform_admin:
+        if not AuthorisationHelper.is_platform_admin(user):
             abort(403)
 
         return func(*args, **kwargs)
 
     return mhclg_login_required(wrapper)
+
+
+def has_grant_role[**P](
+    role: RoleEnum,
+) -> Callable[[Callable[P, ResponseReturnValue]], Callable[P, ResponseReturnValue]]:
+    def decorator(func: Callable[P, ResponseReturnValue]) -> Callable[P, ResponseReturnValue]:
+        @functools.wraps(func)
+        def wrapped(*args: P.args, **kwargs: P.kwargs) -> ResponseReturnValue:
+            current_user = interfaces.user.get_current_user()
+
+            if AuthorisationHelper.is_platform_admin(user=current_user):
+                return func(*args, **kwargs)
+
+            # TODO allow the hierarchy in future
+            if "grant_id" in kwargs:
+                if not AuthorisationHelper.has_grant_role(
+                    grant_id=str(kwargs["grant_id"]), user=current_user, role=role
+                ):
+                    abort(403, description="Access denied")
+
+            return func(*args, **kwargs)
+
+        return mhclg_login_required(wrapped)
+
+    return decorator

--- a/app/common/data/interfaces/grants.py
+++ b/app/common/data/interfaces/grants.py
@@ -4,6 +4,7 @@ from uuid import UUID
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
+from app.common.auth.authorisation_helper import AuthorisationHelper
 from app.common.data.interfaces.exceptions import DuplicateValueError
 from app.common.data.models import Grant
 from app.common.data.models_user import User
@@ -24,7 +25,7 @@ def grant_name_exists(name: str, exclude_grant_id: UUID | None = None) -> bool:
 
 
 def get_all_grants_by_user(user: User) -> Sequence[Grant]:
-    if user.is_platform_admin:
+    if AuthorisationHelper.is_platform_admin(user):
         statement = select(Grant).order_by(Grant.name)
         return db.session.scalars(statement).all()
     else:

--- a/app/common/data/interfaces/grants.py
+++ b/app/common/data/interfaces/grants.py
@@ -4,7 +4,6 @@ from uuid import UUID
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
-from app.common.auth.authorisation_helper import AuthorisationHelper
 from app.common.data.interfaces.exceptions import DuplicateValueError
 from app.common.data.models import Grant
 from app.common.data.models_user import User
@@ -25,6 +24,8 @@ def grant_name_exists(name: str, exclude_grant_id: UUID | None = None) -> bool:
 
 
 def get_all_grants_by_user(user: User) -> Sequence[Grant]:
+    from app.common.auth.authorisation_helper import AuthorisationHelper
+
     if AuthorisationHelper.is_platform_admin(user):
         statement = select(Grant).order_by(Grant.name)
         return db.session.scalars(statement).all()

--- a/app/common/data/models_user.py
+++ b/app/common/data/models_user.py
@@ -41,24 +41,6 @@ class User(BaseModel):
     def get_id(self) -> str:
         return str(self.id)
 
-    # END: Flask-Login attributes
-
-    @property
-    def has_logged_in(self) -> bool:
-        # FIXME: We should have some actual tracking of whether the user has logged in. This could either be a
-        #        field on the model called `last_logged_in_at` or similar, or we could only create entries in the user
-        #        table when the user actually logs in, rather than at invitation-time. Then we could simply trust that
-        #        if a user entry exists, they have definitely logged in.
-        return bool(self.name)
-
-    @property
-    def is_platform_admin(self) -> bool:
-        is_platform_admin = any(
-            role.role == RoleEnum.ADMIN and role.organisation_id is None and role.grant_id is None
-            for role in self.roles
-        )
-        return is_platform_admin
-
 
 class UserRole(BaseModel):
     __tablename__ = "user_role"

--- a/app/common/data/types.py
+++ b/app/common/data/types.py
@@ -12,19 +12,11 @@ class RoleEnum(str, enum.Enum):
         "admin"  # Admin level permissions, combines with null columns in UserRole table to denote level of admin access
     )
     MEMBER = "member"  # Basic read level permissions
-    EDITOR = "editor"  # Read/write level permissions
-    ASSESSOR = "assessor"  # Assessor level permissions
-    S151_OFFICER = "s151_officer"  # S151 officer sign-off permissions
 
 
 # If a user roles implies they get other (lower) roles as well, list the role here with the roles they should get.
 GRANT_ROLES_MAPPING = {
-    RoleEnum.ADMIN: [
-        # Admin gets all roles except S151 officer
-        role
-        for role in RoleEnum
-        if role != RoleEnum.S151_OFFICER
-    ],
+    RoleEnum.ADMIN: [role for role in RoleEnum],
 }
 
 

--- a/app/common/data/types.py
+++ b/app/common/data/types.py
@@ -17,6 +17,17 @@ class RoleEnum(str, enum.Enum):
     S151_OFFICER = "s151_officer"  # S151 officer sign-off permissions
 
 
+# If a user roles implies they get other (lower) roles as well, list the role here with the roles they should get.
+GRANT_ROLES_MAPPING = {
+    RoleEnum.ADMIN: [
+        # Admin gets all roles except S151 officer
+        role
+        for role in RoleEnum
+        if role != RoleEnum.S151_OFFICER
+    ],
+}
+
+
 class QuestionDataType(enum.StrEnum):
     # If adding values here, also update QuestionTypeForm
     # and manually create a migration to update question_type_enum in the db

--- a/app/deliver_grant_funding/forms.py
+++ b/app/deliver_grant_funding/forms.py
@@ -14,8 +14,8 @@ from wtforms.fields.simple import StringField, SubmitField, TextAreaField
 from wtforms.validators import DataRequired, Email, ValidationError
 
 from app.common.auth.authorisation_helper import AuthorisationHelper
-from app.common.data import interfaces
 from app.common.data.interfaces.grants import grant_name_exists
+from app.common.data.interfaces.user import get_user_by_email
 from app.common.data.types import QuestionDataType
 from app.common.forms.validators import CommunitiesEmail, WordRange
 
@@ -213,7 +213,7 @@ class GrantAddUserForm(FlaskForm):
             return False
 
         if self.user_email.data:
-            user_to_add = interfaces.user.get_user_by_email(self.user_email.data)
+            user_to_add = get_user_by_email(self.user_email.data)
             if not user_to_add:
                 return True
 

--- a/app/deliver_grant_funding/forms.py
+++ b/app/deliver_grant_funding/forms.py
@@ -217,9 +217,7 @@ class GrantAddUserForm(FlaskForm):
             if not user_to_add:
                 return True
 
-            if AuthorisationHelper.is_platform_admin(user_to_add) or AuthorisationHelper.is_grant_admin(
-                grant_id=self.grant.id, user=user_to_add
-            ):
+            if AuthorisationHelper.is_platform_admin(user_to_add):
                 self.user_email.errors = list(self.user_email.errors) + [
                     "This user already exists as a Funding Service admin user so you cannot add them"
                 ]

--- a/app/deliver_grant_funding/routes.py
+++ b/app/deliver_grant_funding/routes.py
@@ -213,7 +213,7 @@ def view_grant(grant_id: UUID) -> ResponseReturnValue:
 
 
 @deliver_grant_funding_blueprint.route("/grant/<uuid:grant_id>/users", methods=["GET"])
-@mhclg_login_required
+@has_grant_role(RoleEnum.MEMBER)
 def list_users_for_grant(grant_id: UUID) -> ResponseReturnValue:
     try:
         grant = interfaces.grants.get_grant(grant_id)

--- a/app/deliver_grant_funding/routes.py
+++ b/app/deliver_grant_funding/routes.py
@@ -6,7 +6,8 @@ from sqlalchemy.exc import NoResultFound
 from werkzeug import Response
 from wtforms.fields.core import Field
 
-from app.common.auth.decorators import mhclg_login_required, platform_admin_role_required
+from app.common.auth.authorisation_helper import AuthorisationHelper
+from app.common.auth.decorators import has_grant_role, mhclg_login_required, platform_admin_role_required
 from app.common.data import interfaces
 from app.common.data.interfaces.exceptions import DuplicateValueError
 from app.common.data.types import RoleEnum
@@ -199,13 +200,13 @@ def list_grants() -> Response | str:
     grants = interfaces.grants.get_all_grants_by_user(user=user)
     # TODO if the user is a MEMBER and does not have any grant we need to handle that but if you are a
     #  ADMIN then should be able to see grants or empty page with create grant feature
-    if len(grants) == 1 and not user.is_platform_admin:
+    if len(grants) == 1 and not AuthorisationHelper.is_platform_admin(user):
         return redirect(url_for("deliver_grant_funding.view_grant", grant_id=grants[0].id))
     return render_template("deliver_grant_funding/grant_list.html", grants=grants)
 
 
 @deliver_grant_funding_blueprint.route("/grant/<uuid:grant_id>", methods=["GET"])
-@mhclg_login_required
+@has_grant_role(RoleEnum.MEMBER)
 def view_grant(grant_id: UUID) -> ResponseReturnValue:
     grant = interfaces.grants.get_grant(grant_id)
     return render_template("deliver_grant_funding/grant_view.html", grant=grant)
@@ -247,7 +248,7 @@ def add_user_to_grant(grant_id: UUID) -> ResponseReturnValue:
 
 
 @deliver_grant_funding_blueprint.route("/grant/<uuid:grant_id>/details", methods=["GET"])
-@mhclg_login_required
+@has_grant_role(RoleEnum.MEMBER)
 def grant_details(grant_id: UUID) -> ResponseReturnValue:
     grant = interfaces.grants.get_grant(grant_id)
     return render_template("deliver_grant_funding/grant_details.html", grant=grant)

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_base.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_base.html
@@ -27,7 +27,7 @@
 
 {% set right_nav_items = [] %}
 
-{% if authorisation_helper.is_platform_admin(current_user) %}
+{% if authorisation_helper.is_platform_admin() %}
   {%
     do right_nav_items.append({
         "text": "See all grants",

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_base.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_base.html
@@ -27,7 +27,7 @@
 
 {% set right_nav_items = [] %}
 
-{% if authorisation_helper.is_platform_admin() %}
+{% if authorisation_helper.is_platform_admin(current_user) %}
   {%
     do right_nav_items.append({
         "text": "See all grants",

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_base.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_base.html
@@ -27,7 +27,7 @@
 
 {% set right_nav_items = [] %}
 
-{% if current_user.is_platform_admin %}
+{% if authorisation_helper.is_platform_admin(current_user) %}
   {%
     do right_nav_items.append({
         "text": "See all grants",

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_list.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_list.html
@@ -9,7 +9,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Grants</h1>
-      {% if current_user.is_platform_admin %}
+      {% if authorisation_helper.is_platform_admin(current_user) %}
         {{
           govukButton({
             "text": "Set up a grant",

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_list.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_list.html
@@ -9,7 +9,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Grants</h1>
-      {% if authorisation_helper.is_platform_admin() %}
+      {% if authorisation_helper.is_platform_admin(current_user) %}
         {{
           govukButton({
             "text": "Set up a grant",

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_list.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_list.html
@@ -9,7 +9,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Grants</h1>
-      {% if authorisation_helper.is_platform_admin(current_user) %}
+      {% if authorisation_helper.is_platform_admin() %}
         {{
           govukButton({
             "text": "Set up a grant",

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_team/grant_user_list.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_team/grant_user_list.html
@@ -26,7 +26,7 @@
         <span class="govuk-caption-l">{{ grant.name }}</span>
         Grant team
       </h1>
-      {% if authorisation_helper.is_platform_admin() %}
+      {% if authorisation_helper.is_platform_admin(current_user) %}
         {{
           govukButton({
              "text": "Add grant team member",

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_team/grant_user_list.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_team/grant_user_list.html
@@ -26,7 +26,7 @@
         <span class="govuk-caption-l">{{ grant.name }}</span>
         Grant team
       </h1>
-      {% if authorisation_helper.is_platform_admin(current_user) %}
+      {% if authorisation_helper.is_platform_admin() %}
         {{
           govukButton({
              "text": "Add grant team member",
@@ -39,7 +39,7 @@
 
   {% set table_pending_signin_rows = namespace(items=[]) %}
   {% if grant.users %}
-    {% for user in grant.users if not user.has_logged_in %}
+    {% for user in grant.users if not authorisation_helper.has_logged_in(user) %}
       {%
         set table_pending_signin_rows.items = table_pending_signin_rows.items + [[
           {"text": user.email},
@@ -69,7 +69,7 @@
   {% set table_rows = namespace(items=[]) %}
 
   {% if grant.users %}
-    {% for user in grant.users if user.has_logged_in %}
+    {% for user in grant.users if authorisation_helper.has_logged_in(user) %}
       {%
         set table_rows.items = table_rows.items + [[
           {"text": user.name},

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_team/grant_user_list.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_team/grant_user_list.html
@@ -26,7 +26,7 @@
         <span class="govuk-caption-l">{{ grant.name }}</span>
         Grant team
       </h1>
-      {% if current_user.is_platform_admin %}
+      {% if authorisation_helper.is_platform_admin(current_user) %}
         {{
           govukButton({
              "text": "Add grant team member",

--- a/app/developers/commands.py
+++ b/app/developers/commands.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING, Sequence, TypedDict
 
 import click
 
@@ -9,49 +9,206 @@ from app.developers import developers_blueprint
 
 if TYPE_CHECKING:
     from app.common.data.models import Grant
+from tests.models import (
+    _CollectionFactory,
+    _FormFactory,
+    _GrantFactory,
+    _QuestionFactory,
+    _SectionFactory,
+)
 
 
-def _seed_chessboards_in_parks(grants: Sequence["Grant"]) -> None:
-    grant_name = "Chessboards in parks"
+class QuestionSpec(TypedDict):
+    text: str
+    data_type: QuestionDataType
 
+
+class FormSpec(TypedDict):
+    title: str
+    questions: list[QuestionSpec]
+
+
+class SectionSpec(TypedDict):
+    title: str
+    slug: str
+    forms: list[FormSpec]
+
+
+def _seed_grant(
+    grants: Sequence["Grant"], grant_name: str, collection_name: str, collection_slug: str, sections: list[SectionSpec]
+) -> None:
     if grant := next((grant for grant in grants if grant.name == grant_name), None):
         click.echo(f"Grant '{grant_name}' already exists; recreating it.")
         delete_grant(grant.id)
 
-    from tests.models import (
-        _CollectionFactory,
-        _FormFactory,
-        _GrantFactory,
-        _QuestionFactory,
-        _SectionFactory,
-    )
-
     grant = _GrantFactory.create(name=grant_name)
+    collection = _CollectionFactory.create(grant=grant, name=collection_name, slug=collection_slug)
 
-    collection = _CollectionFactory.create(
-        grant=grant, name="Report on chessboards in parks", slug="report-on-chessboards-in-parks"
-    )
-
-    s = _SectionFactory.create(collection=collection, title="About the park", slug="about-the-park")
-
-    f = _FormFactory.create(section=s, title="Park information")
-
-    _QuestionFactory.create(form=f, text="What is the name of the park?", data_type=QuestionDataType.TEXT_SINGLE_LINE)
-    _QuestionFactory.create(form=f, text="How many chessboards are there?", data_type=QuestionDataType.INTEGER)
-    f = _FormFactory.create(section=s, title="Visitor information")
-    _QuestionFactory.create(
-        form=f, text="How many visitors were there in the last reporting period?", data_type=QuestionDataType.INTEGER
-    )
-
-    s = _SectionFactory.create(collection=collection, title="About the chess", slug="about-the-chess")
-    f = _FormFactory.create(section=s, title="Information about the chess games played")
-    _QuestionFactory.create(
-        form=f,
-        text="Describe the most exciting game played in the last reporting period.",
-        data_type=QuestionDataType.TEXT_MULTI_LINE,
-    )
+    for section_data in sections:
+        section = _SectionFactory.create(collection=collection, title=section_data["title"], slug=section_data["slug"])
+        for form_data in section_data["forms"]:
+            form = _FormFactory.create(section=section, title=form_data["title"])
+            for question in form_data["questions"]:
+                _QuestionFactory.create(form=form, text=question["text"], data_type=question["data_type"])
 
     click.echo(f"Seeded the ‘{grant_name}’ grant.")
+
+
+def _seed_chessboards_in_parks(grants: Sequence["Grant"]) -> None:
+    _seed_grant(
+        grants,
+        grant_name="Chessboards in parks",
+        collection_name="Report on chessboards in parks",
+        collection_slug="report-on-chessboards-in-parks",
+        sections=[
+            {
+                "title": "About the park",
+                "slug": "about-the-park",
+                "forms": [
+                    {
+                        "title": "Park information",
+                        "questions": [
+                            {"text": "What is the name of the park?", "data_type": QuestionDataType.TEXT_SINGLE_LINE},
+                            {"text": "How many chessboards are there?", "data_type": QuestionDataType.INTEGER},
+                        ],
+                    },
+                    {
+                        "title": "Visitor information",
+                        "questions": [
+                            {
+                                "text": "How many visitors were there in the last reporting period?",
+                                "data_type": QuestionDataType.INTEGER,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                "title": "About the chess",
+                "slug": "about-the-chess",
+                "forms": [
+                    {
+                        "title": "Information about the chess games played",
+                        "questions": [
+                            {
+                                "text": "Describe the most exciting game played in the last reporting period.",
+                                "data_type": QuestionDataType.TEXT_MULTI_LINE,
+                            }
+                        ],
+                    }
+                ],
+            },
+        ],
+    )
+
+
+def _seed_playgrounds_in_parks(grants: Sequence["Grant"]) -> None:
+    _seed_grant(
+        grants,
+        grant_name="Playgrounds in Parks",
+        collection_name="Report on playgrounds in parks",
+        collection_slug="report-on-playgrounds-in-parks",
+        sections=[
+            {
+                "title": "Playground Overview",
+                "slug": "playground-overview",
+                "forms": [
+                    {
+                        "title": "Playground Details",
+                        "questions": [
+                            {"text": "What is the name of the park?", "data_type": QuestionDataType.TEXT_SINGLE_LINE},
+                            {
+                                "text": "How many pieces of playground equipment are there?",
+                                "data_type": QuestionDataType.INTEGER,
+                            },
+                            {
+                                "text": "Is the playground accessible to children with disabilities?",
+                                "data_type": QuestionDataType.INTEGER,
+                            },
+                        ],
+                    }
+                ],
+            },
+            {
+                "title": "Usage & Maintenance",
+                "slug": "usage-maintenance",
+                "forms": [
+                    {
+                        "title": "Usage Statistics",
+                        "questions": [
+                            {
+                                "text": "How many children used the playground last month?",
+                                "data_type": QuestionDataType.INTEGER,
+                            },
+                        ],
+                    },
+                    {
+                        "title": "Maintenance Notes",
+                        "questions": [
+                            {
+                                "text": "Were there any safety incidents reported?",
+                                "data_type": QuestionDataType.INTEGER,
+                            },
+                            {
+                                "text": """
+                                Describe any maintenance activities or issues during the last reporting period.
+                                """,
+                                "data_type": QuestionDataType.TEXT_MULTI_LINE,
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    )
+
+
+def _seed_picnic_areas_in_parks(grants: Sequence["Grant"]) -> None:
+    _seed_grant(
+        grants,
+        grant_name="Picnic Areas in Parks",
+        collection_name="Report on picnic areas in parks",
+        collection_slug="report-on-picnic-areas-in-parks",
+        sections=[
+            {
+                "title": "Park Overview",
+                "slug": "park-overview",
+                "forms": [
+                    {
+                        "title": "General Park Information",
+                        "questions": [
+                            {"text": "What is the name of the park?", "data_type": QuestionDataType.TEXT_SINGLE_LINE},
+                            {"text": "How many picnic tables are available?", "data_type": QuestionDataType.INTEGER},
+                        ],
+                    },
+                    {
+                        "title": "Usage Information",
+                        "questions": [
+                            {
+                                "text": "How many families used the picnic area last month?",
+                                "data_type": QuestionDataType.INTEGER,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                "title": "Feedback",
+                "slug": "feedback",
+                "forms": [
+                    {
+                        "title": "Public Feedback on Picnic Areas",
+                        "questions": [
+                            {
+                                "text": "Share any notable comments or stories from visitors about the picnic areas.",
+                                "data_type": QuestionDataType.TEXT_MULTI_LINE,
+                            }
+                        ],
+                    }
+                ],
+            },
+        ],
+    )
 
 
 @developers_blueprint.cli.command("seed-grants", help="Seed exemplar grants to aid development and testing.")
@@ -59,3 +216,5 @@ def seed_grants() -> None:
     grants = interfaces.grants.get_all_grants()
 
     _seed_chessboards_in_parks(grants)
+    _seed_picnic_areas_in_parks(grants)
+    _seed_playgrounds_in_parks(grants)

--- a/tests/integration/common/auth/test_decorators.py
+++ b/tests/integration/common/auth/test_decorators.py
@@ -159,6 +159,19 @@ class TestHasGrantRole:
         response = view_func(grant_id="abc")
         assert response == "OK"
 
+    def test_without_grant_id(self, factories):
+        user = factories.user.create(email="test.member2@communities.gov.uk")
+        grant = factories.grant.create()
+        factories.user_role.create(user=user, role=RoleEnum.MEMBER, grant=grant)
+
+        @has_grant_role(role=RoleEnum.ADMIN)
+        def view_func(grant_id: UUID):
+            return "OK"
+
+        login_user(user)
+        with pytest.raises(ValueError, match="Grant ID required"):
+            view_func(grant_id=None)
+
     def test_member_user_has_access(self, factories):
         user = factories.user.create(email="test.member@communities.gov.uk")
         grant = factories.grant.create()

--- a/tests/integration/common/data/db/test_constraints.py
+++ b/tests/integration/common/data/db/test_constraints.py
@@ -13,26 +13,6 @@ class TestUserRoleConstraints:
             in error.value.args[0]
         )
 
-    @pytest.mark.parametrize("has_organisation, has_grant", [(True, True), (False, True)])
-    def test_s151_officer_role_org_only(self, factories, has_organisation, has_grant):
-        with pytest.raises(IntegrityError) as error:
-            factories.user_role.create(
-                has_organisation=has_organisation, has_grant=has_grant, role=RoleEnum.S151_OFFICER
-            )
-        assert (
-            'new row for relation "user_role" violates check constraint "ck_user_role_s151_officer_role_org_only"'
-            in error.value.args[0]
-        )
-
-    @pytest.mark.parametrize("has_organisation, has_grant", [(True, True), (True, False)])
-    def test_assessor_role_grant_only(self, factories, has_organisation, has_grant):
-        with pytest.raises(IntegrityError) as error:
-            factories.user_role.create(has_organisation=has_organisation, has_grant=has_grant, role=RoleEnum.ASSESSOR)
-        assert (
-            'new row for relation "user_role" violates check constraint "ck_user_role_assessor_role_grant_only"'
-            in error.value.args[0]
-        )
-
     def test_unique_constraint_with_nulls(self, factories):
         user_role = factories.user_role.create(role=RoleEnum.ADMIN)
         with pytest.raises(IntegrityError) as error:

--- a/tests/integration/common/data/interfaces/test_user.py
+++ b/tests/integration/common/data/interfaces/test_user.py
@@ -110,8 +110,6 @@ class TestUpsertUserRole:
         [
             (False, False, RoleEnum.ADMIN),
             (True, False, RoleEnum.MEMBER),
-            (False, True, RoleEnum.ASSESSOR),
-            (True, True, RoleEnum.EDITOR),
         ],
     )
     def test_add_user_role(self, db_session, factories, organisation, grant, role):
@@ -195,8 +193,6 @@ class TestUpsertUserRole:
         "organisation, grant, role, message",
         [
             (False, False, RoleEnum.MEMBER, "A 'member' role must be linked to an organisation or grant."),
-            (True, False, RoleEnum.ASSESSOR, "An 'assessor' role can only be linked to a grant."),
-            (False, True, RoleEnum.S151_OFFICER, "A 's151_officer' role can only be linked to an organisation."),
         ],
     )
     def test_add_invalid_user_role(self, factories, organisation, grant, role, message):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -256,7 +256,7 @@ def mock_notification_service_calls(mocker: MockerFixture) -> Generator[list[_Ca
 
 
 @pytest.fixture()
-def authenticated_client(
+def authenticated_no_role_client(
     anonymous_client: FlaskClient, factories: _Factories, request: FixtureRequest
 ) -> Generator[FlaskClient, None, None]:
     email_mark = request.node.get_closest_marker("authenticate_as")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -108,7 +108,7 @@ def app(setup_db_container: PostgresContainer) -> Generator[Flask, None, None]:
 def _validate_form_argument_to_render_template(response: TestResponse, templates_rendered: TTemplatesRendered) -> None:
     if response.headers["content-type"].startswith("text/html"):
         for _endpoint, render_template in templates_rendered.items():
-            if "form" in render_template.context:
+            if "form" in render_template.context and render_template.context["form"]:
                 assert isinstance(render_template.context["form"], FlaskForm), (
                     "The `form` argument passed to `render_template` is expected to be a FlaskForm instance. "
                     "This powers 'magic' handling of error summary rendering."

--- a/tests/integration/deliver_grant_funding/test_routes.py
+++ b/tests/integration/deliver_grant_funding/test_routes.py
@@ -1,3 +1,5 @@
+import inspect
+import uuid
 from uuid import UUID
 
 import pytest
@@ -5,9 +7,11 @@ from bs4 import BeautifulSoup
 from flask import url_for
 from sqlalchemy import select
 
+from app.common.data import interfaces
 from app.common.data.interfaces.user import get_current_user
-from app.common.data.models import Collection, Form, Grant, Question, Section
-from app.common.data.types import QuestionDataType, RoleEnum
+from app.common.data.models import Collection, Expression, Form, Grant, Question, Section
+from app.common.data.types import ExpressionType, QuestionDataType, RoleEnum, SubmissionModeEnum
+from app.common.expressions.managed import GreaterThan
 from app.deliver_grant_funding.forms import (
     CollectionForm,
     FormForm,
@@ -1031,3 +1035,81 @@ def test_list_users_for_grant_with_member(authenticated_member_client, templates
     users = templates_rendered.get("deliver_grant_funding.list_users_for_grant").context.get("grant").users
     assert users
     assert len(users) == 1
+
+
+def _get_decorators(func):
+    try:
+        src = inspect.getsource(func)
+    except (OSError, TypeError):
+        return []
+    lines = src.splitlines()
+    return [line.strip() for line in lines if line.strip().startswith("@")]
+
+
+@pytest.mark.parametrize(
+    "role,client_fixture",
+    [
+        (RoleEnum.ADMIN, "authenticated_platform_admin_client"),
+        (RoleEnum.MEMBER, "authenticated_member_client"),
+    ],
+)
+def test_accessibility_for_user_role_to_each_endpoint(app, request, factories, role, client_fixture):
+    client = request.getfixturevalue(client_fixture)
+    user = interfaces.user.get_current_user()
+    grant = factories.grant.create()
+    if role == RoleEnum.MEMBER:
+        factories.user_role.create(user=user, role=RoleEnum.MEMBER, grant=grant)
+    collection = factories.collection.create(grant=grant)
+    section = factories.section.create(collection=collection)
+    form = factories.form.create(section=section)
+    question = factories.question.create(form=form, data_type=QuestionDataType.INTEGER)
+    managed_expression = GreaterThan(minimum_value=3000, question_id=question.id)
+    question.expressions.append(
+        Expression(
+            statement=managed_expression.expression,
+            context=managed_expression.model_dump(mode="json"),
+            created_by_id=user.id,
+            type=ExpressionType.CONDITION,
+        )
+    )
+    depends_on_question = factories.question.create(form=form, data_type=QuestionDataType.INTEGER)
+    submission = factories.submission.create(collection=collection)
+    ids = {
+        "grant_id": grant.id,
+        "collection_id": collection.id,
+        "section_id": section.id,
+        "form_id": form.id,
+        "question_id": question.id,
+        "depends_on_question_id": depends_on_question.id,
+        "submission_id": submission.id,
+        "submission_mode": SubmissionModeEnum.TEST,
+        "direction": "down",
+        "magic_link_id": uuid.uuid4(),
+    }
+    ignored_endpoints = {
+        "static",
+        "raise_403",
+        "health_check",
+        "healthcheck.healthcheck",
+        "raise_sqlalchemy_not_found",
+    }
+    for rule in app.url_map.iter_rules():
+        if rule.endpoint in ignored_endpoints:
+            continue
+        url = url_for(rule.endpoint, **{arg: str(ids.get(arg, "1")) for arg in rule.arguments})
+        decorators = _get_decorators(app.view_functions[rule.endpoint])
+        if role == RoleEnum.MEMBER and (
+            "@platform_admin_role_required" in decorators or "@has_grant_role(RoleEnum.ADMIN)" in decorators
+        ):
+            expected = (403, 401)
+        else:
+            expected = (200, 302, 201)
+        if "GET" in rule.methods:
+            response = client.get(url)
+        elif "POST" in rule.methods:
+            response = client.post(url, data={})
+        else:
+            pytest.fail(f"Unsupported HTTP method(s): {rule.methods}")
+        assert response.status_code in expected, (
+            f"{role} accessing {rule.endpoint} returned {response.status_code}, expected one of {expected}"
+        )

--- a/tests/integration/deliver_grant_funding/test_routes.py
+++ b/tests/integration/deliver_grant_funding/test_routes.py
@@ -1,4 +1,3 @@
-import logging
 from uuid import UUID
 
 import pytest
@@ -22,8 +21,6 @@ from app.deliver_grant_funding.forms import (
     QuestionTypeForm,
     SectionForm,
 )
-
-logger = logging.getLogger(__name__)
 
 
 def test_list_grants_as_admin(

--- a/tests/models.py
+++ b/tests/models.py
@@ -82,7 +82,7 @@ class _UserRoleFactory(factory.alchemy.SQLAlchemyModelFactory):
     user = factory.SubFactory(_UserFactory)
     organisation_id = None
     organisation = None
-    grant_id = None
+    grant_id = factory.LazyAttribute(lambda o: o.grant.id if o.grant else None)
     grant = None
     role = None  # This needs to be overridden when initialising the factory
 

--- a/tests/unit/app/common/auth/test_authorisation_helper.py
+++ b/tests/unit/app/common/auth/test_authorisation_helper.py
@@ -66,7 +66,7 @@ class TestAuthorisationHelper:
     def test_is_grant_admin_no_grant(self, factories, role, expected):
         user = factories.user.build()
         grant = factories.grant.build()
-        factories.user_role.build(user=user, role=role, has_grant=False)
+        factories.user_role.build(user=user, role=role, grant=grant)
         assert AuthorisationHelper.is_grant_admin(user=user, grant_id=grant.id) is expected
 
     @pytest.mark.parametrize(

--- a/tests/unit/app/common/auth/test_authorisation_helper.py
+++ b/tests/unit/app/common/auth/test_authorisation_helper.py
@@ -1,0 +1,76 @@
+import pytest
+
+from app import AuthorisationHelper
+from app.common.data.types import RoleEnum
+
+
+class TestAuthorisationHelper:
+    @pytest.mark.parametrize(
+        "name, expected",
+        [
+            ("John", True),
+            (None, False),
+        ],
+    )
+    def test_has_logged_in(self, factories, name, expected):
+        user = factories.user.build(name=name)
+        assert AuthorisationHelper.has_logged_in(user) is expected
+
+    @pytest.mark.parametrize(
+        "role, is_grant, expected",
+        [
+            (RoleEnum.ADMIN, False, True),
+            (RoleEnum.ADMIN, True, False),
+            (RoleEnum.MEMBER, True, False),
+        ],
+    )
+    def test_is_platform_admin(self, factories, role, is_grant, expected):
+        user = factories.user.build()
+        grant = factories.grant.build() if is_grant else None
+        factories.user_role.build(user=user, role=role, grant=grant)
+        assert AuthorisationHelper.is_platform_admin(user) is expected
+
+    @pytest.mark.parametrize(
+        "role, expected",
+        [
+            (RoleEnum.ADMIN, True),
+            (RoleEnum.MEMBER, False),
+        ],
+    )
+    def test_is_grant_admin(self, factories, role, expected):
+        user = factories.user.build()
+        grant = factories.grant.build()
+        factories.user_role.build(user=user, role=role, grant=grant)
+        assert AuthorisationHelper.is_grant_admin(user=user, grant_id=grant.id) is expected
+
+    @pytest.mark.parametrize(
+        "role, expected",
+        [
+            (RoleEnum.ADMIN, False),
+            (RoleEnum.MEMBER, True),
+        ],
+    )
+    def test_is_grant_member(self, factories, role, expected):
+        user = factories.user.build()
+        grant = factories.grant.build()
+        factories.user_role.build(user=user, role=role, grant=grant)
+        assert AuthorisationHelper.is_grant_member(user=user, grant_id=grant.id) is expected
+
+    @pytest.mark.parametrize(
+        "role, expected",
+        [
+            (RoleEnum.ADMIN, True),
+            (RoleEnum.MEMBER, True),
+            (RoleEnum.S151_OFFICER, pytest.raises(ValueError)),
+        ],
+    )
+    def test_has_grant_role(self, factories, role, expected):
+        user = factories.user.build()
+        grant = factories.grant.build()
+        factories.user_role.build(user=user, role=role, grant=grant)
+
+        if isinstance(expected, bool):
+            assert AuthorisationHelper.has_grant_role(user=user, grant_id=grant.id, role=role) is expected
+        else:
+            with expected:
+                AuthorisationHelper.has_grant_role(user=user, grant_id=grant.id, role=role)

--- a/tests/unit/app/common/auth/test_authorisation_helper.py
+++ b/tests/unit/app/common/auth/test_authorisation_helper.py
@@ -93,7 +93,6 @@ class TestAuthorisationHelper:
     def test_is_grant_member_false_not_got_member_role(self, factories):
         user = factories.user.build()
         grant = factories.grant.build()
-        factories.user_role.build(user=user, role=RoleEnum.S151_OFFICER, grant=grant)
         assert AuthorisationHelper.is_grant_member(user=user, grant_id=grant.id) is False
 
     def test_is_grant_member_overriden_by_platform_admin(self, factories):
@@ -107,7 +106,7 @@ class TestAuthorisationHelper:
         [
             (RoleEnum.ADMIN, True),
             (RoleEnum.MEMBER, True),
-            (RoleEnum.S151_OFFICER, pytest.raises(ValueError)),
+            ("S151_OFFICER", pytest.raises(ValueError)),
         ],
     )
     def test_has_grant_role(self, factories, role, expected):

--- a/tests/unit/app/common/auth/test_authorisation_helper.py
+++ b/tests/unit/app/common/auth/test_authorisation_helper.py
@@ -63,32 +63,31 @@ class TestAuthorisationHelper:
             (RoleEnum.MEMBER, False),
         ],
     )
-    def test_is_grant_admin_no_grant(self, factories, role, expected):
+    def test_is_grant_admin_for_grant_roles(self, factories, role, expected):
         user = factories.user.build()
         grant = factories.grant.build()
         factories.user_role.build(user=user, role=role, grant=grant)
         assert AuthorisationHelper.is_grant_admin(user=user, grant_id=grant.id) is expected
 
     @pytest.mark.parametrize(
-        "role, expected",
+        "role",
         [
-            (RoleEnum.ADMIN, True),
-            (RoleEnum.MEMBER, True),
+            RoleEnum.ADMIN,
+            RoleEnum.MEMBER,
         ],
     )
-    def test_is_grant_member_true(self, factories, role, expected):
+    def test_is_grant_member_true(self, factories, role):
         user = factories.user.build()
         grant = factories.grant.build()
         factories.user_role.build(user=user, role=role, grant=grant)
-        assert AuthorisationHelper.is_grant_member(user=user, grant_id=grant.id) is expected
+        assert AuthorisationHelper.is_grant_member(user=user, grant_id=grant.id)
 
     @pytest.mark.parametrize("role", [RoleEnum.ADMIN, RoleEnum.MEMBER])
     def test_is_grant_member_false_member_of_different_grant(self, factories, role):
         user = factories.user.build()
-        grant1 = factories.grant.build()
-        grant2 = factories.grant.build()
-        factories.user_role.build(user=user, role=role, grant=grant1)
-        assert AuthorisationHelper.is_grant_member(user=user, grant_id=grant2.id) is False
+        grants = factories.grant.build_batch(2)
+        factories.user_role.build(user=user, role=role, grant=grants[0])
+        assert AuthorisationHelper.is_grant_member(user=user, grant_id=grants[1].id) is False
 
     def test_is_grant_member_false_not_got_member_role(self, factories):
         user = factories.user.build()

--- a/tests/unit/app/common/auth/test_authorisation_helper.py
+++ b/tests/unit/app/common/auth/test_authorisation_helper.py
@@ -17,17 +17,16 @@ class TestAuthorisationHelper:
         assert AuthorisationHelper.has_logged_in(user) is expected
 
     @pytest.mark.parametrize(
-        "role, is_grant, expected",
+        "role, has_grant_linked_to_role, expected",
         [
             (RoleEnum.ADMIN, False, True),
             (RoleEnum.ADMIN, True, False),
             (RoleEnum.MEMBER, True, False),
         ],
     )
-    def test_is_platform_admin(self, factories, role, is_grant, expected):
+    def test_is_platform_admin(self, factories, role, has_grant_linked_to_role, expected):
         user = factories.user.build()
-        grant = factories.grant.build() if is_grant else None
-        factories.user_role.build(user=user, role=role, grant=grant)
+        factories.user_role.build(user=user, role=role, has_grant=has_grant_linked_to_role)
         assert AuthorisationHelper.is_platform_admin(user) is expected
 
     @pytest.mark.parametrize(
@@ -37,24 +36,71 @@ class TestAuthorisationHelper:
             (RoleEnum.MEMBER, False),
         ],
     )
-    def test_is_grant_admin(self, factories, role, expected):
+    def test_is_grant_admin_correct_grant(self, factories, role, expected):
         user = factories.user.build()
         grant = factories.grant.build()
         factories.user_role.build(user=user, role=role, grant=grant)
         assert AuthorisationHelper.is_grant_admin(user=user, grant_id=grant.id) is expected
 
     @pytest.mark.parametrize(
+        "role",
+        [
+            (RoleEnum.ADMIN),
+            (RoleEnum.MEMBER),
+        ],
+    )
+    def test_is_grant_admin_incorrect_grant(self, factories, role):
+        user = factories.user.build()
+        grant1 = factories.grant.build()
+        grant2 = factories.grant.build()
+        factories.user_role.build(user=user, role=role, grant=grant1)
+        assert AuthorisationHelper.is_grant_admin(user=user, grant_id=grant2.id) is False
+
+    @pytest.mark.parametrize(
         "role, expected",
         [
-            (RoleEnum.ADMIN, False),
+            (RoleEnum.ADMIN, True),
+            (RoleEnum.MEMBER, False),
+        ],
+    )
+    def test_is_grant_admin_no_grant(self, factories, role, expected):
+        user = factories.user.build()
+        grant = factories.grant.build()
+        factories.user_role.build(user=user, role=role, has_grant=False)
+        assert AuthorisationHelper.is_grant_admin(user=user, grant_id=grant.id) is expected
+
+    @pytest.mark.parametrize(
+        "role, expected",
+        [
+            (RoleEnum.ADMIN, True),
             (RoleEnum.MEMBER, True),
         ],
     )
-    def test_is_grant_member(self, factories, role, expected):
+    def test_is_grant_member_true(self, factories, role, expected):
         user = factories.user.build()
         grant = factories.grant.build()
         factories.user_role.build(user=user, role=role, grant=grant)
         assert AuthorisationHelper.is_grant_member(user=user, grant_id=grant.id) is expected
+
+    @pytest.mark.parametrize("role", [RoleEnum.ADMIN, RoleEnum.MEMBER])
+    def test_is_grant_member_false_member_of_different_grant(self, factories, role):
+        user = factories.user.build()
+        grant1 = factories.grant.build()
+        grant2 = factories.grant.build()
+        factories.user_role.build(user=user, role=role, grant=grant1)
+        assert AuthorisationHelper.is_grant_member(user=user, grant_id=grant2.id) is False
+
+    def test_is_grant_member_false_not_got_member_role(self, factories):
+        user = factories.user.build()
+        grant = factories.grant.build()
+        factories.user_role.build(user=user, role=RoleEnum.S151_OFFICER, grant=grant)
+        assert AuthorisationHelper.is_grant_member(user=user, grant_id=grant.id) is False
+
+    def test_is_grant_member_overriden_by_platform_admin(self, factories):
+        user = factories.user.build()
+        grant = factories.grant.build()
+        factories.user_role.build(user=user, role=RoleEnum.ADMIN, grant=None)
+        assert AuthorisationHelper.is_grant_member(user=user, grant_id=grant.id) is True
 
     @pytest.mark.parametrize(
         "role, expected",

--- a/tests/unit/app/deliver_grant_funding/test_forms.py
+++ b/tests/unit/app/deliver_grant_funding/test_forms.py
@@ -52,13 +52,14 @@ def test_grant_ggis_form_fails_when_yes_selected_and_empty(app: Flask):
 def test_user_already_in_grant_users(app: Flask, factories):
     grant = factories.grant.build(name="Test Grant")
     user = factories.user.build(email="test.user@communities.gov.uk")
+    factories.user_role.build(user=user, role=RoleEnum.MEMBER, grant=grant)
 
     form = GrantAddUserForm(grant=grant)
     form.user_email.data = "test.admin@communities.gov.uk"
 
     with (
         patch("app.deliver_grant_funding.forms.get_user_by_email", return_value=user),
-        patch("app.deliver_grant_funding.forms.get_all_grants_by_user", return_value=[grant]),
+        # patch("app.deliver_grant_funding.forms.get_all_grants_by_user", return_value=[grant]),
     ):
         assert form.validate() is False
         assert "already is a member of" in form.user_email.errors[0]

--- a/tests/unit/app/deliver_grant_funding/test_forms.py
+++ b/tests/unit/app/deliver_grant_funding/test_forms.py
@@ -59,7 +59,6 @@ def test_user_already_in_grant_users(app: Flask, factories):
 
     with (
         patch("app.deliver_grant_funding.forms.get_user_by_email", return_value=user),
-        # patch("app.deliver_grant_funding.forms.get_all_grants_by_user", return_value=[grant]),
     ):
         assert form.validate() is False
         assert "already is a member of" in form.user_email.errors[0]

--- a/tests/unit/test_all_routes_access.py
+++ b/tests/unit/test_all_routes_access.py
@@ -19,13 +19,6 @@ all_auth_annotations = [
     "@has_grant_role(RoleEnum.ADMIN)",
     "@platform_admin_role_required",
 ]
-
-
-routes_with_expected_member_only_access = [
-    "deliver_grant_funding.list_users_for_grant",
-    "deliver_grant_funding.view_grant",
-    "deliver_grant_funding.grant_details",
-]
 routes_with_expected_platform_admin_only_access = [
     "developers.grant_developers",
     "developers.grant_developers_collections",
@@ -66,6 +59,13 @@ routes_with_expected_platform_admin_only_access = [
     "deliver_grant_funding.grant_change_description",
     "deliver_grant_funding.grant_change_contact",
 ]
+routes_with_expected_grant_admin_only_access = []
+routes_with_expected_member_only_access = [
+    "deliver_grant_funding.list_users_for_grant",
+    "deliver_grant_funding.view_grant",
+    "deliver_grant_funding.grant_details",
+]
+
 routes_with_expected_mhclg_login_required_access = ["deliver_grant_funding.list_grants"]
 routes_with_no_expected_access_restrictions = [
     "auth.request_a_link_to_sign_in",
@@ -75,9 +75,7 @@ routes_with_no_expected_access_restrictions = [
     "auth.sso_get_token",
     "auth.sign_out",
     "static",
-    "raise_403",
     "healthcheck.healthcheck",
-    "raise_sqlalchemy_not_found",
     "index",
 ]
 
@@ -97,3 +95,16 @@ def test_accessibility_for_user_role_to_each_endpoint(app):
 
         else:
             pytest.fail(f"Unexpected endpoint {rule.endpoint}. Add this to the expected_route_access mapping.")
+
+
+def test_routes_list_is_valid(app):
+    all_declared_routes_in_test = (
+        routes_with_no_expected_access_restrictions
+        + routes_with_expected_mhclg_login_required_access
+        + routes_with_expected_member_only_access
+        + routes_with_expected_grant_admin_only_access
+        + routes_with_expected_platform_admin_only_access
+    )
+
+    all_routes_in_app = [rule.endpoint for rule in app.url_map.iter_rules()]
+    assert set(all_declared_routes_in_test) - set(all_routes_in_app) == set()

--- a/tests/unit/test_all_routes_access.py
+++ b/tests/unit/test_all_routes_access.py
@@ -44,6 +44,7 @@ routes_with_expected_platform_admin_only_access = [
     "developers.collection_confirmation",
     "developers.ask_a_question",
     "developers.check_your_answers",
+    "developers.add_question_validation",
     "developers.list_submissions_for_collection",
     "developers.manage_submission",
     "deliver_grant_funding.grant_setup_intro",

--- a/tests/unit/test_all_routes_access.py
+++ b/tests/unit/test_all_routes_access.py
@@ -1,0 +1,99 @@
+import inspect
+
+import pytest
+
+
+def _get_decorators(func):
+    try:
+        src = inspect.getsource(func)
+    except (OSError, TypeError):
+        return []
+    lines = src.splitlines()
+    return [line.strip() for line in lines if line.strip().startswith("@")]
+
+
+all_auth_annotations = [
+    "@login_required",
+    "@mhclg_login_required",
+    "@has_grant_role(RoleEnum.MEMBER)",
+    "@has_grant_role(RoleEnum.ADMIN)",
+    "@platform_admin_role_required",
+]
+
+
+routes_with_expected_member_only_access = [
+    "deliver_grant_funding.list_users_for_grant",
+    "deliver_grant_funding.view_grant",
+    "deliver_grant_funding.grant_details",
+]
+routes_with_expected_platform_admin_only_access = [
+    "developers.grant_developers",
+    "developers.grant_developers_collections",
+    "developers.setup_collection",
+    "developers.manage_collection",
+    "developers.edit_collection",
+    "developers.add_section",
+    "developers.list_sections",
+    "developers.move_section",
+    "developers.manage_section",
+    "developers.move_form",
+    "developers.manage_form",
+    "developers.edit_section",
+    "developers.add_form",
+    "developers.edit_form",
+    "developers.choose_question_type",
+    "developers.add_question",
+    "developers.move_question",
+    "developers.edit_question",
+    "developers.add_question_condition_select_question",
+    "developers.add_question_condition",
+    "developers.submission_tasklist",
+    "developers.collection_confirmation",
+    "developers.ask_a_question",
+    "developers.check_your_answers",
+    "developers.list_submissions_for_collection",
+    "developers.manage_submission",
+    "deliver_grant_funding.grant_setup_intro",
+    "deliver_grant_funding.grant_setup_ggis",
+    "deliver_grant_funding.grant_setup_name",
+    "deliver_grant_funding.grant_setup_description",
+    "deliver_grant_funding.grant_setup_contact",
+    "deliver_grant_funding.grant_setup_check_your_answers",
+    "deliver_grant_funding.grant_setup_confirmation",
+    "deliver_grant_funding.add_user_to_grant",
+    "deliver_grant_funding.grant_change_ggis",
+    "deliver_grant_funding.grant_change_name",
+    "deliver_grant_funding.grant_change_description",
+    "deliver_grant_funding.grant_change_contact",
+]
+routes_with_expected_mhclg_login_required_access = ["deliver_grant_funding.list_grants"]
+routes_with_no_expected_access_restrictions = [
+    "auth.request_a_link_to_sign_in",
+    "auth.check_email",
+    "auth.claim_magic_link",
+    "auth.sso_sign_in",
+    "auth.sso_get_token",
+    "auth.sign_out",
+    "static",
+    "raise_403",
+    "healthcheck.healthcheck",
+    "raise_sqlalchemy_not_found",
+    "index",
+]
+
+
+def test_accessibility_for_user_role_to_each_endpoint(app):
+    for rule in app.url_map.iter_rules():
+        decorators = _get_decorators(app.view_functions[rule.endpoint])
+        if rule.endpoint in routes_with_expected_platform_admin_only_access:
+            assert "@platform_admin_role_required" in decorators
+        elif rule.endpoint in routes_with_expected_member_only_access:
+            assert "@has_grant_role(RoleEnum.MEMBER)" in decorators
+        elif rule.endpoint in routes_with_expected_mhclg_login_required_access:
+            assert "@mhclg_login_required" in decorators
+        elif rule.endpoint in routes_with_no_expected_access_restrictions:
+            # If route is expected to be unauthenticated, check it doesn't have any auth decorators
+            assert not any(decorator in all_auth_annotations for decorator in decorators)
+
+        else:
+            pytest.fail(f"Unexpected endpoint {rule.endpoint}. Add this to the expected_route_access mapping.")


### PR DESCRIPTION
**Ticket: https://mhclgdigital.atlassian.net/browse/FSPT-463**

This PR introduces a centralised `AuthorisationHelper` class to manage role-based access control across the Funding Service platform. It replaces ad-hoc permission checks and supports a growing hierarchy of roles, starting with:

Platform Admins (`FSD_ADMIN` group members): Full read/write access across all resources

Grant Team Members: Read-only access to specific Grants they are assigned to

## Acceptance Criteria:
-  Platform Admins retain full platform access
-  Grant Members can view assigned grants and nothing more
-  Non-assigned users see nothing even if logged in
-  AuthorisationHelper supports secure, repeatable permission logic
-  All Grant-related views and routes enforce correct role-based access
