### PR TITLE
FSPT-550: Revoke roles on Platform Admin login

### DIFF
--- a/app/common/data/interfaces/user.py
+++ b/app/common/data/interfaces/user.py
@@ -119,3 +119,9 @@ def upsert_user_role(
         raise InvalidUserRoleError(e) from e
 
     return user_role
+
+
+def remove_user_role(user_role_id: uuid.UUID) -> None:
+    role = db.session.query(UserRole).where(UserRole.id == user_role_id).one_or_none()
+    if role is not None:
+        db.session.delete(role)

--- a/app/common/data/interfaces/user.py
+++ b/app/common/data/interfaces/user.py
@@ -2,9 +2,10 @@ import uuid
 from typing import cast
 
 from flask_login import current_user
+from sqlalchemy import and_
 from sqlalchemy.dialects.postgresql import insert as postgresql_upsert
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.sql.expression import select
+from sqlalchemy.sql.expression import delete, select
 
 from app.common.data.interfaces.exceptions import InvalidUserRoleError
 from app.common.data.models_user import User, UserRole
@@ -91,7 +92,7 @@ def upsert_user_by_azure_ad_subject_id(
 
 
 def upsert_user_role(
-    user_id: uuid.UUID, role: RoleEnum, organisation_id: uuid.UUID | None = None, grant_id: uuid.UUID | None = None
+    user: User, role: RoleEnum, organisation_id: uuid.UUID | None = None, grant_id: uuid.UUID | None = None
 ) -> UserRole:
     # As with the `get_or_create_user` function, this feels like it should be a `on_conflict_do_nothing`,
     # except in that case the DB won't return any rows. So we use the same behaviour as above to ensure we always get a
@@ -101,7 +102,7 @@ def upsert_user_role(
         user_role = db.session.scalars(
             postgresql_upsert(UserRole)
             .values(
-                user_id=user_id,
+                user_id=user.id,
                 organisation_id=organisation_id,
                 grant_id=grant_id,
                 role=role,
@@ -117,11 +118,51 @@ def upsert_user_role(
         ).one()
     except IntegrityError as e:
         raise InvalidUserRoleError(e) from e
-
+    db.session.expire(user)
     return user_role
 
 
-def remove_user_role(user_role_id: uuid.UUID) -> None:
-    role = db.session.query(UserRole).where(UserRole.id == user_role_id).one_or_none()
-    if role is not None:
-        db.session.delete(role)
+def set_platform_admin_role_for_user(user: User) -> UserRole:
+    # Before making someone a platform admin we should remove any other roles they might have assigned to them, as a
+    # platform admin should only ever have that one role
+    remove_all_roles_from_user(user)
+    platform_admin_role = upsert_user_role(user, role=RoleEnum.ADMIN)
+    return platform_admin_role
+
+
+def remove_platform_admin_role_from_user(user: User) -> None:
+    statement = delete(UserRole).where(
+        and_(
+            UserRole.user_id == user.id,
+            UserRole.role == RoleEnum.ADMIN,
+            UserRole.organisation_id.is_(None),
+            UserRole.grant_id.is_(None),
+        )
+    )
+    db.session.execute(statement)
+    db.session.flush()
+    db.session.expire(user)
+
+
+def set_grant_team_role_for_user(user: User, grant_id: uuid.UUID, role: RoleEnum) -> UserRole:
+    grant_team_role = upsert_user_role(user=user, grant_id=grant_id, role=role)
+    return grant_team_role
+
+
+def remove_grant_team_role_from_user(user: User, grant_id: uuid.UUID) -> None:
+    statement = delete(UserRole).where(
+        and_(
+            UserRole.user_id == user.id,
+            UserRole.grant_id == grant_id,
+        )
+    )
+    db.session.execute(statement)
+    db.session.flush()
+    db.session.expire(user)
+
+
+def remove_all_roles_from_user(user: User) -> None:
+    statement = delete(UserRole).where(UserRole.user_id == user.id)
+    db.session.execute(statement)
+    db.session.flush()
+    db.session.expire(user)

--- a/app/deliver_grant_funding/routes.py
+++ b/app/deliver_grant_funding/routes.py
@@ -250,7 +250,7 @@ def add_user_to_grant(grant_id: UUID) -> ResponseReturnValue:
             user = next((user for user in grant.users if user.email.lower() == form.user_email.data.lower()), None)
             if user is None:
                 created_user = interfaces.user.upsert_user_by_email(email_address=form.user_email.data)
-                interfaces.user.upsert_user_role(user_id=created_user.id, grant_id=grant_id, role=RoleEnum.MEMBER)
+                interfaces.user.set_grant_team_role_for_user(user=created_user, grant_id=grant_id, role=RoleEnum.MEMBER)
                 notification_service.send_member_confirmation(
                     grant_name=grant.name,
                     email_address=form.user_email.data,

--- a/tests/integration/common/data/interfaces/test_user.py
+++ b/tests/integration/common/data/interfaces/test_user.py
@@ -1,5 +1,3 @@
-from uuid import uuid4
-
 import pytest
 from sqlalchemy import func, select
 
@@ -122,7 +120,7 @@ class TestUpsertUserRole:
         # the DB level and additional tests will be added to check these errors are raised correctly once a custom
         # exception is created for this.
         assert db_session.scalar(select(func.count()).select_from(UserRole)) == 0
-        user_id = factories.user.create(email="test@communities.gov.uk").id
+        user = factories.user.create(email="test@communities.gov.uk")
         organisation_id = factories.organisation.create().id
         grant_id = factories.grant.create().id
 
@@ -130,13 +128,13 @@ class TestUpsertUserRole:
         grant_id_value = grant_id if grant else None
 
         user_role = interfaces.user.upsert_user_role(
-            user_id=user_id, organisation_id=organisation_id_value, grant_id=grant_id_value, role=role
+            user=user, organisation_id=organisation_id_value, grant_id=grant_id_value, role=role
         )
 
         assert db_session.scalar(select(func.count()).select_from(UserRole)) == 1
-        assert user_role.user_id == user_id
+        assert user_role.user_id == user.id
         assert (user_role.user_id, user_role.organisation_id, user_role.grant_id, user_role.role) == (
-            user_id,
+            user.id,
             organisation_id_value,
             grant_id_value,
             role,
@@ -151,13 +149,13 @@ class TestUpsertUserRole:
         grant = factories.grant.create()
 
         interfaces.user.upsert_user_role(
-            user_id=user.id, organisation_id=organisation.id, grant_id=grant.id, role=RoleEnum.MEMBER
+            user=user, organisation_id=organisation.id, grant_id=grant.id, role=RoleEnum.MEMBER
         )
         interfaces.user.upsert_user_role(
-            user_id=user.id, organisation_id=organisation.id, grant_id=None, role=RoleEnum.MEMBER
+            user=user, organisation_id=organisation.id, grant_id=None, role=RoleEnum.MEMBER
         )
-        interfaces.user.upsert_user_role(user_id=user.id, organisation_id=None, grant_id=grant.id, role=RoleEnum.ADMIN)
-        interfaces.user.upsert_user_role(user_id=user.id, organisation_id=None, grant_id=None, role=RoleEnum.ADMIN)
+        interfaces.user.upsert_user_role(user=user, organisation_id=None, grant_id=grant.id, role=RoleEnum.ADMIN)
+        interfaces.user.upsert_user_role(user=user, organisation_id=None, grant_id=None, role=RoleEnum.ADMIN)
 
         user_roles = db_session.query(UserRole).all()
         assert {(ur.user_id, ur.organisation_id, ur.grant_id, ur.role) for ur in user_roles} == {
@@ -168,29 +166,29 @@ class TestUpsertUserRole:
         }
 
     def test_add_existing_user_role(self, db_session, factories):
-        user_id = factories.user.create(email="test@communities.gov.uk").id
-        interfaces.user.upsert_user_role(user_id=user_id, role=RoleEnum.ADMIN)
+        user = factories.user.create(email="test@communities.gov.uk")
+        interfaces.user.upsert_user_role(user=user, role=RoleEnum.ADMIN)
 
         assert db_session.scalar(select(func.count()).select_from(UserRole)) == 1
 
-        user_role = interfaces.user.upsert_user_role(user_id=user_id, role=RoleEnum.ADMIN)
+        user_role = interfaces.user.upsert_user_role(user=user, role=RoleEnum.ADMIN)
 
         assert db_session.scalar(select(func.count()).select_from(UserRole)) == 1
-        assert user_role.user_id == user_id
+        assert user_role.user_id == user.id
         assert (user_role.organisation_id, user_role.grant_id) == (None, None)
         assert user_role.role == RoleEnum.ADMIN
 
     def test_upsert_existing_user_role(self, db_session, factories):
-        user_id = factories.user.create(email="test@communities.gov.uk").id
+        user = factories.user.create(email="test@communities.gov.uk")
         grant = factories.grant.create()
-        interfaces.user.upsert_user_role(user_id=user_id, grant_id=grant.id, role=RoleEnum.MEMBER)
+        interfaces.user.upsert_user_role(user=user, grant_id=grant.id, role=RoleEnum.MEMBER)
 
         assert db_session.scalar(select(func.count()).select_from(UserRole)) == 1
 
-        user_role = interfaces.user.upsert_user_role(user_id=user_id, grant_id=grant.id, role=RoleEnum.ADMIN)
+        user_role = interfaces.user.upsert_user_role(user=user, grant_id=grant.id, role=RoleEnum.ADMIN)
 
         assert db_session.scalar(select(func.count()).select_from(UserRole)) == 1
-        assert user_role.user_id == user_id
+        assert user_role.user == user
         assert (user_role.organisation_id, user_role.grant_id) == (None, grant.id)
         assert user_role.role == RoleEnum.ADMIN
 
@@ -200,8 +198,8 @@ class TestUpsertUserRole:
             (False, False, RoleEnum.MEMBER, "A 'member' role must be linked to an organisation or grant."),
         ],
     )
-    def test_add_invalid_user_role(self, factories, organisation, grant, role, message):
-        user_id = factories.user.create(email="test@communities.gov.uk").id
+    def test_add_invalid_user_role(self, factories, organisation, grant, role, message) -> None:
+        user = factories.user.create(email="test@communities.gov.uk")
         organisation_id = factories.organisation.create().id
         grant_id = factories.grant.create().id
 
@@ -210,7 +208,7 @@ class TestUpsertUserRole:
 
         with pytest.raises(InvalidUserRoleError) as error:
             interfaces.user.upsert_user_role(
-                user_id=user_id,
+                user=user,
                 organisation_id=organisation_id_value,
                 grant_id=grant_id_value,
                 role=role,
@@ -219,22 +217,112 @@ class TestUpsertUserRole:
         assert error.value.message == message
 
 
-class TestRemoveUserRole:
-    def test_remove_user_role(self, db_session, factories):
+class TestSetUserRoleInterfaces:
+    def test_set_platform_admin_role_for_user(self, db_session, factories) -> None:
         user = factories.user.create(email="test@communities.gov.uk")
-        user_role = factories.user_role.create(user=user, role=RoleEnum.ADMIN)
-        assert db_session.scalar(select(func.count()).select_from(UserRole)) == 1
-
-        interfaces.user.remove_user_role(user_role_id=user_role.id)
         assert db_session.scalar(select(func.count()).select_from(UserRole)) == 0
-        assert db_session.scalar(select(func.count()).select_from(User)) == 1
 
-    def test_remove_user_role_when_role_is_none(self, db_session, factories):
+        platform_admin_role = interfaces.user.set_platform_admin_role_for_user(user=user)
+        assert db_session.scalar(select(func.count()).select_from(UserRole)) == 1
+        assert platform_admin_role.user_id == user.id
+        assert len(user.roles) == 1
+
+    def test_set_platform_admin_role_already_exists(self, db_session, factories) -> None:
         user = factories.user.create(email="test@communities.gov.uk")
         factories.user_role.create(user=user, role=RoleEnum.ADMIN)
-        generic_uuid = uuid4()
         assert db_session.scalar(select(func.count()).select_from(UserRole)) == 1
 
-        interfaces.user.remove_user_role(user_role_id=generic_uuid)
+        platform_admin_role = interfaces.user.set_platform_admin_role_for_user(user=user)
         assert db_session.scalar(select(func.count()).select_from(UserRole)) == 1
-        assert db_session.scalar(select(func.count()).select_from(User)) == 1
+        assert platform_admin_role.user_id == user.id
+
+    def test_set_platform_admin_multiple_roles_already_exists(self, db_session, factories) -> None:
+        user = factories.user.create(email="test@communities.gov.uk")
+        factories.user_role.create(user=user, role=RoleEnum.ADMIN)
+        grant = factories.grant.create()
+        factories.user_role.create(user=user, grant=grant, role=RoleEnum.MEMBER)
+        assert db_session.scalar(select(func.count()).select_from(UserRole)) == 2
+
+        platform_admin_role = interfaces.user.set_platform_admin_role_for_user(user=user)
+        assert db_session.scalar(select(func.count()).select_from(UserRole)) == 1
+        assert platform_admin_role.user_id == user.id
+
+    def test_set_grant_team_role_for_user(self, db_session, factories) -> None:
+        user = factories.user.create(email="test@communities.gov.uk")
+        grant = factories.grant.create()
+        assert db_session.scalar(select(func.count()).select_from(UserRole)) == 0
+
+        grant_team_role = interfaces.user.set_grant_team_role_for_user(
+            user=user, grant_id=grant.id, role=RoleEnum.MEMBER
+        )
+        assert db_session.scalar(select(func.count()).select_from(UserRole)) == 1
+        assert grant_team_role.grant_id == grant.id and grant_team_role.user_id == user.id
+        assert len(user.roles) == 1
+
+    def test_set_grant_team_role_already_exists(self, db_session, factories) -> None:
+        user = factories.user.create(email="test@communities.gov.uk")
+        grant = factories.grant.create()
+        factories.user_role.create(user=user, grant=grant, role=RoleEnum.MEMBER)
+        assert db_session.scalar(select(func.count()).select_from(UserRole)) == 1
+
+        grant_team_role = interfaces.user.set_grant_team_role_for_user(
+            user=user, grant_id=grant.id, role=RoleEnum.MEMBER
+        )
+        assert db_session.scalar(select(func.count()).select_from(UserRole)) == 1
+        assert grant_team_role.user_id == user.id and grant_team_role.grant_id == grant.id
+
+
+class TestRemoveUserRoleInterfaces:
+    def test_remove_platform_admin_role_from_user(self, db_session, factories) -> None:
+        user = factories.user.create(email="test@communities.gov.uk")
+        factories.user_role.create(user=user, role=RoleEnum.ADMIN)
+        assert db_session.scalar(select(func.count()).select_from(UserRole)) == 1
+
+        interfaces.user.remove_platform_admin_role_from_user(user)
+        assert db_session.scalar(select(func.count()).select_from(UserRole)) == 0
+        assert user.roles == []
+
+    def test_remove_platform_admin_role_when_only_other_roles_exist(self, db_session, factories) -> None:
+        user = factories.user.create(email="test@communities.gov.uk")
+        grant = factories.grant.create()
+        factories.user_role.create(user=user, grant=grant, role=RoleEnum.MEMBER)
+        assert db_session.scalar(select(func.count()).select_from(UserRole)) == 1
+
+        interfaces.user.remove_platform_admin_role_from_user(user)
+        assert db_session.scalar(select(func.count()).select_from(UserRole)) == 1
+        assert len(user.roles) == 1
+        assert user.roles[0].role == RoleEnum.MEMBER and user.roles[0].grant_id == grant.id
+
+    def test_remove_grant_team_role_from_user(self, db_session, factories) -> None:
+        user = factories.user.create(email="test@communities.gov.uk")
+        grant = factories.grant.create()
+        factories.user_role.create(user=user, grant=grant, role=RoleEnum.MEMBER)
+        assert db_session.scalar(select(func.count()).select_from(UserRole)) == 1
+
+        interfaces.user.remove_grant_team_role_from_user(user, grant_id=grant.id)
+        assert db_session.scalar(select(func.count()).select_from(UserRole)) == 0
+        assert user.roles == []
+
+    def test_remove_grant_team_role_from_user_with_multiple_roles(self, db_session, factories) -> None:
+        user = factories.user.create(email="test@communities.gov.uk")
+        grants = factories.grant.create_batch(2)
+        for grant in grants:
+            factories.user_role.create(user=user, role=RoleEnum.MEMBER, grant=grant)
+        assert db_session.scalar(select(func.count()).select_from(UserRole)) == 2
+
+        interfaces.user.remove_grant_team_role_from_user(user, grant_id=grants[0].id)
+        assert db_session.scalar(select(func.count()).select_from(UserRole)) == 1
+        assert len(user.roles) == 1
+        assert user.roles[0].role == RoleEnum.MEMBER and user.roles[0].grant_id == grants[1].id
+
+    def test_remove_all_roles_from_user(self, db_session, factories) -> None:
+        user = factories.user.create(email="test@communities.gov.uk")
+        factories.user_role.create(user=user, role=RoleEnum.ADMIN)
+        grants = factories.grant.create_batch(2)
+        for grant in grants:
+            factories.user_role.create(user=user, role=RoleEnum.MEMBER, grant=grant)
+        assert db_session.scalar(select(func.count()).select_from(UserRole)) == 3
+
+        interfaces.user.remove_all_roles_from_user(user)
+        assert db_session.scalar(select(func.count()).select_from(UserRole)) == 0
+        assert user.roles == []


### PR DESCRIPTION
If a user who previously had the role as Funding Service admin within the platform logs in without the `FSD_ADMIN` role in the SSO token response, we should revoke their Funding Service admin role so that the MS AD Group is the single source of truth and revoking this permission cascades down the platform.

In addition to this, Funding Service admins who have been given other roles (eg. grant team member) for testing purposes should have these other roles stripped on login - Funding Service admins should only ever have this top level role, and the rest should cascade down.