### PR TITLE
Fix check your answers page not showing 0 answers

### DIFF
--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -233,7 +233,7 @@ class SubmissionHelper:
     def get_answer_for_question(self, question_id: UUID) -> TextSingleLine | TextMultiLine | Integer | None:
         question = self.get_question(question_id)
         serialised_data = self.submission.data.get(str(question_id))
-        return _deserialise_question_type(question, serialised_data) if serialised_data else None
+        return _deserialise_question_type(question, serialised_data) if serialised_data is not None else None
 
     def submit_answer_for_question(self, question_id: UUID, form: DynamicQuestionForm) -> None:
         if self.is_completed:

--- a/tests/integration/common/helpers/test_collections.py
+++ b/tests/integration/common/helpers/test_collections.py
@@ -40,6 +40,18 @@ class TestSubmissionHelper:
 
             assert helper.get_answer_for_question(question.id) == Integer(5)
 
+        def test_can_get_falsey_answers(self, db_session, factories):
+            question = factories.question.build(
+                id=uuid.UUID("d696aebc-49d2-4170-a92f-b6ef42994294"), data_type=QuestionDataType.INTEGER
+            )
+            submission = factories.submission.build(collection=question.form.section.collection)
+            helper = SubmissionHelper(submission)
+
+            form = build_question_form(question, expression_context=EC())(q_d696aebc49d24170a92fb6ef42994294=0)
+            helper.submit_answer_for_question(question.id, form)
+
+            assert helper.get_answer_for_question(question.id) == Integer(0)
+
         def test_cannot_submit_answer_on_submitted_submission(self, db_session, factories):
             question = factories.question.build(id=uuid.UUID("d696aebc-49d2-4170-a92f-b6ef42994294"))
             submission = factories.submission.build(collection=question.form.section.collection)


### PR DESCRIPTION
We need a proper check against None here, rather than truthy/falsey. An answer of '0' is falsey, but it might be the answer the user gave - and we should show that.

## Before
<img width="1046" alt="image" src="https://github.com/user-attachments/assets/d7685c2b-69da-4945-9b59-69c93c22c3e1" />


 ## After
<img width="1091" alt="image" src="https://github.com/user-attachments/assets/15a0584a-9156-4201-85b0-ee4462dfce31" />

