### PR TITLE
BAU Fix validation template

### DIFF
--- a/app/developers/templates/developers/add_question_validation.html
+++ b/app/developers/templates/developers/add_question_validation.html
@@ -14,8 +14,7 @@
 {% set active_item_identifier = "developers" %}
 
 {% block beforeContent %}
-  govukBackLink({ "text": "Back", "href": url_for("developers.edit_question", grant_id=grant.id, collection_id=question.form.section.collection.id, section_id=question.form.section.id, form_id=question.form.id, question_id=question.id) })
-  }}
+  {{ govukBackLink({ "text": "Back", "href": url_for("developers.edit_question", grant_id=grant.id, collection_id=question.form.section.collection.id, section_id=question.form.section.id, form_id=question.form.id, question_id=question.id) }) }}
 {% endblock beforeContent %}
 
 {% block content %}


### PR DESCRIPTION
Suspect this got caught out following a stray template format somewhere, not sure why it passes the HTML lint as it should catch things like tags that are opened and not closed - jinja macros must be an exception. I missed it during the review.