### PR TITLE
FSPT-619: delete validation rules

### DIFF
--- a/app/developers/templates/developers/manage_question_validation.html
+++ b/app/developers/templates/developers/manage_question_validation.html
@@ -2,6 +2,7 @@
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "govuk_frontend_jinja/components/radios/macro.html" import govukRadios %}
 {% from "govuk_frontend_jinja/components/input/macro.html" import govukInput %}
+{% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/checkboxes/macro.html" import govukCheckboxes %}
 {% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
@@ -22,6 +23,18 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      {% if confirm_deletion_form %}
+        {% set banner_html %}
+          <p class="govuk-body govuk-!-font-weight-bold">Are you sure you want to delete this validation?</p>
+          <form method="post" novalidate>
+            {{ confirm_deletion_form.csrf_token }}
+            {{ confirm_deletion_form.confirm_deletion(params={"classes": "govuk-button--warning govuk-!-margin-bottom-0"}) }}
+          </form>
+        {% endset %}
+
+        {{ govukNotificationBanner(params={"role": "alert", "titleText": "Warning", "classes": "app-notification-banner--destructive", "html": banner_html}) }}
+      {% endif %}
+
       <h1 class="govuk-heading-l">{{ submit_label }}</h1>
 
       {{
@@ -42,6 +55,16 @@
 
       {% if question.data_type == QuestionDataType.INTEGER %}
         {{ render_number_validation(form, question, submit_label) }}
+
+        {% if expression %}
+          <div class="govuk-grid-row govuk-!-margin-top-7">
+            <div class="govuk-grid-column-two-thirds">
+              <p class="govuk-body">
+                <a class="govuk-link app-link--destructive" href="{{ url_for('developers.edit_question_validation', grant_id=grant.id, question_id=question.id, expression_id=expression.id, delete='') }}">Delete validation</a>
+              </p>
+            </div>
+          </div>
+        {% endif %}
       {% else %}
         <p class="govuk-body">This question cannot be validated.</p>
       {% endif %}

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -504,10 +504,14 @@ def test_remove_expression(db_session, factories):
     add_question_condition(question, user, managed_expression)
 
     assert len(question.expressions) == 1
+    expression_id = question.expressions[0].id
 
     remove_question_expression(question, question.expressions[0])
 
     assert len(question.expressions) == 0
+
+    with pytest.raises(NoResultFound, match="No row was found when one was required"):
+        get_expression(expression_id)
 
 
 def test_get_expression(db_session, factories):


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FSPT-619

Following the deletion pattern laid out for collections, sections, forms, and questions, let's also make it possible to delete validation rules from the "edit validation" page.

We may be able to optimise this (eg remove the warning step) in the future as the decision is very lightweight and should be easy to reverse, but this feels fine for now. Design should be able to tackle this as part of the domain work.

## Show it
![2025-06-23 21 16 48](https://github.com/user-attachments/assets/ad839888-90f0-40d0-acdc-d00142783255)
