### PR TITLE
FSPT-577: Add auth method to session and decorator

### DIFF
--- a/app/common/auth/__init__.py
+++ b/app/common/auth/__init__.py
@@ -10,6 +10,7 @@ from app.common.auth.decorators import redirect_if_authenticated
 from app.common.auth.forms import SignInForm
 from app.common.auth.sso import build_auth_code_flow, build_msal_app
 from app.common.data import interfaces
+from app.common.data.types import AuthMethodEnum
 from app.common.forms import GenericSubmitForm
 from app.common.security.utils import sanitise_redirect_url
 from app.extensions import auto_commit_after_request, notification_service
@@ -93,6 +94,7 @@ def claim_magic_link(magic_link_code: str) -> ResponseReturnValue:
         if not login_user(user):
             return abort(400)
 
+        session["auth"] = AuthMethodEnum.MAGIC_LINK
         return redirect(sanitise_redirect_url(magic_link.redirect_to_path))
 
     return render_template("common/auth/claim_magic_link.html", form=form, magic_link=magic_link)
@@ -173,6 +175,8 @@ def sso_get_token() -> ResponseReturnValue:
 
     if not login_user(user):
         return abort(400)
+
+    session["auth"] = AuthMethodEnum.SSO
 
     return redirect(redirect_to_path)
 

--- a/app/common/auth/authorisation_helper.py
+++ b/app/common/auth/authorisation_helper.py
@@ -71,3 +71,18 @@ class AuthorisationHelper:
                 return AuthorisationHelper.is_grant_member(grant_id, user)
             case _:
                 raise ValueError(f"Unknown role {role}")
+
+    @staticmethod
+    def is_deliver_grant_funding_user(user: User | AnonymousUserMixin) -> bool:
+        if isinstance(user, AnonymousUserMixin):
+            return False
+
+        if AuthorisationHelper.is_platform_admin(user):
+            return True
+
+        # This is the current definition of a Grant team member, but will need updating as more Deliver Grant Funding
+        # roles are introduced
+        if any(role.grant_id is not None and role.organisation_id is None for role in user.roles):
+            return True
+
+        return False

--- a/app/common/data/types.py
+++ b/app/common/data/types.py
@@ -33,6 +33,11 @@ GRANT_ROLES_MAPPING = {
 }
 
 
+class AuthMethodEnum(str, enum.Enum):
+    SSO = "sso"
+    MAGIC_LINK = "magic link"
+
+
 class QuestionDataType(enum.StrEnum):
     # If adding values here, also update QuestionTypeForm
     # and manually create a migration to update question_type_enum in the db

--- a/app/developers/access_routes.py
+++ b/app/developers/access_routes.py
@@ -3,7 +3,7 @@ import uuid
 from flask import Blueprint, current_app, redirect, render_template, request, session, url_for
 from flask.typing import ResponseReturnValue
 
-from app.common.auth.decorators import is_platform_admin, login_required
+from app.common.auth.decorators import access_grant_funding_login_required, is_platform_admin
 from app.common.collections.runner import AGFFormRunner
 from app.common.data import interfaces
 from app.common.data.interfaces.collections import create_submission, get_collection
@@ -56,7 +56,7 @@ def grant_details(grant_id: uuid.UUID) -> ResponseReturnValue:
 #       with sensible permission and integrity checks
 @developers_access_blueprint.get("/submissions/start/<uuid:collection_id>")
 @auto_commit_after_request
-@login_required
+@access_grant_funding_login_required
 def start_submission_redirect(collection_id: uuid.UUID) -> ResponseReturnValue:
     current_user = interfaces.user.get_current_user()
     collection = get_collection(collection_id)
@@ -66,7 +66,7 @@ def start_submission_redirect(collection_id: uuid.UUID) -> ResponseReturnValue:
 
 @developers_access_blueprint.route("/submissions/<uuid:submission_id>", methods=["GET", "POST"])
 @auto_commit_after_request
