### PR TITLE
Add ty check

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -70,10 +70,20 @@ jobs:
         uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6
         with:
           enable-cache: true
-      - name: install dependencies
-        run: uv sync
       - name: run type checking
         run: uv run mypy
+
+  type_checking_ty:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6
+        with:
+          enable-cache: true
+      - name: run type checking
+        run: uv run ty check
 
   lint_html_formatting:
     runs-on: ubuntu-latest

--- a/app/common/auth/__init__.py
+++ b/app/common/auth/__init__.py
@@ -54,7 +54,7 @@ def request_a_link_to_sign_in() -> ResponseReturnValue:
 def check_email(magic_link_id: uuid.UUID) -> ResponseReturnValue:
     magic_link = interfaces.magic_link.get_magic_link(id_=magic_link_id)
     if not magic_link or not magic_link.is_usable:
-        abort(404)
+        return abort(404)
 
     notification_id = session.pop("magic_link_email_notification_id", None)
     return render_template("common/auth/check_email.html", email=magic_link.email, notification_id=notification_id)
@@ -82,7 +82,7 @@ def claim_magic_link(magic_link_code: str) -> ResponseReturnValue:
             user = interfaces.user.upsert_user_by_email(email_address=str(magic_link.email))
         interfaces.magic_link.claim_magic_link(magic_link=magic_link, user=user)
         if not login_user(user):
-            abort(400)
+            return abort(400)
 
         return redirect(sanitise_redirect_url(magic_link.redirect_to_path))
 
@@ -153,7 +153,7 @@ def sso_get_token() -> ResponseReturnValue:
     session.pop("flow", None)
 
     if not login_user(user):
-        abort(400)
+        return abort(400)
 
     return redirect(redirect_to_path)
 

--- a/app/common/auth/decorators.py
+++ b/app/common/auth/decorators.py
@@ -39,7 +39,7 @@ def redirect_if_authenticated[**P](
             if user.email.endswith(internal_domains):
                 return redirect(url_for("deliver_grant_funding.list_grants"))
 
-            abort(500)
+            return abort(500)
 
         return func(*args, **kwargs)
 
@@ -56,7 +56,7 @@ def is_mhclg_user[**P](
         # not an anonymous user (ie a user is definitely logged-in) if we get here.
         internal_domains = current_app.config["INTERNAL_DOMAINS"]
         if not user.email.endswith(internal_domains):
-            abort(403)
+            return abort(403)
 
         return func(*args, **kwargs)
 
@@ -71,7 +71,7 @@ def is_platform_admin[**P](
         # This decorator is itself wrapped by `is_mhclg_user`, so we know that `current_user` exists and is
         # not an anonymous user (ie a user is definitely logged-in) and an MHCLG user if we get here.
         if not AuthorisationHelper.is_platform_admin(user=interfaces.user.get_current_user()):
-            abort(403)
+            return abort(403)
 
         return func(*args, **kwargs)
 
@@ -92,7 +92,7 @@ def has_grant_role[**P](
                 raise ValueError("Grant ID required.")
 
             if not AuthorisationHelper.has_grant_role(grant_id=UUID(str(kwargs["grant_id"])), role=role, user=user):
-                abort(403, description="Access denied")
+                return abort(403, description="Access denied")
 
             return func(*args, **kwargs)
 

--- a/app/common/data/interfaces/grants.py
+++ b/app/common/data/interfaces/grants.py
@@ -77,15 +77,15 @@ def update_grant(
     primary_contact_email: str | TNotProvided = NOT_PROVIDED,
 ) -> Grant:
     if ggis_number is not NOT_PROVIDED:
-        grant.ggis_number = ggis_number
+        grant.ggis_number = ggis_number  # ty: ignore[invalid-assignment]
     if name is not NOT_PROVIDED:
-        grant.name = name
+        grant.name = name  # ty: ignore[invalid-assignment]
     if description is not NOT_PROVIDED:
-        grant.description = description
+        grant.description = description  # ty: ignore[invalid-assignment]
     if primary_contact_name is not NOT_PROVIDED:
-        grant.primary_contact_name = primary_contact_name
+        grant.primary_contact_name = primary_contact_name  # ty: ignore[invalid-assignment]
     if primary_contact_email is not NOT_PROVIDED:
-        grant.primary_contact_email = primary_contact_email
+        grant.primary_contact_email = primary_contact_email  # ty: ignore[invalid-assignment]
     try:
         db.session.flush()
     except IntegrityError as e:

--- a/app/common/data/interfaces/magic_link.py
+++ b/app/common/data/interfaces/magic_link.py
@@ -45,7 +45,7 @@ def get_magic_link(id_: uuid.UUID | None = None, code: str | None = None) -> Mag
     return db.session.scalar(stmt)
 
 
-def claim_magic_link(magic_link: MagicLink, user: User) -> None:
+def claim_magic_link(magic_link: MagicLink, user: User | None) -> None:
     if not user:
         raise ValueError("User must be provided")
     magic_link.claimed_at_utc = func.now()

--- a/app/common/data/migrations/versions/001_bootstrap.py
+++ b/app/common/data/migrations/versions/001_bootstrap.py
@@ -27,7 +27,7 @@ submission_event_key_enum = sa.Enum(
 
 def upgrade() -> None:
     public_citext = PGExtension(schema="public", signature="citext")
-    op.create_entity(public_citext)
+    op.create_entity(public_citext)  # ty: ignore[unresolved-attribute]
     op.create_table(
         "grant",
         sa.Column("id", sa.Uuid(), nullable=False),
@@ -274,4 +274,4 @@ def downgrade() -> None:
     submission_event_key_enum.drop(op.get_bind())
 
     public_citext = PGExtension(schema="public", signature="citext")
-    op.drop_entity(public_citext)
+    op.drop_entity(public_citext)  # ty: ignore[unresolved-attribute]

--- a/app/common/data/migrations/versions/011_sync_role_enum.py
+++ b/app/common/data/migrations/versions/011_sync_role_enum.py
@@ -21,7 +21,7 @@ def upgrade() -> None:
 
     # WARNING: this also deletes the check constraints touching the enum, so we need to regenerate the ones we want
     #           to keep afterwards.
-    op.sync_enum_values(
+    op.sync_enum_values(  # ty: ignore[unresolved-attribute]
         enum_schema="public",
         enum_name="role_enum",
         new_values=["ADMIN", "MEMBER"],
@@ -37,7 +37,7 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.sync_enum_values(
+    op.sync_enum_values(  # ty: ignore[unresolved-attribute]
         enum_schema="public",
         enum_name="role_enum",
         new_values=["ADMIN", "MEMBER", "EDITOR", "ASSESSOR", "S151_OFFICER"],

--- a/app/common/expressions/__init__.py
+++ b/app/common/expressions/__init__.py
@@ -175,7 +175,7 @@ def _evaluate_expression_with_context(expression: "Expression", context: Express
     # Remove all nodes except those we explicitly allowlist
     evaluator.nodes = {
         ast_expr: ast_fn
-        for ast_expr, ast_fn in evaluator.nodes.items()
+        for ast_expr, ast_fn in evaluator.nodes.items()  # ty: ignore[possibly-unbound-attribute]
         if ast_expr
         in {
             ast.UnaryOp,

--- a/app/common/expressions/managed.py
+++ b/app/common/expressions/managed.py
@@ -137,8 +137,8 @@ class BottomOfRangeIsLower:
         self.message = message
 
     def __call__(self, form: "FlaskForm", field: "Field") -> None:
-        bottom_of_range = form.between_bottom_of_range and form.between_bottom_of_range.data
-        top_of_range = form.between_top_of_range and form.between_top_of_range.data
+        bottom_of_range = form.between_bottom_of_range and form.between_bottom_of_range.data  # ty: ignore[unresolved-attribute]
+        top_of_range = form.between_top_of_range and form.between_top_of_range.data  # ty: ignore[unresolved-attribute]
         if bottom_of_range and top_of_range:
             if bottom_of_range >= top_of_range:
                 raise ValidationError(self.message)
@@ -186,14 +186,14 @@ class GreaterThan(ManagedExpression):
 
     @staticmethod
     def update_validators(form: "_ManagedExpressionForm") -> None:
-        form.greater_than_value.validators = [InputRequired("Enter the minimum value allowed for this question")]
+        form.greater_than_value.validators = [InputRequired("Enter the minimum value allowed for this question")]  # ty: ignore[unresolved-attribute]
 
     @staticmethod
     def build_from_form(form: "_ManagedExpressionForm", question: "Question") -> "GreaterThan":
         return GreaterThan(
             question_id=question.id,
-            minimum_value=form.greater_than_value.data,
-            inclusive=form.greater_than_inclusive.data,
+            minimum_value=form.greater_than_value.data,  # ty: ignore[unresolved-attribute]
+            inclusive=form.greater_than_inclusive.data,  # ty: ignore[unresolved-attribute]
         )
 
 
@@ -239,14 +239,14 @@ class LessThan(ManagedExpression):
 
     @staticmethod
     def update_validators(form: "_ManagedExpressionForm") -> None:
-        form.less_than_value.validators = [InputRequired("Enter the maximum value allowed for this question")]
+        form.less_than_value.validators = [InputRequired("Enter the maximum value allowed for this question")]  # ty: ignore[unresolved-attribute]
 
     @staticmethod
     def build_from_form(form: "_ManagedExpressionForm", question: "Question") -> "LessThan":
         return LessThan(
             question_id=question.id,
-            maximum_value=form.less_than_value.data,
-            inclusive=form.less_than_inclusive.data,
+            maximum_value=form.less_than_value.data,  # ty: ignore[unresolved-attribute]
+            inclusive=form.less_than_inclusive.data,  # ty: ignore[unresolved-attribute]
         )
 
 
@@ -322,11 +322,11 @@ class Between(ManagedExpression):
 
     @staticmethod
     def update_validators(form: "_ManagedExpressionForm") -> None:
-        form.between_bottom_of_range.validators = [
+        form.between_bottom_of_range.validators = [  # ty: ignore[unresolved-attribute]
             InputRequired("Enter the minimum value allowed for this question"),
             BottomOfRangeIsLower("The minimum value must be lower than the maximum value"),
         ]
-        form.between_top_of_range.validators = [
+        form.between_top_of_range.validators = [  # ty: ignore[unresolved-attribute]
             InputRequired("Enter the maximum value allowed for this question"),
             BottomOfRangeIsLower("The maximum value must be higher than the minimum value"),
         ]
@@ -335,10 +335,10 @@ class Between(ManagedExpression):
     def build_from_form(form: "_ManagedExpressionForm", question: "Question") -> "Between":
         return Between(
             question_id=question.id,
-            minimum_value=form.between_bottom_of_range.data,
-            minimum_inclusive=form.between_bottom_inclusive.data,
-            maximum_value=form.between_top_of_range.data,
-            maximum_inclusive=form.between_top_inclusive.data,
+            minimum_value=form.between_bottom_of_range.data,  # ty: ignore[unresolved-attribute]
+            minimum_inclusive=form.between_bottom_inclusive.data,  # ty: ignore[unresolved-attribute]
+            maximum_value=form.between_top_of_range.data,  # ty: ignore[unresolved-attribute]
+            maximum_inclusive=form.between_top_inclusive.data,  # ty: ignore[unresolved-attribute]
         )
 
 

--- a/app/deliver_grant_funding/routes.py
+++ b/app/deliver_grant_funding/routes.py
@@ -216,7 +216,7 @@ def list_users_for_grant(grant_id: UUID) -> ResponseReturnValue:
     try:
         grant = interfaces.grants.get_grant(grant_id)
     except NoResultFound:
-        abort(404)
+        return abort(404)
     return render_template(
         "deliver_grant_funding/grant_team/grant_user_list.html",
         grant=grant,

--- a/app/developers/commands.py
+++ b/app/developers/commands.py
@@ -22,13 +22,18 @@ def to_dict(instance: BaseModel) -> dict[str, Any]:
     return {col.name: getattr(instance, col.name) for col in instance.__table__.columns}
 
 
-class GrantExport(TypedDict):
-    grant: dict[str, Any]
-    collections: list[Any]
-    sections: list[Any]
-    forms: list[Any]
-    questions: list[Any]
-    expressions: list[Any]
+GrantExport = TypedDict(
+    "GrantExport",
+    {
+        "grant": dict[str, Any],
+        "collections": list[Any],
+        "sections": list[Any],
+        "forms": list[Any],
+        "questions": list[Any],
+        "expressions": list[Any],
+    },
+)
+ExportData = TypedDict("ExportData", {"grants": list[GrantExport], "users": list[Any]})
 
 
 @developers_blueprint.cli.command("export-grants", help="Export configured grants to consistently seed environments")
@@ -57,7 +62,7 @@ def export_grants(grant_ids: list[uuid.UUID]) -> None:
         click.echo(f"Could not find the following grant(s): {','.join(missing_grants)}")
         exit(1)
 
-    export_data: dict[str, list[Any]] = {
+    export_data: ExportData = {
         "grants": [],
         "users": [],
     }
@@ -71,6 +76,7 @@ def export_grants(grant_ids: list[uuid.UUID]) -> None:
             "questions": [],
             "expressions": [],
         }
+
         export_data["grants"].append(grant_export)
         users = set()
 

--- a/app/developers/deliver_routes.py
+++ b/app/developers/deliver_routes.py
@@ -36,6 +36,7 @@ from app.common.data.interfaces.exceptions import DuplicateValueError
 from app.common.data.interfaces.temporary import (
     delete_collection,
     delete_form,
+    delete_grant,
     delete_question,
     delete_section,
     delete_submissions_created_by_user,
@@ -78,7 +79,7 @@ def grant_developers(grant_id: UUID) -> ResponseReturnValue:
         and confirm_deletion_form.validate_on_submit()
         and confirm_deletion_form.confirm_deletion.data
     ):
-        interfaces.temporary.delete_grant(grant_id=grant.id)
+        delete_grant(grant_id=grant.id)
         return redirect(url_for("deliver_grant_funding.list_grants"))
 
     return render_template(
@@ -219,7 +220,7 @@ def move_section(grant_id: UUID, collection_id: UUID, section_id: UUID, directio
     elif direction == "down":
         move_section_down(section)
     else:
-        abort(400)
+        return abort(400)
 
     return redirect(url_for("developers.deliver.list_sections", grant_id=grant_id, collection_id=collection_id))
 
@@ -272,7 +273,7 @@ def move_form(
     elif direction == "down":
         move_form_down(form)
     else:
-        abort(400)
+        return abort(400)
 
     return redirect(
         url_for(
@@ -520,7 +521,7 @@ def move_question(
     question = get_question_by_id(question_id=question_id)
 
     if direction not in ["up", "down"]:
-        abort(400)
+        return abort(400)
 
     try:
         if direction == "up":

--- a/app/extensions/__init__.py
+++ b/app/extensions/__init__.py
@@ -11,7 +11,7 @@ from app.extensions.flask_assets_vite import FlaskAssetsViteExtension
 from app.extensions.record_sqlalchemy_queries import RecordSqlalchemyQueriesExtension
 from app.services.notify import NotificationService
 
-db = SQLAlchemy()
+db = SQLAlchemy(engine_options={"echo": False})
 auto_commit_after_request = AutoCommitAfterRequestExtension(db=db)
 migrate = Migrate()
 toolbar = DebugToolbarExtension()

--- a/app/extensions/record_sqlalchemy_queries.py
+++ b/app/extensions/record_sqlalchemy_queries.py
@@ -42,10 +42,10 @@ import inspect
 import typing as t
 from time import perf_counter
 
-import sqlalchemy as sa
 import sqlalchemy.event as sa_event
 from flask import Flask, current_app, g, has_app_context
 from flask_sqlalchemy_lite import SQLAlchemy
+from sqlalchemy import Engine, ExecutionContext
 
 
 @dataclasses.dataclass
@@ -73,19 +73,19 @@ class RecordSqlalchemyQueriesExtension:
             with app.app_context():
                 self._listen(db.engine)
 
-    def _listen(self, engine: sa.engine.Engine) -> None:
+    def _listen(self, engine: Engine) -> None:
         sa_event.listen(engine, "before_cursor_execute", self._record_start, named=True)
         sa_event.listen(engine, "after_cursor_execute", self._record_end, named=True)
 
     @staticmethod
-    def _record_start(context: sa.engine.ExecutionContext, **kwargs: t.Any) -> None:
+    def _record_start(context: ExecutionContext, **kwargs: t.Any) -> None:
         if not has_app_context():
             return
 
         context._rsq_start_time = perf_counter()  # type: ignore[attr-defined]
 
     @staticmethod
-    def _record_end(context: sa.engine.ExecutionContext, **kwargs: t.Any) -> None:
+    def _record_end(context: ExecutionContext, **kwargs: t.Any) -> None:
         if not has_app_context():
             return
 

--- a/app/logging.py
+++ b/app/logging.py
@@ -7,7 +7,7 @@ from logging import LogRecord
 from logging.config import dictConfig
 from os import getpid
 from threading import get_ident as get_thread_ident
-from typing import Any
+from typing import Any, cast
 
 from flask import Flask, Response, current_app, request
 from flask.ctx import has_request_context
@@ -127,12 +127,12 @@ def attach_request_loggers(app: Flask) -> None:
             log_data = {
                 "status": response.status_code,
                 "duration_real": (
-                    (time.perf_counter() - request.before_request_real_time)
+                    (time.perf_counter() - cast(float, request.before_request_real_time))
                     if hasattr(request, "before_request_real_time")
                     else None
                 ),
                 "duration_process": (
-                    (time.process_time() - request.before_request_process_time)
+                    (time.process_time() - cast(float, request.before_request_process_time))
                     if hasattr(request, "before_request_process_time")
                     else None
                 ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ dev = [
     "freezegun==1.5.2",
     "import-linter==2.3",
     "alembic-postgresql-enum==1.7.0",
+    "ty>=0.0.1a13",
 ]
 
 [tool.uv]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ from _pytest.config import Config
 from _pytest.config.argparsing import Parser
 from flask import Flask
 from flask.testing import FlaskClient
+from html5lib.html5parser import ParseError
 from sqlalchemy.orm import Session
 from werkzeug.test import TestResponse
 
@@ -108,9 +109,7 @@ class FundingServiceTestClient(FlaskClient):
 
                 # TODO: remove this when https://github.com/communitiesuk/funding-service/pull/36 has been merged.
                 if "FLASK_VITE_HEADER" not in line_with_context and "^ unexpected-end-tag" not in line_with_context:
-                    raise html5lib.html5parser.ParseError(
-                        f"\n\n{line_with_context}\n{' ' * (character_number - 1)}^ {error}"
-                    )
+                    raise ParseError(f"\n\n{line_with_context}\n{' ' * (character_number - 1)}^ {error}")
 
         return response
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 from flask.typing import ResponseReturnValue
 from flask_login import login_user
-from playwright.sync_api import BrowserContext, Page, expect
+from playwright.sync_api import BrowserContext, Page, ViewportSize, expect
 from pytest import FixtureRequest
 from pytest_playwright import CreateContextCallback
 
@@ -21,7 +21,7 @@ from tests.utils import build_db_config
 @pytest.fixture(autouse=True)
 def _viewport(request: FixtureRequest, page: Page) -> None:
     width, height = request.config.getoption("viewport").split("x")
-    page.set_viewport_size({"width": int(width), "height": int(height)})
+    page.set_viewport_size(ViewportSize(width=int(width), height=int(height)))
 
 
 @pytest.fixture
@@ -135,7 +135,9 @@ def login_with_session_cookie(page: Page, domain: str, e2e_test_secrets: EndToEn
         cookies = result.headers.get("Set-Cookie", None)
         cookie_value = cookies.split(";")[0].split("=")[1] if cookies else None
         if not cookie_value:
-            pytest.fail(f"Unable to extract session cookie value from fake-login response headers: {result.headers}")
+            raise pytest.fail(
+                f"Unable to extract session cookie value from fake-login response headers: {result.headers}"
+            )
 
     sso_sign_in_page = SSOSignInPage(page, domain)
     sso_sign_in_page.page.context.add_cookies(

--- a/tests/e2e/test_magic_link_auth.py
+++ b/tests/e2e/test_magic_link_auth.py
@@ -16,6 +16,7 @@ def test_magic_link_redirect_journey(page: Page, domain: str, e2e_test_secrets: 
 
     page.wait_for_url(re.compile(rf"{domain}/check-your-email/.+"))
     notification_id = page.locator("[data-notification-id]").get_attribute("data-notification-id")
+    assert notification_id
 
     magic_link_url = retrieve_magic_link(notification_id, e2e_test_secrets)
     page.goto(magic_link_url)

--- a/tests/e2e/test_sso_auth.py
+++ b/tests/e2e/test_sso_auth.py
@@ -33,7 +33,7 @@ def test_real_sso_journey(page: Page, domain: str):
     sign_in_email = getenv("SERVICE_ACCOUNT_USERNAME", None)
     sign_in_password = getenv("SERVICE_ACCOUNT_PASSWORD", None)
     if not sign_in_email or not sign_in_password:
-        pytest.fail("SERVICE_ACCOUNT_USERNAME and SERVICE_ACCOUNT_PASSWORD must be set for this test")
+        raise pytest.fail("SERVICE_ACCOUNT_USERNAME and SERVICE_ACCOUNT_PASSWORD must be set for this test")
     sso_sign_in_page = SSOSignInPage(page, domain)
     sso_sign_in_page.navigate()
     sso_sign_in_page.click_sign_in()
@@ -46,6 +46,6 @@ def test_real_sso_journey(page: Page, domain: str):
     if not page.url == f"{domain}/grants":
         page.get_by_role("link", name="Click here for more details").click()
         page.screenshot()
-        pytest.fail("SSO login did not redirect to /grants as expected")
+        raise pytest.fail("SSO login did not redirect to /grants as expected")
 
     expect(page).to_have_url(f"{domain}/grants")

--- a/tests/integration/common/auth/test_auth.py
+++ b/tests/integration/common/auth/test_auth.py
@@ -10,7 +10,7 @@ from app.common.auth.authorisation_helper import AuthorisationHelper
 from app.common.data import interfaces
 from app.common.data.models_user import MagicLink, User, UserRole
 from app.common.data.types import RoleEnum
-from tests.utils import AnyStringMatching, page_has_error
+from tests.utils import AnyStringMatching, get_h1_text, get_h2_text, page_has_error
 
 
 class TestSignInView:
@@ -112,7 +112,7 @@ class TestClaimMagicLinkView:
         )
         soup = BeautifulSoup(response.data, "html.parser")
         assert response.status_code == 200
-        assert "Link expired" in soup.h2.text
+        assert "Link expired" in get_h2_text(soup)
 
     def test_redirect_on_expired_magic_link(self, anonymous_client, factories):
         magic_link = factories.magic_link.create(
@@ -265,7 +265,7 @@ class TestSSOGetTokenView:
             )
         assert response.status_code == 200
         soup = BeautifulSoup(response.data, "html.parser")
-        assert dummy_grant.name in soup.h1.text
+        assert dummy_grant.name in get_h1_text(soup)
 
         with anonymous_client.session_transaction() as session:
             assert "next" not in session

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -359,14 +359,14 @@ def test_move_question_with_dependencies(db_session, factories):
     # q3 can't move above its dependency q2
     with pytest.raises(DependencyOrderException) as e:
         move_question_up(q3)
-    assert e.value.question == q3
-    assert e.value.depends_on_question == q2
+    assert e.value.question == q3  # ty: ignore[unresolved-attribute]
+    assert e.value.depends_on_question == q2  # ty: ignore[unresolved-attribute]
 
     # q2 can't move below q3 which depends on it
     with pytest.raises(DependencyOrderException) as e:
         move_question_down(q2)
-    assert e.value.question == q3
-    assert e.value.depends_on_question == q2
+    assert e.value.question == q3  # ty: ignore[unresolved-attribute]
+    assert e.value.depends_on_question == q2  # ty: ignore[unresolved-attribute]
 
     # q1 can freely move up and down as it has no dependencies
     move_question_down(q1)

--- a/tests/integration/common/data/interfaces/test_grants.py
+++ b/tests/integration/common/data/interfaces/test_grants.py
@@ -1,4 +1,5 @@
 import pytest
+from _pytest._code import ExceptionInfo
 
 from app.common.data.interfaces.grants import (
     DuplicateValueError,
@@ -66,6 +67,7 @@ def test_create_duplicate_grant(factories) -> None:
             primary_contact_name="Jane Doe",
             primary_contact_email="janedoe@example.com",
         )
+    assert isinstance(e, ExceptionInfo)
     assert e.value.model_name == "grant"
     assert e.value.field_name == "name"
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,3 +1,5 @@
+# mypy: disable-error-code="unused-ignore"
+
 import multiprocessing
 import os
 import typing as t
@@ -43,7 +45,7 @@ def setup_db_container() -> Generator[PostgresContainer, None, None]:
 
     # Reduce sleep/wait time from 1 second to 0.1 seconds. We could drop this if it ever causes any problems, but shaves
     # off a little bit of time - why not.
-    testcontainers_config.sleep_time = 0.1
+    testcontainers_config.sleep_time = 0.1  # ty: ignore[invalid-assignment]
 
     test_postgres = PostgresContainer("postgres:17.5")
     test_postgres.start()
@@ -86,7 +88,7 @@ def app(setup_db_container: PostgresContainer) -> Generator[Flask, None, None]:
 
     @app.route("/_testing/403")
     def raise_403() -> ResponseReturnValue:
-        abort(403)
+        return abort(403)
 
     @app.route("/_testing/sqlalchemy-not-found")
     def raise_sqlalchemy_not_found() -> ResponseReturnValue:
@@ -95,7 +97,7 @@ def app(setup_db_container: PostgresContainer) -> Generator[Flask, None, None]:
             app.extensions["sqlalchemy"].session.query(User).where(User.id == uuid.uuid4()).one()
         except Exception as e:
             if not isinstance(e, NoResultFound):
-                abort(500)
+                return abort(500)
             raise e
         raise RuntimeError("query expected no results and an error, but didn't")
 
@@ -146,7 +148,7 @@ def anonymous_client(app: Flask, templates_rendered: TTemplatesRendered) -> Fund
                 method = kwargs.get("method") or (args[0] if args else "GET")
                 path = kwargs.get("path") or (args[0] if args else "/")
 
-                pytest.fail(
+                raise pytest.fail(
                     f"Detected uncommitted changes in the SQLAlchemy session after handling "
                     f"{method} request to {path}. "
                     f"To ensure database consistency, wrap your request handler with @auto_commit_after_request."

--- a/tests/integration/deliver_grant_funding/test_routes.py
+++ b/tests/integration/deliver_grant_funding/test_routes.py
@@ -20,6 +20,7 @@ from app.deliver_grant_funding.forms import (
     QuestionTypeForm,
     SectionForm,
 )
+from tests.utils import get_h1_text, get_h2_text
 
 
 def test_list_grants_as_admin(
@@ -38,7 +39,7 @@ def test_list_grants_as_admin(
     expected_headers = ["Grant", "GGIS number", "Email"]
     for expected in expected_headers:
         assert expected in header_texts, f"Header '{expected}' not found in table"
-    assert soup.h1.text == "Grants"
+    assert get_h1_text(soup) == "Grants"
     assert len(queries) == 3  # 1) select user, 2) select user_role, 3) select grants
 
 
@@ -73,7 +74,7 @@ def test_list_grants_as_member_with_multiple_grants(
     expected_headers = ["Grant", "GGIS number", "Email"]
     for expected in expected_headers:
         assert expected in header_texts, f"Header '{expected}' not found in table"
-    assert soup.h1.text == "Grants"
+    assert get_h1_text(soup) == "Grants"
 
 
 @pytest.mark.authenticate_as("test@google.com")
@@ -91,8 +92,8 @@ class TestViewGrantDetails:
         assert result.status_code == 200
         assert templates_rendered.get("deliver_grant_funding.grant_details").context.get("grant") == grant
         soup = BeautifulSoup(result.data, "html.parser")
-        assert grant.name in soup.h1.text.strip()
-        assert "Grant details" in soup.h1.text.strip()
+        assert grant.name in get_h1_text(soup)
+        assert "Grant details" in get_h1_text(soup)
 
         change_links = [link for link in soup.select("a") if "Change" in link.get_text()]
         assert {link.get_text().strip() for link in change_links} == {
@@ -108,8 +109,8 @@ class TestViewGrantDetails:
         assert result.status_code == 200
         assert templates_rendered.get("deliver_grant_funding.grant_details").context.get("grant") == grant
         soup = BeautifulSoup(result.data, "html.parser")
-        assert grant.name in soup.h1.text.strip()
-        assert "Grant details" in soup.h1.text.strip()
+        assert grant.name in get_h1_text(soup)
+        assert "Grant details" in get_h1_text(soup)
 
         change_links = [link for link in soup.select("a") if "Change" in link.get_text()]
         assert {link.get_text().strip() for link in change_links} == {
@@ -126,8 +127,8 @@ class TestViewGrantDetails:
         assert result.status_code == 200
         assert templates_rendered.get("deliver_grant_funding.grant_details").context.get("grant") == grant
         soup = BeautifulSoup(result.data, "html.parser")
-        assert grant.name in soup.h1.text.strip()
-        assert "Grant details" in soup.h1.text.strip()
+        assert grant.name in get_h1_text(soup)
+        assert "Grant details" in get_h1_text(soup)
 
         change_links = [link for link in soup.select("a") if "Change" in link.get_text()]
         assert {link.get_text().strip() for link in change_links} == set()
@@ -141,7 +142,7 @@ def test_grant_change_ggis_get(authenticated_platform_admin_client, factories, t
     assert result.status_code == 200
     assert templates_rendered.get("deliver_grant_funding.grant_change_ggis").context.get("grant") == grant
     soup = BeautifulSoup(result.data, "html.parser")
-    assert "What is the GGIS reference number?" in soup.h1.text.strip()
+    assert "What is the GGIS reference number?" in get_h1_text(soup)
 
 
 def test_grant_change_name_get(authenticated_grant_admin_client, factories, templates_rendered):
@@ -150,7 +151,7 @@ def test_grant_change_name_get(authenticated_grant_admin_client, factories, temp
     assert result.status_code == 200
     assert templates_rendered.get("deliver_grant_funding.grant_change_name").context.get("grant") == grant
     soup = BeautifulSoup(result.data, "html.parser")
-    assert "What is the name of this grant?" in soup.h1.text.strip()
+    assert "What is the name of this grant?" in get_h1_text(soup)
 
 
 def test_grant_change_description_get(authenticated_grant_admin_client, factories, templates_rendered):
@@ -161,7 +162,7 @@ def test_grant_change_description_get(authenticated_grant_admin_client, factorie
     assert result.status_code == 200
     assert templates_rendered.get("deliver_grant_funding.grant_change_description").context.get("grant") == grant
     soup = BeautifulSoup(result.data, "html.parser")
-    assert "What is the main purpose of this grant?" in soup.h1.text.strip()
+    assert "What is the main purpose of this grant?" in get_h1_text(soup)
 
 
 def test_grant_change_contact_get(authenticated_grant_admin_client, factories, templates_rendered):
@@ -172,7 +173,7 @@ def test_grant_change_contact_get(authenticated_grant_admin_client, factories, t
     assert result.status_code == 200
     assert templates_rendered.get("deliver_grant_funding.grant_change_contact").context.get("grant") == grant
     soup = BeautifulSoup(result.data, "html.parser")
-    assert "Who is the main contact for this grant?" in soup.h1.text.strip()
+    assert "Who is the main contact for this grant?" in get_h1_text(soup)
 
 
 def test_grant_change_name_post(authenticated_platform_admin_client, factories, templates_rendered, db_session):
@@ -268,7 +269,7 @@ def test_grant_change_name_post_with_errors(authenticated_platform_admin_client,
     assert result.status_code == 200
 
     soup = BeautifulSoup(result.data, "html.parser")
-    assert soup.h2.text.strip() == "There is a problem"
+    assert get_h2_text(soup) == "There is a problem"
     assert len(soup.find_all("a", href="#name")) == 1
     assert soup.find_all("a", href="#name")[0].text.strip() == "Grant name already in use"
 
@@ -281,7 +282,7 @@ def test_create_collection_get(authenticated_platform_admin_client, factories, t
     assert result.status_code == 200
 
     soup = BeautifulSoup(result.data, "html.parser")
-    assert soup.h1.text.strip() == "What is the name of the collection?"
+    assert get_h1_text(soup) == "What is the name of the collection?"
 
 
 def test_create_collection_post(authenticated_platform_admin_client, factories, db_session):
@@ -309,7 +310,7 @@ def test_create_collection_post_duplicate_name(authenticated_platform_admin_clie
     assert result.status_code == 200
 
     soup = BeautifulSoup(result.data, "html.parser")
-    assert soup.h2.text.strip() == "There is a problem"
+    assert get_h2_text(soup) == "There is a problem"
     assert len(soup.find_all("a", href="#name")) == 1
     assert soup.find_all("a", href="#name")[0].text.strip() == "Name already in use"
 
@@ -322,7 +323,7 @@ def test_create_section_get(authenticated_platform_admin_client, factories, temp
     assert result.status_code == 200
 
     soup = BeautifulSoup(result.data, "html.parser")
-    assert soup.h1.text.strip() == "What is the name of the section?"
+    assert get_h1_text(soup) == "What is the name of the section?"
 
 
 def test_create_section_post(authenticated_platform_admin_client, factories, db_session):
@@ -351,7 +352,7 @@ def test_create_section_post_duplicate_name(authenticated_platform_admin_client,
     )
 
     soup = BeautifulSoup(result.data, "html.parser")
-    assert soup.h2.text.strip() == "There is a problem"
+    assert get_h2_text(soup) == "There is a problem"
     assert len(soup.find_all("a", href="#title")) == 1
     assert soup.find_all("a", href="#title")[0].text.strip() == "Title already in use"
 
@@ -369,7 +370,7 @@ def test_create_form_get(authenticated_platform_admin_client, factories, templat
     assert result.status_code == 200
 
     soup = BeautifulSoup(result.data, "html.parser")
-    assert soup.h1.text.strip() == "Add a form"
+    assert get_h1_text(soup) == "Add a form"
 
     result = authenticated_platform_admin_client.get(
         url_for(
@@ -383,7 +384,7 @@ def test_create_form_get(authenticated_platform_admin_client, factories, templat
     assert result.status_code == 200
 
     soup = BeautifulSoup(result.data, "html.parser")
-    assert soup.h1.text.strip() == "What is the name of the form?"
+    assert get_h1_text(soup) == "What is the name of the form?"
 
 
 def test_create_form_post(authenticated_platform_admin_client, factories, db_session):
@@ -427,7 +428,7 @@ def test_create_form_post_duplicate_name(authenticated_platform_admin_client, fa
     )
     assert result.status_code == 200
     soup = BeautifulSoup(result.data, "html.parser")
-    assert soup.h2.text.strip() == "There is a problem"
+    assert get_h2_text(soup) == "There is a problem"
     assert len(soup.find_all("a", href="#title")) == 1
     assert soup.find_all("a", href="#title")[0].text.strip() == "Title already in use"
 
@@ -637,7 +638,7 @@ def test_create_question_choose_type_get(authenticated_platform_admin_client, fa
     assert result.status_code == 200
 
     soup = BeautifulSoup(result.data, "html.parser")
-    assert soup.h1.text.strip() == "What is the type of the question?"
+    assert get_h1_text(soup) == "What is the type of the question?"
 
 
 def test_create_question_choose_type_post(authenticated_platform_admin_client, factories):
@@ -680,7 +681,7 @@ def test_create_question_choose_type_post_error(authenticated_platform_admin_cli
     )
     assert result.status_code == 200
     soup = BeautifulSoup(result.data, "html.parser")
-    assert soup.h2.text.strip() == "There is a problem"
+    assert get_h2_text(soup) == "There is a problem"
     assert len(soup.find_all("a", href="#question type")) == 1
     assert soup.find_all("a", href="#question type")[0].text.strip() == "Select a question type"
 
@@ -700,7 +701,7 @@ def test_add_text_question_get(authenticated_platform_admin_client, factories):
     assert result.status_code == 200
 
     soup = BeautifulSoup(result.data, "html.parser")
-    assert soup.h1.text.strip() == "Add question"
+    assert get_h1_text(soup) == "Add question"
 
     assert (
         soup.find_all("dd", class_="govuk-summary-list__value")[0].text.strip()
@@ -754,7 +755,7 @@ def test_add_text_question_post_duplicate_text(authenticated_platform_admin_clie
     assert result.status_code == 200
 
     soup = BeautifulSoup(result.data, "html.parser")
-    assert soup.h2.text.strip() == "There is a problem"
+    assert get_h2_text(soup) == "There is a problem"
     assert len(soup.find_all("a", href="#text")) == 1
     assert soup.find_all("a", href="#text")[0].text.strip() == "Text already in use"
 
@@ -775,7 +776,7 @@ def test_edit_question_get(authenticated_platform_admin_client, factories):
     assert result.status_code == 200
 
     soup = BeautifulSoup(result.data, "html.parser")
-    assert soup.h1.text.strip() == "Edit question"
+    assert get_h1_text(soup) == "Edit question"
 
 
 def test_edit_question_post(authenticated_platform_admin_client, factories, db_session):
@@ -812,7 +813,7 @@ def test_grant_setup_intro_get(authenticated_platform_admin_client):
     response = authenticated_platform_admin_client.get(url_for("deliver_grant_funding.grant_setup_intro"))
     assert response.status_code == 200
     soup = BeautifulSoup(response.data, "html.parser")
-    assert soup.h1.text.strip() == "Tell us about the grant"
+    assert get_h1_text(soup) == "Tell us about the grant"
 
 
 def test_grant_setup_intro_post(authenticated_platform_admin_client):
@@ -832,7 +833,7 @@ def test_grant_setup_ggis_get_with_session(authenticated_platform_admin_client):
     response = authenticated_platform_admin_client.get(url_for("deliver_grant_funding.grant_setup_ggis"))
     assert response.status_code == 200
     soup = BeautifulSoup(response.data, "html.parser")
-    assert soup.h1.text.strip() == "Do you have a Government Grants Information System (GGIS) reference number?"
+    assert get_h1_text(soup) == "Do you have a Government Grants Information System (GGIS) reference number?"
 
 
 def test_grant_setup_ggis_get_without_session_redirects(authenticated_platform_admin_client):
@@ -871,7 +872,7 @@ def test_grant_setup_ggis_required_info_get(authenticated_platform_admin_client)
     response = authenticated_platform_admin_client.get(url_for("deliver_grant_funding.grant_setup_ggis_required_info"))
     assert response.status_code == 200
     soup = BeautifulSoup(response.data, "html.parser")
-    assert "You need to have a GGIS reference number before you can add this grant" in soup.h1.text.strip()
+    assert "You need to have a GGIS reference number before you can add this grant" in get_h1_text(soup)
 
 
 def test_grant_setup_name_get_with_session(authenticated_platform_admin_client):
@@ -881,7 +882,7 @@ def test_grant_setup_name_get_with_session(authenticated_platform_admin_client):
     response = authenticated_platform_admin_client.get(url_for("deliver_grant_funding.grant_setup_name"))
     assert response.status_code == 200
     soup = BeautifulSoup(response.data, "html.parser")
-    assert soup.h1.text.strip() == "What is the name of this grant?"
+    assert get_h1_text(soup) == "What is the name of this grant?"
 
 
 def test_grant_setup_name_post(authenticated_platform_admin_client):
@@ -903,7 +904,7 @@ def test_grant_setup_description_get_with_session(authenticated_platform_admin_c
     response = authenticated_platform_admin_client.get(url_for("deliver_grant_funding.grant_setup_description"))
     assert response.status_code == 200
     soup = BeautifulSoup(response.data, "html.parser")
-    assert soup.h1.text.strip() == "What is the main purpose of this grant?"
+    assert get_h1_text(soup) == "What is the main purpose of this grant?"
 
 
 def test_grant_setup_description_post_too_long(authenticated_platform_admin_client):
@@ -917,7 +918,7 @@ def test_grant_setup_description_post_too_long(authenticated_platform_admin_clie
     )
     assert response.status_code == 200
     soup = BeautifulSoup(response.data, "html.parser")
-    assert soup.h2.text.strip() == "There is a problem"
+    assert get_h2_text(soup) == "There is a problem"
     assert len(soup.find_all("a", href="#description")) == 1
     assert "Description must be 200 words or fewer" in soup.find_all("a", href="#description")[0].text.strip()
 
@@ -941,7 +942,7 @@ def test_grant_setup_contact_get_with_session(authenticated_platform_admin_clien
     response = authenticated_platform_admin_client.get(url_for("deliver_grant_funding.grant_setup_contact"))
     assert response.status_code == 200
     soup = BeautifulSoup(response.data, "html.parser")
-    assert soup.h1.text.strip() == "Who is the main contact for this grant?"
+    assert get_h1_text(soup) == "Who is the main contact for this grant?"
 
 
 def test_grant_setup_contact_post_valid(authenticated_platform_admin_client):

--- a/tests/models.py
+++ b/tests/models.py
@@ -13,6 +13,7 @@ from uuid import uuid4
 
 import factory
 import factory.fuzzy
+from factory.alchemy import SQLAlchemyModelFactory
 from flask import url_for
 
 from app.common.data.models import (
@@ -35,7 +36,7 @@ def _required() -> None:
     raise ValueError("Value must be set explicitly for tests")
 
 
-class _GrantFactory(factory.alchemy.SQLAlchemyModelFactory):
+class _GrantFactory(SQLAlchemyModelFactory):
     class Meta:
         model = Grant
         sqlalchemy_session_factory = lambda: db.session  # noqa: E731
@@ -49,7 +50,7 @@ class _GrantFactory(factory.alchemy.SQLAlchemyModelFactory):
     primary_contact_email = factory.Faker("email")
 
 
-class _UserFactory(factory.alchemy.SQLAlchemyModelFactory):
+class _UserFactory(SQLAlchemyModelFactory):
     class Meta:
         model = User
         sqlalchemy_session_factory = lambda: db.session  # noqa: E731
@@ -62,7 +63,7 @@ class _UserFactory(factory.alchemy.SQLAlchemyModelFactory):
     last_logged_in_at_utc = factory.LazyFunction(lambda: datetime.datetime.now())
 
 
-class _OrganisationFactory(factory.alchemy.SQLAlchemyModelFactory):
+class _OrganisationFactory(SQLAlchemyModelFactory):
     class Meta:
         model = Organisation
         sqlalchemy_session_factory = lambda: db.session  # noqa: E731
@@ -71,7 +72,7 @@ class _OrganisationFactory(factory.alchemy.SQLAlchemyModelFactory):
     name = factory.Sequence(lambda n: "Organisation %d" % n)
 
 
-class _UserRoleFactory(factory.alchemy.SQLAlchemyModelFactory):
+class _UserRoleFactory(SQLAlchemyModelFactory):
     class Meta:
         model = UserRole
         sqlalchemy_session_factory = lambda: db.session  # noqa: E731
@@ -97,7 +98,7 @@ class _UserRoleFactory(factory.alchemy.SQLAlchemyModelFactory):
         )
 
 
-class _MagicLinkFactory(factory.alchemy.SQLAlchemyModelFactory):
+class _MagicLinkFactory(SQLAlchemyModelFactory):
     class Meta:
         model = MagicLink
         sqlalchemy_session_factory = lambda: db.session  # noqa: E731
@@ -113,7 +114,7 @@ class _MagicLinkFactory(factory.alchemy.SQLAlchemyModelFactory):
     claimed_at_utc = None
 
 
-class _CollectionFactory(factory.alchemy.SQLAlchemyModelFactory):
+class _CollectionFactory(SQLAlchemyModelFactory):
     class Meta:
         model = Collection
         sqlalchemy_session_factory = lambda: db.session  # noqa: E731
@@ -130,7 +131,7 @@ class _CollectionFactory(factory.alchemy.SQLAlchemyModelFactory):
     grant = factory.SubFactory(_GrantFactory)
 
 
-class _SubmissionFactory(factory.alchemy.SQLAlchemyModelFactory):
+class _SubmissionFactory(SQLAlchemyModelFactory):
     class Meta:
         model = Submission
         sqlalchemy_session_factory = lambda: db.session  # noqa: E731
@@ -149,7 +150,7 @@ class _SubmissionFactory(factory.alchemy.SQLAlchemyModelFactory):
     collection_version = factory.LazyAttribute(lambda o: o.collection.version)
 
 
-class _SectionFactory(factory.alchemy.SQLAlchemyModelFactory):
+class _SectionFactory(SQLAlchemyModelFactory):
     class Meta:
         model = Section
         sqlalchemy_session_factory = lambda: db.session  # noqa: E731
@@ -164,7 +165,7 @@ class _SectionFactory(factory.alchemy.SQLAlchemyModelFactory):
     collection_id = factory.LazyAttribute(lambda o: o.collection.id)
 
 
-class _FormFactory(factory.alchemy.SQLAlchemyModelFactory):
+class _FormFactory(SQLAlchemyModelFactory):
     class Meta:
         model = Form
         sqlalchemy_session_factory = lambda: db.session  # noqa: E731
@@ -179,7 +180,7 @@ class _FormFactory(factory.alchemy.SQLAlchemyModelFactory):
     section_id = factory.LazyAttribute(lambda o: o.section.id)
 
 
-class _QuestionFactory(factory.alchemy.SQLAlchemyModelFactory):
+class _QuestionFactory(SQLAlchemyModelFactory):
     class Meta:
         model = Question
         sqlalchemy_session_factory = lambda: db.session  # noqa: E731
@@ -196,7 +197,7 @@ class _QuestionFactory(factory.alchemy.SQLAlchemyModelFactory):
     form_id = factory.LazyAttribute(lambda o: o.form.id)
 
 
-class _SubmissionEventFactory(factory.alchemy.SQLAlchemyModelFactory):
+class _SubmissionEventFactory(SQLAlchemyModelFactory):
     class Meta:
         model = SubmissionEvent
         sqlalchemy_session_factory = lambda: db.session  # noqa: E731
@@ -208,7 +209,7 @@ class _SubmissionEventFactory(factory.alchemy.SQLAlchemyModelFactory):
     created_by = factory.SubFactory(_UserFactory)
 
 
-class _ExpressionFactory(factory.alchemy.SQLAlchemyModelFactory):
+class _ExpressionFactory(SQLAlchemyModelFactory):
     class Meta:
         model = Expression
         sqlalchemy_session_factory = lambda: db.session  # noqa: E731
@@ -227,7 +228,7 @@ class _ExpressionFactory(factory.alchemy.SQLAlchemyModelFactory):
     type = factory.LazyFunction(_required)
 
 
-class _InvitationFactory(factory.alchemy.SQLAlchemyModelFactory):
+class _InvitationFactory(SQLAlchemyModelFactory):
     class Meta:
         model = Invitation
         sqlalchemy_session_factory = lambda: db.session  # noqa: E731

--- a/tests/unit/common/expressions/test_forms.py
+++ b/tests/unit/common/expressions/test_forms.py
@@ -12,6 +12,7 @@ class TestBuildManagedExpressionForm:
 
     def test_integer_data_type(self):
         _FormClass = build_managed_expression_form(ExpressionType.CONDITION, QuestionDataType.INTEGER)
+        assert _FormClass
         form = _FormClass()
 
         assert form.type.choices == [
@@ -22,6 +23,7 @@ class TestBuildManagedExpressionForm:
 
     def test_recognises_invalid_data_for_a_managed_expression(self):
         _FormClass = build_managed_expression_form(ExpressionType.CONDITION, QuestionDataType.INTEGER)
+        assert _FormClass
         form = _FormClass(
             formdata=MultiDict(
                 {
@@ -47,6 +49,7 @@ class TestBuildManagedExpressionForm:
         question = factories.question.build()
 
         _FormClass = build_managed_expression_form(ExpressionType.CONDITION, QuestionDataType.INTEGER)
+        assert _FormClass
         form = _FormClass(
             formdata=MultiDict(
                 {

--- a/tests/unit/common/helpers/test_collections.py
+++ b/tests/unit/common/helpers/test_collections.py
@@ -134,7 +134,7 @@ class TestSubmissionHelper:
 
             helper = SubmissionHelper(submission)
             question = helper.get_first_question_for_form(form)
-            assert question.id == uuid.UUID("00000000-0000-0000-0000-000000000000")
+            assert question.id == uuid.UUID("00000000-0000-0000-0000-000000000000")  # ty: ignore[possibly-unbound-attribute]
 
         def test_no_visible_questions_in_form(self, db_session, factories):
             form = factories.form.build()
@@ -155,7 +155,7 @@ class TestSubmissionHelper:
 
             helper = SubmissionHelper(submission)
             question = helper.get_last_question_for_form(form)
-            assert question.id == uuid.UUID("00000000-0000-0000-0000-000000000004")
+            assert question.id == uuid.UUID("00000000-0000-0000-0000-000000000004")  # ty: ignore[possibly-unbound-attribute]
 
         def test_no_visible_questions_in_form(self, db_session, factories):
             form = factories.form.build()
@@ -204,10 +204,10 @@ class TestSubmissionHelper:
 
             helper = SubmissionHelper(submission)
 
-            assert helper.get_next_question(uuid.UUID(int=0)).id == uuid.UUID(int=1)
-            assert helper.get_next_question(uuid.UUID(int=1)).id == uuid.UUID(int=2)
-            assert helper.get_next_question(uuid.UUID(int=2)).id == uuid.UUID(int=3)
-            assert helper.get_next_question(uuid.UUID(int=3)).id == uuid.UUID(int=4)
+            assert helper.get_next_question(uuid.UUID(int=0)).id == uuid.UUID(int=1)  # ty: ignore[possibly-unbound-attribute]
+            assert helper.get_next_question(uuid.UUID(int=1)).id == uuid.UUID(int=2)  # ty: ignore[possibly-unbound-attribute]
+            assert helper.get_next_question(uuid.UUID(int=2)).id == uuid.UUID(int=3)  # ty: ignore[possibly-unbound-attribute]
+            assert helper.get_next_question(uuid.UUID(int=3)).id == uuid.UUID(int=4)  # ty: ignore[possibly-unbound-attribute]
 
         def test_current_question_exists_but_is_last_question(self, db_session, factories):
             form = factories.form.build()
@@ -246,7 +246,9 @@ class TestSubmissionHelper:
 
             helper = SubmissionHelper(submission)
 
-            assert helper.get_next_question(question_one.id).id == question_three.id
+            question = helper.get_next_question(question_one.id)
+            assert question
+            assert question.id == question_three.id
 
     class TestGetPreviousQuestion:
         def test_current_question_exists_and_is_not_first_question(self, db_session, factories):
@@ -257,10 +259,10 @@ class TestSubmissionHelper:
 
             helper = SubmissionHelper(submission)
 
-            assert helper.get_previous_question(uuid.UUID(int=1)).id == uuid.UUID(int=0)
-            assert helper.get_previous_question(uuid.UUID(int=2)).id == uuid.UUID(int=1)
-            assert helper.get_previous_question(uuid.UUID(int=3)).id == uuid.UUID(int=2)
-            assert helper.get_previous_question(uuid.UUID(int=4)).id == uuid.UUID(int=3)
+            assert helper.get_previous_question(uuid.UUID(int=1)).id == uuid.UUID(int=0)  # ty: ignore[possibly-unbound-attribute]
+            assert helper.get_previous_question(uuid.UUID(int=2)).id == uuid.UUID(int=1)  # ty: ignore[possibly-unbound-attribute]
+            assert helper.get_previous_question(uuid.UUID(int=3)).id == uuid.UUID(int=2)  # ty: ignore[possibly-unbound-attribute]
+            assert helper.get_previous_question(uuid.UUID(int=4)).id == uuid.UUID(int=3)  # ty: ignore[possibly-unbound-attribute]
 
         def test_current_question_exists_but_is_first_question(self, db_session, factories):
             form = factories.form.build()
@@ -299,7 +301,9 @@ class TestSubmissionHelper:
 
             helper = SubmissionHelper(submission)
 
-            assert helper.get_previous_question(question_three.id).id == question_one.id
+            question = helper.get_previous_question(question_three.id)
+            assert question
+            assert question.id == question_one.id
 
     class TestStatuses:
         def test_all_forms_are_completed(self, db_session, factories):

--- a/tests/unit/test_all_routes_access.py
+++ b/tests/unit/test_all_routes_access.py
@@ -100,7 +100,7 @@ def test_accessibility_for_user_role_to_each_endpoint(app):
             assert not any(decorator in all_auth_annotations for decorator in decorators)
 
         else:
-            pytest.fail(f"Unexpected endpoint {rule.endpoint}. Add this to the expected_route_access mapping.")
+            raise pytest.fail(f"Unexpected endpoint {rule.endpoint}. Add this to the expected_route_access mapping.")  # ty: ignore[call-non-callable]
 
 
 def test_routes_list_is_valid(app):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -107,3 +107,15 @@ def build_db_config(setup_db_container: PostgresContainer | None) -> Dict[str, A
             {"username": setup_db_container.username, "password": setup_db_container.password}
         ),
     }
+
+
+def get_h1_text(soup: BeautifulSoup) -> str:
+    h1 = soup.h1
+    assert h1, "Could not find <h1> on page"
+    return cast(str, h1.text).strip()
+
+
+def get_h2_text(soup: BeautifulSoup) -> str:
+    h2 = soup.h2
+    assert h2, "Could not find <h2> on page"
+    return cast(str, h2.text).strip()

--- a/uv.lock
+++ b/uv.lock
@@ -569,6 +569,7 @@ dev = [
     { name = "ruff" },
     { name = "sqlalchemy-utils" },
     { name = "testcontainers" },
+    { name = "ty" },
     { name = "types-boto3" },
     { name = "types-flask-migrate" },
     { name = "types-html5lib" },
@@ -629,6 +630,7 @@ dev = [
     { name = "ruff", specifier = "==0.12.2" },
     { name = "sqlalchemy-utils", specifier = "==0.41.2" },
     { name = "testcontainers", extras = ["postgres"], specifier = "==4.10.0" },
+    { name = "ty", specifier = ">=0.0.1a13" },
     { name = "types-boto3", specifier = "==1.39.0" },
     { name = "types-flask-migrate", specifier = "==4.1.0.20250112" },
     { name = "types-html5lib", specifier = "==1.1.11.20250516" },
@@ -1548,6 +1550,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.1a13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a0/b3/09d622729551bc5071e41ce13cc6c57a71eae0a100c993d8a6024c60ce2d/ty-0.0.1a13.tar.gz", hash = "sha256:2a0a96146540e66264dd8ead9530cc77f4283256b97f2c25588283572e012717", size = 3146596, upload-time = "2025-07-02T17:52:14.198Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/5e/eadff1754c3b59797077b069202d12b9187b32f6fcd529bebcac54c6f299/ty-0.0.1a13-py3-none-linux_armv6l.whl", hash = "sha256:9c35d6782d88231c72be8fd525183a63e10b3eaae70d425c9697f06a2beaa08b", size = 6900007, upload-time = "2025-07-02T17:51:45.011Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/06/a4b21058fc7b2671641ffd51f8bdc37334de0e85b80433ce664afc6dbcac/ty-0.0.1a13-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:abd2e52b66b6f30ebb645b26232bd80ef6cb5a06ce71f0ff55aeb7a038491116", size = 7018543, upload-time = "2025-07-02T17:51:47.123Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/37/4345064293bd6543242ba9e627763ab3b2b13fc17d360a9aebc58189b6e4/ty-0.0.1a13-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c824899c45377af42c46a798c19d0dac00b91e5155f8766c701df4fd98a043fd", size = 6645758, upload-time = "2025-07-02T17:51:48.979Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/9e/d0b2d3bb147704effeb3ad06276708c90038af709e7fa30f3bac1729c267/ty-0.0.1a13-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:186ac4ec02746ac46f39651dec2b65ebc5bc026650452e28c55d8b58422ed649", size = 6783008, upload-time = "2025-07-02T17:51:50.393Z" },
+    { url = "https://files.pythonhosted.org/packages/96/74/062881a4eb2009702d46c75dafe3f7ba275ff97bdb8a3e6b68ba19c1a049/ty-0.0.1a13-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a9f398130e9db4be33d162c7a2ddcaf2e7ec6a4c3db895be419857d30960f14a", size = 6753432, upload-time = "2025-07-02T17:51:52.199Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ef/31d4f3ca9eac47ad32b8f245af3f944f0f2cf08fb91d2977c5b1a5fda243/ty-0.0.1a13-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8ee3278edffbf1f4ad2abbd679fa31d2f6f39ab6fb652effc17866441559b77f", size = 7560344, upload-time = "2025-07-02T17:51:54.153Z" },
+    { url = "https://files.pythonhosted.org/packages/72/3c/b4260108b51f9e1212e06f82fbe5134546159f90239207ef6ebe5746533c/ty-0.0.1a13-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:0f8d957620c1bc7dba6a996915a4527ae6b252b552bee71b2fd85cecc2b62e69", size = 7997046, upload-time = "2025-07-02T17:51:55.695Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/3f/00eefb65b61574816efaecb4779b2f7b8e81de1a90b890aea5d3c9a989dc/ty-0.0.1a13-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e58e41fdaf4e8c4639718e29945322070c2c70eea2daa33800d8b2e677b4582", size = 7659362, upload-time = "2025-07-02T17:51:57.246Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/c4/d6d9e5f53ae3f3ce82eafb68ab053758a604cabedb29122f1d3f4bcbbb80/ty-0.0.1a13-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:58836d12a8238550dcad0e9258af646c8d83e07485b97213ec0cdad0b6afc108", size = 7502769, upload-time = "2025-07-02T17:51:58.899Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/fb/85fd217563c68c6e4db419a4e8c4db4b5cdcdc29af4ba736123d6a2224dc/ty-0.0.1a13-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d0f36beac8c8833e4fb9dcba47c7028a2be25736c10f9c8836e46981b93c030b", size = 7313939, upload-time = "2025-07-02T17:52:00.573Z" },
+    { url = "https://files.pythonhosted.org/packages/47/18/c72ff3354022b8918f6cd0e169b64e1e85f7ccb739343985fefb4ecf09f5/ty-0.0.1a13-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:082d430c12b6c8fd58774cd1f5a9e7337d5900ef3cb56a567f21915e975ea02c", size = 6678662, upload-time = "2025-07-02T17:52:02.363Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/39/8f81eb2b01623725c838437ccdf2733502de8c28a2302a3705d04f6cb681/ty-0.0.1a13-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:d4dd460a78d2931415fdbe114a91533a811b83e02b57960486ccb7e9d038bd55", size = 6782460, upload-time = "2025-07-02T17:52:04.15Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/da/107a3beb2768a9591b6753f630dcb64b336eb9e44379e9cca22635fb5706/ty-0.0.1a13-py3-none-musllinux_1_2_i686.whl", hash = "sha256:64d7239718a3bb7bc771c51da1d7d7f3239eead03903a97bc689fff10f4ae9e4", size = 7210683, upload-time = "2025-07-02T17:52:05.919Z" },
+    { url = "https://files.pythonhosted.org/packages/21/31/392fc16133ce393b2271248ac8505c29bd682aacaf1dc9067b02a5c332b0/ty-0.0.1a13-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:2e86c4348961bbc23543c59a642aad324d7735dc4a3abdce9e7f828bf566b49b", size = 7380187, upload-time = "2025-07-02T17:52:07.693Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/f1/7d2afa92c10e57e3a5cd106fb13b0b327d3518cc45e62088c005786e2cdb/ty-0.0.1a13-py3-none-win32.whl", hash = "sha256:18234d30b30ab6df9a5c1891051cf137184ea5bc446172200c25f497cd49eb2a", size = 6514867, upload-time = "2025-07-02T17:52:09.095Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/91/93df4ef3b0368cbd59a20c5d72c4806169d0c0f125241148ededdc712896/ty-0.0.1a13-py3-none-win_amd64.whl", hash = "sha256:6e0dc212853166c4083fc2d5d9253f32d97f94b8afd90224dfea78bceffc2569", size = 7120290, upload-time = "2025-07-02T17:52:10.967Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/62/fe6cc92db2aa1a344937e5313ba3bbdaed24e54332b8a12fe28a92d314ce/ty-0.0.1a13-py3-none-win_arm64.whl", hash = "sha256:5f2237bb301078d51d006170992abb1e5f3b37cec47a11e6db416a76346f60b5", size = 6727050, upload-time = "2025-07-02T17:52:12.874Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
Adds [ty](https://docs.astral.sh/ty/) to our app and makes a PR CI check for it. This check won't be enforced/enabled for now as `ty` is still very much in a non-prod-ready state, but I think useful to try it out for a little while and see how it feels.

If it does reach a production state, it will be a lot faster than `mypy`, so would be nice to switch out if it gets there.

## 📸 Show the thing (screenshots, gifs)

```
✦3 ❯ rm -rf .mypy_cache/ && time uv run mypy
Success: no issues found in 136 source files

real    0m8.085s
user    0m7.400s
sys     0m0.612s

✦3 ❯ time uv run mypy
Success: no issues found in 136 source files

real    0m0.230s
user    0m0.153s
sys     0m0.074s

✦3 ❯ time uv run ty check
WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
All checks passed!

real    0m0.099s
user    0m0.473s
sys     0m0.107s
```