### PR TITLE
Fix anonymous users

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -111,6 +111,10 @@ def create_app() -> Flask:
     login_manager.init_app(app)
     record_sqlalchemy_queries.init_app(app, db)
 
+    from app.common.data.models_user import AnonymousUser
+
+    login_manager.anonymous_user = AnonymousUser
+
     @login_manager.user_loader  # type: ignore[misc]
     def load_user(user_id: str) -> Optional["User"]:
         return interfaces.user.get_user(user_id)

--- a/app/common/data/interfaces/user.py
+++ b/app/common/data/interfaces/user.py
@@ -14,13 +14,14 @@ from app.extensions import db
 from app.types import NOT_PROVIDED, TNotProvided
 
 
-def get_user(id_: str | uuid.UUID) -> User | None:
-    return db.session.get(User, id_)
-
-
+# todo: move this thing somewhere else
 def get_current_user() -> User:
     user = cast(User, current_user)
     return user
+
+
+def get_user(id_: str | uuid.UUID) -> User | None:
+    return db.session.get(User, id_)
 
 
 def get_user_by_email(email_address: str) -> User | None:

--- a/app/common/data/models_user.py
+++ b/app/common/data/models_user.py
@@ -38,8 +38,27 @@ class User(BaseModel):
     def is_anonymous(self) -> bool:
         return False
 
-    def get_id(self) -> str:
+    def get_id(self) -> str | None:
         return str(self.id)
+
+
+class AnonymousUser(User):
+    __abstract__ = True
+
+    @property
+    def is_active(self) -> bool:
+        return False
+
+    @property
+    def is_authenticated(self) -> bool:
+        return False
+
+    @property
+    def is_anonymous(self) -> bool:
+        return True
+
+    def get_id(self) -> None:
+        return
 
 
 class UserRole(BaseModel):

--- a/tests/unit/app/common/auth/test_authorisation_helper.py
+++ b/tests/unit/app/common/auth/test_authorisation_helper.py
@@ -1,6 +1,7 @@
 import pytest
 
 from app import AuthorisationHelper
+from app.common.data.models_user import AnonymousUser
 from app.common.data.types import RoleEnum
 
 
@@ -28,6 +29,10 @@ class TestAuthorisationHelper:
         user = factories.user.build()
         factories.user_role.build(user=user, role=role, has_grant=has_grant_linked_to_role)
         assert AuthorisationHelper.is_platform_admin(user) is expected
+
+    def test_is_platform_admin_works_for_anonymous_user(self):
+        user = AnonymousUser()
+        assert AuthorisationHelper.is_platform_admin(user) is False
 
     @pytest.mark.parametrize(
         "role, expected",


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
Our AuthorisationHelper needs to be able to work with non-logged-in users. By default, Flask-Login provides an instance of AnonymousUserMixin in this case. This does not have any of our custom user attributes, like the `roles` list.

Instead, we can create an empty User and return that. This will mean the authorisation helper can still do things like poke at its roles, but it will just have an empty list.

## 🧪 Testing
I tested it in combination with this PR: https://github.com/communitiesuk/funding-service/pull/420/files.

Merge that branch into this one, then go to one of the AGF grant pages as a logged-in user and as an anonymous user.

## 📋 Developer Checklist

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [ ] I need the reviewer(s) to pull and run this change locally
~- [ ] New (non-developer) functionality has appropriate unit and integration tests~
~- [ ] End-to-end tests have been updated (if applicable)~
~- [ ] Edge cases and error conditions are tested~