### PR TITLE
Add helper for creating DB expression

### DIFF
--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -345,13 +345,7 @@ def add_question_condition(question: Question, user: User, managed_expression: "
             managed_expression.referenced_question,
         )
 
-    expression = Expression(
-        statement=managed_expression.statement,
-        context=managed_expression.model_dump(mode="json"),
-        created_by=user,
-        type=ExpressionType.CONDITION,
-        managed_name=managed_expression._key,
-    )
+    expression = Expression.from_managed(managed_expression, user)
     question.expressions.append(expression)
     try:
         db.session.flush()

--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -313,3 +313,17 @@ class Expression(BaseModel):
     @property
     def managed(self) -> "ManagedExpression":
         return get_managed_expression(self)
+
+    @classmethod
+    def from_managed(
+        cls,
+        managed_expression: "ManagedExpression",
+        created_by: "User",
+    ) -> "Expression":
+        return Expression(
+            statement=managed_expression.statement,
+            context=managed_expression.model_dump(mode="json"),
+            created_by=created_by,
+            type=ExpressionType.CONDITION,
+            managed_name=managed_expression._key,
+        )

--- a/tests/integration/common/expressions/test_init.py
+++ b/tests/integration/common/expressions/test_init.py
@@ -1,7 +1,7 @@
 import pytest
 from immutabledict import immutabledict
 
-from app.common.data.interfaces.collections import add_question_condition
+from app.common.data.models import Expression
 from app.common.expressions import ExpressionContext, evaluate
 from app.common.expressions.managed import GreaterThan
 
@@ -93,9 +93,10 @@ class TestEvaluatingManagedExpressions:
     def test_greater_than(self, factories):
         user = factories.user.create()
         q0 = factories.question.create()
-        question = factories.question.create(form=q0.form)
-        managed_expression = GreaterThan(minimum_value=3000, question_id=q0.id)
-        add_question_condition(question, user, managed_expression)
+        question = factories.question.create(
+            form=q0.form,
+            expressions=[Expression.from_managed(GreaterThan(question_id=q0.id, minimum_value=3000), user)],
+        )
 
         expr = question.expressions[0]
 

--- a/tests/integration/common/expressions/test_managed.py
+++ b/tests/integration/common/expressions/test_managed.py
@@ -2,7 +2,7 @@ import uuid
 
 import pytest
 
-from app.common.data.interfaces.collections import add_question_condition, get_question_by_id
+from app.common.data.interfaces.collections import get_question_by_id
 from app.common.data.models import Expression
 from app.common.expressions import evaluate
 from app.common.expressions.managed import Between, GreaterThan, LessThan
@@ -12,9 +12,13 @@ class TestBaseManagedExpression:
     def test_gets_referenced_question(self, factories):
         user = factories.user.create()
         depends_on_question = factories.question.create()
-        question = factories.question.create(form=depends_on_question.form)
+        question = factories.question.create(
+            form=depends_on_question.form,
+            expressions=[
+                Expression.from_managed(GreaterThan(question_id=depends_on_question.id, minimum_value=1000), user)
+            ],
+        )
 
-        add_question_condition(question, user, GreaterThan(question_id=depends_on_question.id, minimum_value=1000))
         from_db = get_question_by_id(question.id)
 
         assert from_db.conditions[0].managed.referenced_question.id == depends_on_question.id


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
If you have a managed expression instance, it feels like it should be easy to convert that to a DB Expression instance for when you're creating new expressions. This adds a small helper method to do that.

## 🧪 Testing
Run the tests

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [-] I need the reviewer(s) to pull and run this change locally
- [-] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested