### PR TITLE
Refactor dynamic question form creation and expressions context

### DIFF
--- a/app/common/data/types.py
+++ b/app/common/data/types.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import enum
 from typing import Any, Dict
 
+from immutabledict import immutabledict
+
 scalars = str | int | float | bool | None
 json_scalars = Dict[str, Any]
 json_flat_scalars = Dict[str, scalars]
+immutable_json_flat_scalars = immutabledict[str, scalars]
 
 
 class RoleEnum(str, enum.Enum):

--- a/app/common/data/types.py
+++ b/app/common/data/types.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import enum
 from typing import Any, Dict
 
+scalars = str | int | float | bool | None
 json_scalars = Dict[str, Any]
-json_flat_scalars = Dict[str, str | int | float | bool]
+json_flat_scalars = Dict[str, None]
 
 
 class RoleEnum(str, enum.Enum):

--- a/app/common/data/types.py
+++ b/app/common/data/types.py
@@ -5,7 +5,7 @@ from typing import Any, Dict
 
 scalars = str | int | float | bool | None
 json_scalars = Dict[str, Any]
-json_flat_scalars = Dict[str, None]
+json_flat_scalars = Dict[str, scalars]
 
 
 class RoleEnum(str, enum.Enum):

--- a/app/common/expressions/__init__.py
+++ b/app/common/expressions/__init__.py
@@ -6,7 +6,7 @@ import simpleeval
 from flask import current_app
 from immutabledict import immutabledict
 
-from app.common.data.types import json_flat_scalars, scalars
+from app.common.data.types import immutable_json_flat_scalars, json_flat_scalars, scalars
 
 if TYPE_CHECKING:
     from app.common.data.models import Expression
@@ -28,7 +28,7 @@ class InvalidEvaluationResult(BaseExpressionError):
     pass
 
 
