### PR TITLE
FSPT-670: Refactor form builder to take question

### DIFF
--- a/app/common/expressions/forms.py
+++ b/app/common/expressions/forms.py
@@ -44,10 +44,13 @@ class _ManagedExpressionForm(FlaskForm):
 
 
 def build_managed_expression_form(  # noqa: C901
-    type_: ExpressionType, question_type: QuestionDataType, expression: Expression | None = None
+    type_: ExpressionType, question: Question, expression: Expression | None = None
 ) -> type["_ManagedExpressionForm"] | None:
     """
-    For a given question type, generate a FlaskForm that will allow a user to select one of its managed expressions.
+    For a given question, generate a FlaskForm that will allow a user to select one of its managed expressions.
+
+    We take a question instance rather than the data type, as some managed expressions may refer to values on the
+    question itself (eg radios, checkboxes).
 
     Each managed expression declares the data that defines it, and has hooks that can be used to attach, validate, and
     render the specific form fields it needs.
@@ -55,7 +58,7 @@ def build_managed_expression_form(  # noqa: C901
     The form is constructed dynamically from the definition of all registered managed expressions; each one lists
     the question types that can be a condition for, and that it can validate against.
     """
-    managed_expressions = get_managed_expressions_for_question_type(question_type)
+    managed_expressions = get_managed_expressions_for_question_type(question.data_type)
     if not managed_expressions:
         return None
 
@@ -68,7 +71,7 @@ def build_managed_expression_form(  # noqa: C901
             raise RuntimeError("unknown expression type")
 
     class ManagedExpressionForm(_ManagedExpressionForm):
-        _question_data_type = question_type
+        _question_data_type = question.data_type
         _managed_expressions = managed_expressions
 
         type = RadioField(

--- a/app/developers/deliver_routes.py
+++ b/app/developers/deliver_routes.py
@@ -658,7 +658,7 @@ def add_question_condition(grant_id: UUID, question_id: UUID, depends_on_questio
     question = get_question_by_id(question_id)
     depends_on_question = get_question_by_id(depends_on_question_id)
 
-    ConditionForm = build_managed_expression_form(ExpressionType.CONDITION, depends_on_question.data_type)
+    ConditionForm = build_managed_expression_form(ExpressionType.CONDITION, depends_on_question)
     form = ConditionForm() if ConditionForm else None
     if form and form.validate_on_submit():
         expression = form.get_expression(depends_on_question)
@@ -717,7 +717,7 @@ def edit_question_condition(grant_id: UUID, question_id: UUID, expression_id: UU
             )
         )
 
-    ConditionForm = build_managed_expression_form(ExpressionType.CONDITION, depends_on_question.data_type, expression)
+    ConditionForm = build_managed_expression_form(ExpressionType.CONDITION, depends_on_question, expression)
     form = ConditionForm() if ConditionForm else None
 
     if form and form.validate_on_submit():
@@ -761,7 +761,7 @@ def edit_question_condition(grant_id: UUID, question_id: UUID, expression_id: UU
 def add_question_validation(grant_id: UUID, question_id: UUID) -> ResponseReturnValue:
     question = get_question_by_id(question_id)
 
-    ValidationForm = build_managed_expression_form(ExpressionType.VALIDATION, question.data_type)
+    ValidationForm = build_managed_expression_form(ExpressionType.VALIDATION, question)
     form = ValidationForm() if ValidationForm else None
     if form and form.validate_on_submit():
         expression = form.get_expression(question)
@@ -821,7 +821,7 @@ def edit_question_validation(grant_id: UUID, question_id: UUID, expression_id: U
             )
         )
 
-    ValidationForm = build_managed_expression_form(ExpressionType.VALIDATION, question.data_type, expression)
+    ValidationForm = build_managed_expression_form(ExpressionType.VALIDATION, question, expression)
     form = ValidationForm() if ValidationForm else None
 
     if form and form.validate_on_submit():

--- a/tests/unit/common/expressions/test_forms.py
+++ b/tests/unit/common/expressions/test_forms.py
@@ -10,8 +10,9 @@ class TestBuildManagedExpressionForm:
     # Not intended to be an exhaustive check against all question data types, but to prove that fundamentally the
     # system/framework is capable.
 
-    def test_integer_data_type(self):
-        _FormClass = build_managed_expression_form(ExpressionType.CONDITION, QuestionDataType.INTEGER)
+    def test_integer_data_type(self, factories):
+        question = factories.question.build(data_type=QuestionDataType.INTEGER)
+        _FormClass = build_managed_expression_form(ExpressionType.CONDITION, question)
         assert _FormClass
         form = _FormClass()
 
@@ -21,8 +22,9 @@ class TestBuildManagedExpressionForm:
             (ManagedExpressionsEnum.BETWEEN, ManagedExpressionsEnum.BETWEEN),
         ]
 
-    def test_recognises_invalid_data_for_a_managed_expression(self):
-        _FormClass = build_managed_expression_form(ExpressionType.CONDITION, QuestionDataType.INTEGER)
+    def test_recognises_invalid_data_for_a_managed_expression(self, factories):
+        question = factories.question.build(data_type=QuestionDataType.INTEGER)
+        _FormClass = build_managed_expression_form(ExpressionType.CONDITION, question)
         assert _FormClass
         form = _FormClass(
             formdata=MultiDict(
@@ -46,9 +48,9 @@ class TestBuildManagedExpressionForm:
         }
 
     def test_can_build_a_managed_expression_from_valid_data(self, factories):
-        question = factories.question.build()
+        question = factories.question.build(data_type=QuestionDataType.INTEGER)
 
-        _FormClass = build_managed_expression_form(ExpressionType.CONDITION, QuestionDataType.INTEGER)
+        _FormClass = build_managed_expression_form(ExpressionType.CONDITION, question)
         assert _FormClass
         form = _FormClass(
             formdata=MultiDict(


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-670

## 📝 Description
Some managed expressions may need to refer to information on a question instance itself (eg radios, checkboxes pulling the choices that are available). So we can't just build from an abstract data type any more - we need a concrete instance.

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested