### PR TITLE
Delete grants at the end of e2e test runs

### DIFF
--- a/app/developers/templates/developers/grant_developers.html
+++ b/app/developers/templates/developers/grant_developers.html
@@ -1,6 +1,7 @@
 {% extends "deliver_grant_funding/grant_base.html" %}
 {% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
 {% from "govuk_frontend_jinja/components/phase-banner/macro.html" import govukPhaseBanner %}
+{% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
 
 {% set page_title = "Developers - " ~ grant.name %}
 {% set active_item_identifier = "developers" %}
@@ -8,6 +9,18 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      {% if confirm_deletion_form %}
+        {% set banner_html %}
+          <p class="govuk-body govuk-!-font-weight-bold">Are you sure you want to delete this grant?</p>
+          <form method="post" novalidate>
+            {{ confirm_deletion_form.csrf_token }}
+            {{ confirm_deletion_form.confirm_deletion(params={"classes": "govuk-button--warning govuk-!-margin-bottom-0"}) }}
+          </form>
+        {% endset %}
+
+        {{ govukNotificationBanner(params={"role": "alert", "titleText": "Warning", "classes": "app-notification-banner--destructive", "html": banner_html}) }}
+      {% endif %}
+
       <h1 class="govuk-heading-l">
         <span class="govuk-caption-l">{{ grant.name }}</span>
         Developers
@@ -34,6 +47,14 @@
             }]
         })
       }}
+
+      <div class="govuk-grid-row govuk-!-margin-top-7">
+        <div class="govuk-grid-column-two-thirds">
+          <p class="govuk-body">
+            <a class="govuk-link app-link--destructive" href="{{ url_for('developers.grant_developers', grant_id=grant.id, delete='') }}">Delete this grant</a>
+          </p>
+        </div>
+      </div>
     </div>
   </div>
 {% endblock content %}

--- a/tests/e2e/developer_pages.py
+++ b/tests/e2e/developer_pages.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from playwright.sync_api import Locator, Page, expect
 
 from app.common.data.types import ManagedExpressionsEnum
 from app.common.expressions.managed import GreaterThan, LessThan, ManagedExpression
+
+if TYPE_CHECKING:
+    from tests.e2e.pages import AllGrantsPage
 
 
 class GrantDevelopersBasePage:
@@ -24,6 +27,8 @@ class GrantDevelopersBasePage:
 
 class GrantDevelopersPage(GrantDevelopersBasePage):
     manage_collections_link: Locator
+    delete_link: Locator
+    confirm_delete: Locator
 
     def __init__(self, page: Page, domain: str, grant_name: str) -> None:
         super().__init__(
@@ -31,11 +36,23 @@ class GrantDevelopersPage(GrantDevelopersBasePage):
         )
         self.manage_collections_link = self.page.get_by_role("link", name="Manage")
 
+        self.delete_link = page.get_by_role("link", name="Delete this grant")
+        self.confirm_delete = page.get_by_role("button", name="Confirm deletion")
+
     def click_manage_collections(self, grant_name: str) -> ListCollectionsPage:
         self.manage_collections_link.click()
         list_collections_page = ListCollectionsPage(self.page, self.domain, self.grant_name)
         expect(list_collections_page.heading).to_be_visible()
         return list_collections_page
+
+    def delete_grant(self) -> "AllGrantsPage":
+        from tests.e2e.pages import AllGrantsPage
+
+        self.delete_link.click()
+        self.confirm_delete.click()
+        all_grants_page = AllGrantsPage(self.page, self.domain)
+        expect(all_grants_page.title).to_be_visible()
+        return all_grants_page
 
 
 class ListCollectionsPage(GrantDevelopersBasePage):

--- a/tests/e2e/test_create_view_edit_grant.py
+++ b/tests/e2e/test_create_view_edit_grant.py
@@ -12,67 +12,75 @@ from tests.e2e.pages import AllGrantsPage
 def test_create_view_edit_grant_success(
     page: Page, domain: str, e2e_test_secrets: EndToEndTestSecrets, authenticated_browser_sso: E2ETestUser
 ):
-    all_grants_page = AllGrantsPage(page, domain)
-    all_grants_page.navigate()
+    try:
+        all_grants_page = AllGrantsPage(page, domain)
+        all_grants_page.navigate()
 
