### PR TITLE
Rename expression -> statement

### DIFF
--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -280,7 +280,7 @@ def clear_submission_events(submission: Submission, key: SubmissionEventKey, for
 
 def add_question_condition(question: Question, user: User, managed_expression: "BaseExpression") -> Question:
     expression = Expression(
-        statement=managed_expression.expression,
+        statement=managed_expression.statement,
         context=managed_expression.model_dump(mode="json"),
         created_by=user,
         type=ExpressionType.CONDITION,
@@ -292,7 +292,7 @@ def add_question_condition(question: Question, user: User, managed_expression: "
 
 def add_question_validation(question: Question, user: User, managed_expression: "BaseExpression") -> Question:
     expression = Expression(
-        statement=managed_expression.expression,
+        statement=managed_expression.statement,
         context=managed_expression.model_dump(mode="json"),
         created_by=user,
         type=ExpressionType.VALIDATION,
@@ -313,7 +313,7 @@ def remove_question_expression(question: Question, expression: Expression) -> Qu
 
 
 def update_question_expression(expression: Expression, managed_expression: "BaseExpression") -> Expression:
-    expression.statement = managed_expression.expression
+    expression.statement = managed_expression.statement
     expression.context = managed_expression.model_dump(mode="json")
     db.session.flush()
     return expression

--- a/app/common/expressions/managed.py
+++ b/app/common/expressions/managed.py
@@ -15,7 +15,7 @@ class BaseExpression(BaseModel):
 
     @property
     @abc.abstractmethod
-    def expression(self) -> str:
+    def statement(self) -> str:
         raise NotImplementedError
 
     @property
@@ -38,7 +38,7 @@ class GreaterThan(BaseExpression):
         return f"The answer must be greater than {'or equal to ' if self.inclusive else ''}{self.minimum_value}"
 
     @property
-    def expression(self) -> str:
+    def statement(self) -> str:
         qid = mangle_question_id_for_context(self.question_id)
         return f"{qid} >{'=' if self.inclusive else ''} {self.minimum_value}"
 
@@ -58,7 +58,7 @@ class LessThan(BaseExpression):
         return f"The answer must be less than {'or equal to ' if self.inclusive else ''}{self.maximum_value}"
 
     @property
-    def expression(self) -> str:
+    def statement(self) -> str:
         qid = mangle_question_id_for_context(self.question_id)
         return f"{qid} <{'=' if self.inclusive else ''} {self.maximum_value}"
 
@@ -89,7 +89,7 @@ class Between(BaseExpression):
         )
 
     @property
-    def expression(self) -> str:
+    def statement(self) -> str:
         # todo: do you refer to the question by ID or slugs - pros and cons - discuss - by the end of the epic
         qid = mangle_question_id_for_context(self.question_id)
         return (

--- a/tests/integration/common/expressions/test_managed.py
+++ b/tests/integration/common/expressions/test_managed.py
@@ -62,7 +62,7 @@ class TestGreaterThanExpression:
         qid = uuid.uuid4()
         expr = GreaterThan(question_id=qid, minimum_value=minimum_value, inclusive=inclusive)
         assert (
-            evaluate(Expression(statement=expr.expression, context={mangle_question_id_for_context(qid): answer}))
+            evaluate(Expression(statement=expr.statement, context={mangle_question_id_for_context(qid): answer}))
             is expected_result
         )
 
@@ -81,7 +81,7 @@ class TestLessThanExpression:
         qid = uuid.uuid4()
         expr = LessThan(question_id=qid, maximum_value=maximum_value, inclusive=inclusive)
         assert (
-            evaluate(Expression(statement=expr.expression, context={mangle_question_id_for_context(qid): answer}))
+            evaluate(Expression(statement=expr.statement, context={mangle_question_id_for_context(qid): answer}))
             is expected_result
         )
 
@@ -110,6 +110,6 @@ class TestBetweenExpression:
             maximum_inclusive=maximum_inclusive,
         )
         assert (
-            evaluate(Expression(statement=expr.expression, context={mangle_question_id_for_context(qid): answer}))
+            evaluate(Expression(statement=expr.statement, context={mangle_question_id_for_context(qid): answer}))
             is expected_result
         )


### PR DESCRIPTION
On ManagedExpressions we had the actual line that gets evaluated called `expression` still. This used to match the DB model but we did then change that to be called `statement` instead; so let's update this to stay aligned.