### PR TITLE
FSPT-602 Access grant funding forms

### DIFF
--- a/app/developers/access_routes.py
+++ b/app/developers/access_routes.py
@@ -1,15 +1,20 @@
 import uuid
+from contextlib import suppress
+from typing import ClassVar
 
 from flask import Blueprint, redirect, render_template, request, session, url_for
 from flask.typing import ResponseReturnValue
 
 from app.common.auth.decorators import is_platform_admin
+from app.common.collections.runner import FormRunner, runner_url_map
 from app.common.data import interfaces
+from app.common.data.interfaces.collections import create_submission, get_collection
 from app.common.data.interfaces.grants import get_grant
 from app.common.data.interfaces.temporary import get_submission_by_collection_and_user
-from app.common.data.types import SubmissionStatusEnum
+from app.common.data.types import FormRunnerState, SubmissionModeEnum, SubmissionStatusEnum
 from app.common.forms import GenericSubmitForm
 from app.common.helpers.collections import SubmissionHelper
+from app.extensions import auto_commit_after_request
 
 developers_access_blueprint = Blueprint("access", __name__, url_prefix="/access")
 
@@ -48,3 +53,93 @@ def grant_details(grant_id: uuid.UUID) -> ResponseReturnValue:
         submission_helpers=submission_helpers,
         form=form,
     )
+
+
+class AGFFormRunner(FormRunner):
+    url_map: ClassVar[runner_url_map] = {
+        FormRunnerState.QUESTION: lambda runner, question, _form, source: url_for(
+            "developers.access.ask_a_question",
+            submission_id=runner.submission.id,
+            question_id=question.id if question else None,
+            source=source,
+        ),
+        FormRunnerState.TASKLIST: lambda runner, _question, _form, _source: url_for(
+            "developers.access.submission_tasklist",
+            submission_id=runner.submission.id,
+            form_id=runner.form.id if runner.form else None,
+        ),
+        FormRunnerState.CHECK_YOUR_ANSWERS: lambda runner, _question, form, source: url_for(
+            "developers.access.check_your_answers",
+            submission_id=runner.submission.id,
+            form_id=form.id if form else runner.form.id if runner.form else None,
+            source=source,
+        ),
+    }
+
+
+# todo: this a developers solution only - anything actually doing this should be through POST
+#       with sensible permission and integrity checks
+@developers_access_blueprint.get("/submissions/start/<uuid:collection_id>")
+@auto_commit_after_request
+@is_platform_admin
+def start_submission_redirect(collection_id: uuid.UUID) -> ResponseReturnValue:
+    current_user = interfaces.user.get_current_user()
+    collection = get_collection(collection_id)
+    submission = create_submission(collection=collection, created_by=current_user, mode=SubmissionModeEnum.TEST)
+    return redirect(url_for("developers.access.submission_tasklist", submission_id=submission.id))
+
+
+@developers_access_blueprint.route("/submissions/<uuid:submission_id>", methods=["GET", "POST"])
+@auto_commit_after_request
+@is_platform_admin
+def submission_tasklist(submission_id: uuid.UUID) -> ResponseReturnValue:
+    source = request.args.get("source")
+    runner = AGFFormRunner.load(submission_id).context(source=FormRunnerState(source) if source else None)
+
+    if runner.tasklist_form.validate_on_submit():
+        with suppress(ValueError):
+            runner.submit(interfaces.user.get_current_user())
+            return redirect(url_for("developers.access.grant_details", grant_id=runner.submission.grant.id))
+
+    return render_template(
+        "developers/access/collection_tasklist.html",
+        runner=runner,
+    )
+
+
+@developers_access_blueprint.route("/submissions/<uuid:submission_id>/<uuid:question_id>", methods=["GET", "POST"])
+@is_platform_admin
+@auto_commit_after_request
+def ask_a_question(submission_id: uuid.UUID, question_id: uuid.UUID) -> ResponseReturnValue:
+    source = request.args.get("source")
+    runner = AGFFormRunner.load(submission_id).context(
+        question_id=question_id, source=FormRunnerState(source) if source else None
+    )
+
+    if not runner.validate():
+        return redirect(runner.next_url)
+
+    if runner.question_form and runner.question_form.validate_on_submit():
+        runner.save_question_answer()
+        return redirect(runner.next_url)
+
+    return render_template("developers/access/ask_a_question.html", runner=runner)
+
+
+@developers_access_blueprint.route(
+    "/submissions/<uuid:submission_id>/check-yours-answers/<uuid:form_id>", methods=["GET", "POST"]
+)
+@auto_commit_after_request
+@is_platform_admin
+def check_your_answers(submission_id: uuid.UUID, form_id: uuid.UUID) -> ResponseReturnValue:
+    source = request.args.get("source")
+    runner = AGFFormRunner.load(submission_id).context(
+        form_id=form_id, source=FormRunnerState(source) if source else None
+    )
+
+    if runner.check_your_answers_form.validate_on_submit():
+        with suppress(ValueError):
+            runner.save_is_form_completed(interfaces.user.get_current_user())
+            return redirect(runner.next_url)
+
+    return render_template("developers/access/check_your_answers.html", runner=runner)

