### PR TITLE
Typo fixes for WordRange validator

### DIFF
--- a/app/common/forms/validators.py
+++ b/app/common/forms/validators.py
@@ -32,9 +32,17 @@ class WordRange:
         word_count = len(words)
         field_display_name = self.field_display_name or field.name
 
+        # Ensure first character is uppercase since we start all validation messages with it.
+        field_display_name = field_display_name[0].upper() + field_display_name[1:]
+
         if self.min_words is not None and self.max_words is not None:
+            if self.min_words == self.max_words and word_count != self.min_words:
+                raise ValidationError(f"{field_display_name} must contain exactly {self.min_words} words")
+
             if word_count < self.min_words or word_count > self.max_words:
-                raise ValidationError(f"{field_display_name} must be between {self.min_words} and {self.max_words}")
+                raise ValidationError(
+                    f"{field_display_name} must be between {self.min_words} words and {self.max_words} words"
+                )
 
         if self.min_words is not None:
             if word_count < self.min_words:
@@ -42,7 +50,7 @@ class WordRange:
 
         if self.max_words is not None:
             if word_count > self.max_words:
-                raise ValidationError(f"{field_display_name} must be {self.max_words} words or less")
+                raise ValidationError(f"{field_display_name} must be {self.max_words} words or fewer")
 
 
 class CommunitiesEmail(Email):

--- a/app/deliver_grant_funding/forms.py
+++ b/app/deliver_grant_funding/forms.py
@@ -94,7 +94,7 @@ class GrantDescriptionForm(GrantSetupForm):
         "What is the main purpose of this grant?",
         validators=[
             DataRequired("Enter the main purpose of this grant"),
-            WordRange(max_words=DESCRIPTION_MAX_WORDS, field_display_name="Description"),
+            WordRange(max_words=DESCRIPTION_MAX_WORDS, field_display_name="description"),
         ],
         filters=[strip_string_if_not_empty],
         widget=GovCharacterCount(),

--- a/tests/integration/deliver_grant_funding/test_routes.py
+++ b/tests/integration/deliver_grant_funding/test_routes.py
@@ -871,7 +871,7 @@ def test_grant_setup_description_post_too_long(authenticated_platform_admin_clie
     soup = BeautifulSoup(response.data, "html.parser")
     assert soup.h2.text.strip() == "There is a problem"
     assert len(soup.find_all("a", href="#description")) == 1
-    assert "Description must be 200 words or less" in soup.find_all("a", href="#description")[0].text.strip()
+    assert "Description must be 200 words or fewer" in soup.find_all("a", href="#description")[0].text.strip()
 
 
 def test_grant_setup_description_post_valid(authenticated_platform_admin_client):

--- a/tests/unit/app/common/forms/test_validators.py
+++ b/tests/unit/app/common/forms/test_validators.py
@@ -7,49 +7,70 @@ from app.common.forms.validators import CommunitiesEmail, WordRange
 
 
 class TestWordRange:
+    def _get_mocks(self) -> tuple[Mock, Mock]:
+        form = Mock()
+        field = Mock()
+        field.name = "answer"
+        return form, field
+
     def test_max_words_valid_within_limit(self):
         validator = WordRange(max_words=3)
-        form, field = Mock(), Mock()
+        form, field = self._get_mocks()
         field.data = "Three words here"
 
         validator(form, field)  # Should not raise
 
     def test_max_words_invalid_exceeds_limit(self):
         validator = WordRange(max_words=2)
-        form, field = Mock(), Mock()
+        form, field = self._get_mocks()
         field.data = "This has three words"
 
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValidationError, match="Answer must be 2 words or fewer"):
             validator(form, field)
 
     def test_min_words_valid_above_minimum(self):
         validator = WordRange(min_words=2)
-        form, field = Mock(), Mock()
+        form, field = self._get_mocks()
         field.data = "Three words here"
 
         validator(form, field)  # Should not raise
 
     def test_min_words_invalid_below_minimum(self):
         validator = WordRange(min_words=5)
-        form, field = Mock(), Mock()
+        form, field = self._get_mocks()
         field.data = "Too short"
 
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValidationError, match="Answer must be 5 words or more"):
+            validator(form, field)
+
+    def test_meets_exact_range(self):
+        validator = WordRange(min_words=2, max_words=2)
+        form, field = self._get_mocks()
+        field.data = "Two words"
+
+        validator(form, field)
+
+    def test_outside_exact_range(self):
+        validator = WordRange(min_words=2, max_words=2)
+        form, field = self._get_mocks()
+        field.data = "Three words here"
+
+        with pytest.raises(ValidationError, match="Answer must contain exactly 2 words"):
             validator(form, field)
 
     def test_valid_within_range(self):
         validator = WordRange(min_words=2, max_words=5)
-        form, field = Mock(), Mock()
+        form, field = self._get_mocks()
         field.data = "Four words total here"
 
         validator(form, field)  # Should not raise
 
     def test_invalid_outside_range(self):
         validator = WordRange(min_words=3, max_words=6)
-        form, field = Mock(), Mock()
+        form, field = self._get_mocks()
         field.data = "Too short"
 
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValidationError, match="Answer must be between 3 words and 6 words"):
             validator(form, field)
 
     def test_both_min_words_or_max_words_absent(self):
@@ -61,8 +82,8 @@ class TestWordRange:
             WordRange(min_words=2, max_words=1)
 
     def test_field_display_name(self):
-        validator = WordRange(min_words=3, field_display_name="Test display name")
-        form, field = Mock(), Mock()
+        validator = WordRange(min_words=3, field_display_name="test display name")
+        form, field = self._get_mocks()
         field.data = "Too short"
 
         with pytest.raises(ValidationError, match="Test display name must be 3 words or more"):


### PR DESCRIPTION
- "fewer" rather than "less" for countable things
- support validating an exact word count
- update tests to validate the error message shown
- pass `field_display_name` lowercase