### PR TITLE
FSPT-598: Access grant funding 'grant' page

### DIFF
--- a/app/common/auth/authorisation_helper.py
+++ b/app/common/auth/authorisation_helper.py
@@ -6,6 +6,10 @@ from app.common.data.types import GRANT_ROLES_MAPPING, RoleEnum
 
 class AuthorisationHelper:
     @staticmethod
+    def is_logged_in(user: User) -> bool:
+        return user.is_authenticated
+
+    @staticmethod
     def has_logged_in(user: User) -> bool:
         # FIXME: We should have some actual tracking of whether the user has logged in. This could either be a
         #        field on the model called `last_logged_in_at` or similar, or we could only create entries in the user

--- a/app/developers/access_routes.py
+++ b/app/developers/access_routes.py
@@ -1,8 +1,12 @@
+import uuid
+
 from flask import Blueprint, render_template
 from flask.typing import ResponseReturnValue
 
 from app.common.auth.decorators import is_platform_admin
 from app.common.data import interfaces
+from app.common.data.interfaces.grants import get_grant
+from app.common.data.types import SubmissionStatusEnum
 
 developers_access_blueprint = Blueprint("access", __name__, url_prefix="/access")
 
@@ -12,3 +16,16 @@ developers_access_blueprint = Blueprint("access", __name__, url_prefix="/access"
 def grants_list() -> ResponseReturnValue:
     grants = interfaces.grants.get_all_grants_by_user(interfaces.user.get_current_user())
     return render_template("developers/access/index.html", grants=grants)
+
+
+# note: no auth decorator on this page, fully public, the template itself deals with varying the response based on
+#       anonymous vs logged-in user.
+@developers_access_blueprint.get("/grant/<uuid:grant_id>")
+def grant_details(grant_id: uuid.UUID) -> ResponseReturnValue:
+    grant = get_grant(grant_id)
+    # todo: feed submissions/submission_helpers into the template to render statuses
+    return render_template(
+        "developers/access/grant_details.html",
+        grant=grant,
+        statuses=SubmissionStatusEnum,
+    )

--- a/app/developers/templates/developers/access/grant_details.html
+++ b/app/developers/templates/developers/access/grant_details.html
@@ -1,0 +1,61 @@
+{% extends "developers/access/base.html" %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
+{% from "govuk_frontend_jinja/components/task-list/macro.html" import govukTaskList %}
+{% from "common/macros/status.html" import status %}
+
+{% set page_title = "Grants" %}
+
+{% block beforeContent %}
+  {{
+    govukBackLink({
+        "text": "Back",
+        "href": url_for("developers.access.grants_list")
+    })
+  }}
+{% endblock beforeContent %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">{{ grant.name }}</h1>
+      <p class="govuk-body">{{ grant.description }}</p>
+
+      {% if authorisation_helper.is_logged_in(current_user) %}
+        <h2 class="govuk-heading-m">Collections</h2>
+        {% if grant.collections %}
+          {% set rows=[] %}
+          {% for collection in grant.collections %}
+            {# todo: this should be a link to create (if required), then redirect to, a submission for the collection #}
+            {% set linkHref = "#" %}
+            {# todo: link status up via submission_helper (one per collection? :sweat:) #}
+            {%
+              do rows.append({
+                    "title": {
+                      "text": collection.name,
+                    },
+                  "status": {
+                    "html": status(statuses.NOT_STARTED, statuses)
+                  },
+                "href": linkHref,
+              })
+            %}
+          {% endfor %}
+
+          {{
+            govukTaskList({
+              "idPrefix": "collections",
+              "items": rows
+            })
+          }}
+        {% else %}
+          <p class="govuk-body">There are no collections for this grant yet.</p>
+        {% endif %}
+      {% else %}
+        <p class="govuk-body">
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('auth.request_a_link_to_sign_in') }}">Sign in to access this grant</a>
+        </p>
+      {% endif %}
+    </div>
+  </div>
+{% endblock content %}

--- a/app/developers/templates/developers/access/grant_details.html
+++ b/app/developers/templates/developers/access/grant_details.html
@@ -7,12 +7,14 @@
 {% set page_title = "Grants" %}
 
 {% block beforeContent %}
-  {{
-    govukBackLink({
-        "text": "Back",
-        "href": url_for("developers.access.grants_list")
-    })
-  }}
+  {% if authorisation_helper.is_platform_admin(current_user) %}
+    {{
+      govukBackLink({
+          "text": "Back",
+          "href": url_for("developers.access.grants_list")
+      })
+    }}
+  {% endif %}
 {% endblock beforeContent %}
 
 {% block content %}

--- a/app/developers/templates/developers/access/index.html
+++ b/app/developers/templates/developers/access/index.html
@@ -11,7 +11,7 @@
           {% for grant in grants %}
             <li>
               <h2 class="govuk-heading-m">
-                <a class="govuk-link govuk-link--no-visited-state" href="#">{{ grant.name }}</a>
+                <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('developers.access.grant_details', grant_id=grant.id) }}">{{ grant.name }}</a>
               </h2>
               <p class="govuk-body">{{ grant.description }}</p>
               <hr class="govuk-section-break--m" />

--- a/tests/unit/test_all_routes_access.py
+++ b/tests/unit/test_all_routes_access.py
@@ -71,6 +71,7 @@ routes_with_expected_member_only_access = [
 
 routes_with_expected_is_mhclg_user_access = ["deliver_grant_funding.list_grants"]
 routes_with_no_expected_access_restrictions = [
+    "developers.access.grant_details",
     "auth.request_a_link_to_sign_in",
     "auth.check_email",
     "auth.claim_magic_link",


### PR DESCRIPTION
Relies on https://github.com/communitiesuk/funding-service/pull/418

## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-598

## 📝 Description
Builds out a basic details page for a grant, from the view of an Access grant funding user.

This is just a developer draft of the page, aimed at proving some part of the end-to-end funding journey, so will not look like this when real users access it.

The page just lists all of the collections created for the grant on the page, and in the future will let the user create/edit/manage a submission against any of those collections.

This is a fully-public page; if you aren't logged in, you can still see the page. You won't see any collections and will instead see a link to the sign in with a magic link page.

## 📸 Show the thing (screenshots, gifs)
![image](https://github.com/user-attachments/assets/e15efa57-bf72-4eb5-8c74-7b0aea4a7846)

## 🧪 Testing
I loaded the page as a platform admin, and in a private window (ie anonymous user).

## 📋 Developer Checklist

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
~- [ ] I need the reviewer(s) to pull and run this change locally~
~- [ ] New (non-developer) functionality has appropriate unit and integration tests~
~- [ ] End-to-end tests have been updated (if applicable)~
~- [ ] Edge cases and error conditions are tested~