### PR TITLE
Use InputRequired over DataRequired

### DIFF
--- a/app/common/expressions/forms.py
+++ b/app/common/expressions/forms.py
@@ -5,7 +5,7 @@ from flask_wtf import FlaskForm
 from govuk_frontend_wtf.wtforms_widgets import GovCheckboxInput, GovRadioInput, GovSubmitInput, GovTextInput
 from wtforms import IntegerField, RadioField, SubmitField, ValidationError
 from wtforms.fields.simple import BooleanField
-from wtforms.validators import DataRequired, Optional
+from wtforms.validators import DataRequired, InputRequired, Optional
 
 from app.common.data.models import Expression, Question
 from app.common.data.types import ManagedExpressionsEnum, json_flat_scalars
@@ -67,16 +67,20 @@ class AddIntegerExpressionForm(_BaseExpressionForm):
     def validate(self, extra_validators: Mapping[str, Sequence[Any]] | None = None) -> bool:
         match self.type.data:
             case ManagedExpressionsEnum.GREATER_THAN.value:
-                self.greater_than_value.validators = [DataRequired("Enter the minimum value allowed for this question")]
+                self.greater_than_value.validators = [
+                    InputRequired("Enter the minimum value allowed for this question"),
+                ]
             case ManagedExpressionsEnum.LESS_THAN.value:
-                self.less_than_value.validators = [DataRequired("Enter the maximum value allowed for this question")]
+                self.less_than_value.validators = [
+                    InputRequired("Enter the maximum value allowed for this question"),
+                ]
             case ManagedExpressionsEnum.BETWEEN.value:
                 self.bottom_of_range.validators = [
-                    DataRequired("Enter the minimum value allowed for this question"),
+                    InputRequired("Enter the minimum value allowed for this question"),
                     BottomOfRangeIsLower("The minimum value must be lower than the maximum value"),
                 ]
                 self.top_of_range.validators = [
-                    DataRequired("Enter the maximum value allowed for this question"),
+                    InputRequired("Enter the maximum value allowed for this question"),
                     BottomOfRangeIsLower("The maximum value must be higher than the minimum value"),
                 ]
 

--- a/tests/integration/common/expressions/test_forms.py
+++ b/tests/integration/common/expressions/test_forms.py
@@ -1,3 +1,5 @@
+from werkzeug.datastructures import MultiDict
+
 from app.common.data.interfaces.collections import add_question_validation
 from app.common.data.types import ManagedExpressionsEnum, QuestionDataType
 from app.common.expressions.forms import AddIntegerExpressionForm
@@ -8,7 +10,11 @@ class TestAddIntegerValidationForm:
     def test_get_greater_than_expression(self, factories):
         question = factories.question.build(data_type=QuestionDataType.INTEGER)
         form = AddIntegerExpressionForm(
-            type=ManagedExpressionsEnum.GREATER_THAN.value, greater_than_value=2000, greater_than_inclusive=False
+            formdata=MultiDict(
+                dict(
+                    type=ManagedExpressionsEnum.GREATER_THAN.value, greater_than_value="2000", greater_than_inclusive=""
+                )
+            )
         )
 
         expression = form.get_expression(question)
@@ -19,7 +25,9 @@ class TestAddIntegerValidationForm:
     def test_get_less_than_expression(self, factories):
         question = factories.question.build(data_type=QuestionDataType.INTEGER)
         form = AddIntegerExpressionForm(
-            type=ManagedExpressionsEnum.LESS_THAN.value, less_than_value=2000, less_than_inclusive=False
+            formdata=MultiDict(
+                dict(type=ManagedExpressionsEnum.LESS_THAN.value, less_than_value="2000", less_than_inclusive="")
+            )
         )
 
         expression = form.get_expression(question)
@@ -30,11 +38,15 @@ class TestAddIntegerValidationForm:
     def test_get_between_expression(self, factories):
         question = factories.question.build(data_type=QuestionDataType.INTEGER)
         form = AddIntegerExpressionForm(
-            type=ManagedExpressionsEnum.BETWEEN.value,
-            bottom_of_range=10,
-            bottom_inclusive=False,
-            top_of_range=20,
-            top_inclusive=False,
+            formdata=MultiDict(
+                dict(
+                    type=ManagedExpressionsEnum.BETWEEN.value,
+                    bottom_of_range="10",
+                    bottom_inclusive="",
+                    top_of_range="20",
+                    top_inclusive="",
+                )
+            )
         )
 
         expression = form.get_expression(question)

--- a/tests/unit/common/expressions/test_forms.py
+++ b/tests/unit/common/expressions/test_forms.py
@@ -1,10 +1,14 @@
+from werkzeug.datastructures import MultiDict
+
 from app.common.data.types import ManagedExpressionsEnum
 from app.common.expressions.forms import AddIntegerExpressionForm
 
 
 class TestAddIntegerValidationForm:
     def test_custom_between_validator(self):
-        form = AddIntegerExpressionForm(type=ManagedExpressionsEnum.BETWEEN.value, bottom_of_range=10, top_of_range=5)
+        form = AddIntegerExpressionForm(
+            formdata=MultiDict(dict(type=ManagedExpressionsEnum.BETWEEN.value, bottom_of_range="10", top_of_range="5"))
+        )
         assert not form.validate()
         assert "The minimum value must be lower than the maximum value" in form.errors["bottom_of_range"]
         assert "The maximum value must be higher than the minimum value" in form.errors["top_of_range"]


### PR DESCRIPTION
We need to use InputRequired for integer fields. DataRequired only passes if the result is 'truthy', and so it will reject an answer of '0'. We think this is OK as the minimum/maximum bound for some validations/conditions.

## Broken state that this fixes
<img width="754" alt="image" src="https://github.com/user-attachments/assets/e1040499-c05f-4895-9ae5-893ad605578b" />
