### PR TITLE
FSPT-598: bootstrap access grant funding

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -131,6 +131,7 @@ def create_app() -> Flask:
     app.jinja_loader = ChoiceLoader(
         [
             PackageLoader("app.common"),
+            PackageLoader("app.access_grant_funding"),
             PackageLoader("app.deliver_grant_funding"),
             PackageLoader("app.developers"),
             PrefixLoader({"govuk_frontend_jinja": PackageLoader("govuk_frontend_jinja")}),
@@ -185,12 +186,14 @@ def create_app() -> Flask:
     # Attach routes
     _register_custom_converters(app)
 
+    from app.access_grant_funding.routes import access_grant_funding_blueprint
     from app.common.auth import auth_blueprint
     from app.deliver_grant_funding.routes import deliver_grant_funding_blueprint
     from app.developers import developers_blueprint
     from app.healthcheck import healthcheck_blueprint
 
     app.register_blueprint(healthcheck_blueprint)
+    app.register_blueprint(access_grant_funding_blueprint)
     app.register_blueprint(deliver_grant_funding_blueprint)
     app.register_blueprint(developers_blueprint)
     app.register_blueprint(auth_blueprint)

--- a/app/access_grant_funding/routes.py
+++ b/app/access_grant_funding/routes.py
@@ -1,0 +1,3 @@
+from flask import Blueprint
+
+access_grant_funding_blueprint = Blueprint(name="access_grant_funding", import_name=__name__, url_prefix="/access")

--- a/app/access_grant_funding/templates/access_grant_funding/base.html
+++ b/app/access_grant_funding/templates/access_grant_funding/base.html
@@ -1,0 +1,21 @@
+{% extends "common/base.html" %}
+{% from "common/partials/mhclg-header.html" import mhclgHeader %}
+{% from "common/partials/navigation.html" import accessGrantFundingServiceNavigation %}
+
+{% set nav_items = nav_items or [] %}
+{% set right_nav_items = right_nav_items or [] %}
+
+{% block pageTitle %}{{ page_title }} - {{ super() }}{% endblock pageTitle %}
+
+{% block header %}
+  {{
+    mhclgHeader(
+      params={
+        "homepageUrl": "#",
+        "assetPath": assetPath
+      },
+      currentUser=current_user,
+    )
+  }}
+  {{ accessGrantFundingServiceNavigation(nav_items, right_nav_items) }}
+{% endblock header %}

--- a/app/common/templates/common/base.html
+++ b/app/common/templates/common/base.html
@@ -17,6 +17,7 @@
 {% endblock head %}
 
 {% block header %}
+  {# todo: have this header read a homepageUrl variable, then any subclasses can just use super() calls #}
   {{
     mhclgHeader(
       params={

--- a/app/common/templates/common/partials/navigation.html
+++ b/app/common/templates/common/partials/navigation.html
@@ -1,5 +1,16 @@
 {% from "govuk_frontend_jinja/components/service-navigation/macro.html" import govukServiceNavigation %}
 
+{% macro accessGrantFundingServiceNavigation(nav_items=[], right_nav_items=[]) %}
+  {{
+    govukServiceNavigation({
+    "serviceName": "Access grant funding",
+    "serviceUrl": "#",
+    "navigation": nav_items + right_nav_items,
+    "navigationClasses": "app-service-navigation__wrapper--sectional" if right_nav_items else "",
+    })
+  }}
+{% endmacro %}
+
 {% macro deliverGrantFundingServiceNavigation(nav_items=[], right_nav_items=[]) %}
   {{
     govukServiceNavigation({

--- a/app/developers/__init__.py
+++ b/app/developers/__init__.py
@@ -12,6 +12,7 @@ def inject_variables() -> dict[str, Any]:
     return dict(show_watermark=True)
 
 
-from app.developers import commands, deliver_routes  # noqa: E402, F401
+from app.developers import access_routes, commands, deliver_routes  # noqa: E402, F401
 
 developers_blueprint.register_blueprint(deliver_routes.developers_deliver_blueprint)
+developers_blueprint.register_blueprint(access_routes.developers_access_blueprint)

--- a/app/developers/access_routes.py
+++ b/app/developers/access_routes.py
@@ -1,0 +1,14 @@
+from flask import Blueprint, render_template
+from flask.typing import ResponseReturnValue
+
+from app.common.auth.decorators import is_platform_admin
+from app.common.data import interfaces
+
+developers_access_blueprint = Blueprint("access", __name__, url_prefix="/access")
+
+
+@developers_access_blueprint.get("/grants")
+@is_platform_admin
+def grants_list() -> ResponseReturnValue:
+    grants = interfaces.grants.get_all_grants_by_user(interfaces.user.get_current_user())
+    return render_template("developers/access/index.html", grants=grants)

--- a/app/developers/templates/developers/access/base.html
+++ b/app/developers/templates/developers/access/base.html
@@ -1,0 +1,48 @@
+{% extends "common/base.html" %}
+{% from "common/partials/mhclg-header.html" import mhclgHeader %}
+{% from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary %}
+{% from "common/partials/navigation.html" import accessGrantFundingServiceNavigation %}
+
+{% set nav_items = nav_items or [] %}
+{% set right_nav_items = right_nav_items or [] %}
+
+{% block pageTitle %}{{ page_title }} - {{ super() }}{% endblock pageTitle %}
+
+{% block header %}
+  {{
+    mhclgHeader(
+      params={
+        "homepageUrl": "#",
+        "assetPath": assetPath
+      },
+      currentUser=current_user,
+    )
+  }}
+  {{ accessGrantFundingServiceNavigation(nav_items, right_nav_items) }}
+{% endblock header %}
+
+{% block main %}
+  <div {% if show_watermark %}class="app-watermark-container"{% endif %}>
+    <div class="govuk-width-container {% if containerClasses %}{{ containerClasses }}{% endif %}">
+      {% block beforeContent %}{% endblock %}
+      <div class="govuk-main-wrapper {% if mainClasses %}{{ mainClasses }}{% endif %}">
+        {% block mainWrapper %}
+          <main id="main-content" {% if mainLang %}lang="{{ mainLang }}"{% endif %}>
+            {% block errorSummary %}
+              <div class="govuk-grid-row">
+                <div class="govuk-grid-column-two-thirds">
+                  {% if form is defined and form.errors %}
+                    {{ govukErrorSummary(wtforms_errors(form)) }}
+                  {% endif %}
+                </div>
+              </div>
+            {% endblock errorSummary %}
+
+            {% block content %}
+            {% endblock content %}
+          </main>
+        {% endblock mainWrapper %}
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/app/developers/templates/developers/access/index.html
+++ b/app/developers/templates/developers/access/index.html
@@ -1,0 +1,26 @@
+{% extends "developers/access/base.html" %}
+
+{% set page_title = "Grants" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">Grants</h1>
+      {% if grants %}
+        <ul class="govuk-list">
+          {% for grant in grants %}
+            <li>
+              <h2 class="govuk-heading-m">
+                <a class="govuk-link govuk-link--no-visited-state" href="#">{{ grant.name }}</a>
+              </h2>
+              <p class="govuk-body">{{ grant.description }}</p>
+              <hr class="govuk-section-break--m" />
+            </li>
+          {% endfor %}
+        </ul>
+      {% else %}
+        <p class="govuk-body">No grants available at the moment.</p>
+      {% endif %}
+    </div>
+  </div>
+{% endblock content %}

--- a/app/developers/templates/developers/deliver/access_grant_funding_base.html
+++ b/app/developers/templates/developers/deliver/access_grant_funding_base.html
@@ -7,6 +7,8 @@
 
 {% block pageTitle %}{{ page_title }} - {{ super() }}{% endblock pageTitle %}
 
+{# todo: kill me and move things appropriately to developers/access/base.html, or make them work with developers/deliver/base.html appropriately #}
+
 {#
 common/base.html embeds "Deliver grant funding" in the service navigation. That doesn't feel right here, so this just removes it.
 

--- a/tests/unit/test_all_routes_access.py
+++ b/tests/unit/test_all_routes_access.py
@@ -20,6 +20,7 @@ all_auth_annotations = [
     "@is_platform_admin",
 ]
 routes_with_expected_platform_admin_only_access = [
+    "developers.access.grants_list",
     "developers.deliver.grant_developers",
     "developers.deliver.grant_developers_collections",
     "developers.deliver.setup_collection",


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-598

## 📝 Description
This bootstraps the main 'access grant funding' part of the codebase with a blueprint and a base template (based off 'deliver grant funding').

It also sets up another section of the developers area that is scoped for access grant funding, and adds a basic 'list all grants' view for platform admins.

## 📸 Show the thing (screenshots, gifs)
<img width="1022" alt="image" src="https://github.com/user-attachments/assets/873d2fe7-0e30-4f0d-a37f-89e5c8bcbd47" />

## 🧪 Testing
I've run the tests (inc e2e), and manually stepped through a few existing deliver + developer_deliver pages; all looks the same.

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
~- [ ] New (non-developer) functionality has appropriate unit and integration tests~
~- [ ] End-to-end tests have been updated (if applicable)~
~- [ ] Edge cases and error conditions are tested~
