### PR TITLE
Rename managed expression base

### DIFF
--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -29,7 +29,7 @@ from app.common.utils import slugify
 from app.extensions import db
 
 if TYPE_CHECKING:
-    from app.common.expressions.managed import BaseExpression
+    from app.common.expressions.managed import ManagedExpression
 
 
 def create_collection(*, name: str, user: User, grant: Grant, version: int = 1) -> Collection:
@@ -278,7 +278,7 @@ def clear_submission_events(submission: Submission, key: SubmissionEventKey, for
     return submission
 
 
-def add_question_condition(question: Question, user: User, managed_expression: "BaseExpression") -> Question:
+def add_question_condition(question: Question, user: User, managed_expression: "ManagedExpression") -> Question:
     expression = Expression(
         statement=managed_expression.statement,
         context=managed_expression.model_dump(mode="json"),
@@ -290,7 +290,7 @@ def add_question_condition(question: Question, user: User, managed_expression: "
     return question
 
 
-def add_question_validation(question: Question, user: User, managed_expression: "BaseExpression") -> Question:
+def add_question_validation(question: Question, user: User, managed_expression: "ManagedExpression") -> Question:
     expression = Expression(
         statement=managed_expression.statement,
         context=managed_expression.model_dump(mode="json"),
@@ -316,7 +316,7 @@ def remove_question_expression(question: Question, expression: Expression) -> Qu
     return question
 
 
-def update_question_expression(expression: Expression, managed_expression: "BaseExpression") -> Expression:
+def update_question_expression(expression: Expression, managed_expression: "ManagedExpression") -> Expression:
     expression.statement = managed_expression.statement
     expression.context = managed_expression.model_dump(mode="json")
     try:

--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -26,7 +26,7 @@ from app.common.expressions.managed import get_managed_expression
 
 if TYPE_CHECKING:
     from app.common.data.models_user import UserRole
-    from app.common.expressions.managed import BaseExpression
+    from app.common.expressions.managed import ManagedExpression
 
 
 class Grant(BaseModel):
@@ -306,5 +306,5 @@ class Expression(BaseModel):
     )
 
     @property
-    def managed(self) -> "BaseExpression":
+    def managed(self) -> "ManagedExpression":
         return get_managed_expression(self)

--- a/app/common/expressions/forms.py
+++ b/app/common/expressions/forms.py
@@ -12,12 +12,12 @@ from app.common.data.types import ManagedExpressionsEnum
 from app.common.expressions.managed import Between, GreaterThan, LessThan
 
 if TYPE_CHECKING:
-    from app.common.expressions.managed import BaseExpression
+    from app.common.expressions.managed import ManagedExpression
 
 
 class _BaseExpressionForm(FlaskForm):
     @abstractmethod
-    def get_expression(self, question: Question) -> "BaseExpression": ...
+    def get_expression(self, question: Question) -> "ManagedExpression": ...
 
     @staticmethod
     @abstractmethod
@@ -42,7 +42,7 @@ class AddIntegerConditionForm(_BaseExpressionForm):
         # fixme: IDE realises this is a FlaskForm and bool but mypy is calling it "Any" on pre-commit
         return super().validate(extra_validators=extra_validators)  # type: ignore
 
-    def get_expression(self, question: Question) -> "BaseExpression":
+    def get_expression(self, question: Question) -> "ManagedExpression":
         match self.type.data:
             case ManagedExpressionsEnum.GREATER_THAN.value:
                 assert self.value.data
@@ -91,7 +91,7 @@ class AddIntegerValidationForm(_BaseExpressionForm):
         # fixme: IDE realises this is a FlaskForm and bool but mypy is calling it "Any" on pre-commit
         return super().validate(extra_validators=extra_validators)  # type: ignore
 
-    def get_expression(self, question: Question) -> "BaseExpression":
+    def get_expression(self, question: Question) -> "ManagedExpression":
         if not self.validate():
             raise RuntimeError("Form must be validated before building an expression")
 

--- a/app/common/expressions/managed.py
+++ b/app/common/expressions/managed.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from app.common.data.models import Expression
 
 
-class BaseExpression(BaseModel):
+class ManagedExpression(BaseModel):
     key: ManagedExpressionsEnum
 
     @property
@@ -27,7 +27,7 @@ class BaseExpression(BaseModel):
     def description(self) -> str: ...
 
 
-class GreaterThan(BaseExpression):
+class GreaterThan(ManagedExpression):
     key: ManagedExpressionsEnum = ManagedExpressionsEnum.GREATER_THAN
     question_id: UUID
     minimum_value: int
@@ -47,7 +47,7 @@ class GreaterThan(BaseExpression):
         return f"{qid} >{'=' if self.inclusive else ''} {self.minimum_value}"
 
 
-class LessThan(BaseExpression):
+class LessThan(ManagedExpression):
     key: ManagedExpressionsEnum = ManagedExpressionsEnum.LESS_THAN
     question_id: UUID
     maximum_value: int
@@ -67,7 +67,7 @@ class LessThan(BaseExpression):
         return f"{qid} <{'=' if self.inclusive else ''} {self.maximum_value}"
 
 
-class Between(BaseExpression):
+class Between(ManagedExpression):
     key: ManagedExpressionsEnum = ManagedExpressionsEnum.BETWEEN
     question_id: UUID
     minimum_value: int
@@ -105,7 +105,7 @@ class Between(BaseExpression):
         )
 
 
-def get_managed_expression(expression: "Expression") -> BaseExpression:
+def get_managed_expression(expression: "Expression") -> ManagedExpression:
     # todo: fetching this to know what type is starting to feel strange - maybe this should be a top level property
     match expression.context.get("key"):
         case ManagedExpressionsEnum.GREATER_THAN:


### PR DESCRIPTION
I've found it hard to mentally separate BaseExpression (pydantic thing) from Expression (DB table). I think this might help a little bit?