### PR TITLE
Revert #423 and adjust anonymous user behaviour

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -111,10 +111,6 @@ def create_app() -> Flask:
     login_manager.init_app(app)
     record_sqlalchemy_queries.init_app(app, db)
 
-    from app.common.data.models_user import AnonymousUser
-
-    login_manager.anonymous_user = AnonymousUser
-
     @login_manager.user_loader  # type: ignore[misc]
     def load_user(user_id: str) -> Optional["User"]:
         return interfaces.user.get_user(user_id)

--- a/app/common/data/models_user.py
+++ b/app/common/data/models_user.py
@@ -42,25 +42,6 @@ class User(BaseModel):
         return str(self.id)
 
 
-class AnonymousUser(User):
-    __abstract__ = True
-
-    @property
-    def is_active(self) -> bool:
-        return False
-
-    @property
-    def is_authenticated(self) -> bool:
-        return False
-
-    @property
-    def is_anonymous(self) -> bool:
-        return True
-
-    def get_id(self) -> None:
-        return
-
-
 class UserRole(BaseModel):
     __tablename__ = "user_role"
 

--- a/tests/unit/app/common/auth/test_authorisation_helper.py
+++ b/tests/unit/app/common/auth/test_authorisation_helper.py
@@ -1,7 +1,7 @@
 import pytest
+from flask_login import AnonymousUserMixin
 
 from app import AuthorisationHelper
-from app.common.data.models_user import AnonymousUser
 from app.common.data.types import RoleEnum
 
 
@@ -31,8 +31,7 @@ class TestAuthorisationHelper:
         assert AuthorisationHelper.is_platform_admin(user) is expected
 
     def test_is_platform_admin_works_for_anonymous_user(self):
-        user = AnonymousUser()
-        assert AuthorisationHelper.is_platform_admin(user) is False
+        assert AuthorisationHelper.is_platform_admin(AnonymousUserMixin()) is False
 
     @pytest.mark.parametrize(
         "role, expected",


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
We merged https://github.com/communitiesuk/funding-service/pull/423, hoping that providing a more User-like anonymous user instance would make it easier to treat all users in the same way.

However, anonymous users still might end up being fed into interfaces to query our DB if we don't treat them carefully. Without providing extra attributes (eg IDs, names, emails) etc, these will still break.

We need to understand that, on public pages, we may be dealing with non-logged-in users that aren't real User objects, and treat them appropriately. This means our auth helper should be able to deal with AnonymousUserMixins, which is what Flask-Login hands across by default.

This needs to be dealt with manually.

Our views may also need to make decisions based on the user appropriately, so as not to call our DB interfaces with non-user-like things.

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
~- [ ] New (non-developer) functionality has appropriate unit and integration tests~
~- [ ] End-to-end tests have been updated (if applicable)~
~- [ ] Edge cases and error conditions are tested~