### PR TITLE
Sync removed roles from enum

### DIFF
--- a/app/common/data/interfaces/exceptions.py
+++ b/app/common/data/interfaces/exceptions.py
@@ -43,8 +43,6 @@ class InvalidUserRoleError(Exception):
 
     constraint_message_map: dict[str, str] = {
         "ck_user_role_member_role_not_platform": "A 'member' role must be linked to an organisation or grant.",
-        "ck_user_role_s151_officer_role_org_only": "A 's151_officer' role can only be linked to an organisation.",
-        "ck_user_role_assessor_role_grant_only": "An 'assessor' role can only be linked to a grant.",
     }
 
     def __init__(self, integrity_error: IntegrityError) -> None:

--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-010_expression_managed_name
+011_sync_role_enum

--- a/app/common/data/migrations/env.py
+++ b/app/common/data/migrations/env.py
@@ -3,6 +3,7 @@ from logging.config import fileConfig
 from pathlib import Path
 from typing import Iterable, cast
 
+import alembic_postgresql_enum  # noqa
 from alembic import context
 from alembic.operations import MigrationScript
 from alembic.runtime.migration import MigrationContext

--- a/app/common/data/migrations/versions/011_sync_role_enum.py
+++ b/app/common/data/migrations/versions/011_sync_role_enum.py
@@ -1,0 +1,62 @@
+"""sync role enum for changed values
+
+Revision ID: 011_sync_role_enum
+Revises: 010_expression_managed_name
+Create Date: 2025-06-28 12:44:36.920129
+
+"""
+
+from alembic import op
+from alembic_postgresql_enum import TableReference
+from sqlalchemy import text
+
+revision = "011_sync_role_enum"
+down_revision = "010_expression_managed_name"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(text("DELETE FROM user_role WHERE role IN ('EDITOR', 'ASSESSOR', 'S151_OFFICER')"))
+
+    # WARNING: this also deletes the check constraints touching the enum, so we need to regenerate the ones we want
+    #           to keep afterwards.
+    op.sync_enum_values(
+        enum_schema="public",
+        enum_name="role_enum",
+        new_values=["ADMIN", "MEMBER"],
+        affected_columns=[TableReference(table_schema="public", table_name="user_role", column_name="role")],
+        enum_values_to_rename=[],
+    )
+
+    op.create_check_constraint(
+        "member_role_not_platform",
+        "user_role",
+        "role != 'MEMBER' OR NOT (organisation_id IS NULL AND grant_id IS NULL)",
+    )
+
+
+def downgrade() -> None:
+    op.sync_enum_values(
+        enum_schema="public",
+        enum_name="role_enum",
+        new_values=["ADMIN", "MEMBER", "EDITOR", "ASSESSOR", "S151_OFFICER"],
+        affected_columns=[TableReference(table_schema="public", table_name="user_role", column_name="role")],
+        enum_values_to_rename=[],
+    )
+
+    op.create_check_constraint(
+        "assessor_role_grant_only",
+        "user_role",
+        "role != 'ASSESSOR' OR (organisation_id IS NULL AND grant_id IS NOT NULL)",
+    )
+    op.create_check_constraint(
+        "member_role_not_platform",
+        "user_role",
+        "role != 'MEMBER' OR NOT (organisation_id IS NULL AND grant_id IS NULL)",
+    )
+    op.create_check_constraint(
+        "s151_officer_role_org_only",
+        "user_role",
+        "role != 'S151_OFFICER' OR (organisation_id IS NOT NULL AND grant_id IS NULL)",
+    )

--- a/app/common/data/models_user.py
+++ b/app/common/data/models_user.py
@@ -81,12 +81,4 @@ class UserRole(BaseModel):
             "role != 'MEMBER' OR NOT (organisation_id IS NULL AND grant_id IS NULL)",
             name="member_role_not_platform",
         ),
-        CheckConstraint(
-            "role != 'S151_OFFICER' OR (organisation_id IS NOT NULL AND grant_id IS NULL)",
-            name="s151_officer_role_org_only",
-        ),
-        CheckConstraint(
-            "role != 'ASSESSOR' OR (organisation_id IS NULL AND grant_id IS NOT NULL)",
-            name="assessor_role_grant_only",
-        ),
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dev = [
     "types-boto3==1.38.42",
     "freezegun==1.5.2",
     "import-linter==2.3",
+    "alembic-postgresql-enum>=1.7.0",
 ]
 
 [tool.uv]

--- a/uv.lock
+++ b/uv.lock
@@ -17,6 +17,19 @@ wheels = [
 ]
 
 [[package]]
+name = "alembic-postgresql-enum"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "alembic" },
+    { name = "sqlalchemy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/45/d3a66a8c7604baba5b498727539539120897fd8f931a6c89aa68ff0d7cb3/alembic_postgresql_enum-1.7.0.tar.gz", hash = "sha256:1a12a2b25f3f49440f419821888530496511573875438b6e9a08cbcb8a6f006f", size = 15637, upload-time = "2025-02-20T08:22:36.285Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/9a/05d3f24be838af98f52e2a961f1f78f8575091198542a2add5cff7d62ef8/alembic_postgresql_enum-1.7.0-py3-none-any.whl", hash = "sha256:2a64260f3f1ed96f1bf984f55cb838e5d915693b8478b7b6ffea13cc09184ae0", size = 23516, upload-time = "2025-02-20T08:22:34.239Z" },
+]
+
+[[package]]
 name = "alembic-utils"
 version = "0.8.8"
 source = { registry = "https://pypi.org/simple" }
@@ -534,6 +547,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "alembic-postgresql-enum" },
     { name = "beautifulsoup4" },
     { name = "boto3" },
     { name = "debugpy" },
@@ -593,6 +607,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "alembic-postgresql-enum", specifier = ">=1.7.0" },
     { name = "beautifulsoup4", specifier = "==4.13.4" },
     { name = "boto3", specifier = "==1.38.42" },
     { name = "debugpy", specifier = "==1.8.14" },


### PR DESCRIPTION
In https://github.com/communitiesuk/funding-service/pull/330 we removed a few roles from the role enum, but didn't generate a migration for them.

This generates that migration using the `alembic_postgresql_enum` extension, which plugs enum values into alembic for automatic sync detection. This should make it harder to miss in the future.

When dropping values, we need to first delete (or appropriately handle) any rows that use the old enum values.