### PR TITLE
Log e2e test run durations

### DIFF
--- a/.github/workflows/run_e2e_tests.yml
+++ b/.github/workflows/run_e2e_tests.yml
@@ -71,7 +71,7 @@ jobs:
           aws-region: eu-west-2
 
       - name: run e2e tests
-        run: uv run --frozen pytest --e2e --e2e-env ${{ inputs.environment }} --tracing=retain-on-failure --browser chromium
+        run: uv run --frozen pytest --e2e --e2e-env ${{ inputs.environment }} --tracing=retain-on-failure --browser chromium -vv --durations=999 tests/e2e
         env:
           SERVICE_ACCOUNT_USERNAME: ${{ secrets.SERVICE_ACCOUNT_USERNAME }}
           SERVICE_ACCOUNT_PASSWORD: ${{ secrets.SERVICE_ACCOUNT_PASSWORD }}

--- a/.github/workflows/run_e2e_tests_docker_compose.yml
+++ b/.github/workflows/run_e2e_tests_docker_compose.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: run e2e tests
         run: |
-          uv run --frozen pytest --e2e --tracing=retain-on-failure --browser chromium --screenshot=only-on-failure
+          uv run --frozen pytest --e2e --tracing=retain-on-failure --browser chromium --screenshot=only-on-failure -vv --durations=999 tests/e2e
 
       - name: stop docker compose
         if: always() # Ensure this runs even if the previous step fails


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
[Dev env run](https://github.com/communitiesuk/funding-service/actions/runs/16005894205/job/45152884031): 4 mins
[Test env run](https://github.com/communitiesuk/funding-service/actions/runs/16005894205/job/45153425723): 2 mins

I want to understand where the slowness is a bit better.

I'm doing a 🤏 look at parallelising the e2e tests but it's not trivial. We can start to parallelise them with the `--dist worksteal -n2` options, but it introduces some flakiness against the stub server which can't handle multiple logins at the same time. Parallelising by default doesn't work with xdist; this seems down to the default distribution method being `load`, and that because we only have a few e2e tests, they all get scheduled against a single worker (theoretically to reduce overhead, but this doesn't pan out). The `worksteal` dist method will let idle workers steal jobs queued against others, which can work to fix some of this. We also may want to investigate something like [pytest-slowest-first](https://github.com/klimkin/pytest-slowest-first), which could mean our longest-running test always gets picked up first. This would reduce the variation in time vs random scheduling.