### PR TITLE
Fix validators on our form fields

### DIFF
--- a/app/common/collections/forms.py
+++ b/app/common/collections/forms.py
@@ -8,7 +8,7 @@ from immutabledict import immutabledict
 from wtforms import Field, Form, RadioField
 from wtforms.fields.numeric import IntegerField
 from wtforms.fields.simple import StringField, SubmitField
-from wtforms.validators import DataRequired, Optional, ValidationError
+from wtforms.validators import DataRequired, InputRequired, Optional, ValidationError
 
 from app.common.data.models import Expression, Question
 from app.common.data.types import QuestionDataType, immutable_json_flat_scalars
@@ -115,18 +115,21 @@ def build_question_form(question: Question, expression_context: ExpressionContex
                 label=question.text,
                 description=question.hint or "",
                 widget=GovTextInput(),
+                validators=[DataRequired()],
             )
         case QuestionDataType.TEXT_MULTI_LINE:
             field = StringField(
                 label=question.text,
                 description=question.hint or "",
                 widget=GovTextArea(),
+                validators=[DataRequired()],
             )
         case QuestionDataType.INTEGER:
             field = IntegerField(
                 label=question.text,
                 description=question.hint or "",
                 widget=GovTextInput(),
+                validators=[InputRequired()],
             )
         case _:
             raise Exception("Unable to generate dynamic form for question type {_}")

--- a/tests/integration/common/collections/test_forms.py
+++ b/tests/integration/common/collections/test_forms.py
@@ -1,6 +1,7 @@
 import uuid
 
 import pytest
+from werkzeug.datastructures import MultiDict
 
 from app.common.collections.forms import build_question_form
 from app.common.data import interfaces
@@ -30,7 +31,7 @@ def test_validation_attached_to_field_and_runs(factories, value, error_message):
     )
 
     _FormClass = build_question_form(question, expression_context=ExpressionContext())
-    form = _FormClass(data={"q_e4bd98ab41ef4d23b1e59c0404891e7a": value})
+    form = _FormClass(formdata=MultiDict({"q_e4bd98ab41ef4d23b1e59c0404891e7a": str(value)}))
 
     valid = form.validate()
     if error_message:


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
In the recent shuffle to validators, we dropped off our DataRequired/InputRequired validation on form fields. This adds them back.

We currently don't have any questions shown to users which can't have an answer provided, so for now this will enforce that.