### PR TITLE
BAU Tidy up the grants team member page

### DIFF
--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_team/grant_user_add.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_team/grant_user_add.html
@@ -17,8 +17,8 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">
-        <span class="govuk-caption-xl">Add grant team member</span>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l">Add grant team member</span>
         What’s their email address?
       </h1>
       <form method="post" novalidate>

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_team/grant_user_list.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_team/grant_user_list.html
@@ -6,6 +6,8 @@
 {% set page_title = "Grant team - " ~ grant.name %}
 {% set active_item_identifier = "grant_team" %}
 
+{% set can_add_users = authorisation_helper.is_platform_admin(current_user) %}
+
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -26,7 +28,12 @@
         <span class="govuk-caption-l">{{ grant.name }}</span>
         Grant team
       </h1>
-      {% if authorisation_helper.is_platform_admin(current_user) %}
+
+      {% if not grant.users %}
+        <p class="govuk-body">No grant team members have been added to this grant yet.</p>
+      {% endif %}
+
+      {% if can_add_users %}
         {{
           govukButton({
              "text": "Add grant team member",
@@ -38,18 +45,16 @@
   </div>
 
   {% set table_pending_signin_rows = namespace(items=[]) %}
-  {% if grant.users %}
-    {% for user in grant.users if not authorisation_helper.has_logged_in(user) %}
-      {%
-        set table_pending_signin_rows.items = table_pending_signin_rows.items + [[
-          {"text": user.email},
-          {"text": "Grant team member"}
-        ]]
-      %}
-    {% endfor %}
-  {% endif %}
+  {% for user in grant.users if not authorisation_helper.has_logged_in(user) %}
+    {%
+      set table_pending_signin_rows.items = table_pending_signin_rows.items + [[
+        {"text": user.email},
+        {"text": "Grant team member"}
+      ]]
+    %}
+  {% endfor %}
 
-  {% if table_pending_signin_rows.items|length > 0 %}
+  {% if table_pending_signin_rows.items %}
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
         <h2 class="govuk-heading-m govuk-!-margin-bottom-1 govuk-!-margin-top-9">Not yet signed in</h2>
@@ -68,18 +73,17 @@
 
   {% set table_rows = namespace(items=[]) %}
 
-  {% if grant.users %}
-    {% for user in grant.users if authorisation_helper.has_logged_in(user) %}
-      {%
-        set table_rows.items = table_rows.items + [[
-          {"text": user.name},
-          {"text": user.email},
-          {"text": "Grant team member"}
-        ]]
-      %}
-    {% endfor %}
-  {% endif %}
-  {% if table_rows.items|length > 0 %}
+  {% for user in grant.users if authorisation_helper.has_logged_in(user) %}
+    {%
+      set table_rows.items = table_rows.items + [[
+        {"text": user.name},
+        {"text": user.email},
+        {"text": "Grant team member"}
+      ]]
+    %}
+  {% endfor %}
+
+  {% if table_rows.items %}
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
         <h2 class="govuk-heading-m govuk-!-margin-bottom-1 govuk-!-margin-top-9">Grant team members</h2>
@@ -94,15 +98,17 @@
       </div>
     </div>
   {% endif %}
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      <h2 class="govuk-heading-m govuk-!-margin-top-5">If you need to add other grant team members</h2>
-      <p class="govuk-body">
-        Contact us through our
-        <a class="govuk-link govuk-link--no-visited-state" href="{{ service_desk_url }}" target="_blank">support desk (opens in new tab)</a>
-        .
-      </p>
-      <p class="govuk-body">Monday to Friday, 9am to 5pm (except public holidays).</p>
+  {% if not can_add_users %}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <h2 class="govuk-heading-m govuk-!-margin-top-5">If you need to add other grant team members</h2>
+        <p class="govuk-body">
+          Contact us through our
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ service_desk_url }}" target="_blank">support desk (opens in new tab)</a>
+          .
+        </p>
+        <p class="govuk-body">Monday to Friday, 9am to 5pm (except public holidays).</p>
+      </div>
     </div>
-  </div>
+  {% endif %}
 {% endblock content %}


### PR DESCRIPTION
Happy for this to be closed or reverted if its coming in future tickets.

The primary change here is to remove the "Contact us" prompt if the user already has permissions to add a new user - this should only need to be shown to users that don't have permissions to do it themselves (the page currently limits this to users with administrative permissions).

When thats removed the page looks empty and broken without any users - bring in the empty no users disclaimers from the prototype to avoid this.

Misc.
- moves xl headings to l heading as we've agreed we'll use those consistently now
- use empty lists being falsey for what feels like a more readable template to me
- the SQLAlchemy model for Grant will always populate an empty list of users, no need to guard against it being missed for readability

Grant team page if there are no users and you are a platform admin (there should be no reason you're seeing no users without being a platform admin) - you don't get the contact us prompt:

![Screenshot 2025-06-25 at 23 00 57](https://github.com/user-attachments/assets/b637eb02-a909-4722-9e80-c5c48c2b0873)

Grant team page if you're a platform admin and there is a user - you don't get the the contact us prompt:

![Screenshot 2025-06-25 at 23 00 46](https://github.com/user-attachments/assets/a29afa79-0854-4e3c-8505-5f05faea251c)

Grant team page if you are not a platform admin - you get the contact us prompt:

![Screenshot 2025-06-25 at 23 00 36](https://github.com/user-attachments/assets/7dc337dd-a87b-4b0b-a50a-33e5aed50e15)
