### PR TITLE
FSPT-596 block questions moving above/ below questions they depend on

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -36,6 +36,7 @@ from app.extensions import (
 )
 from app.monkeypatch import patch_sqlalchemy_lite_async
 from app.sentry import init_sentry
+from app.types import FlashMessageType
 
 if TYPE_CHECKING:
     from app.common.data.models_user import User
@@ -211,5 +212,6 @@ def create_app() -> Flask:
     # should make an intentional decision for when to be setting this
     app.config["SEND_FILE_MAX_AGE_DEFAULT"] = 3600
     app.add_template_global(AuthorisationHelper, "authorisation_helper")
+    app.add_template_global(FlashMessageType, "flash_message_type")
 
     return app

--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -266,7 +266,7 @@ class DependencyOrderException(Exception, FlashableException):
 
 
 # todo: we might want something more generalisable that checks all order dependencies across a form
-#       but this gives us the specific result we want for for the UX for now
+#       but this gives us the specific result we want for the UX for now
 def check_question_order_dependency(question: Question, swap_question: Question) -> None:
     for condition in question.conditions:
         if condition.managed and condition.managed.question_id == swap_question.id:

--- a/app/developers/deliver_routes.py
+++ b/app/developers/deliver_routes.py
@@ -58,6 +58,7 @@ from app.developers.forms import (
     ConfirmDeletionForm,
 )
 from app.extensions import auto_commit_after_request, notification_service
+from app.types import FlashMessageType
 
 if TYPE_CHECKING:
     from app.common.data.models import Form, Question, Submission
@@ -527,7 +528,7 @@ def move_question(
         elif direction == "down":
             move_question_down(question)
     except DependencyOrderException as e:
-        flash(e.as_flash_context(), "dependency_order_error")  # type:ignore [arg-type]
+        flash(e.as_flash_context(), FlashMessageType.DEPENDENCY_ORDER_ERROR.value)  # type:ignore [arg-type]
 
     return redirect(
         url_for(

--- a/app/developers/templates/developers/deliver/manage_form.html
+++ b/app/developers/templates/developers/deliver/manage_form.html
@@ -21,7 +21,7 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      {% with errors = get_flashed_messages(with_categories="dependency_order_error") %}
+      {% with errors = get_flashed_messages(with_categories=flash_message_type.DEPENDENCY_ORDER_ERROR) %}
         {% if errors %}
           {% set type, error = errors[0] %}
           {% set question_link = url_for("developers.deliver.edit_question", grant_id=grant.id, collection_id=collection.id, section_id=section.id, form_id=db_form.id, question_id=error.question_id) %}
@@ -29,13 +29,13 @@
 
 
           {% set banner_html %}
-            <p class="govuk-body govuk-!-font-weight-bold">You cannot move questions above answers they depend on.</p>
-            <p class="govuk-body govuk-!-font-weight-bold">Question:</p>
+            <p class="govuk-body govuk-!-font-weight-bold">{{ error.message }}</p>
             <p class="govuk-body govuk-!-font-weight-bold">
+              Question:
               <a class="govuk-notification-banner__link" href="{{ question_link }}">{{ error.question_text }}</a>
             </p>
-            <p class="govuk-body govuk-!-font-weight-bold">Depends on the answer to:</p>
             <p class="govuk-body govuk-!-font-weight-bold">
+              Depends on the answer to:
               <a class="govuk-notification-banner__link" href="{{ depends_on_link }}">{{ error.depends_on_question_text }}</a>
             </p>
           {% endset %}

--- a/app/developers/templates/developers/deliver/manage_form.html
+++ b/app/developers/templates/developers/deliver/manage_form.html
@@ -21,6 +21,29 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      {% with errors = get_flashed_messages(with_categories="dependency_order_error") %}
+        {% if errors %}
+          {% set type, error = errors[0] %}
+          {% set question_link = url_for("developers.edit_question", grant_id=grant.id, collection_id=collection.id, section_id=section.id, form_id=db_form.id, question_id=error.question_id) %}
+          {% set depends_on_link = url_for("developers.edit_question", grant_id=grant.id, collection_id=collection.id, section_id=section.id, form_id=db_form.id, question_id=error.depends_on_question_id) %}
+
+
+          {% set banner_html %}
+            <p class="govuk-body govuk-!-font-weight-bold">You cannot move questions above answers they depend on.</p>
+            <p class="govuk-body govuk-!-font-weight-bold">Question:</p>
+            <p class="govuk-body govuk-!-font-weight-bold">
+              <a class="govuk-notification-banner__link" href="{{ question_link }}">{{ error.question_text }}</a>
+            </p>
+            <p class="govuk-body govuk-!-font-weight-bold">Depends on the answer to:</p>
+            <p class="govuk-body govuk-!-font-weight-bold">
+              <a class="govuk-notification-banner__link" href="{{ depends_on_link }}">{{ error.depends_on_question_text }}</a>
+            </p>
+          {% endset %}
+
+          {{ govukNotificationBanner(params={"role": "alert", "titleText": "Warning", "classes": "app-notification-banner--destructive", "html": banner_html}) }}
+        {% endif %}
+      {% endwith %}
+
       {% if form %}
         {% set banner_html %}
           <p class="govuk-body govuk-!-font-weight-bold">Are you sure you want to delete this form?</p>

--- a/app/developers/templates/developers/deliver/manage_form.html
+++ b/app/developers/templates/developers/deliver/manage_form.html
@@ -24,8 +24,8 @@
       {% with errors = get_flashed_messages(with_categories="dependency_order_error") %}
         {% if errors %}
           {% set type, error = errors[0] %}
-          {% set question_link = url_for("developers.edit_question", grant_id=grant.id, collection_id=collection.id, section_id=section.id, form_id=db_form.id, question_id=error.question_id) %}
-          {% set depends_on_link = url_for("developers.edit_question", grant_id=grant.id, collection_id=collection.id, section_id=section.id, form_id=db_form.id, question_id=error.depends_on_question_id) %}
+          {% set question_link = url_for("developers.deliver.edit_question", grant_id=grant.id, collection_id=collection.id, section_id=section.id, form_id=db_form.id, question_id=error.question_id) %}
+          {% set depends_on_link = url_for("developers.deliver.edit_question", grant_id=grant.id, collection_id=collection.id, section_id=section.id, form_id=db_form.id, question_id=error.depends_on_question_id) %}
 
 
           {% set banner_html %}

--- a/app/types.py
+++ b/app/types.py
@@ -10,3 +10,7 @@ class TNotProvided(Enum):
 
 
 NOT_PROVIDED = TNotProvided.token
+
+
+class FlashMessageType(Enum):
+    DEPENDENCY_ORDER_ERROR = "dependency_order_error"


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-596

## 📝 Description
For now this implements guards to stop two questions from being moved
above/ below other questions that they depend on.

We'll probably want to think through a method of generally checking the
integrity of the order of all questions in a form and any type of
dependency (condition, validation, personalised text).

For now the only managed option which can be configured that depends on
other questions are conditions so lets just start with those.

By being specific about question conditions its easy to provide which
questions are the problem specifically through the UI without coming up
with brand new patterns.

This proposes encapsulating the dependency failure as a generic
exception which should then be able to be passed through to the
template.

## 📸 Show the thing (screenshots, gifs)
![screenshot-jul-1](https://github.com/user-attachments/assets/6400b855-05c8-4ed0-a0de-03c8b96b3a27)


## 🧪 Testing
As this hooks into the "swap" operation its currently covered at the interface level, that will want to be considered again if doing any higher level integrity checks (the current behaviour relies on _starting_  in a healthy state and should then restrict you to continue in one)

## 📋 Developer Checklist

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Performance and security
~- [ ] No N+1 query problems introduced~
~- [ ] Any new DB queries include appropriate where clauses based on the user's permissions~

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [ ] End-to-end tests have been updated (if applicable)
- [x] Edge cases and error conditions are tested
