### PR TITLE
FIX Get supported question types for managed expressions

### DIFF
--- a/app/common/expressions/registry.py
+++ b/app/common/expressions/registry.py
@@ -21,7 +21,7 @@ _registry_by_data_type: dict[QuestionDataType, list[type["ManagedExpression"]]] 
 
 def get_registered_data_types() -> set[QuestionDataType]:
     """Returns the set of question data types that have at least one managed expression supporting them."""
-    return set(_registry_by_data_type.keys())
+    return set(k for k, v in _registry_by_data_type.items() if v)
 
 
 def get_managed_expressions_for_question_type(question_type: QuestionDataType) -> list[type["ManagedExpression"]]:
@@ -47,4 +47,4 @@ def register_managed_expression(cls: type["ManagedExpression"]) -> type["Managed
 
 def get_supported_form_questions(question: "Question") -> list["Question"]:
     questions = question.form.questions
-    return [q for q in questions if q.data_type in _registry_by_data_type and q.id != question.id]
+    return [q for q in questions if q.data_type in get_registered_data_types() and q.id != question.id]

--- a/tests/integration/common/expressions/test_registry.py
+++ b/tests/integration/common/expressions/test_registry.py
@@ -1,14 +1,24 @@
 from app.common.data.types import QuestionDataType
-from app.common.expressions.registry import get_supported_form_questions
+from app.common.expressions.registry import (
+    get_managed_expressions_for_question_type,
+    get_registered_data_types,
+    get_supported_form_questions,
+)
 
 
 class TestManagedExpressions:
+    def test_get_registered_data_types(self, factories):
+        unsupported_question_type = QuestionDataType.TEXT_SINGLE_LINE
+
+        # because we're using a defaultdict we should make sure reading empty values can't change the logic
+        assert get_managed_expressions_for_question_type(unsupported_question_type) == []
+        assert unsupported_question_type not in get_registered_data_types()
+
     def test_get_supported_form_questions_filters_question_types(self, factories):
         form = factories.form.build()
         factories.question.build_batch(3, data_type=QuestionDataType.TEXT_SINGLE_LINE, form=form)
         only_supported_target = factories.question.build(data_type=QuestionDataType.INTEGER, form=form)
         question = factories.question.build(data_type=QuestionDataType.INTEGER, form=form)
-
         supported_questions = get_supported_form_questions(question)
         assert len(supported_questions) == 1
         assert supported_questions[0].id == only_supported_target.id


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
We're using a defaultdict for the registered data types on the managed expression registry - this lets us safely access properties of the supported data types even if they've not explicitly been registered.

This ended up causing a minor regression when showing supported question types that depended on the "keys" property of the registered data types. If the defaultdict had been accessed for unsupported data types it would count them as valid supported types.

This tweaks an accessor to get the registered types to discount falsey values and updates the get supported questions method to use that.

## 🧪 Testing
Of particular interest here is that the method was well covered by tests but the behaviour only emerged after the registry had been accessed and default values were produced - this adds a very small test to make sure it doesn't regress to only relying on keys.

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Performance and security
~- [ ] No N+1 query problems introduced~
~- [ ] Any new DB queries include appropriate where clauses based on the user's permissions~

### Testing
~- [ ] I have tested this change and it meets the acceptance criteria for the ticket~
- [x] I need the reviewer(s) to pull and run this change locally
~- [ ] New (non-developer) functionality has appropriate unit and integration tests~
~- [ ] End-to-end tests have been updated (if applicable)~
- [x] Edge cases and error conditions are tested
