### PR TITLE
Add nightly GH action to sync seeded grants

### DIFF
--- a/.github/workflows/refresh_seeded_grants.yml
+++ b/.github/workflows/refresh_seeded_grants.yml
@@ -1,0 +1,44 @@
+name: Refresh seeded grants
+on:
+  schedule:
+    - cron: "30 2 * * *"
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: ${{ matrix.environment }}
+    strategy:
+      matrix:
+        environment:
+          - dev
+          - test
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read  # This is required for actions/checkout
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/GithubCopilotDeploy
+          role-session-name: "${{ inputs.app_name }}_${{ inputs.environment }}_copilot_${{ steps.currentdatetime.outputs.datetime }}"
+          aws-region: eu-west-2
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: 3.13.5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6.3.1
+        with:
+          enable-cache: true
+
+      - name: Seed grants in ${{ matrix.environment }} environment
+        run: |
+          echo "Running seed-grants against ${{ matrix.environment }} environment ..."
+          uv run ./scripts/run-ad-hoc-task.py --command "flask developers seed-grants"
+          echo "Done."


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-636

## 📝 Description
These seeded grants give us a nice, well-defined and fleshed-out sample grant that can be used for testing, product review, and demos. We should keep it up to date with new features and functionality.

This nightly-running task will mean that any changes made (accidentally or otherwise) to our sample grants will be reset each night, giving us a consistent thing to use.

## 🧪 Testing
https://github.com/communitiesuk/funding-service/actions/runs/16118891686/job/45479309268

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [ ] I need the reviewer(s) to pull and run this change locally
- [-] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested