### PR TITLE
Fix SQLAlchemy query listing for Flask-DebugToolbar

### DIFF
--- a/app/extensions/record_sqlalchemy_queries.py
+++ b/app/extensions/record_sqlalchemy_queries.py
@@ -34,6 +34,9 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
+# TODO: Remove this module if/when https://github.com/pallets-eco/flask-sqlalchemy-lite/pull/21 is merged and
+#       a matching update has been made to Flask-DebugToolbar to use that functiomnality natively.
+
 import dataclasses
 import inspect
 import typing as t
@@ -86,8 +89,8 @@ class RecordSqlalchemyQueriesExtension:
         if not has_app_context():
             return
 
-        if "_recorded_sqlalchemy_queries" not in g:
-            g._recorded_sqlalchemy_queries = []
+        if "_sqlalchemy_queries" not in g:
+            g._sqlalchemy_queries = []
 
         import_top = current_app.import_name.partition(".")[0]
         import_dot = f"{import_top}."
@@ -110,7 +113,7 @@ class RecordSqlalchemyQueriesExtension:
         if "SAVEPOINT" in statement:
             return
 
-        g._recorded_sqlalchemy_queries.append(
+        g._sqlalchemy_queries.append(
             QueryInfo(
                 statement=context.statement,
                 parameters=context.parameters,
@@ -122,4 +125,4 @@ class RecordSqlalchemyQueriesExtension:
 
 
 def get_recorded_queries() -> list[QueryInfo]:
-    return t.cast(list[QueryInfo], g.get("_recorded_sqlalchemy_queries", []))
+    return t.cast(list[QueryInfo], g.get("_sqlalchemy_queries", []))


### PR DESCRIPTION
This patch updates our copy of `record_queries` to store queries on the Flask global object in the same place as Flask-SQLAlchemy (https://github.com/pallets-eco/flask-sqlalchemy/blob/main/src/flask_sqlalchemy/record_queries.py#L90-L91). This implementation takes advantage of ("abuses") a few things in order to make the integration with Flask-DebugToolbar:

- Flask-DebugToolbar (FDT) only supports Flask-SQLAlchemy (FS) for now in theory, not explicitly Flask-SQLAlchemy-Lite (FSL).
- But we have FS installed as a dependency for our app, because Flask-Migrate requires it.
- FDT thinks that FS is installed as an extension because FSL uses the same extension namespace (`app.extensions['sqlalchemy']`).
- So if we configure query recording on, FDT will use FS's `get_recorded_queries` function to lookup executed queries.
- If our copy of the extension writes queries to the same namespace as FS then FDT will read and show our recorded queries.

This is all a little bit fragile and magical, but should work for now (and for a while) because FS and FDT haven't changed much about how this works in a while. Hopefully official support for these query recording can get into FSQLA and FDT though.

## Show it
![2025-06-30 06 56 30](https://github.com/user-attachments/assets/a63a540e-b9b0-42ee-838f-3a5f4c15435c)