### PR TITLE
Actually fix reordering of sections/forms/questions on delete

### DIFF
--- a/app/common/data/interfaces/temporary.py
+++ b/app/common/data/interfaces/temporary.py
@@ -56,6 +56,11 @@ def delete_collection(collection_id: UUID) -> None:
 
 
 def delete_section(section: Section) -> None:
+    # remove the instance from its collection specifically, which triggers reordering of all other sections
+    # correctly.
+    # todo: when/if this becomes a non-temporary interface, TEST THOROUGHLY. The OrderingList we're using for this
+    # definitely has a few quirks.
+    section.collection.sections.remove(section)  # type: ignore[no-untyped-call]
     db.session.delete(section)
     section.collection.sections.reorder()
     db.session.execute(
@@ -65,6 +70,11 @@ def delete_section(section: Section) -> None:
 
 
 def delete_form(form: Form) -> None:
+    # remove the instance from its collection specifically, which triggers reordering of all other sections
+    # correctly.
+    # todo: when/if this becomes a non-temporary interface, TEST THOROUGHLY. The OrderingList we're using for this
+    # definitely has a few quirks.
+    form.section.forms.remove(form)  # type: ignore[no-untyped-call]
     db.session.delete(form)
     form.section.forms.reorder()
     db.session.execute(
@@ -75,7 +85,11 @@ def delete_form(form: Form) -> None:
 
 def delete_question(question: Question) -> None:
     raise_if_question_has_any_dependencies(question)
-
+    # remove the instance from its collection specifically, which triggers reordering of all other sections
+    # correctly.
+    # todo: when/if this becomes a non-temporary interface, TEST THOROUGHLY. The OrderingList we're using for this
+    # definitely has a few quirks.
+    question.form.questions.remove(question)  # type: ignore[no-untyped-call]
     db.session.delete(question)
     question.form.questions.reorder()
     db.session.execute(


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
This still wasn't working quite right 100% of the time when deleting things (the first delete of a question in the middle of this form wasn't syncing order 😭)

## 📸 Show the thing (screenshots, gifs)

### Before
![2025-07-08 18 49 44](https://github.com/user-attachments/assets/87563afe-bf48-43ad-a3a3-537929c9fa8b)

### After
![2025-07-08 18 48 18](https://github.com/user-attachments/assets/d5aa232f-5c63-432a-a4ac-6a71bc171f48)

## 🧪 Testing
- Delete a question that is in the middle of a bunch of others
- Try to add a new question
- Compare and contrast main branch vs this branch
