### PR TITLE
FIX Appropriately manage order when deleting entities

### DIFF
--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -124,7 +124,7 @@ def create_submission(*, collection: Collection, created_by: User, mode: Submiss
 
 def create_section(*, title: str, collection: Collection) -> Section:
     section = Section(title=title, collection_id=collection.id, slug=slugify(title))
-    collection.sections.append(section)
+    collection.sections.append(section)  # type: ignore[no-untyped-call]
     db.session.add(section)
     try:
         db.session.flush()
@@ -194,7 +194,7 @@ def get_form_by_id(form_id: UUID, with_all_questions: bool = False) -> Form:
 
 def create_form(*, title: str, section: Section) -> Form:
     form = Form(title=title, section_id=section.id, slug=slugify(title))
-    section.forms.append(form)
+    section.forms.append(form)  # type: ignore[no-untyped-call]
     db.session.add(form)
 
     try:
@@ -229,7 +229,7 @@ def update_form(form: Form, *, title: str) -> Form:
 
 def create_question(form: Form, *, text: str, hint: str, name: str, data_type: QuestionDataType) -> Question:
     question = Question(text=text, form_id=form.id, slug=slugify(text), hint=hint, name=name, data_type=data_type)
-    form.questions.append(question)
+    form.questions.append(question)  # type: ignore[no-untyped-call]
     db.session.add(question)
 
     try:

--- a/app/common/data/interfaces/temporary.py
+++ b/app/common/data/interfaces/temporary.py
@@ -17,6 +17,7 @@ from app.common.data.models import (
     Collection,
     Form,
     Grant,
+    Question,
     Section,
     Submission,
 )
@@ -52,38 +53,27 @@ def delete_collection(collection_id: UUID) -> None:
     db.session.flush()
 
 
-def delete_section(section_id: UUID, collection_id: UUID) -> None:
-    collection = db.session.query(Collection).where(Collection.id == collection_id).one()
-    section = next(section for section in collection.sections if section.id == section_id)
-
+def delete_section(section: Section) -> None:
     db.session.delete(section)
-    collection.sections.remove(section)
-
+    section.collection.sections.reorder()
     db.session.execute(
         text("SET CONSTRAINTS uq_section_order_collection, uq_form_order_section, uq_question_order_form DEFERRED")
     )
     db.session.flush()
 
 
-def delete_form(form_id: UUID, section_id: UUID) -> None:
-    section = db.session.query(Section).where(Section.id == section_id).one()
-    form = next(form for form in section.forms if form.id == form_id)
-
+def delete_form(form: Form) -> None:
     db.session.delete(form)
-    section.forms.remove(form)
-
+    form.section.forms.reorder()
     db.session.execute(
         text("SET CONSTRAINTS uq_section_order_collection, uq_form_order_section, uq_question_order_form DEFERRED")
     )
     db.session.flush()
 
 
-def delete_question(question_id: UUID, form_id: UUID) -> None:
-    form = db.session.query(Form).where(Form.id == form_id).one()
-    question = next(question for question in form.questions if question.id == question_id)
-
+def delete_question(question: Question) -> None:
     db.session.delete(question)
-    form.questions.remove(question)
+    question.form.questions.reorder()
     db.session.execute(
         text("SET CONSTRAINTS uq_section_order_collection, uq_form_order_section, uq_question_order_form DEFERRED")
     )

--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -7,7 +7,7 @@ from pytz import utc
 from sqlalchemy import Enum as SqlEnum
 from sqlalchemy import ForeignKey, ForeignKeyConstraint, Index, UniqueConstraint, text
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.ext.orderinglist import ordering_list
+from sqlalchemy.ext.orderinglist import OrderingList, ordering_list
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy_json import mutable_json_type
 
@@ -105,7 +105,7 @@ class Collection(BaseModel):
         cascade="all, delete-orphan",
     )
 
