### PR TITLE
FSPT-411 E2E tests against AWS envs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 SECRET_KEY=pretend_secret_key
+SSO_USER_ID=<Get this from the id column of your local users table, for a user who has the correct permissions for the e2e tests>
 
 DATABASE_HOST=localhost
 DATABASE_PORT=5432

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 SECRET_KEY=pretend_secret_key
-SSO_USER_ID=<Get this from the id column of your local users table, for a user who has the correct permissions for the e2e tests>
+SSO_PLATFORM_ADMIN_USER_ID=<Get this from the id column of your local users table, for a user who has the correct permissions for the e2e tests>
 
 DATABASE_HOST=localhost
 DATABASE_PORT=5432

--- a/README.md
+++ b/README.md
@@ -71,3 +71,12 @@ Additional flags must be passed to the `pytest` command:
 
 * dev: `--e2e-env dev --e2e-aws-vault-profile <your_dev_aws_profile_name>`
 * test: `--e2e-env test --e2e-aws-vault-profile <your_test_aws_profile_name>`
+
+### Run E2E tests against a local environment with SSO
+By default the e2e test config assumes that locally you are running with the stub SSO server, and this is the default for docker compose.
+
+However, if you have enabled SSO locally as per [the instructions above](#sso), you can still run the e2e tests against your local environment as follows:
+- PreRequisites:
+    - Login locally using the SSO stub server with the email address `svc-Preaward-Funds@test.communities.gov.uk`, and tick the "Platform admin type login" option.
+- Update your local `.env` file with the UUID that matches the user `svc-Preaward-Funds@test.communities.gov.uk` in your local database: `SELECT id from "user" where email='svc-Preaward-Funds@test.communities.gov.uk';`
+- Edit [authenticated_browser_sso()](./tests/e2e/conftest.py) to use 'login_with_session_cookie()' for the local env.

--- a/app/config.py
+++ b/app/config.py
@@ -281,8 +281,7 @@ class LocalConfig(_SharedConfig):
     AZURE_AD_CLIENT_ID: str = "00000000-0000-0000-0000-000000000000"
     AZURE_AD_CLIENT_SECRET: str = "incorrect_value"
     AZURE_AD_TENANT_ID: str = "00000000-0000-0000-0000-000000000000"
-    # AZURE_AD_BASE_URL: str = "https://sso.communities.gov.localhost:4005/"
-    AZURE_AD_BASE_URL: str = "https://login.microsoftonline.com/"
+    AZURE_AD_BASE_URL: str = "https://sso.communities.gov.localhost:4005/"
 
     # Talisman security settings
     TALISMAN_CONTENT_SECURITY_POLICY: dict[str, list[str]] = make_development_csp()

--- a/app/config.py
+++ b/app/config.py
@@ -281,7 +281,8 @@ class LocalConfig(_SharedConfig):
     AZURE_AD_CLIENT_ID: str = "00000000-0000-0000-0000-000000000000"
     AZURE_AD_CLIENT_SECRET: str = "incorrect_value"
     AZURE_AD_TENANT_ID: str = "00000000-0000-0000-0000-000000000000"
-    AZURE_AD_BASE_URL: str = "https://sso.communities.gov.localhost:4005/"
+    # AZURE_AD_BASE_URL: str = "https://sso.communities.gov.localhost:4005/"
+    AZURE_AD_BASE_URL: str = "https://login.microsoftonline.com/"
 
     # Talisman security settings
     TALISMAN_CONTENT_SECURITY_POLICY: dict[str, list[str]] = make_development_csp()

--- a/tests/e2e/config.py
+++ b/tests/e2e/config.py
@@ -19,7 +19,7 @@ class EndToEndTestSecrets(Protocol):
     def SECRET_KEY(self) -> str: ...
 
     @property
-    def SSO_USER_ID(self) -> UUID: ...
+    def SSO_PLATFORM_ADMIN_USER_ID(self) -> UUID: ...
 
 
 class LocalEndToEndSecrets:
@@ -46,9 +46,9 @@ class LocalEndToEndSecrets:
             return secret_key_line.group(1)
 
     @property
-    def SSO_USER_ID(self) -> UUID:
+    def SSO_PLATFORM_ADMIN_USER_ID(self) -> UUID:
         with open(".env") as env_file:
-            sso_user_id_line = re.search(r"^SSO_USER_ID=(.+)$", env_file.read(), flags=re.MULTILINE)
+            sso_user_id_line = re.search(r"^SSO_PLATFORM_ADMIN_USER_ID=(.+)$", env_file.read(), flags=re.MULTILINE)
             if not sso_user_id_line:
                 raise ValueError("Could not read SSO user ID from local .env file")
 
@@ -109,5 +109,7 @@ class AWSEndToEndSecrets:
         return self._read_aws_parameter_store_value("/apprunner/funding-service/SECRET_KEY")
 
     @property
-    def SSO_USER_ID(self) -> UUID:
-        return cast(UUID, self._read_aws_parameter_store_value("/apprunner/funding-service/SSO_USER_ID"))
+    def SSO_PLATFORM_ADMIN_USER_ID(self) -> UUID:
+        return cast(
+            UUID, self._read_aws_parameter_store_value("/apprunner/funding-service/E2E_SSO_PLATFORM_ADMIN_USER_ID")
+        )

--- a/tests/e2e/config.py
+++ b/tests/e2e/config.py
@@ -10,6 +10,9 @@ from playwright.sync_api import HttpCredentials
 
 class EndToEndTestSecrets(Protocol):
     @property
+    def E2E_ENV(self) -> Literal["local", "dev", "test"]: ...
+
+    @property
     def HTTP_BASIC_AUTH(self) -> HttpCredentials | None: ...
 
     @property
@@ -23,6 +26,10 @@ class EndToEndTestSecrets(Protocol):
 
 
 class LocalEndToEndSecrets:
+    @property
+    def E2E_ENV(self) -> Literal["local"]:
+        return "local"
+
     @property
     def HTTP_BASIC_AUTH(self) -> None:
         return None
@@ -56,6 +63,13 @@ class LocalEndToEndSecrets:
 
 
 class AWSEndToEndSecrets:
+    e2e_env: Literal["dev", "test"]
+    e2e_aws_vault_profile: str | None
+
+    @property
+    def E2E_ENV(self) -> Literal["dev", "test"]:
+        return self.e2e_env
+
     def __init__(self, e2e_env: Literal["dev", "test"], e2e_aws_vault_profile: str | None):
         self.e2e_env = e2e_env
         self.e2e_aws_vault_profile = e2e_aws_vault_profile

--- a/tests/e2e/config.py
+++ b/tests/e2e/config.py
@@ -59,7 +59,7 @@ class LocalEndToEndSecrets:
             if not sso_user_id_line:
                 raise ValueError("Could not read SSO user ID from local .env file")
 
-            return cast(UUID, sso_user_id_line.group(1))
+            return UUID(sso_user_id_line.group(1))
 
 
 class AWSEndToEndSecrets:
@@ -124,6 +124,4 @@ class AWSEndToEndSecrets:
 
     @property
     def SSO_PLATFORM_ADMIN_USER_ID(self) -> UUID:
-        return cast(
-            UUID, self._read_aws_parameter_store_value("/apprunner/funding-service/E2E_SSO_PLATFORM_ADMIN_USER_ID")
-        )
+        return UUID(self._read_aws_parameter_store_value("/apprunner/funding-service/E2E_SSO_PLATFORM_ADMIN_USER_ID"))

--- a/tests/e2e/pages.py
+++ b/tests/e2e/pages.py
@@ -58,7 +58,8 @@ class SSOSignInPage(BasePage):
 
     def navigate(self) -> None:
         self.page.goto(f"{self.domain}/sso/sign-in")
-        expect(self.title).to_be_visible()
+        # If already logged in, this will redirect to /grants
+        expect(self.title.or_(self.page.get_by_role("heading", name="Grants"))).to_be_visible()
 
     def click_sign_in(self) -> None:
         self.sign_in.click()

--- a/tests/e2e/test_create_view_edit_grant.py
+++ b/tests/e2e/test_create_view_edit_grant.py
@@ -8,7 +8,7 @@ from tests.e2e.dataclasses import E2ETestUser
 from tests.e2e.pages import AllGrantsPage
 
 
-@pytest.mark.skip_in_environments(["prod"])
+@pytest.mark.skip_in_environments(["dev", "test", "prod"])
 def test_create_view_edit_grant_success(
     page: Page, domain: str, e2e_test_secrets: EndToEndTestSecrets, authenticated_browser_sso: E2ETestUser
 ):

--- a/tests/e2e/test_create_view_edit_grant.py
+++ b/tests/e2e/test_create_view_edit_grant.py
@@ -8,7 +8,7 @@ from tests.e2e.dataclasses import E2ETestUser
 from tests.e2e.pages import AllGrantsPage
 
 
-@pytest.mark.skip_in_environments(["dev", "test", "prod"])
+@pytest.mark.skip_in_environments(["prod"])
 def test_create_view_edit_grant_success(
     page: Page, domain: str, e2e_test_secrets: EndToEndTestSecrets, authenticated_browser_sso: E2ETestUser
 ):

--- a/tests/e2e/test_developer_journey.py
+++ b/tests/e2e/test_developer_journey.py
@@ -54,7 +54,7 @@ def navigate_to_collection_detail_page(
     return collection_detail_page
 
 
-@pytest.mark.skip_in_environments(["dev", "test", "prod"])
+@pytest.mark.skip_in_environments(["prod"])
 def test_create_and_preview_collection(
     page: Page, domain: str, e2e_test_secrets: EndToEndTestSecrets, authenticated_browser_sso: E2ETestUser
 ):

--- a/tests/e2e/test_developer_journey.py
+++ b/tests/e2e/test_developer_journey.py
@@ -54,7 +54,7 @@ def navigate_to_collection_detail_page(
     return collection_detail_page
 
 
-@pytest.mark.skip_in_environments(["prod"])
+@pytest.mark.skip_in_environments(["dev", "test", "prod"])
 def test_create_and_preview_collection(
     page: Page, domain: str, e2e_test_secrets: EndToEndTestSecrets, authenticated_browser_sso: E2ETestUser
 ):

--- a/tests/e2e/test_sso_auth.py
+++ b/tests/e2e/test_sso_auth.py
@@ -1,12 +1,19 @@
+import os
 from os import getenv
+from unittest.mock import patch
 
 import pytest
-from playwright.sync_api import Page, expect
+from flask_login import login_user
+from playwright.sync_api import BrowserContext, Page, expect
 
+from app import create_app
+from app.common.data.models_user import User
+from tests.e2e.config import EndToEndTestSecrets
 from tests.e2e.pages import MicrosoftLoginPageEmail, SSOSignInPage, StubSSOEmailLoginPage
+from tests.utils import build_db_config
 
 
-@pytest.mark.skip_in_environments(["dev", "test", "prod"])
+@pytest.mark.skip_in_environments(["local", "dev", "test", "prod"])
 def test_stub_sso_journey(page: Page, domain: str):
     sso_sign_in_page = SSOSignInPage(page, domain)
     sso_sign_in_page.navigate()
@@ -19,7 +26,7 @@ def test_stub_sso_journey(page: Page, domain: str):
     expect(page).to_have_url(f"{domain}/grants")
 
 
-@pytest.mark.skip_in_environments(["local"])
+# @pytest.mark.skip_in_environments(["local"])
 def test_real_sso_journey(page: Page, domain: str):
     """
     Test the real SSO journey using a service account.
@@ -48,4 +55,44 @@ def test_real_sso_journey(page: Page, domain: str):
         page.screenshot()
         pytest.fail("SSO login did not redirect to /grants as expected")
 
+    expect(page).to_have_url(f"{domain}/grants")
+
+
+def test_login_with_fake_cookie(
+    page: Page, domain: str, context: BrowserContext, e2e_test_secrets: EndToEndTestSecrets
+):
+    # TODO use id of a real user in dev/test
+    user_obj = User(name="E2E Test User", id=e2e_test_secrets.SSO_USER_ID)
+    with patch.dict(os.environ, build_db_config(None)):
+        new_app = create_app()
+    new_app.config["SECRET_KEY"] = e2e_test_secrets.SECRET_KEY
+
+    @new_app.route("/fake_login")
+    def fake_login():
+        login_user(user=user_obj, fresh=True)
+        return "OK"
+
+    with new_app.test_request_context():
+        login_user(user=user_obj, fresh=True)
+        test_client = new_app.test_client()
+        result = test_client.get("/fake_login")
+        assert result.status_code == 200, "Fake login did not return 200 OK"
+        cookies = result.headers.get("Set-Cookie", None)
+        cookie_value = cookies.split(";")[0].split("=")[1] if cookies else None
+
+    sso_sign_in_page = SSOSignInPage(page, domain)
+    sso_sign_in_page.page.context.add_cookies(
+        [
+            {
+                "name": "session",
+                "value": cookie_value,
+                "domain": domain.split("https://")[1].split(":8080")[0],
+                "path": "/",
+                "httpOnly": True,
+                "secure": True,
+            }
+        ]
+    )
+    sso_sign_in_page.navigate()
+    # If the browser contains a valid cookie, it should redirect to the grants page
     expect(page).to_have_url(f"{domain}/grants")

--- a/tests/e2e/test_sso_auth.py
+++ b/tests/e2e/test_sso_auth.py
@@ -26,7 +26,7 @@ def test_stub_sso_journey(page: Page, domain: str):
     expect(page).to_have_url(f"{domain}/grants")
 
 
-# @pytest.mark.skip_in_environments(["local"])
+@pytest.mark.skip_in_environments(["local", "dev", "test", "prod"])
 def test_real_sso_journey(page: Page, domain: str):
     """
     Test the real SSO journey using a service account.
@@ -61,8 +61,7 @@ def test_real_sso_journey(page: Page, domain: str):
 def test_login_with_fake_cookie(
     page: Page, domain: str, context: BrowserContext, e2e_test_secrets: EndToEndTestSecrets
 ):
-    # TODO use id of a real user in dev/test
-    user_obj = User(name="E2E Test User", id=e2e_test_secrets.SSO_USER_ID)
+    user_obj = User(name="E2E Test User", id=e2e_test_secrets.SSO_PLATFORM_ADMIN_USER_ID)
     with patch.dict(os.environ, build_db_config(None)):
         new_app = create_app()
     new_app.config["SECRET_KEY"] = e2e_test_secrets.SECRET_KEY

--- a/tests/e2e/test_sso_auth.py
+++ b/tests/e2e/test_sso_auth.py
@@ -1,19 +1,12 @@
-import os
 from os import getenv
-from unittest.mock import patch
 
 import pytest
-from flask_login import login_user
-from playwright.sync_api import BrowserContext, Page, expect
+from playwright.sync_api import Page, expect
 
-from app import create_app
-from app.common.data.models_user import User
-from tests.e2e.config import EndToEndTestSecrets
 from tests.e2e.pages import MicrosoftLoginPageEmail, SSOSignInPage, StubSSOEmailLoginPage
-from tests.utils import build_db_config
 
 
-@pytest.mark.skip_in_environments(["local", "dev", "test", "prod"])
+@pytest.mark.skip_in_environments(["dev", "test", "prod"])
 def test_stub_sso_journey(page: Page, domain: str):
     sso_sign_in_page = SSOSignInPage(page, domain)
     sso_sign_in_page.navigate()
@@ -55,43 +48,4 @@ def test_real_sso_journey(page: Page, domain: str):
         page.screenshot()
         pytest.fail("SSO login did not redirect to /grants as expected")
 
-    expect(page).to_have_url(f"{domain}/grants")
-
-
-def test_login_with_fake_cookie(
-    page: Page, domain: str, context: BrowserContext, e2e_test_secrets: EndToEndTestSecrets
-):
-    user_obj = User(name="E2E Test User", id=e2e_test_secrets.SSO_PLATFORM_ADMIN_USER_ID)
-    with patch.dict(os.environ, build_db_config(None)):
-        new_app = create_app()
-    new_app.config["SECRET_KEY"] = e2e_test_secrets.SECRET_KEY
-
-    @new_app.route("/fake_login")
-    def fake_login():
-        login_user(user=user_obj, fresh=True)
-        return "OK"
-
-    with new_app.test_request_context():
-        login_user(user=user_obj, fresh=True)
-        test_client = new_app.test_client()
-        result = test_client.get("/fake_login")
-        assert result.status_code == 200, "Fake login did not return 200 OK"
-        cookies = result.headers.get("Set-Cookie", None)
-        cookie_value = cookies.split(";")[0].split("=")[1] if cookies else None
-
-    sso_sign_in_page = SSOSignInPage(page, domain)
-    sso_sign_in_page.page.context.add_cookies(
-        [
-            {
-                "name": "session",
-                "value": cookie_value,
-                "domain": domain.split("https://")[1].split(":8080")[0],
-                "path": "/",
-                "httpOnly": True,
-                "secure": True,
-            }
-        ]
-    )
-    sso_sign_in_page.navigate()
-    # If the browser contains a valid cookie, it should redirect to the grants page
     expect(page).to_have_url(f"{domain}/grants")

--- a/tests/e2e/test_sso_auth.py
+++ b/tests/e2e/test_sso_auth.py
@@ -20,7 +20,6 @@ def test_stub_sso_journey(page: Page, domain: str):
 
 
 @pytest.mark.skip_in_environments(["local"])
-@pytest.mark.xfail
 def test_real_sso_journey(page: Page, domain: str):
     """
     Test the real SSO journey using a service account.


### PR DESCRIPTION
Updates the `authenticated_browser_sso` fixtures to login differently depending on the target environment:
- Local: uses the existing stub SSO server login route
- Dev/Test: Creates a session cookie manually and injects it into the Page context, so the browser redirects you without needing to login.

Also updated the README with how to update the e2e tests to work locally if you have changed your config to use real SSO locally.

Note: The e2e tests currently fail in the deployed environments due to the notify api key we are using being set to 'Team' only. Ongoing discussion on how to fix this.

Latest run against test, showing the `create_grant` test working (this proves the fake cookie login route works): https://github.com/communitiesuk/funding-service/actions/runs/15852249305/job/44688473483