### PR TITLE
FSPT-669: standard interface for submission answers

### DIFF
--- a/app/common/collections/types.py
+++ b/app/common/collections/types.py
@@ -1,0 +1,37 @@
+from typing import Any, Protocol
+
+from pydantic import RootModel
+
+
+class SubmissionAnswerProtocol(Protocol):
+    # We have to underscore this because of the composition with pydantic's base model meta class
+    # pydantic models don't let you have non-underscores properties defined outright on classes.
+    _render_answer_template: str
+
+    def get_value_for_submission(self) -> Any: ...
+    def get_value_for_form(self) -> Any: ...
+    def get_value_for_expression(self) -> Any: ...
+    def get_value_for_text_export(self) -> Any: ...
+
+
+class SubmissionAnswerRootModel[T](RootModel[T]):
+    @property
+    def _render_answer_template(self) -> str:
+        return "common/partials/answers/root.html"
+
+    def get_value_for_submission(self) -> T:
+        return self.root
+
+    def get_value_for_form(self) -> T:
+        return self.root
+
+    def get_value_for_expression(self) -> T:
+        return self.root
+
+    def get_value_for_text_export(self) -> T:
+        return self.root
+
+
+TextSingleLine = SubmissionAnswerRootModel[str]
+TextMultiLine = SubmissionAnswerRootModel[str]
+Integer = SubmissionAnswerRootModel[int]

--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING, Any, Never, Protocol
 from uuid import UUID
 
-from pydantic import BaseModel
 from sqlalchemy import select, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import joinedload, selectinload
 
