### PR TITLE
FSPT-515 Invitations Table

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -30,6 +30,7 @@ from app.extensions import (
     migrate,
     notification_service,
     record_sqlalchemy_queries,
+    register_signals,
     talisman,
     toolbar,
 )
@@ -109,6 +110,7 @@ def create_app() -> Flask:
     notification_service.init_app(app)
     talisman.init_app(app, **app.config["TALISMAN_SETTINGS"])
     login_manager.init_app(app)
+    register_signals(app)
     record_sqlalchemy_queries.init_app(app, db)
 
     @login_manager.user_loader  # type: ignore[misc]

--- a/app/common/data/interfaces/magic_link.py
+++ b/app/common/data/interfaces/magic_link.py
@@ -3,8 +3,7 @@ import uuid
 
 from sqlalchemy import func, select, update
 
-from app.common.data.models import MagicLink
-from app.common.data.models_user import User
+from app.common.data.models_user import MagicLink, User
 from app.extensions import db
 
 

--- a/app/common/data/interfaces/user.py
+++ b/app/common/data/interfaces/user.py
@@ -34,6 +34,11 @@ def get_user_by_azure_ad_subject_id(azure_ad_subject_id: str) -> User | None:
     return db.session.execute(select(User).where(User.azure_ad_subject_id == azure_ad_subject_id)).scalar_one_or_none()
 
 