--- a/app/developers/templates/developers/access/ask_a_question.html
+++ b/app/developers/templates/developers/access/ask_a_question.html
@@ -1,0 +1,17 @@
+{% from "common/macros/collections.html" import collection_question %}
+{% from "common/macros/collections.html" import collection_before %}
+{% extends "developers/access/base.html" %}
+
+{% set page_title = runner.question.text ~ " - " ~ runner.form.title %}
+
+{% set form = runner.question_form %}
+
+{% block beforeContent %}
+  {{ collection_before(runner) }}
+{% endblock beforeContent %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">{{ collection_question(runner) }}</div>
+  </div>
+{% endblock content %}

--- a/app/developers/templates/developers/access/check_your_answers.html
+++ b/app/developers/templates/developers/access/check_your_answers.html
@@ -1,0 +1,17 @@
+{% from "common/macros/collections.html" import collection_check_your_answers %}
+{% from "common/macros/collections.html" import collection_before %}
+{% extends "developers/access/base.html" %}
+
+{% set page_title = "Check your answers - " ~ runner.form.title %}
+
+{% set form = runner.check_your_answers_form %}
+
+{% block beforeContent %}
+  {{ collection_before(runner) }}
+{% endblock beforeContent %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">{{ collection_check_your_answers(runner) }}</div>
+  </div>
+{% endblock content %}

--- a/app/developers/templates/developers/access/collection_tasklist.html
+++ b/app/developers/templates/developers/access/collection_tasklist.html
@@ -1,0 +1,37 @@
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% from "common/partials/mhclg-test-banner.html" import mhclgTestBanner %}
+{% from "common/macros/status.html" import status %}
+{% from "common/macros/collections.html" import collection_tasklist %}
+{% extends "developers/access/base.html" %}
+
+{% set page_title = "Collection for " ~ runner.submission.name %}
+
+{% set form = runner.tasklist_form %}
+
+{% block beforeContent %}
+  {% if runner.submission.is_test %}
+    {{ mhclgTestBanner("Test submission") }}
+  {% endif %}
+  {{
+    govukBackLink({
+        "text": "Back",
+        "href": url_for("developers.access.grant_details", grant_id=runner.submission.grant.id)
+    })
+  }}
+{% endblock beforeContent %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">{{ runner.submission.name }}</h1>
+
+      {# NOTE: Should we have this as a custom component or macro-ize it? #}
+      <dl class="app-metadata govuk-!-margin-bottom-7">
+        <dt class="app-metadata__key">Status:</dt>
+        <dd class="app-metadata__value" data-testid="submission-status">{{ status(runner.submission.status, submission_status) }}</dd>
+      </dl>
+    </div>
+  </div>
+
+  {{ collection_tasklist(runner) }}
+{% endblock content %}

--- a/app/developers/templates/developers/access/grant_details.html
+++ b/app/developers/templates/developers/access/grant_details.html
@@ -28,18 +28,22 @@
           {% set rows=[] %}
           {% for collection in grant.collections %}
             {% set submission_helper = submission_helpers.get(collection.id) %}
-            {# todo: this should be a link to create (if required), then redirect to, a submission for the collection #}
-            {% set linkHref = "#" %}
-            {# todo: link status up via submission_helper (one per collection? :sweat:) #}
+            {%
+              set link_href = (
+                url_for("developers.access.submission_tasklist", submission_id=submission_helper.id)
+                if submission_helper
+                else url_for("developers.access.start_submission_redirect", collection_id=collection.id)
+              )
+            %}
             {%
               do rows.append({
-                    "title": {
-                      "text": collection.name,
-                    },
-                  "status": {
-                    "html": status(submission_helper.status if submission_helper else statuses.NOT_STARTED, statuses)
-                  },
-                "href": linkHref,
+                "title": {
+                  "text": collection.name,
+                },
+                "status": {
+                  "html": status(submission_helper.status if submission_helper else statuses.NOT_STARTED, statuses)
+                },
+                "href": link_href,
               })
             %}
           {% endfor %}

--- a/tests/unit/test_all_routes_access.py
+++ b/tests/unit/test_all_routes_access.py
@@ -21,6 +21,10 @@ all_auth_annotations = [
 ]
 routes_with_expected_platform_admin_only_access = [
     "developers.access.grants_list",
+    "developers.access.start_submission_redirect",
+    "developers.access.submission_tasklist",
+    "developers.access.ask_a_question",
+    "developers.access.check_your_answers",
     "developers.deliver.grant_developers",
     "developers.deliver.setup_collection",
     "developers.deliver.manage_collection",


### PR DESCRIPTION
Depends on https://github.com/communitiesuk/funding-service/pull/435

## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-602

## 📝 Description
This commit hooks up a form runner to Access Grant Funding using the
library and macros shared by Deliver Grant Funding.

This implementation of a collections form is built into the access
funding base template and behaves differently from the Deliver Grant
Funding forms (going back to the list of collections when complete for
the time being) but should hopefully share all of its core business/
state logic with Deliver Grant Funding.

That should allow us to update the form runner and macros and be
confident it will work everywhere we need it to.

## 📸 Show the thing (screenshots, gifs)

https://github.com/user-attachments/assets/98a54fa5-1fbf-448e-85f4-d1440a60362d

