### PR TITLE
Bypass extension for query context

### DIFF
--- a/app/extensions/record_sqlalchemy_queries.py
+++ b/app/extensions/record_sqlalchemy_queries.py
@@ -99,7 +99,7 @@ class RecordSqlalchemyQueriesExtension:
         while frame:
             name = frame.f_globals.get("__name__")
 
-            if name and (name == import_top or name.startswith(import_dot)):
+            if name and (name == import_top or name.startswith(import_dot)) and "record_sqlalchemy_queries" not in name:
                 code = frame.f_code
                 location = f"{code.co_filename}:{frame.f_lineno} ({code.co_name})"
                 break


### PR DESCRIPTION
All query contexts were showing as coming from the `record_sqlalchemy_queries` file, which isn't actually useful.

## Before
<img width="534" alt="image" src="https://github.com/user-attachments/assets/4fb9738a-a8cb-4aa8-b015-0bbbaffeac34" />

## After
<img width="669" alt="image" src="https://github.com/user-attachments/assets/e194cf53-68d3-4b66-b3cc-74ba4e5414dc" />