+def set_user_last_logged_in_at_utc(user: User) -> User:
+    user.last_logged_in_at_utc = func.current_timestamp()
+    return user
+
+
 def upsert_user_by_email(
     email_address: str,
     *,

--- a/app/common/data/interfaces/user.py
+++ b/app/common/data/interfaces/user.py
@@ -187,3 +187,15 @@ def create_invitation(
     db.session.add(invitation)
     db.session.flush()
     return invitation
+
+
+def get_invitation(invitation_id: uuid.UUID) -> Invitation | None:
+    return db.session.get(Invitation, invitation_id)
+
+
+def claim_invitation(invitation: Invitation, user: User) -> Invitation:
+    invitation.claimed_at_utc = func.now()
+    invitation.user = user
+    db.session.add(invitation)
+    db.session.flush()
+    return invitation

--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-011_sync_role_enum
+012_adding_invitations_table

--- a/app/common/data/migrations/versions/012_adding_invitations_table.py
+++ b/app/common/data/migrations/versions/012_adding_invitations_table.py
@@ -1,0 +1,60 @@
+"""Adding invitations table, and last_logged_in_at_utc to user
+
+Revision ID: 012_adding_invitations_table
+Revises: 011_sync_role_enum
+Create Date: 2025-06-26 13:37:11.014236
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "012_adding_invitations_table"
+down_revision = "011_sync_role_enum"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "invitation",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("created_at_utc", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at_utc", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.Column("email", postgresql.CITEXT(), nullable=False),
+        sa.Column("user_id", sa.Uuid(), nullable=True),
+        sa.Column("organisation_id", sa.Uuid(), nullable=True),
+        sa.Column("grant_id", sa.Uuid(), nullable=True),
+        sa.Column("role", postgresql.ENUM(name="role_enum", create_type=False), nullable=False),
+        sa.Column("expires_at_utc", sa.DateTime(), nullable=False),
+        sa.Column("claimed_at_utc", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["grant_id"], ["grant.id"], name=op.f("fk_invitation_grant_id_grant"), ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["organisation_id"],
+            ["organisation.id"],
+            name=op.f("fk_invitation_organisation_id_organisation"),
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], name=op.f("fk_invitation_user_id_user")),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_invitation")),
+    )
+    with op.batch_alter_table("magic_link", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("email", postgresql.CITEXT(), nullable=True))
+        batch_op.alter_column("user_id", existing_type=sa.UUID(), nullable=True)
+
+    with op.batch_alter_table("user", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("last_logged_in_at_utc", sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("user", schema=None) as batch_op:
+        batch_op.drop_column("last_logged_in_at_utc")
+
+    with op.batch_alter_table("magic_link", schema=None) as batch_op:
+        batch_op.drop_column("email")
+        batch_op.alter_column("user_id", existing_type=sa.UUID(), nullable=False)
+
+    op.drop_table("invitation")

--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -1,9 +1,6 @@
-import datetime
-import secrets
 import uuid
 from typing import TYPE_CHECKING, Optional
 
-from pytz import utc
 from sqlalchemy import Enum as SqlEnum
 from sqlalchemy import ForeignKey, ForeignKeyConstraint, Index, UniqueConstraint, text
 from sqlalchemy.dialects.postgresql import JSONB
@@ -58,24 +55,6 @@ class Organisation(BaseModel):
     roles: Mapped[list["UserRole"]] = relationship(
         "UserRole", back_populates="organisation", cascade="all, delete-orphan"
     )
-
-
-class MagicLink(BaseModel):
-    __tablename__ = "magic_link"
-
-    code: Mapped[str] = mapped_column(unique=True, default=lambda: secrets.token_urlsafe(12))
-    user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("user.id"))
-    redirect_to_path: Mapped[str]
-    expires_at_utc: Mapped[datetime.datetime]
-    claimed_at_utc: Mapped[datetime.datetime | None]
-
-    user: Mapped[User] = relationship("User", back_populates="magic_links")
-
-    __table_args__ = (Index(None, code, unique=True, postgresql_where="claimed_at_utc IS NOT NULL"),)
-
-    @property
-    def usable(self) -> bool:
-        return self.claimed_at_utc is None and self.expires_at_utc > datetime.datetime.now(utc).replace(tzinfo=None)
 
 
 class Collection(BaseModel):

--- a/app/extensions/__init__.py
+++ b/app/extensions/__init__.py
@@ -1,9 +1,11 @@
+from flask import Flask
 from flask_debugtoolbar import DebugToolbarExtension
-from flask_login import LoginManager
+from flask_login import LoginManager, user_logged_in
 from flask_migrate import Migrate
 from flask_sqlalchemy_lite import SQLAlchemy
 from flask_talisman import Talisman
 
+from app.common.data.models_user import User
 from app.extensions.auto_commit_after_request import AutoCommitAfterRequestExtension
 from app.extensions.flask_assets_vite import FlaskAssetsViteExtension
 from app.extensions.record_sqlalchemy_queries import RecordSqlalchemyQueriesExtension
@@ -19,6 +21,16 @@ flask_assets_vite = FlaskAssetsViteExtension()
 login_manager = LoginManager()
 record_sqlalchemy_queries = RecordSqlalchemyQueriesExtension()
 
+
+def register_signals(app: Flask) -> None:
+    @user_logged_in.connect_via(app)  # type: ignore
+    def user_logged_in_signal(sender: Flask, user: User) -> None:
+        # This needs to be imported within the function to avoid a circular import with the `db` extension
+        from app.common.data.interfaces.user import set_user_last_logged_in_at_utc
+
+        set_user_last_logged_in_at_utc(user)
+
+
 __all__ = [
     "db",
     "auto_commit_after_request",
@@ -29,4 +41,5 @@ __all__ = [
     "flask_assets_vite",
     "login_manager",
     "record_sqlalchemy_queries",
+    "register_signals",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ from tests.models import (
     _ExpressionFactory,
     _FormFactory,
     _GrantFactory,
+    _InvitationFactory,
     _MagicLinkFactory,
     _OrganisationFactory,
     _QuestionFactory,
@@ -143,6 +144,7 @@ _Factories = namedtuple(
         "user_role",
         "submission_event",
         "expression",
+        "invitation",
     ],
 )
 
@@ -162,4 +164,5 @@ def factories(db_session: Session) -> _Factories:
         user_role=_UserRoleFactory,
         submission_event=_SubmissionEventFactory,
         expression=_ExpressionFactory,
+        invitation=_InvitationFactory,
     )

--- a/tests/integration/common/auth/test_auth.py
+++ b/tests/integration/common/auth/test_auth.py
@@ -8,8 +8,7 @@ from sqlalchemy import func, select
 
 from app.common.auth.authorisation_helper import AuthorisationHelper
 from app.common.data import interfaces
-from app.common.data.models import MagicLink
-from app.common.data.models_user import User, UserRole
+from app.common.data.models_user import MagicLink, User, UserRole
 from app.common.data.types import RoleEnum
 from tests.utils import AnyStringMatching, page_has_error
 

--- a/tests/integration/common/data/interfaces/test_user.py
+++ b/tests/integration/common/data/interfaces/test_user.py
@@ -59,6 +59,13 @@ class TestGetUserByAzureAdSubjectId:
         assert user is None
 
 
+class TestSetUserLastLoggedInAt:
+    def test_set_user_last_logged_in_at_utc(self, db_session, factories) -> None:
+        user = factories.user.create(email="test@communites.gov.uk", last_logged_in_at_utc=None)
+        interfaces.user.set_user_last_logged_in_at_utc(user)
+        assert user.last_logged_in_at_utc is not None
+
+
 class TestUpsertUserByEmail:
     def test_create_new_user(self, db_session):
         assert db_session.scalar(select(func.count()).select_from(User)) == 0

--- a/tests/integration/deliver_grant_funding/test_routes.py
+++ b/tests/integration/deliver_grant_funding/test_routes.py
@@ -39,7 +39,7 @@ def test_list_grants_as_admin(
     for expected in expected_headers:
         assert expected in header_texts, f"Header '{expected}' not found in table"
     assert soup.h1.text == "Grants"
-    assert len(queries) == 3  # 1) select grant, 2) rollback, 3) savepoint
+    assert len(queries) == 3  # 1) select user, 2) select user_role, 3) select grants
 
 
 def test_list_grants_as_member_with_single_grant(
@@ -52,7 +52,7 @@ def test_list_grants_as_member_with_single_grant(
 
     nav_items = [item.text.strip() for item in soup.select(".govuk-service-navigation__item")]
     assert nav_items == ["Grant details", "Grant team"]
-    assert len(queries) == 2
+    assert len(queries) == 3  # 1) select user, 2) select user_role, 3) select grants
 
 
 def test_list_grants_as_member_with_multiple_grants(

--- a/tests/models.py
+++ b/tests/models.py
@@ -20,14 +20,13 @@ from app.common.data.models import (
     Expression,
     Form,
     Grant,
-    MagicLink,
     Organisation,
     Question,
     Section,
     Submission,
     SubmissionEvent,
 )
-from app.common.data.models_user import User, UserRole
+from app.common.data.models_user import MagicLink, User, UserRole
 from app.common.data.types import QuestionDataType, SubmissionEventKey, SubmissionModeEnum, SubmissionStatusEnum
 from app.extensions import db
 
@@ -60,6 +59,7 @@ class _UserFactory(factory.alchemy.SQLAlchemyModelFactory):
     name = factory.Faker("name")
     email = factory.Faker("email")
     azure_ad_subject_id = factory.fuzzy.FuzzyText(length=25)
+    last_logged_in_at_utc = factory.LazyFunction(lambda: datetime.datetime.now())
 
 
 class _OrganisationFactory(factory.alchemy.SQLAlchemyModelFactory):

--- a/tests/models.py
+++ b/tests/models.py
@@ -26,7 +26,7 @@ from app.common.data.models import (
     Submission,
     SubmissionEvent,
 )
-from app.common.data.models_user import MagicLink, User, UserRole
+from app.common.data.models_user import Invitation, MagicLink, User, UserRole
 from app.common.data.types import QuestionDataType, SubmissionEventKey, SubmissionModeEnum, SubmissionStatusEnum
 from app.extensions import db
 
@@ -107,6 +107,7 @@ class _MagicLinkFactory(factory.alchemy.SQLAlchemyModelFactory):
     code = factory.LazyFunction(lambda: secrets.token_urlsafe(12))
     user_id = factory.LazyAttribute(lambda o: o.user.id)
     user = factory.SubFactory(_UserFactory)
+    email = factory.Faker("email")
     redirect_to_path = factory.LazyFunction(lambda: url_for("deliver_grant_funding.list_grants"))
     expires_at_utc = factory.LazyFunction(lambda: datetime.datetime.now() + datetime.timedelta(minutes=15))
     claimed_at_utc = None
@@ -224,3 +225,37 @@ class _ExpressionFactory(factory.alchemy.SQLAlchemyModelFactory):
     #       makes some kind of sense for the question type
     statement = factory.LazyFunction(_required)
     type = factory.LazyFunction(_required)
+
+
+class _InvitationFactory(factory.alchemy.SQLAlchemyModelFactory):
+    class Meta:
+        model = Invitation
+        sqlalchemy_session_factory = lambda: db.session  # noqa: E731
+        sqlalchemy_session_persistence = "commit"
+
+    id = factory.LazyFunction(uuid4)
+    email = factory.Faker("email")
+    user_id = None
+    user = None
+    organisation_id = None
+    organisation = None
+    grant_id = None
+    grant = None
+    role = None
+    expires_at_utc = factory.LazyFunction(lambda: datetime.datetime.now() + datetime.timedelta(days=7))
+    claimed_at_utc = None
+
+    class Params:
+        has_organisation = factory.Trait(
+            organisation_id=factory.LazyAttribute(lambda o: o.organisation.id),
+            organisation=factory.SubFactory(_OrganisationFactory),
+        )
+        has_grant = factory.Trait(
+            grant_id=factory.LazyAttribute(lambda o: o.grant.id),
+            grant=factory.SubFactory(_GrantFactory),
+        )
+        is_claimed = factory.Trait(
+            claimed_at_utc=factory.LazyFunction(lambda: datetime.datetime.now()),
+            user=factory.SubFactory(_UserFactory),
+            user_id=factory.LazyAttribute(lambda o: o.user.id if o.user else None),
+        )


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-515

## 📝 Description
We currently create users directly when grant team members are added and when users try to authenticate via magic links, but this could lead to a lot of bad data in the user table (users never logging in, incorrect email addresses, etc.)

This adds an 'Invitations' table to the database to act as a kind of provisional user table for Deliver Grant Funding users authenticating with SSO, with the invitation being 'claimed' when a user signs in for the first time and a User is created in the database, and also stop the magic links journey from creating users before a magic link has been accepted.

See "Additional notes" below for some more context.

## 📸 Show the thing (screenshots, gifs)
No vis in this one

## 🧪 Testing
Difficult to test as this is a non-destructive change that mainly adds the new table and a couple of interfaces, but interfaces are tested with integration tests and other related tables should not currently be affected and behaviour should continue as normal. 

## 📋 Developer Checklist

### Review Readiness
- [X] PR title and description provide sufficient context for reviewers
- [X] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- [X] No N+1 query problems introduced
~- [ ] Any new DB queries include appropriate where clauses based on the user's permissions~

### Testing
- [X] I have tested this change and it meets the acceptance criteria for the ticket
- [X] I need the reviewer(s) to pull and run this change locally
- [X] New (non-developer) functionality has appropriate unit and integration tests
~- [ ] End-to-end tests have been updated (if applicable)~
- [X] Edge cases and error conditions are tested

## 📚 Additional Notes

This is the first of what we expect will be 3 PRs to cover this change:

1. Create the Invitation table and add relationships 👈  (this PR) 
2. Update the magic link functionality to not create users until they login ([very draft WIP PR](https://github.com/communitiesuk/funding-service/pull/425))
3. Update the SSO functionality to use invitations

Also adds a `last_logged_in_at_utc` column to the User table so that we can start to track when users log in (via sso or magic link), which is set when a user successfully logs in with `login(user)` by listening for the flask_login `user_logged_in` signal) rather than having to rely on whether a User's `name` field is populated in the database to indicate they've signed in with SSO.

One slight change to the ticket detail - the more we worked through the models the less sense it made for Magic Links to share this Invitation mechanism with SSO users, as magic links are already a kind of (very time limited) invitation, and syncing up a 15m expiry magic link with a 7 day expiry invitation would lead to lots of very frustrating and very avoidable edge cases. With magic links also being used for Access Grant Funding, they likely won't use the 'Invitation' functionality at all (at least for now when there's no invitation concept for Access Grant Funding), so instead we'll just wait to create the User until they've claimed the magic link and signed in - this migration preps for this change in flow.