### PR TITLE
`0` is a valid answer for some questions

### DIFF
--- a/app/common/expressions/forms.py
+++ b/app/common/expressions/forms.py
@@ -93,22 +93,22 @@ class AddIntegerExpressionForm(_BaseExpressionForm):
 
         match self.type.data:
             case ManagedExpressionsEnum.GREATER_THAN.value:
-                assert self.greater_than_value.data
+                assert self.greater_than_value.data is not None
                 return GreaterThan(
                     question_id=question.id,
                     minimum_value=self.greater_than_value.data,
                     inclusive=self.greater_than_inclusive.data,
                 )
             case ManagedExpressionsEnum.LESS_THAN.value:
-                assert self.less_than_value.data
+                assert self.less_than_value.data is not None
                 return LessThan(
                     question_id=question.id,
                     maximum_value=self.less_than_value.data,
                     inclusive=self.less_than_inclusive.data,
                 )
             case ManagedExpressionsEnum.BETWEEN.value:
-                assert self.bottom_of_range.data
-                assert self.top_of_range.data
+                assert self.bottom_of_range.data is not None
+                assert self.top_of_range.data is not None
                 return Between(
                     question_id=question.id,
                     minimum_value=self.bottom_of_range.data,


### PR DESCRIPTION
We're asserting on the user having submitted an answer, but 0 is a valid answer - it's falsey. So let's be explicit about checking vs none.

This was caught during a standup demo when trying to add a 'between 0 and 100' validation, the 0 was treated as 'no answer submitted' and threw a 500.