-    # Set up new grant
-    grant_intro_page = all_grants_page.click_set_up_a_grant()
-    grant_ggis_page = grant_intro_page.click_continue()
-    grant_ggis_page.select_yes()
-    ggis_ref = f"GGIS-{uuid.uuid4()}"
-    grant_ggis_page.fill_ggis_number(ggis_ref)
-    grant_name_page = grant_ggis_page.click_save_and_continue()
-    new_grant_name = f"E2E {uuid.uuid4()}"
-    grant_name_page.fill_name(new_grant_name)
-    grant_description_page = grant_name_page.click_save_and_continue()
-    new_grant_description = f"Description for {new_grant_name}"
-    grant_description_page.fill_description(new_grant_description)
-    grant_contact_page = grant_description_page.click_save_and_continue()
-    contact_name = "Test contact name"
-    contact_email = "test@contact.com"
-    grant_contact_page.fill_contact_name(contact_name)
-    grant_contact_page.fill_contact_email(contact_email)
-    grant_check_your_answers_page = grant_contact_page.click_save_and_continue()
-    grant_dashboard_page = grant_check_your_answers_page.click_add_grant()
+        # Set up new grant
+        grant_intro_page = all_grants_page.click_set_up_a_grant()
+        grant_ggis_page = grant_intro_page.click_continue()
+        grant_ggis_page.select_yes()
+        ggis_ref = f"GGIS-{uuid.uuid4()}"
+        grant_ggis_page.fill_ggis_number(ggis_ref)
+        grant_name_page = grant_ggis_page.click_save_and_continue()
+        new_grant_name = f"E2E {uuid.uuid4()}"
+        grant_name_page.fill_name(new_grant_name)
+        grant_description_page = grant_name_page.click_save_and_continue()
+        new_grant_description = f"Description for {new_grant_name}"
+        grant_description_page.fill_description(new_grant_description)
+        grant_contact_page = grant_description_page.click_save_and_continue()
+        contact_name = "Test contact name"
+        contact_email = "test@contact.com"
+        grant_contact_page.fill_contact_name(contact_name)
+        grant_contact_page.fill_contact_email(contact_email)
+        grant_check_your_answers_page = grant_contact_page.click_save_and_continue()
+        grant_dashboard_page = grant_check_your_answers_page.click_add_grant()
 
-    # On grant dashboard
-    grant_dashboard_page.check_grant_name(new_grant_name)
-    grant_details_page = grant_dashboard_page.click_settings(new_grant_name)
+        # On grant dashboard
+        grant_dashboard_page.check_grant_name(new_grant_name)
+        grant_details_page = grant_dashboard_page.click_settings(new_grant_name)
 
-    # Change grant name
-    change_grant_name_page = grant_details_page.click_change_grant_name(new_grant_name)
-    edited_grant_name = f"{new_grant_name} - edited"
-    change_grant_name_page.fill_in_grant_name(edited_grant_name)
-    grant_details_page = change_grant_name_page.click_submit(edited_grant_name)
-    expect(grant_details_page.page.get_by_text(f"Name {edited_grant_name}")).to_be_visible()
+        # Change grant name
+        change_grant_name_page = grant_details_page.click_change_grant_name(new_grant_name)
+        edited_grant_name = f"{new_grant_name} - edited"
+        change_grant_name_page.fill_in_grant_name(edited_grant_name)
+        grant_details_page = change_grant_name_page.click_submit(edited_grant_name)
+        expect(grant_details_page.page.get_by_text(f"Name {edited_grant_name}")).to_be_visible()
 
-    # Change GGIS reference
-    change_ggis_page = grant_details_page.click_change_grant_ggis(existing_ggis_ref=ggis_ref)
-    expect(change_ggis_page.ggis_textbox).to_have_value(ggis_ref)
-    new_ggis_ref = f"edit-{uuid.uuid4()}"
-    change_ggis_page.fill_ggis_number(new_ggis_ref)
-    grant_details_page = change_ggis_page.click_submit(grant_name=edited_grant_name)
-    expect(grant_details_page.page.get_by_text(new_ggis_ref)).to_be_visible()
+        # Change GGIS reference
+        change_ggis_page = grant_details_page.click_change_grant_ggis(existing_ggis_ref=ggis_ref)
+        expect(change_ggis_page.ggis_textbox).to_have_value(ggis_ref)
+        new_ggis_ref = f"edit-{uuid.uuid4()}"
+        change_ggis_page.fill_ggis_number(new_ggis_ref)
+        grant_details_page = change_ggis_page.click_submit(grant_name=edited_grant_name)
+        expect(grant_details_page.page.get_by_text(new_ggis_ref)).to_be_visible()
 
-    # Change grant description
-    change_description_page = grant_details_page.click_change_grant_description(new_grant_description)
-    new_description = f"New grant description {uuid.uuid4()}"
-    change_description_page.fill_in_grant_description(new_description)
-    grant_details_page = change_description_page.click_submit(edited_grant_name)
-    expect(grant_details_page.page.get_by_text(f"Main purpose {new_description}")).to_be_visible()
+        # Change grant description
+        change_description_page = grant_details_page.click_change_grant_description(new_grant_description)
+        new_description = f"New grant description {uuid.uuid4()}"
+        change_description_page.fill_in_grant_description(new_description)
+        grant_details_page = change_description_page.click_submit(edited_grant_name)
+        expect(grant_details_page.page.get_by_text(f"Main purpose {new_description}")).to_be_visible()
 
-    # Change main contact
-    change_contact_page = grant_details_page.click_change_grant_contact_details(
-        existing_contact_name=contact_name, existing_contact_email=contact_email
-    )
-    new_contact_name = f"New contact {uuid.uuid4()}"
-    change_contact_page.fill_contact_name(new_contact_name)
-    new_contact_email = f"contact-{uuid.uuid4()}@example.com"
-    change_contact_page.fill_contact_email(new_contact_email)
-    grant_details_page = change_contact_page.click_submit(edited_grant_name)
-    expect(grant_details_page.page.get_by_text(f"Main contact {new_contact_name}{new_contact_email}")).to_be_visible()
+        # Change main contact
+        change_contact_page = grant_details_page.click_change_grant_contact_details(
+            existing_contact_name=contact_name, existing_contact_email=contact_email
+        )
+        new_contact_name = f"New contact {uuid.uuid4()}"
+        change_contact_page.fill_contact_name(new_contact_name)
+        new_contact_email = f"contact-{uuid.uuid4()}@example.com"
+        change_contact_page.fill_contact_email(new_contact_email)
+        grant_details_page = change_contact_page.click_submit(edited_grant_name)
+        expect(
+            grant_details_page.page.get_by_text(f"Main contact {new_contact_name}{new_contact_email}")
+        ).to_be_visible()
 
-    # Go back to Grants list and check new name appears/old name doesn't appear
-    all_grants_page = grant_details_page.click_grants()
-    all_grants_page.check_grant_exists(edited_grant_name)
-    all_grants_page.check_grant_doesnt_exist(new_grant_name)
+        # Go back to Grants list and check new name appears/old name doesn't appear
+        all_grants_page = grant_details_page.click_grants()
+        all_grants_page.check_grant_exists(edited_grant_name)
+        all_grants_page.check_grant_doesnt_exist(new_grant_name)
+    finally:
+        # Tidy up by deleting the grant, which will cascade to all related entities
+        grant_dashboard_page = all_grants_page.click_grant(edited_grant_name)
+        developers_page = grant_dashboard_page.click_developers(edited_grant_name)
+        developers_page.delete_grant()

--- a/tests/e2e/test_developer_journey.py
+++ b/tests/e2e/test_developer_journey.py
@@ -86,135 +86,143 @@ def navigate_to_collection_detail_page(
 def test_create_and_preview_collection(
     page: Page, domain: str, e2e_test_secrets: EndToEndTestSecrets, authenticated_browser_sso: E2ETestUser
 ):
-    new_grant_name = f"E2E developer_grant {uuid.uuid4()}"
-    all_grants_page = AllGrantsPage(page, domain)
-    all_grants_page.navigate()
+    try:
+        new_grant_name = f"E2E developer_grant {uuid.uuid4()}"
+        all_grants_page = AllGrantsPage(page, domain)
+        all_grants_page.navigate()
 
-    # Set up new grant
-    grant_intro_page = all_grants_page.click_set_up_a_grant()
-    grant_ggis_page = grant_intro_page.click_continue()
-    grant_ggis_page.select_yes()
-    grant_ggis_page.fill_ggis_number()
-    grant_name_page = grant_ggis_page.click_save_and_continue()
-    grant_name_page.fill_name(new_grant_name)
-    grant_description_page = grant_name_page.click_save_and_continue()
-    grant_description_page.fill_description()
-    grant_contact_page = grant_description_page.click_save_and_continue()
-    grant_contact_page.fill_contact_name()
-    grant_contact_page.fill_contact_email()
-    grant_check_your_answers_page = grant_contact_page.click_save_and_continue()
-    grant_dashboard_page = grant_check_your_answers_page.click_add_grant()
+        # Set up new grant
+        grant_intro_page = all_grants_page.click_set_up_a_grant()
+        grant_ggis_page = grant_intro_page.click_continue()
+        grant_ggis_page.select_yes()
+        grant_ggis_page.fill_ggis_number()
+        grant_name_page = grant_ggis_page.click_save_and_continue()
+        grant_name_page.fill_name(new_grant_name)
+        grant_description_page = grant_name_page.click_save_and_continue()
+        grant_description_page.fill_description()
+        grant_contact_page = grant_description_page.click_save_and_continue()
+        grant_contact_page.fill_contact_name()
+        grant_contact_page.fill_contact_email()
+        grant_check_your_answers_page = grant_contact_page.click_save_and_continue()
+        grant_dashboard_page = grant_check_your_answers_page.click_add_grant()
 
-    # Go to developers tab
-    developers_page = grant_dashboard_page.click_developers(new_grant_name)
-    manage_collections_page = developers_page.click_manage_collections(grant_name=new_grant_name)
+        # Go to developers tab
+        developers_page = grant_dashboard_page.click_developers(new_grant_name)
+        manage_collections_page = developers_page.click_manage_collections(grant_name=new_grant_name)
 
-    # Add a new collection
-    add_collection_page = manage_collections_page.click_add_collection()
-    new_collection_name = f"E2E collection {uuid.uuid4()}"
-    add_collection_page.fill_in_collection_name(new_collection_name)
-    manage_collections_page = add_collection_page.click_submit(new_grant_name)
-    manage_collections_page.check_collection_exists(new_collection_name)
+        # Add a new collection
+        add_collection_page = manage_collections_page.click_add_collection()
+        new_collection_name = f"E2E collection {uuid.uuid4()}"
+        add_collection_page.fill_in_collection_name(new_collection_name)
+        manage_collections_page = add_collection_page.click_submit(new_grant_name)
+        manage_collections_page.check_collection_exists(new_collection_name)
 
-    # Add a new section
-    collection_detail_page = manage_collections_page.click_on_collection(
-        collection_name=new_collection_name, grant_name=new_grant_name
-    )
-    add_section_page = collection_detail_page.click_add_section()
-    new_section_name = f"E2E section {uuid.uuid4()}"
-    add_section_page.fill_in_section_title(new_section_name)
-    sections_list_page = add_section_page.click_submit(collection_name=new_collection_name)
-    sections_list_page.check_section_exists(new_section_name)
+        # Add a new section
+        collection_detail_page = manage_collections_page.click_on_collection(
+            collection_name=new_collection_name, grant_name=new_grant_name
+        )
+        add_section_page = collection_detail_page.click_add_section()
+        new_section_name = f"E2E section {uuid.uuid4()}"
+        add_section_page.fill_in_section_title(new_section_name)
+        sections_list_page = add_section_page.click_submit(collection_name=new_collection_name)
+        sections_list_page.check_section_exists(new_section_name)
 
-    # Add a new form
-    section_detail_page = sections_list_page.click_manage_section(new_section_name)
-    form_type_page = section_detail_page.click_add_form()
-    form_type_page.click_add_empty_form()
-    form_details_page = form_type_page.click_continue()
-    form_name = f"E2E form {uuid.uuid4()}"
-    form_details_page.fill_in_form_name(form_name)
-    section_detail_page = form_details_page.click_add_form()
-    section_detail_page.check_form_exists(form_name)
+        # Add a new form
+        section_detail_page = sections_list_page.click_manage_section(new_section_name)
+        form_type_page = section_detail_page.click_add_form()
+        form_type_page.click_add_empty_form()
+        form_details_page = form_type_page.click_continue()
+        form_name = f"E2E form {uuid.uuid4()}"
+        form_details_page.fill_in_form_name(form_name)
+        section_detail_page = form_details_page.click_add_form()
+        section_detail_page.check_form_exists(form_name)
 
-    # Add a question of each type
-    manage_form_page = section_detail_page.click_manage_form(form_name)
-    create_question(QuestionDataType.TEXT_SINGLE_LINE, manage_form_page)
-    create_question(QuestionDataType.TEXT_MULTI_LINE, manage_form_page)
-    create_question(QuestionDataType.INTEGER, manage_form_page)
+        # Add a question of each type
+        manage_form_page = section_detail_page.click_manage_form(form_name)
+        create_question(QuestionDataType.TEXT_SINGLE_LINE, manage_form_page)
+        create_question(QuestionDataType.TEXT_MULTI_LINE, manage_form_page)
+        create_question(QuestionDataType.INTEGER, manage_form_page)
 
-    add_validation(
-        manage_form_page,
-        question_text_by_type[QuestionDataType.INTEGER],
-        GreaterThan(question_id=uuid.uuid4(), minimum_value=1, inclusive=False),  # question_id does not matter here
-    )
-
-    add_validation(
-        manage_form_page,
-        question_text_by_type[QuestionDataType.INTEGER],
-        LessThan(question_id=uuid.uuid4(), maximum_value=100, inclusive=True),  # question_id does not matter here
-    )
-
-    # Preview the form
-    collection_detail_page = navigate_to_collection_detail_page(page, domain, new_grant_name, new_collection_name)
-    tasklist_page = collection_detail_page.click_preview_collection()
-
-    # Check the tasklist has loaded
-    expect(tasklist_page.page.get_by_role("heading", name=new_section_name)).to_be_visible()
-    expect(
-        tasklist_page.collection_status_box.filter(has=tasklist_page.page.get_by_text("Not started"))
-    ).to_be_visible()
-    expect(tasklist_page.submit_button).to_be_disabled()
-    expect(tasklist_page.page.get_by_role("link", name=form_name)).to_be_visible()
-
-    # Complete the first form
-    tasklist_page.click_on_form(form_name=form_name)
-    for question in created_questions_to_test:
-        question_page = QuestionPage(page, domain, new_grant_name, question["question_text"])
-        expect(question_page.heading).to_be_visible()
-
-        for question_response in question["question_responses"]:
-            question_page.respond_to_question(answer=question_response.answer)
-            question_page.click_continue()
-
-            if question_response.error_message:
-                expect(question_page.page.get_by_role("link", name=question_response.error_message)).to_be_visible()
-
-    # Check the answers page
-    check_your_answers = CheckYourAnswersPage(page, domain, new_grant_name)
-
-    for question in created_questions_to_test:
-        question_heading = check_your_answers.page.get_by_text(question["question_text"], exact=True)
-        expect(question_heading).to_be_visible()
-        expect(check_your_answers.page.get_by_test_id(f"answer-{question['question_text']}")).to_have_text(
-            question["question_responses"][-1].answer
+        add_validation(
+            manage_form_page,
+            question_text_by_type[QuestionDataType.INTEGER],
+            GreaterThan(question_id=uuid.uuid4(), minimum_value=1, inclusive=False),  # question_id does not matter here
         )
 
-    expect(check_your_answers.page.get_by_text("Have you completed this section?", exact=True)).to_be_visible()
+        add_validation(
+            manage_form_page,
+            question_text_by_type[QuestionDataType.INTEGER],
+            LessThan(question_id=uuid.uuid4(), maximum_value=100, inclusive=True),  # question_id does not matter here
+        )
 
-    check_your_answers.click_mark_as_complete_yes()
-    tasklist_page = check_your_answers.click_save_and_continue(collection_name=new_collection_name)
+        # Preview the form
+        collection_detail_page = navigate_to_collection_detail_page(page, domain, new_grant_name, new_collection_name)
+        tasklist_page = collection_detail_page.click_preview_collection()
 
-    # Submit the collection
-    expect(
-        tasklist_page.collection_status_box.filter(has=tasklist_page.page.get_by_text("In progress"))
-    ).to_be_visible()
-    expect(tasklist_page.submit_button).to_be_enabled()
-
-    confirmation_page = tasklist_page.click_submit()
-    collection_reference = confirmation_page.collection_reference.inner_text()
-
-    # Go back to schema detail page
-    collection_detail_page = navigate_to_collection_detail_page(page, domain, new_grant_name, new_collection_name)
-
-    # View the collection
-    expect(collection_detail_page.summary_row_submissions.get_by_text("1 test submission")).to_be_visible()
-    collections_list_page = collection_detail_page.click_view_submissions()
-
-    view_collection_page = collections_list_page.click_on_submission(collection_reference=collection_reference)
-
-    answers_list = view_collection_page.get_questions_list_for_form(form_name)
-    expect(answers_list).to_be_visible()
-    for question in created_questions_to_test:
+        # Check the tasklist has loaded
+        expect(tasklist_page.page.get_by_role("heading", name=new_section_name)).to_be_visible()
         expect(
-            answers_list.get_by_text(f"{question['question_text']} {question['question_responses'][-1].answer}")
+            tasklist_page.collection_status_box.filter(has=tasklist_page.page.get_by_text("Not started"))
         ).to_be_visible()
+        expect(tasklist_page.submit_button).to_be_disabled()
+        expect(tasklist_page.page.get_by_role("link", name=form_name)).to_be_visible()
+
+        # Complete the first form
+        tasklist_page.click_on_form(form_name=form_name)
+        for question in created_questions_to_test:
+            question_page = QuestionPage(page, domain, new_grant_name, question["question_text"])
+            expect(question_page.heading).to_be_visible()
+
+            for question_response in question["question_responses"]:
+                question_page.respond_to_question(answer=question_response.answer)
+                question_page.click_continue()
+
+                if question_response.error_message:
+                    expect(question_page.page.get_by_role("link", name=question_response.error_message)).to_be_visible()
+
+        # Check the answers page
+        check_your_answers = CheckYourAnswersPage(page, domain, new_grant_name)
+
+        for question in created_questions_to_test:
+            question_heading = check_your_answers.page.get_by_text(question["question_text"], exact=True)
+            expect(question_heading).to_be_visible()
+            expect(check_your_answers.page.get_by_test_id(f"answer-{question['question_text']}")).to_have_text(
+                question["question_responses"][-1].answer
+            )
+
+        expect(check_your_answers.page.get_by_text("Have you completed this section?", exact=True)).to_be_visible()
+
+        check_your_answers.click_mark_as_complete_yes()
+        tasklist_page = check_your_answers.click_save_and_continue(collection_name=new_collection_name)
+
+        # Submit the collection
+        expect(
+            tasklist_page.collection_status_box.filter(has=tasklist_page.page.get_by_text("In progress"))
+        ).to_be_visible()
+        expect(tasklist_page.submit_button).to_be_enabled()
+
+        confirmation_page = tasklist_page.click_submit()
+        collection_reference = confirmation_page.collection_reference.inner_text()
+
+        # Go back to schema detail page
+        collection_detail_page = navigate_to_collection_detail_page(page, domain, new_grant_name, new_collection_name)
+
+        # View the collection
+        expect(collection_detail_page.summary_row_submissions.get_by_text("1 test submission")).to_be_visible()
+        collections_list_page = collection_detail_page.click_view_submissions()
+
+        view_collection_page = collections_list_page.click_on_submission(collection_reference=collection_reference)
+
+        answers_list = view_collection_page.get_questions_list_for_form(form_name)
+        expect(answers_list).to_be_visible()
+        for question in created_questions_to_test:
+            expect(
+                answers_list.get_by_text(f"{question['question_text']} {question['question_responses'][-1].answer}")
+            ).to_be_visible()
+
+    finally:
+        # Tidy up by deleting the grant, which will cascade to all related entities
+        all_grants_page.navigate()
+        grant_dashboard_page = all_grants_page.click_grant(new_grant_name)
+        developers_page = grant_dashboard_page.click_developers(new_grant_name)
+        developers_page.delete_grant()


### PR DESCRIPTION
Note: best reviewed with whitespace changes ignored

We want our dev/test environments (especially test) to look+feel fairly legitimate, without a bunch of UUID-ified grants that slowly pile up from our e2e tests.

This patch adds a 'Delete this grant' link following the existing 'delete thing' patterns, and updates the e2e tests which create grants, to delete them at the end as well.

A rudimentary attempt is made to still tidy up if the e2e test fails part way through. There's a small argument for leaving it around in case you want to poke at the grant/collection/etc to see what went wrong, but I think this is more likely to be annoying that actually useful for debugging. The e2e test artifacts (eg screenshots) should be more helpful.