### PR TITLE
FSPT-598: load submission status for AGF grant page

### DIFF
--- a/app/common/data/interfaces/temporary.py
+++ b/app/common/data/interfaces/temporary.py
@@ -11,7 +11,7 @@ The only place that should import from here is the `app.developers` package.
 
 from uuid import UUID
 
-from sqlalchemy import text
+from sqlalchemy import select, text
 
 from app.common.data.models import (
     Collection,
@@ -21,6 +21,7 @@ from app.common.data.models import (
     Section,
     Submission,
 )
+from app.common.data.models_user import User
 from app.extensions import db
 
 
@@ -78,3 +79,9 @@ def delete_question(question: Question) -> None:
         text("SET CONSTRAINTS uq_section_order_collection, uq_form_order_section, uq_question_order_form DEFERRED")
     )
     db.session.flush()
+
+
+def get_submission_by_collection_and_user(collection: Collection, user: "User") -> Submission | None:
+    return db.session.scalar(
+        select(Submission).where(Submission.collection == collection, Submission.created_by == user)
+    )

--- a/app/developers/templates/developers/access/grant_details.html
+++ b/app/developers/templates/developers/access/grant_details.html
@@ -28,6 +28,7 @@
         {% if grant.collections %}
           {% set rows=[] %}
           {% for collection in grant.collections %}
+            {% set submission_helper = submission_helpers.get(collection.id) %}
             {# todo: this should be a link to create (if required), then redirect to, a submission for the collection #}
             {% set linkHref = "#" %}
             {# todo: link status up via submission_helper (one per collection? :sweat:) #}
@@ -37,7 +38,7 @@
                       "text": collection.name,
                     },
                   "status": {
-                    "html": status(statuses.NOT_STARTED, statuses)
+                    "html": status(submission_helper.status if submission_helper else statuses.NOT_STARTED, statuses)
                   },
                 "href": linkHref,
               })


### PR DESCRIPTION
Relies on #420 

## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-598

## 📝 Description
Updates the Access grant funding 'Grant details' page to load the status of any submissions that exist for the user into the collections table.

## 📸 Show the thing (screenshots, gifs)

### Before
![image](https://github.com/user-attachments/assets/e15efa57-bf72-4eb5-8c74-7b0aea4a7846)

### After
![image](https://github.com/user-attachments/assets/6ecf7269-cb61-4a89-b951-4c81c4397b48)

## 🧪 Testing
I created multiple collections, started one through Deliver grant funding, and then checked the grant details page on Access grant funding.

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
~- [ ] I need the reviewer(s) to pull and run this change locally~
~- [ ] New (non-developer) functionality has appropriate unit and integration tests~
~- [ ] End-to-end tests have been updated (if applicable)~
~- [ ] Edge cases and error conditions are tested~