+from app.common.collections.types import SubmissionAnswerRootModel
 from app.common.data.interfaces.exceptions import DuplicateValueError
 from app.common.data.models import (
     Collection,
@@ -77,8 +77,10 @@ def update_collection(collection: Collection, *, name: str) -> Collection:
     return collection
 
 
-def update_submission_data(submission: Submission, question: Question, data: BaseModel) -> Submission:
-    submission.data[str(question.id)] = data.model_dump()
+def update_submission_data(
+    submission: Submission, question: Question, data: SubmissionAnswerRootModel[Any]
+) -> Submission:
+    submission.data[str(question.id)] = data.get_value_for_submission()
     db.session.flush()
     return submission
 

--- a/app/common/templates/common/macros/collections.html
+++ b/app/common/templates/common/macros/collections.html
@@ -44,7 +44,7 @@
     {% set answer = submission.get_answer_for_question(question.id) %}
     {% if answer is not none %}
       {% set value_html %}
-        <span data-testid="answer-{{ question.text }}">{{ answer.root }}</span>
+        {% include answer._render_answer_template %}
       {% endset %}
       {%
         set actions = (

--- a/app/common/templates/common/partials/answers/root.html
+++ b/app/common/templates/common/partials/answers/root.html
@@ -1,0 +1,1 @@
+<span data-testid="answer-{{ question.text }}">{{ answer.root }}</span>

--- a/app/developers/templates/developers/deliver/manage_submission.html
+++ b/app/developers/templates/developers/deliver/manage_submission.html
@@ -36,6 +36,15 @@
       {% set rows = [] %}
       {% for question in submission_helper.get_ordered_visible_questions_for_form(form) %}
 
+        {% set answer = submission_helper.get_answer_for_question(question.id) %}
+        {% set value_html %}
+          {% if answer %}
+            {% include answer._render_answer_template %}
+          {% else %}
+            (Not answered)
+          {% endif %}
+        {% endset %}
+
         {# the answer is a well formed, validated pydantic thing we could access any of the properties #}
         {# of for the templates use - we'll probably generally just want the interface of that model to tell #}
         {# us what to put when we need a single line text representation #}
@@ -45,7 +54,7 @@
               "text": question.text
             },
             "value": {
-              "text": submission_helper.get_answer_for_question(question.id).root or "(Not answered)"
+              "text": value_html
             }
           })
         %}

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -3,6 +3,7 @@ import uuid
 import pytest
 from sqlalchemy.exc import NoResultFound
 
+from app.common.collections.types import TextSingleLine
 from app.common.data.interfaces.collections import (
     DependencyOrderException,
     add_question_condition,
@@ -35,7 +36,6 @@ from app.common.data.interfaces.exceptions import DuplicateValueError
 from app.common.data.models import Collection, Expression
 from app.common.data.types import ExpressionType, ManagedExpressionsEnum, QuestionDataType, SubmissionEventKey
 from app.common.expressions.managed import GreaterThan, LessThan
-from app.common.helpers.collections import TextSingleLine
 
 
 def test_get_collection(db_session, factories):

--- a/tests/integration/common/helpers/test_collections.py
+++ b/tests/integration/common/helpers/test_collections.py
@@ -4,9 +4,10 @@ import pytest
 from immutabledict import immutabledict
 
 from app.common.collections.forms import build_question_form
+from app.common.collections.types import Integer, TextSingleLine
 from app.common.data.types import QuestionDataType, SubmissionStatusEnum
 from app.common.expressions import ExpressionContext
-from app.common.helpers.collections import Integer, SubmissionHelper, TextSingleLine
+from app.common.helpers.collections import SubmissionHelper
 from tests.utils import AnyStringMatching
 
 EC = ExpressionContext

--- a/tests/unit/common/collections/test_runner.py
+++ b/tests/unit/common/collections/test_runner.py
@@ -3,8 +3,9 @@ from unittest.mock import Mock
 import pytest
 
 from app.common.collections.runner import FormRunner
+from app.common.collections.types import TextSingleLine
 from app.common.data.types import FormRunnerState, QuestionDataType
-from app.common.helpers.collections import SubmissionHelper, TextSingleLine
+from app.common.helpers.collections import SubmissionHelper
 
 
 class TestFormRunner:
@@ -31,7 +32,8 @@ class TestFormRunner:
     def test_form_runner_correctly_configures_dynamic_question_form(self, factories):
         question = factories.question.build(data_type=QuestionDataType.TEXT_SINGLE_LINE)
         submission = factories.submission.build(
-            collection=question.form.section.collection, data={str(question.id): TextSingleLine("An answer").root}
+            collection=question.form.section.collection,
+            data={str(question.id): TextSingleLine("An answer").get_value_for_submission()},
         )
         helper = SubmissionHelper(submission)
 

--- a/tests/unit/common/collections/test_types.py
+++ b/tests/unit/common/collections/test_types.py
@@ -1,0 +1,25 @@
+import pytest
+
+from app.common.collections.types import Integer, TextMultiLine, TextSingleLine
+
+
+@pytest.mark.parametrize(
+    "model, data",
+    (
+        (TextSingleLine, "hello"),
+        (TextMultiLine, "hello\nthere"),
+        (Integer, 5),
+    ),
+)
+class TestSubmissionAnswerRootModels:
+    def test_get_value_for_submission(self, model, data):
+        assert model(data).get_value_for_submission() == data
+
+    def test_get_value_for_form(self, model, data):
+        assert model(data).get_value_for_form() == data
+
+    def test_get_value_for_expression(self, model, data):
+        assert model(data).get_value_for_expression() == data
+
+    def test_get_value_for_text_export(self, model, data):
+        assert model(data).get_value_for_text_export() == data


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net.mcas.ms/browse/FSPT-669

## 📝 Description
We need to use answers that have been submitted in a lot of different parts of the system. Having a single way of (de)serialising these for use in different places will give us confidence that we are treating answers in a consistent way. Using pydantic base models also gives us a good developer experience/intellisense/code completion/etc.

## 🧪 Testing
- Run all of the tests.
- Check each of the places where answers are used in the system. They should all look/work the same.
  - Check your answers page
  - Assessment pages.

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested