### PR TITLE
Fix spaces between links and full stops

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,11 +22,11 @@ vite:
 
 .PHONY: check-html
 check-html:
-	npx prettier --plugin=prettier-plugin-jinja-template --parser=jinja-template --tab-width=2 --html-whitespace-sensitivity ignore --bracket-same-line=true --print-width=240 --check **/*.html
+	npx prettier --plugin=prettier-plugin-jinja-template --parser=jinja-template --tab-width=2 --html-whitespace-sensitivity css --bracket-same-line=true --print-width=240 --check **/*.html
 
 .PHONY: format-html
 format-html:
-	npx prettier --plugin=prettier-plugin-jinja-template --parser=jinja-template --tab-width=2 --html-whitespace-sensitivity ignore --bracket-same-line=true --print-width=240 --write **/*.html
+	npx prettier --plugin=prettier-plugin-jinja-template --parser=jinja-template --tab-width=2 --html-whitespace-sensitivity css --bracket-same-line=true --print-width=240 --write **/*.html
 
 .PHONY: build
 build:

--- a/app/common/templates/common/auth/check_email.html
+++ b/app/common/templates/common/auth/check_email.html
@@ -14,8 +14,7 @@
       <p class="govuk-body">The email may take a few minutes to arrive.</p>
       <p class="govuk-body">
         Check your spam or junk folders – if it still has not arrived,
-        <a href="{{ url_for('auth.request_a_link_to_sign_in') }}" class="govuk-link govuk-link--no-visited-state">request a new link</a>
-        .
+        <a href="{{ url_for('auth.request_a_link_to_sign_in') }}" class="govuk-link govuk-link--no-visited-state">request a new link</a>.
       </p>
     </div>
   </div>

--- a/app/common/templates/common/auth/mhclg-user-not-authorised.html
+++ b/app/common/templates/common/auth/mhclg-user-not-authorised.html
@@ -9,8 +9,7 @@
       <p class="govuk-body">You do not have permission to log into the Funding Service.</p>
       <p class="govuk-body">
         If you think you should have access, please contact us through our
-        <a class="govuk-link govuk-link--no-visited-state" href="{{ service_desk_url }}" target="_blank">support desk</a>
-        .
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ service_desk_url }}" target="_blank">support desk</a>.
       </p>
     </div>
   </div>

--- a/app/common/templates/common/errors/403.html
+++ b/app/common/templates/common/errors/403.html
@@ -8,8 +8,7 @@
       <h1 class="govuk-heading-l">You do not have permission to access this page</h1>
       <p class="govuk-body">
         If you believe this is incorrect, please contact us through our
-        <a class="govuk-link govuk-link--no-visited-state" href="{{ service_desk_url }}" target="_blank">support desk</a>
-        .
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ service_desk_url }}" target="_blank">support desk</a>.
       </p>
       <p class="govuk-body">Monday to Friday, 9am to 5pm (except public holidays).</p>
     </div>

--- a/app/common/templates/common/errors/404.html
+++ b/app/common/templates/common/errors/404.html
@@ -10,8 +10,7 @@
       <p class="govuk-body">If you pasted the web address, check you copied the entire address.</p>
       <p class="govuk-body">
         If the web address is correct or you selected a link or button, contact the
-        <a class="govuk-link govuk-link--no-visited-state" href="{{ service_desk_url }}" target="_blank">Funding Service support desk</a>
-        .
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ service_desk_url }}" target="_blank">Funding Service support desk</a>.
       </p>
       <p class="govuk-body">Monday to Friday: 9am to 5pm (except public holidays).</p>
     </div>

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_setup/ggis_required_info.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_setup/ggis_required_info.html
@@ -25,8 +25,7 @@
       </p>
       <p class="govuk-body">
         If you've lost your GGIS reference number, contact the team at
-        <a href="mailto:{{ config.GGIS_TEAM_EMAIL }}" class="govuk-link">{{ config.GGIS_TEAM_EMAIL }}</a>
-        .
+        <a href="mailto:{{ config.GGIS_TEAM_EMAIL }}" class="govuk-link">{{ config.GGIS_TEAM_EMAIL }}</a>.
       </p>
     </div>
   </div>

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_team/grant_user_list.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_team/grant_user_list.html
@@ -104,8 +104,7 @@
         <h2 class="govuk-heading-m govuk-!-margin-top-5">If you need to add other grant team members</h2>
         <p class="govuk-body">
           Contact us through our
-          <a class="govuk-link govuk-link--no-visited-state" href="{{ service_desk_url }}" target="_blank">support desk (opens in new tab)</a>
-          .
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ service_desk_url }}" target="_blank">support desk (opens in new tab)</a>.
         </p>
         <p class="govuk-body">Monday to Friday, 9am to 5pm (except public holidays).</p>
       </div>


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
Our prettier config was forcing full stops onto new lines. If the full stop directly followed a link </a>, then a newline would add a space between the link text and the full stop - which is ugly.

Switching the HTML whitespace sensitivity to `css` tells prettier to work out the display style of the blocks, and treat whitespace sensitively and avoid adding or removing whitespace. This lets us tuck the full stop directly after the </a> tag and not have it moved onto a new line by prettier (but also, prettier won't force existing full stops off of newlines if they're on them).

## 📸 Show the thing (screenshots, gifs)
<!-- Include screenshots for UI changes, new features, or visual modifications -->
<!-- Use "Before" and "After" sections if showing changes to existing functionality -->

### Before
![image](https://github.com/user-attachments/assets/8083571f-63ef-42f2-83cb-f956f35307ee)

### After
![image](https://github.com/user-attachments/assets/f76aa5e5-52e3-4b5e-a323-373358a32150)

## 🧪 Testing
look at it

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [-] I need the reviewer(s) to pull and run this change locally
- [-] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested

## 📚 Additional Notes
<!-- Any additional context, concerns, or considerations for reviewers -->