-    sections: Mapped[list["Section"]] = relationship(
+    sections: Mapped[OrderingList["Section"]] = relationship(
         "Section",
         lazy=True,
         order_by="Section.order",
@@ -170,7 +170,7 @@ class Section(BaseModel):
     collection_version: Mapped[int]
     collection: Mapped[Collection] = relationship("Collection", back_populates="sections")
 
-    forms: Mapped[list["Form"]] = relationship(
+    forms: Mapped[OrderingList["Form"]] = relationship(
         "Form",
         lazy=True,
         order_by="Form.order",
@@ -211,7 +211,7 @@ class Form(BaseModel):
         UniqueConstraint("slug", "section_id", name="uq_form_slug_section"),
     )
 
-    questions: Mapped[list["Question"]] = relationship(
+    questions: Mapped[OrderingList["Question"]] = relationship(
         "Question",
         lazy=True,
         order_by="Question.order",

--- a/app/developers/routes.py
+++ b/app/developers/routes.py
@@ -244,7 +244,7 @@ def manage_section(
         and confirm_deletion_form.validate_on_submit()
         and confirm_deletion_form.confirm_deletion.data
     ):
-        delete_section(section_id=section_id, collection_id=collection_id)
+        delete_section(section)
         # TODO: Flash message for deletion?
         return redirect(url_for("developers.manage_collection", grant_id=grant_id, collection_id=collection_id))
 
@@ -296,7 +296,7 @@ def manage_form(grant_id: UUID, collection_id: UUID, section_id: UUID, form_id: 
 
     form = ConfirmDeletionForm()
     if "delete" in request.args and form.validate_on_submit() and form.confirm_deletion.data:
-        delete_form(form_id=form_id, section_id=section_id)
+        delete_form(db_form)
         # TODO: Flash message for deletion?
         return redirect(
             url_for("developers.manage_section", grant_id=grant_id, collection_id=collection_id, section_id=section_id)
@@ -551,7 +551,7 @@ def edit_question(
         and confirm_deletion_form.validate_on_submit()
         and confirm_deletion_form.confirm_deletion.data
     ):
-        delete_question(question_id=question_id, form_id=form_id)
+        delete_question(question)
         # TODO: Flash message for deletion?
         return redirect(
             url_for(

--- a/app/developers/routes.py
+++ b/app/developers/routes.py
@@ -244,7 +244,7 @@ def manage_section(
         and confirm_deletion_form.validate_on_submit()
         and confirm_deletion_form.confirm_deletion.data
     ):
-        delete_section(section_id=section_id)
+        delete_section(section_id=section_id, collection_id=collection_id)
         # TODO: Flash message for deletion?
         return redirect(url_for("developers.manage_collection", grant_id=grant_id, collection_id=collection_id))
 
@@ -296,7 +296,7 @@ def manage_form(grant_id: UUID, collection_id: UUID, section_id: UUID, form_id: 
 
     form = ConfirmDeletionForm()
     if "delete" in request.args and form.validate_on_submit() and form.confirm_deletion.data:
-        delete_form(form_id=form_id)
+        delete_form(form_id=form_id, section_id=section_id)
         # TODO: Flash message for deletion?
         return redirect(
             url_for("developers.manage_section", grant_id=grant_id, collection_id=collection_id, section_id=section_id)
@@ -551,7 +551,7 @@ def edit_question(
         and confirm_deletion_form.validate_on_submit()
         and confirm_deletion_form.confirm_deletion.data
     ):
-        delete_question(question_id=question_id)
+        delete_question(question_id=question_id, form_id=form_id)
         # TODO: Flash message for deletion?
         return redirect(
             url_for(


### PR DESCRIPTION
Note: all of the methods covered by this fix are in a "temporary" interface that doesn't have coverage and is intended to make things work for now. This commit doesn't intend to change that but it should stop us running into errors if removing and then adding again.

Deleting questions, forms or sections and then trying to add another currently raises a `DuplicateValueError` for their ordering constraints (i.e `uq_question_order_form`).

This is especially noticeable when you remove the first entity in the ordered list. When the entity is removed the order of all of the other entities remains the same (in this example if you have 0, 1, 2 and remove 0, the two remaining will stay at 1 and 2).

If you try and add a new entity now it will be assigned the order "2" as there are 2 other entities remaining and the order index starts at 0 - this will then conflict with the existing entity with the order 2.

If we want to lean on the ORM to manage the ordering using an ordered list we'll need to tell it that the entity has been removed which will trigger an appropriate update to the existing elements order and means any new entity then added will have a unique value based on the max of whats there.

Steps to reproduce:
- remove the first question on a form
- add a new question to the form