### PR TITLE
FSPT-577: Add redirects/blocks to SSO and magic link flows

### DIFF
--- a/app/common/auth/forms.py
+++ b/app/common/auth/forms.py
@@ -1,9 +1,7 @@
 from flask_wtf import FlaskForm
 from govuk_frontend_wtf.wtforms_widgets import GovSubmitInput, GovTextInput
 from wtforms import StringField, SubmitField
-from wtforms.validators import DataRequired
-
-from app.common.forms.validators import CommunitiesEmail
+from wtforms.validators import DataRequired, Email
 
 
 class SignInForm(FlaskForm):
@@ -11,7 +9,7 @@ class SignInForm(FlaskForm):
         "Email address",
         validators=[
             DataRequired(message="Enter your email address"),
-            CommunitiesEmail(),
+            Email(message="Enter an email address in the correct format, like name@example.com"),
         ],
         filters=[lambda x: x.strip() if x else x],
         widget=GovTextInput(),

--- a/app/common/templates/common/auth/sign_in_magic_link.html
+++ b/app/common/templates/common/auth/sign_in_magic_link.html
@@ -8,11 +8,10 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% if link_expired %}
-        {{ govukNotificationBanner(params={"titleText": "Link expired", "text": "Your link has expired, please request a new one."}) }}
+        {{ govukNotificationBanner(params={"titleText": "Link expired", "text": "Your link has expired. Request a new link to sign in."}) }}
       {% endif %}
       <h1 class="govuk-heading-l">Request a link to sign in</h1>
       <p class="govuk-body">Enter your email address and we’ll send you a link to sign in.</p>
-      <p class="govuk-body">You’ll need to use your ‘@communities.gov.uk’ email address.</p>
       {{ govukInsetText(params={"text": "The link will work once and stop working after 15 minutes."}) }}
       <form method="post" novalidate>
         {{ form.csrf_token }}

--- a/app/common/templates/common/auth/sign_in_sso.html
+++ b/app/common/templates/common/auth/sign_in_sso.html
@@ -1,10 +1,14 @@
 {% extends "deliver_grant_funding/base.html" %}
 
 {% block pageTitle %}Deliver grant funding - {{ super() }}{% endblock pageTitle %}
+{% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
 
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      {% if magic_link_redirect %}
+        {{ govukNotificationBanner({"titleText": "Sign in with Microsoft", "text": "As an MHCLG user, sign in through Microsoft with your @communities email address."}) }}
+      {% endif %}
       <h1 class="govuk-heading-xl">Deliver grant funding</h1>
       <p class="govuk-body">A connected and consistent digital service for users within Funding Service, and grant teams.</p>
       <p class="govuk-body">The service includes:</p>

--- a/tests/e2e/test_magic_link_auth.py
+++ b/tests/e2e/test_magic_link_auth.py
@@ -1,5 +1,6 @@
 import re
 
+import pytest
 from playwright.sync_api import Page, expect
 
 from tests.e2e.config import EndToEndTestSecrets
@@ -7,11 +8,14 @@ from tests.e2e.helpers import retrieve_magic_link
 from tests.e2e.pages import RequestALinkToSignInPage
 
 
-def test_magic_link_redirect_journey(page: Page, domain: str, e2e_test_secrets: EndToEndTestSecrets, email: str):
+# TODO in FSPT-676: Skipping in deployed environments until we decide how we want to tackle e2e test authentication in
+# deployed envs which use team/live Notify keys and can't or shouldn't send to emails we don't own.
+@pytest.mark.skip_in_environments(["dev", "test", "prod"])
+def test_magic_link_redirect_journey(page: Page, domain: str, e2e_test_secrets: EndToEndTestSecrets):
     # Magic link page is no longer the default unauthenticated redirect so just go through that flow.
     request_a_link_page = RequestALinkToSignInPage(page, domain)
     request_a_link_page.navigate()
-    request_a_link_page.fill_email_address(email)
+    request_a_link_page.fill_email_address("non-mhclg-email@example.com")
     request_a_link_page.click_request_a_link()
 
     page.wait_for_url(re.compile(rf"{domain}/check-your-email/.+"))
@@ -22,4 +26,4 @@ def test_magic_link_redirect_journey(page: Page, domain: str, e2e_test_secrets: 
     page.goto(magic_link_url)
 
     # JavaScript on the page automatically claims the link and should redirect to where they started.
-    expect(page).to_have_url(f"{domain}/grants")
+    expect(page).to_have_url(f"{domain}/developers/access/grants")


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-577

## 📝 Description
Remove the internal domains block on magic link sign-in to allow non-MHCLG emails to authenticate via magic link to access to AGF routes.

In doing this we can now also check if an internal user (ie. one with `@communities` or `@test.communities` email) tries to sign-in via magic link and redirect them to authenticate via SSO. In doing this we're enforcing internal MHCLG users to authenticate via SSO so we can fetch any necessary Azure AD info and make sure they've got the right roles and permissions.

Magic Link users signing in via magic link will now default to hitting the (currently platform_admin protected) `developers/access/grants_list.html` in lieu of a better default landing page, but otherwise will be redirected to the page they were trying to access (eg. an AGF grant details page).

All Deliver Grant Funding routes (except the developers AGF routes) are currently behind some level of internal only/role-based access control so Magic Link users can't access anything there.

One of two PRs on this work:
- Clean up SSO/Magic Link flows to include redirects and blocks 👈 (this PR)
- Add session variable to track if a user has authenticated via magic link or SSO, and add additional route security that magic link users should 403 if they visit any DGF routes ([Draft PR](https://github.com/communitiesuk/funding-service/pull/463))

## 📸 Show the thing (screenshots, gifs)

Placeholder notification banner shown to users who try to authenticate with an `@communities` or `@test.communities` email address and get redirected to this SSO sign-in page.

<img width="693" height="738" alt="image" src="https://github.com/user-attachments/assets/fd9c0a28-be36-4ff5-81e0-b8eb1c5ad9da" />

## 🧪 Testing
- Tested permutations of MHCLG user trying to log-in via Magic Link, Non-MHCLG user logging in via magic link, tested redirects and 403s for hitting routes afterwards
- Set the base `login_required` redirect to the magic link sign-in page to test onward redirect behaviour
- Updated tests to check for this updated behaviour

## 📋 Developer Checklist

### Review Readiness
- [X] PR title and description provide sufficient context for reviewers
- [X] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- ~[ ] No N+1 query problems introduced~
- ~[ ] Any new DB queries include appropriate where clauses based on the user's permissions~

### Testing
- [X] I have tested this change and it meets the acceptance criteria for the ticket
- [X] I need the reviewer(s) to pull and run this change locally
- [X] New (non-developer) functionality has appropriate unit and integration tests
- [X] End-to-end tests have been updated (if applicable)
- [X] Edge cases and error conditions are tested

## 📚 Additional Notes
<!-- Any additional context, concerns, or considerations for reviewers -->