-class ExpressionContext(json_flat_scalars):
+class ExpressionContext(immutable_json_flat_scalars):
     """
     A thin wrapper around three immutable dicts, where access to keys is done in priority order:
     - Keys from the `form` come first (data just submitted by the user answering some questions)
@@ -44,9 +44,9 @@ class ExpressionContext(json_flat_scalars):
 
     def __init__(
         self,
-        from_form: immutabledict[str, scalars] | None = None,
-        from_submission: immutabledict[str, scalars] | None = None,
-        from_expression: immutabledict[str, scalars] | None = None,
+        from_form: immutable_json_flat_scalars | None = None,
+        from_submission: immutable_json_flat_scalars | None = None,
+        from_expression: immutable_json_flat_scalars | None = None,
         *args: Any,
         **kwargs: Any,
     ):
@@ -55,54 +55,48 @@ class ExpressionContext(json_flat_scalars):
         super().__init__(*args, **kwargs)
 
         if from_form is None:
-            from_form = immutabledict()
+            from_form = cast(immutable_json_flat_scalars, immutabledict())
         if from_submission is None:
-            from_submission = immutabledict()
+            from_submission = cast(immutable_json_flat_scalars, immutabledict())
         if from_expression is None:
-            from_expression = immutabledict()
+            from_expression = cast(immutable_json_flat_scalars, immutabledict())
 
-        self._form_context: immutabledict[str, scalars] = from_form
-        self._submission_context: immutabledict[str, scalars] = from_submission
-        self._expression_context: immutabledict[str, scalars] = from_expression
+        self._form_context: immutable_json_flat_scalars = from_form
+        self._submission_context: immutable_json_flat_scalars = from_submission
+        self._expression_context: immutable_json_flat_scalars = from_expression
         self._update_keys()
 
     @property
-    def form_context(self) -> immutabledict[str, scalars]:
+    def form_context(self) -> immutable_json_flat_scalars:
         return self._form_context
 
     @form_context.setter
-    def form_context(self, value: immutabledict[str, scalars]) -> None:
+    def form_context(self, value: immutable_json_flat_scalars) -> None:
         self._form_context = value
         self._update_keys()
 
     @property
-    def submission_context(self) -> immutabledict[str, scalars]:
+    def submission_context(self) -> immutable_json_flat_scalars:
         return self._submission_context
 
     @submission_context.setter
-    def submission_context(self, value: immutabledict[str, scalars]) -> None:
+    def submission_context(self, value: immutable_json_flat_scalars) -> None:
         self._submission_context = value
         self._update_keys()
 
     @property
-    def expression_context(self) -> immutabledict[str, scalars]:
+    def expression_context(self) -> immutable_json_flat_scalars:
         return self._expression_context
 
     @expression_context.setter
-    def expression_context(self, value: immutabledict[str, scalars]) -> None:
+    def expression_context(self, value: immutable_json_flat_scalars) -> None:
         self._expression_context = value
         self._update_keys()
 
     def _update_keys(self) -> None:
-        _form_context: json_flat_scalars | immutabledict[str, scalars] = self.form_context or cast(
-            json_flat_scalars, {}
-        )
-        _submission_context: json_flat_scalars | immutabledict[str, scalars] = self.submission_context or cast(
-            json_flat_scalars, {}
-        )
-        _expression_context: json_flat_scalars | immutabledict[str, scalars] = self.expression_context or cast(
-            json_flat_scalars, {}
-        )
+        _form_context: json_flat_scalars = cast(json_flat_scalars, self.form_context or {})
+        _submission_context: json_flat_scalars = cast(json_flat_scalars, self.submission_context or {})
+        _expression_context: json_flat_scalars = cast(json_flat_scalars, self.expression_context or {})
 
         _keys: dict[str, None] = dict()
 

--- a/app/common/expressions/__init__.py
+++ b/app/common/expressions/__init__.py
@@ -1,8 +1,12 @@
 import ast
 import uuid
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Iterator, cast
 
 import simpleeval
+from flask import current_app
+from immutabledict import immutabledict
+
+from app.common.data.types import json_flat_scalars, scalars
 
 if TYPE_CHECKING:
     from app.common.data.models import Expression
@@ -24,9 +28,134 @@ class InvalidEvaluationResult(BaseExpressionError):
     pass
 
 
-def _evaluate_expression_with_context(
-    expression: "Expression", context: dict[str, str | int | float | bool | None] | None = None
-) -> Any:
+class ExpressionContext(json_flat_scalars):
+    """
+    A thin wrapper around three immutable dicts, where access to keys is done in priority order:
+    - Keys from the `form` come first (data just submitted by the user answering some questions)
+    - Keys from the `submission` come next (all data currently held about a submission)
+    - Keys from the `expression` come last (DB expression.context)
+
+    The only overlap should be between `form` and `submission`, where `form` holds the latest data and `submission`
+    holds the previous answer (until the page is saved).
+
+    The main reason for this is to treat each of these things as immutable, but overlay them. To do this with a standard
+    dict would mean creating lots of copies/merges/duplicates and juggling them.
+    """
+
+    def __init__(
+        self,
+        from_form: immutabledict[str, scalars] | None = None,
+        from_submission: immutabledict[str, scalars] | None = None,
+        from_expression: immutabledict[str, scalars] | None = None,
+        *args: Any,
+        **kwargs: Any,
+    ):
+        # TODO: we will probably end up with some of these dicts having nested data (eg for complex questions like
+        #       address; so `scalars` likely won't last forever.
+        super().__init__(*args, **kwargs)
+
+        if from_form is None:
+            from_form = immutabledict()
+        if from_submission is None:
+            from_submission = immutabledict()
+        if from_expression is None:
+            from_expression = immutabledict()
+
+        self._form_context: immutabledict[str, scalars] = from_form
+        self._submission_context: immutabledict[str, scalars] = from_submission
+        self._expression_context: immutabledict[str, scalars] = from_expression
+        self._update_keys()
+
+    @property
+    def form_context(self) -> immutabledict[str, scalars]:
+        return self._form_context
+
+    @form_context.setter
+    def form_context(self, value: immutabledict[str, scalars]) -> None:
+        self._form_context = value
+        self._update_keys()
+
+    @property
+    def submission_context(self) -> immutabledict[str, scalars]:
+        return self._submission_context
+
+    @submission_context.setter
+    def submission_context(self, value: immutabledict[str, scalars]) -> None:
+        self._submission_context = value
+        self._update_keys()
+
+    @property
+    def expression_context(self) -> immutabledict[str, scalars]:
+        return self._expression_context
+
+    @expression_context.setter
+    def expression_context(self, value: immutabledict[str, scalars]) -> None:
+        self._expression_context = value
+        self._update_keys()
+
+    def _update_keys(self) -> None:
+        _form_context: json_flat_scalars | immutabledict[str, scalars] = self.form_context or cast(
+            json_flat_scalars, {}
+        )
+        _submission_context: json_flat_scalars | immutabledict[str, scalars] = self.submission_context or cast(
+            json_flat_scalars, {}
+        )
+        _expression_context: json_flat_scalars | immutabledict[str, scalars] = self.expression_context or cast(
+            json_flat_scalars, {}
+        )
+
+        _keys: dict[str, None] = dict()
+
+        for _dict in [_form_context, _submission_context, _expression_context]:
+            for _key in _dict:
+                _keys.setdefault(_key, None)
+
+        self._keys = _keys
+
+    def __getitem__(self, key: str) -> scalars | None:
+        if key in self.form_context:
+            return self.form_context[key]
+        elif key in self.submission_context:
+            return self.submission_context[key]
+        elif key in self.expression_context:
+            return self.expression_context[key]
+        else:
+            raise KeyError(key)
+
+    def get(self, key: str, default: scalars | None = None) -> scalars | None:  # type: ignore[override]
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
+    def __contains__(self, key: object) -> bool:
+        return key in self._keys
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._keys)
+
+    def __len__(self) -> int:
+        return len(self._keys)
+
+    def __repr__(self) -> str:
+        items = {key: self[key] for key in self._keys}
+        return f"ExpressionContext({items})"
+
+    def __str__(self) -> str:
+        items = {key: self[key] for key in self._keys}
+        return str(items)
+
+    def keys(self) -> list[str]:  # type: ignore[override]
+        return list(self._keys)
+
+    def values(self) -> list[scalars | None]:  # type: ignore[override]
+        return [self[key] for key in self._keys]
+
+    def items(self) -> list[tuple[str, scalars | None]]:  # type: ignore[override]
+        return [(key, self[key]) for key in self._keys]
+
+
+def _evaluate_expression_with_context(expression: "Expression", context: ExpressionContext | None = None) -> Any:
     """
     The base evaluator to use for handling all expressions.
 
@@ -37,19 +166,16 @@ def _evaluate_expression_with_context(
     The addition of any new AST nodes should be well-tested and intentional consideration should be given to any
     ways of exploit or misuse.
     """
-    expr_context = expression.context or {}
-    context = context or {}
+    if context is None:
+        context = ExpressionContext()
+    context.expression_context = immutabledict(expression.context or {})
 
-    if context_overlap := set(expr_context).intersection(set(context)):
-        raise ValueError(
-            f"Cannot safely evaluate with overlapping contexts. "
-            f"The following keys exist in both the expression.context and additional context: {context_overlap}."
-        )
-
-    merged_context = {**expr_context, **context}
+    current_app.logger.debug(
+        "Evaluating %(statement)s with %(context)s", dict(statement=expression.statement, context=str(context))
+    )
 
     # May want EvalWithCompoundTypes at some point, but for now simple+very limited is OK.
-    evaluator = simpleeval.SimpleEval(names=merged_context)  # type: ignore[no-untyped-call]
+    evaluator = simpleeval.SimpleEval(names=context)  # type: ignore[no-untyped-call]
 
     # Remove all nodes except those we explicitly allowlist
     evaluator.nodes = {
@@ -83,10 +209,10 @@ def _evaluate_expression_with_context(
 
 
 # todo: interpolate an expression (eg for injecting dynamic data into question text, error messages, etc)
-def interpolate(expression: "Expression", context: dict[str, str | int | float | bool | None] | None = None) -> Any: ...
+def interpolate(expression: "Expression", context: ExpressionContext | None) -> Any: ...
 
 
-def evaluate(expression: "Expression", context: dict[str, str | int | float | bool | None] | None = None) -> bool:
+def evaluate(expression: "Expression", context: ExpressionContext | None = None) -> bool:
     result = _evaluate_expression_with_context(expression, context)
 
     # do we want these to evalaute to non-bool types like int/str ever?

--- a/app/developers/routes.py
+++ b/app/developers/routes.py
@@ -898,11 +898,11 @@ def collection_confirmation(submission_id: UUID) -> ResponseReturnValue:
 def ask_a_question(submission_id: UUID, question_id: UUID) -> ResponseReturnValue:
     submission_helper = SubmissionHelper.load(submission_id)
     question = submission_helper.get_question(question_id)
-    answer = submission_helper.get_answer_for_question(question.id)
 
     # this method should work as long as data types are a single field and may
     # need to be revised if we have compound data types
-    form = build_question_form(question)(question=answer.root if answer else None)
+    submission_context = submission_helper.expression_context
+    form = build_question_form(question)(data=submission_context)
 
     if submission_helper.is_completed:
         if form.is_submitted():

--- a/app/developers/templates/developers/ask_a_question.html
+++ b/app/developers/templates/developers/ask_a_question.html
@@ -28,9 +28,9 @@
         {# So we just manually add the caption here. #}
         <span class="govuk-caption-l">{{ question.form.title }}</span>
         {% if question.data_type == question_types.TEXT_SINGLE_LINE or question.data_type == question_types.TEXT_MULTI_LINE %}
-          {{ form.question(params={"label": {"classes": "govuk-label--l", "isPageHeading": true} }) }}
+          {{ form.render_question(question, params={"label": {"classes": "govuk-label--l", "isPageHeading": true} }) }}
         {% elif question.data_type == question_types.INTEGER %}
-          {{ form.question(params={"label": {"classes": "govuk-label--l", "isPageHeading": true}, "inputmode": "numeric", "spellcheck": false }) }}
+          {{ form.render_question(question, params={"label": {"classes": "govuk-label--l", "isPageHeading": true}, "inputmode": "numeric", "spellcheck": false }) }}
         {% endif %}
 
         {{ form.submit }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "sqlalchemy-json==0.7.0",
     "simpleeval==1.0.3",
     "num2words==0.5.14",
+    "immutabledict>=4.2.1",
 ]
 
 [dependency-groups]

--- a/tests/integration/common/expressions/test_init.py
+++ b/tests/integration/common/expressions/test_init.py
@@ -1,6 +1,92 @@
+import pytest
+from immutabledict import immutabledict
+
 from app.common.data.interfaces.collections import add_question_condition
-from app.common.expressions import evaluate, mangle_question_id_for_context
+from app.common.expressions import ExpressionContext, evaluate, mangle_question_id_for_context
 from app.common.expressions.managed import GreaterThan
+
+
+class TestExpressionContext:
+    def test_layering(self):
+        ex = ExpressionContext(
+            from_form=immutabledict({"a": 1, "b": 1, "e": 1}),
+            from_submission=immutabledict({"a": 2, "c": 2}),
+            from_expression=immutabledict({"a": 3, "c": 3, "d": 3}),
+        )
+        assert ex["a"] == 1
+        assert ex["b"] == 1
+        assert ex["c"] == 2
+        assert ex["d"] == 3
+        assert ex["e"] == 1
+
+        with pytest.raises(KeyError):
+            assert ex["f"]
+
+    def test_iteration(self):
+        ex = ExpressionContext(
+            from_form=immutabledict({"a": 1, "b": 1, "e": 1}),
+            from_submission=immutabledict({"a": 2, "c": 2}),
+            from_expression=immutabledict({"a": 3, "c": 3, "d": 3}),
+        )
+        assert [k for k in ex] == ["a", "b", "e", "c", "d"]
+
+    def test_get(self):
+        ex = ExpressionContext(
+            from_form=immutabledict({"a": 1, "b": 1, "e": 1}),
+            from_submission=immutabledict({"a": 2, "c": 2}),
+            from_expression=immutabledict({"a": 3, "c": 3, "d": 3}),
+        )
+        assert ex.get("a") == 1
+        assert ex.get("b") == 1
+        assert ex.get("c") == 2
+        assert ex.get("d") == 3
+        assert ex.get("e") == 1
+        assert ex.get("f") is None
+
+    def test_length(self):
+        ex = ExpressionContext(
+            from_form=immutabledict({"a": 1, "b": 1, "e": 1}),
+            from_submission=immutabledict({"a": 2, "c": 2}),
+            from_expression=immutabledict({"a": 3, "c": 3, "d": 3}),
+        )
+        assert len(ex) == 5
+
+    def test_contains(self):
+        ex = ExpressionContext(
+            from_form=immutabledict({"a": 1, "b": 1, "e": 1}),
+            from_submission=immutabledict({"a": 2, "c": 2}),
+            from_expression=immutabledict({"a": 3, "c": 3, "d": 3}),
+        )
+        assert "a" in ex
+        assert "b" in ex
+        assert "c" in ex
+        assert "d" in ex
+        assert "e" in ex
+        assert "f" not in ex
+
+    def test_keys(self):
+        ex = ExpressionContext(
+            from_form=immutabledict({"a": 1, "b": 1, "e": 1}),
+            from_submission=immutabledict({"a": 2, "c": 2}),
+            from_expression=immutabledict({"a": 3, "c": 3, "d": 3}),
+        )
+        assert list(ex.keys()) == ["a", "b", "e", "c", "d"]
+
+    def test_values(self):
+        ex = ExpressionContext(
+            from_form=immutabledict({"a": 1, "b": 1, "e": 1}),
+            from_submission=immutabledict({"a": 2, "c": 2}),
+            from_expression=immutabledict({"a": 3, "c": 3, "d": 3}),
+        )
+        assert ex.values() == [1, 1, 1, 2, 3]
+
+    def test_items(self):
+        ex = ExpressionContext(
+            from_form=immutabledict({"a": 1, "b": 1, "e": 1}),
+            from_submission=immutabledict({"a": 2, "c": 2}),
+            from_expression=immutabledict({"a": 3, "c": 3, "d": 3}),
+        )
+        assert ex.items() == [("a", 1), ("b", 1), ("e", 1), ("c", 2), ("d", 3)]
 
 
 class TestEvaluatingManagedExpressions:
@@ -14,6 +100,6 @@ class TestEvaluatingManagedExpressions:
 
         # todo: find a smooth way of doing this
         question_id_for_context = mangle_question_id_for_context(question.id)
-        assert evaluate(expr, {question_id_for_context: 500}) is False
-        assert evaluate(expr, {question_id_for_context: 3000}) is False
-        assert evaluate(expr, {question_id_for_context: 3001}) is True
+        assert evaluate(expr, ExpressionContext(immutabledict({question_id_for_context: 500}))) is False
+        assert evaluate(expr, ExpressionContext(immutabledict({question_id_for_context: 3000}))) is False
+        assert evaluate(expr, ExpressionContext(immutabledict({question_id_for_context: 3001}))) is True

--- a/tests/integration/common/helpers/test_collections.py
+++ b/tests/integration/common/helpers/test_collections.py
@@ -1,3 +1,5 @@
+import uuid
+
 import pytest
 
 from app.common.collections.forms import build_question_form
@@ -9,33 +11,35 @@ from tests.utils import AnyStringMatching
 class TestSubmissionHelper:
     class TestGetAndSubmitAnswerForQuestion:
         def test_submit_valid_data(self, db_session, factories):
-            question = factories.question.build()
+            question = factories.question.build(id=uuid.UUID("d696aebc-49d2-4170-a92f-b6ef42994294"))
             submission = factories.submission.build(collection=question.form.section.collection)
             helper = SubmissionHelper(submission)
 
             assert helper.get_answer_for_question(question.id) is None
 
-            form = build_question_form(question)(question="User submitted data")
+            form = build_question_form(question)(q_d696aebc49d24170a92fb6ef42994294="User submitted data")
             helper.submit_answer_for_question(question.id, form)
 
             assert helper.get_answer_for_question(question.id) == TextSingleLine("User submitted data")
 
         def test_get_data_maps_type(self, db_session, factories):
-            question = factories.question.build(data_type=QuestionDataType.INTEGER)
+            question = factories.question.build(
+                id=uuid.UUID("d696aebc-49d2-4170-a92f-b6ef42994294"), data_type=QuestionDataType.INTEGER
+            )
             submission = factories.submission.build(collection=question.form.section.collection)
             helper = SubmissionHelper(submission)
 
-            form = build_question_form(question)(question=5)
+            form = build_question_form(question)(q_d696aebc49d24170a92fb6ef42994294=5)
             helper.submit_answer_for_question(question.id, form)
 
             assert helper.get_answer_for_question(question.id) == Integer(5)
 
         def test_cannot_submit_answer_on_submitted_submission(self, db_session, factories):
-            question = factories.question.build()
+            question = factories.question.build(id=uuid.UUID("d696aebc-49d2-4170-a92f-b6ef42994294"))
             submission = factories.submission.build(collection=question.form.section.collection)
             helper = SubmissionHelper(submission)
 
-            form = build_question_form(question)(question="User submitted data")
+            form = build_question_form(question)(q_d696aebc49d24170a92fb6ef42994294="User submitted data")
             helper.submit_answer_for_question(question.id, form)
             helper.toggle_form_completed(question.form, submission.created_by, True)
             helper.submit(submission.created_by)
@@ -52,9 +56,11 @@ class TestSubmissionHelper:
         def test_form_status_based_on_questions(self, db_session, factories):
             form = factories.form.build()
             form_two = factories.form.build(section=form.section)
-            question_one = factories.question.build(form=form)
-            question_two = factories.question.build(form=form)
-            question_three = factories.question.build(form=form_two)
+            question_one = factories.question.build(form=form, id=uuid.UUID("d696aebc-49d2-4170-a92f-b6ef42994294"))
+            question_two = factories.question.build(form=form, id=uuid.UUID("d696aebc-49d2-4170-a92f-b6ef42994295"))
+            question_three = factories.question.build(
+                form=form_two, id=uuid.UUID("d696aebc-49d2-4170-a92f-b6ef42994296")
+            )
 
             submission = factories.submission.build(collection=form.section.collection)
             helper = SubmissionHelper(submission)
@@ -62,13 +68,15 @@ class TestSubmissionHelper:
             assert helper.get_status_for_form(form) == SubmissionStatusEnum.NOT_STARTED
 
             helper.submit_answer_for_question(
-                question_one.id, build_question_form(question_one)(question="User submitted data")
+                question_one.id,
+                build_question_form(question_one)(q_d696aebc49d24170a92fb6ef42994294="User submitted data"),
             )
 
             assert helper.get_status_for_form(form) == SubmissionStatusEnum.IN_PROGRESS
 
             helper.submit_answer_for_question(
-                question_two.id, build_question_form(question_two)(question="User submitted data")
+                question_two.id,
+                build_question_form(question_two)(q_d696aebc49d24170a92fb6ef42994295="User submitted data"),
             )
 
             assert helper.get_status_for_form(form) == SubmissionStatusEnum.IN_PROGRESS
@@ -79,7 +87,8 @@ class TestSubmissionHelper:
 
             # make sure the second form is unaffected by the first forms status
             helper.submit_answer_for_question(
-                question_three.id, build_question_form(question_three)(question="User submitted data")
+                question_three.id,
+                build_question_form(question_three)(q_d696aebc49d24170a92fb6ef42994296="User submitted data"),
             )
             assert helper.get_status_for_form(form_two) == SubmissionStatusEnum.IN_PROGRESS
 
@@ -90,9 +99,9 @@ class TestSubmissionHelper:
             assert helper.get_status_for_form(form) == SubmissionStatusEnum.NOT_STARTED
 
         def test_submission_status_based_on_forms(self, db_session, factories):
-            question = factories.question.build()
+            question = factories.question.build(id=uuid.UUID("d696aebc-49d2-4170-a92f-b6ef42994294"))
             form_two = factories.form.build(section=question.form.section)
-            question_two = factories.question.build(form=form_two)
+            question_two = factories.question.build(form=form_two, id=uuid.UUID("d696aebc-49d2-4170-a92f-b6ef42994295"))
 
             submission = factories.submission.build(collection=question.form.section.collection)
             helper = SubmissionHelper(submission)
@@ -100,7 +109,7 @@ class TestSubmissionHelper:
             assert helper.status == SubmissionStatusEnum.NOT_STARTED
 
             helper.submit_answer_for_question(
-                question.id, build_question_form(question)(question="User submitted data")
+                question.id, build_question_form(question)(q_d696aebc49d24170a92fb6ef42994294="User submitted data")
             )
             helper.toggle_form_completed(question.form, submission.created_by, True)
 
@@ -108,7 +117,8 @@ class TestSubmissionHelper:
             assert helper.status == SubmissionStatusEnum.IN_PROGRESS
 
             helper.submit_answer_for_question(
-                question_two.id, build_question_form(question_two)(question="User submitted data")
+                question_two.id,
+                build_question_form(question_two)(q_d696aebc49d24170a92fb6ef42994295="User submitted data"),
             )
             helper.toggle_form_completed(question_two.form, submission.created_by, True)
 
@@ -121,7 +131,7 @@ class TestSubmissionHelper:
             assert helper.status == SubmissionStatusEnum.COMPLETED
 
         def test_toggle_form_status(self, db_session, factories):
-            question = factories.question.build()
+            question = factories.question.build(id=uuid.UUID("d696aebc-49d2-4170-a92f-b6ef42994294"))
             form = question.form
             submission = factories.submission.build(collection=form.section.collection)
             helper = SubmissionHelper(submission)
@@ -134,7 +144,7 @@ class TestSubmissionHelper:
             )
 
             helper.submit_answer_for_question(
-                question.id, build_question_form(question)(question="User submitted data")
+                question.id, build_question_form(question)(q_d696aebc49d24170a92fb6ef42994294="User submitted data")
             )
             helper.toggle_form_completed(form, submission.created_by, True)
 
@@ -147,14 +157,14 @@ class TestSubmissionHelper:
             # a second form with questions ensures nothing is conflating the submission and individual form statuses
             second_form = factories.form.build(section=section)
 
-            question = factories.question.build(form=form)
+            question = factories.question.build(form=form, id=uuid.UUID("d696aebc-49d2-4170-a92f-b6ef42994294"))
             factories.question.build(form=second_form)
 
             submission = factories.submission.build(collection=section.collection)
             helper = SubmissionHelper(submission)
 
             helper.submit_answer_for_question(
-                question.id, build_question_form(question)(question="User submitted data")
+                question.id, build_question_form(question)(q_d696aebc49d24170a92fb6ef42994294="User submitted data")
             )
             helper.toggle_form_completed(question.form, submission.created_by, True)
 
@@ -165,12 +175,12 @@ class TestSubmissionHelper:
             assert len(submission.events) == 1
 
         def test_submit_submission_rejected_if_not_complete(self, db_session, factories):
-            question = factories.question.build()
+            question = factories.question.build(id=uuid.UUID("d696aebc-49d2-4170-a92f-b6ef42994294"))
             submission = factories.submission.build(collection=question.form.section.collection)
             helper = SubmissionHelper(submission)
 
             helper.submit_answer_for_question(
-                question.id, build_question_form(question)(question="User submitted data")
+                question.id, build_question_form(question)(q_d696aebc49d24170a92fb6ef42994294="User submitted data")
             )
 
             with pytest.raises(ValueError) as e:

--- a/tests/unit/app/common/collections/test_forms.py
+++ b/tests/unit/app/common/collections/test_forms.py
@@ -1,3 +1,5 @@
+import uuid
+
 import pytest
 from govuk_frontend_wtf.wtforms_widgets import GovTextArea, GovTextInput
 from wtforms.fields.numeric import IntegerField
@@ -10,9 +12,13 @@ from app.common.data.types import QuestionDataType
 
 class TestBuildQuestionForm:
     def test_expected_fields_exist(self, app):
-        q = Question(text="Question text", data_type=QuestionDataType.TEXT_SINGLE_LINE)
+        q = Question(
+            id=uuid.UUID("31673d51-95b0-4589-b254-33b866dfd94f"),
+            text="Question text",
+            data_type=QuestionDataType.TEXT_SINGLE_LINE,
+        )
         form = build_question_form(q)
-        assert hasattr(form, "question")
+        assert hasattr(form, "q_31673d5195b04589b25433b866dfd94f")
         assert hasattr(form, "submit")
 
     def test_the_next_test_exhausts_QuestionDataType(self):
@@ -30,10 +36,11 @@ class TestBuildQuestionForm:
     )
     def test_expected_field_types(self, app, data_type, expected_field_type, expected_widget):
         """Feels like a bit of a redundant test that's just reimplementing the function, but ... :shrug:"""
-        q = Question(text="Question text", hint="Question hint", data_type=data_type)
+        q = Question(id=uuid.uuid4(), text="Question text", hint="Question hint", data_type=data_type)
         form = build_question_form(q)()
 
-        assert isinstance(form.question, expected_field_type)
-        assert isinstance(form.question.widget, expected_widget)
-        assert form.question.label.text == "Question text"
-        assert form.question.description == "Question hint"
+        question_field = form.get_question_field(q)
+        assert isinstance(question_field, expected_field_type)
+        assert isinstance(question_field.widget, expected_widget)
+        assert question_field.label.text == "Question text"
+        assert question_field.description == "Question hint"

--- a/tests/unit/common/expressions/test_expressions.py
+++ b/tests/unit/common/expressions/test_expressions.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock
 
 import pytest
+from immutabledict import immutabledict
 
 from app.common.data.models import Expression
 from app.common.expressions import (
@@ -93,7 +94,10 @@ class TestEvaluate:
         assert evaluate(Expression(statement="True is False"), ExpressionContext()) is False
 
     def test_additional_context(self):
-        assert evaluate(Expression(statement="answer == 1"), context=ExpressionContext({"answer": 1})) is True
+        assert (
+            evaluate(Expression(statement="answer == 1"), context=ExpressionContext(immutabledict({"answer": 1})))
+            is True
+        )
 
     def test_raise_on_non_boolean_result(self):
         with pytest.raises(InvalidEvaluationResult):

--- a/uv.lock
+++ b/uv.lock
@@ -517,6 +517,7 @@ dependencies = [
     { name = "govuk-frontend-jinja" },
     { name = "govuk-frontend-wtf" },
     { name = "gunicorn", extra = ["gevent"] },
+    { name = "immutabledict" },
     { name = "msal" },
     { name = "notifications-python-client" },
     { name = "num2words" },
@@ -575,6 +576,7 @@ requires-dist = [
     { name = "govuk-frontend-jinja", specifier = "==3.5.0" },
     { name = "govuk-frontend-wtf", specifier = "==3.2.0" },
     { name = "gunicorn", extras = ["gevent"], specifier = "==23.0.0" },
+    { name = "immutabledict", specifier = ">=4.2.1" },
     { name = "msal", specifier = "==1.32.3" },
     { name = "notifications-python-client", specifier = "==10.0.1" },
     { name = "num2words", specifier = "==0.5.14" },
@@ -774,6 +776,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+]
+
+[[package]]
+name = "immutabledict"
+version = "4.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/c5/4240186fbabc58fba41bbe17c5f0cd37ffd4c0b85a5029ab104f946df175/immutabledict-4.2.1.tar.gz", hash = "sha256:d91017248981c72eb66c8ff9834e99c2f53562346f23e7f51e7a5ebcf66a3bcc", size = 6228, upload-time = "2024-11-17T13:25:21.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/56/25ca7b848164b7d93dbd5fc97dd7751700c93e324fe854afbeb562ee2f98/immutabledict-4.2.1-py3-none-any.whl", hash = "sha256:c56a26ced38c236f79e74af3ccce53772827cef5c3bce7cab33ff2060f756373", size = 4700, upload-time = "2024-11-17T13:25:19.52Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FSPT-592

---

The current dynamic question forms that we use to render questions on
the page for a submission only supports a single field, with the
hard-coded name `question`. We know that we will eventually want to
render multiple questions on one page, and that these will need to be on
a single wtform, so the `question` name won't work.

This refactor attaches questions to the form class based on their
question id. By reusing the ("mangled") question ID that feeds the
expression evaluation engine, we can more neatly map data that the user
is submitting in the form to data that the expressions will evaluate
against.

We probably should rename this mangling function and abstract it/provide
a cleaner interface for it soon if we're making this touch a few more
places.

With the form field names matching the question id format in
expressions, we can then pull data straight from the form and pass it to
the evaluation engine without any further mutation.

With each form field scoped to its question ID, the dynamic form should
work automatically when we support adding multiple questions to it, and
those fields' data will flow into the evaluation engine easily and
without any further changes.

We do need helpers on the form to set/grab the field for a specific
question, since we can no longer do something hardcoded like
`form.question`, so this adds getters/setters for form fields based on
question instances.

We also need a helper on the form to render questions in our jinja
templates, enter `render_question(question)`. This can also be passed
`params` for GOV.UK Frontend Jinja macros, as you'd normally pass with
direct macro calls.

---

This tweaks the expression evaluation interface to take a specific
dict-like object instead of an arbitrary dict.

This new 'ExpressionContext' object wraps three levels of dicts:
1. form data
2. submission data
3. expression data

The ExpressionContext is immutable and the wrapped dicts are immutable
too. This means that we can pass them around and use them across
multiple validators without worrying about copying or merging dicts,
which should save a lot of memory churn and - with some familiarity -
make it easier to track/trust that the right data is in the right place.
