### PR TITLE
Run e2e docker compose tests on PR

### DIFF
--- a/.github/workflows/run_e2e_tests_docker_compose.yml
+++ b/.github/workflows/run_e2e_tests_docker_compose.yml
@@ -5,6 +5,9 @@ permissions:
   id-token: write  # This is required for authenticating with aws
 
 on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
   workflow_call:
     secrets:
       PULLPREVIEW_GOVUK_NOTIFY_API_KEY:


### PR DESCRIPTION
Make the e2e tests run on all PRs. This runs them in docker-compose, so not against a deployed environment. They run against deployed dev/test environments post-merge, but running them on a PR first should catch 99% of issues.

I am not intending to make these a blocking check quite yet because they run significantly slower than the rest of the PR CI checks (~3 minutes vs ~30 seconds). We should aim to optimise the e2e test runs - if we can get them down to ~60 seconds then I'd feel a lot more comfortable making them a required pass.