-@login_required
+@access_grant_funding_login_required
 def submission_tasklist(submission_id: uuid.UUID) -> ResponseReturnValue:
     source = request.args.get("source")
     runner = AGFFormRunner.load(submission_id=submission_id, source=FormRunnerState(source) if source else None)
@@ -83,7 +83,7 @@ def submission_tasklist(submission_id: uuid.UUID) -> ResponseReturnValue:
 
 
 @developers_access_blueprint.route("/submissions/<uuid:submission_id>/<uuid:question_id>", methods=["GET", "POST"])
-@login_required
+@access_grant_funding_login_required
 @auto_commit_after_request
 def ask_a_question(submission_id: uuid.UUID, question_id: uuid.UUID) -> ResponseReturnValue:
     source = request.args.get("source")
@@ -105,7 +105,7 @@ def ask_a_question(submission_id: uuid.UUID, question_id: uuid.UUID) -> Response
     "/submissions/<uuid:submission_id>/check-yours-answers/<uuid:form_id>", methods=["GET", "POST"]
 )
 @auto_commit_after_request
-@login_required
+@access_grant_funding_login_required
 def check_your_answers(submission_id: uuid.UUID, form_id: uuid.UUID) -> ResponseReturnValue:
     source = request.args.get("source")
     runner = AGFFormRunner.load(
@@ -120,7 +120,7 @@ def check_your_answers(submission_id: uuid.UUID, form_id: uuid.UUID) -> Response
 
 
 @developers_access_blueprint.route("/submissions/<uuid:submission_id>/confirmation", methods=["GET", "POST"])
-@login_required
+@access_grant_funding_login_required
 def collection_confirmation(submission_id: uuid.UUID) -> ResponseReturnValue:
     submission_helper = SubmissionHelper.load(submission_id)
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -3,6 +3,7 @@ from typing import Generator, cast
 from unittest.mock import patch
 
 import pytest
+from flask import session
 from flask.typing import ResponseReturnValue
 from flask_login import login_user
 from playwright.sync_api import BrowserContext, Page, ViewportSize, expect
@@ -11,6 +12,7 @@ from pytest_playwright import CreateContextCallback
 
 from app import create_app
 from app.common.data.models_user import User
+from app.common.data.types import AuthMethodEnum
 from tests.e2e.config import AWSEndToEndSecrets, EndToEndTestSecrets, LocalEndToEndSecrets
 from tests.e2e.dataclasses import E2ETestUser
 from tests.e2e.helpers import retrieve_magic_link
@@ -126,6 +128,7 @@ def login_with_session_cookie(page: Page, domain: str, e2e_test_secrets: EndToEn
     @new_app.route("/fake_login")
     def fake_login() -> ResponseReturnValue:
         login_user(user=user_obj, fresh=True)
+        session["auth"] = AuthMethodEnum.SSO
         return "OK"
 
     with new_app.test_request_context():

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -30,7 +30,7 @@ from werkzeug.test import TestResponse
 
 from app import create_app
 from app.common.data.models_user import User
-from app.common.data.types import RoleEnum
+from app.common.data.types import AuthMethodEnum, RoleEnum
 from app.extensions.record_sqlalchemy_queries import QueryInfo, get_recorded_queries
 from app.services.notify import Notification
 from tests.conftest import FundingServiceTestClient, _Factories, _precompile_templates
@@ -270,6 +270,9 @@ def authenticated_no_role_client(
     # `auto_commit_after_request` decorator, but here we're not in an existing session and would be left with a dirty
     # session after this client is used in tests, so we need to commit this change to the user before we continue.
     login_user(user)
+    with anonymous_client.session_transaction() as session:
+        session["auth"] = AuthMethodEnum.SSO
+
     anonymous_client.user = user
     db_session.commit()
 
@@ -288,6 +291,8 @@ def authenticated_grant_member_client(
     factories.user_role.create(user_id=user.id, user=user, role=RoleEnum.MEMBER, grant=grant)
 
     login_user(user)
+    with anonymous_client.session_transaction() as session:
+        session["auth"] = AuthMethodEnum.SSO
     anonymous_client.user = user
     anonymous_client.grant = grant
     db_session.commit()
@@ -311,6 +316,8 @@ def authenticated_grant_admin_client(
     factories.user_role.create(user_id=user.id, user=user, role=RoleEnum.ADMIN, grant=grant)
 
     login_user(user)
+    with anonymous_client.session_transaction() as session:
+        session["auth"] = AuthMethodEnum.SSO
     anonymous_client.user = user
     anonymous_client.grant = grant
     db_session.commit()
@@ -329,6 +336,8 @@ def authenticated_platform_admin_client(
     factories.user_role.create(user_id=user.id, user=user, role=RoleEnum.ADMIN)
 
     login_user(user)
+    with anonymous_client.session_transaction() as session:
+        session["auth"] = AuthMethodEnum.SSO
     anonymous_client.user = user
     db_session.commit()
 

--- a/tests/unit/test_all_routes_access.py
+++ b/tests/unit/test_all_routes_access.py
@@ -68,7 +68,7 @@ routes_with_expected_member_only_access = [
     "deliver_grant_funding.list_users_for_grant",
     "deliver_grant_funding.grant_details",
 ]
-routes_with_expected_logged_in_access = [
+routes_with_expected_access_grant_funding_logged_in_access = [
     "developers.access.start_submission_redirect",
     "developers.access.submission_tasklist",
     "developers.access.ask_a_question",
@@ -104,8 +104,8 @@ def test_accessibility_for_user_role_to_each_endpoint(app):
             assert "@is_mhclg_user" in decorators
         # todo: this will be the access grant funding routes where the user is logged in
         #       and will likely have access through their org, this should be updated as part of that work
-        elif rule.endpoint in routes_with_expected_logged_in_access:
-            assert "@login_required" in decorators
+        elif rule.endpoint in routes_with_expected_access_grant_funding_logged_in_access:
+            assert "@access_grant_funding_login_required" in decorators
         elif rule.endpoint in routes_with_no_expected_access_restrictions:
             # If route is expected to be unauthenticated, check it doesn't have any auth decorators
             assert not any(decorator in all_auth_annotations for decorator in decorators)


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-577

## 📝 Description
As a final layer of security, we want to make sure that the users use the right authentication method to access the right service (ie. Deliver Grant Funding should only be accessed via SSO). The previous PR added checks to stop this happening but, in case it somehow happens, we now inject a session variable `auth` when a user authenticates via magic link or SSO to indicate which auth method they used, and adds some additional checks in our Deliver Grant Funding route decorators which enforce auth to make sure only users authenticating via SSO can access these routes.

With the changes in this ticket, the `login_required` decorator also started to make less sense now that we have a clearer concept of Access Grant Funding routes and that Deliver Grant Funding users should always be authenticating with SSO, as the default `login_required` redirect was for SSO. Now adds a new decorator for Access Grant Funding routes to redirect to the magic link sign in page for unauthenticated users.

One of two PRs on this work:

- ~[Clean up SSO/Magic Link flows to include redirects and blocks](https://github.com/communitiesuk/funding-service/pull/453)~ ✅  **Merged**
- Add session variable to track if a user has authenticated via magic link or SSO, and add additional route security that magic link users should 403 if they visit any DGF routes 👈 (this PR)

## 📸 Show the thing (screenshots, gifs)
No visible changes for screenshots!

## 🧪 Testing
- Auth via magic link and try to hit some Deliver Grant Funding routes (though this should have been protected by the previous PR)
- Mess with the session in tests to make sure you get redirected/500s/403s as appropriate

## 📋 Developer Checklist

### Review Readiness
- [X] PR title and description provide sufficient context for reviewers
- [X] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- ~[ ] No N+1 query problems introduced~
- ~[ ] Any new DB queries include appropriate where clauses based on the user's permissions~

### Testing
- [X] I have tested this change and it meets the acceptance criteria for the ticket
- ~[ ] I need the reviewer(s) to pull and run this change locally~
- [X] New (non-developer) functionality has appropriate unit and integration tests
- [X] End-to-end tests have been updated (if applicable)
- [X] Edge cases and error conditions are tested

## 📚 Additional Notes

