### PR TITLE
FSPT-667: Allow managed expressons to choose between validation and conditions

### DIFF
--- a/app/common/expressions/forms.py
+++ b/app/common/expressions/forms.py
@@ -9,7 +9,8 @@ from wtforms.validators import DataRequired
 from app.common.data.models import Expression, Question
 from app.common.data.types import ExpressionType, QuestionDataType
 from app.common.expressions.registry import (
-    get_managed_expressions_for_question_type,
+    get_managed_conditions_by_data_type,
+    get_managed_validators_by_data_type,
 )
 
 if TYPE_CHECKING:
@@ -58,17 +59,18 @@ def build_managed_expression_form(  # noqa: C901
     The form is constructed dynamically from the definition of all registered managed expressions; each one lists
     the question types that can be a condition for, and that it can validate against.
     """
-    managed_expressions = get_managed_expressions_for_question_type(question.data_type)
-    if not managed_expressions:
-        return None
-
     match type_:
         case ExpressionType.CONDITION:
             type_validation_message = "Select what the answer should be to show this question"
+            managed_expressions = get_managed_conditions_by_data_type(question.data_type)
         case ExpressionType.VALIDATION:
             type_validation_message = "Select the kind of validation to apply"
+            managed_expressions = get_managed_validators_by_data_type(question.data_type)
         case _:
             raise RuntimeError("unknown expression type")
+
+    if not managed_expressions:
+        return None
 
     class ManagedExpressionForm(_ManagedExpressionForm):
         _question_data_type = question.data_type

--- a/app/common/expressions/managed.py
+++ b/app/common/expressions/managed.py
@@ -26,7 +26,8 @@ if TYPE_CHECKING:
 class ManagedExpression(BaseModel, SafeQidMixin):
     # Defining this as a ClassVar allows direct access from the class and excludes it from pydantic instance
     name: ClassVar[ManagedExpressionsEnum]
-    question_data_types: ClassVar[set[QuestionDataType]]
+    supported_condition_data_types: ClassVar[set[QuestionDataType]]
+    supported_validator_data_types: ClassVar[set[QuestionDataType]]
 
     _key: ManagedExpressionsEnum
     question_id: UUID
@@ -147,7 +148,8 @@ class BottomOfRangeIsLower:
 @register_managed_expression
 class GreaterThan(ManagedExpression):
     name: ClassVar[ManagedExpressionsEnum] = ManagedExpressionsEnum.GREATER_THAN
-    question_data_types: ClassVar[set[QuestionDataType]] = {QuestionDataType.INTEGER}
+    supported_condition_data_types: ClassVar[set[QuestionDataType]] = {QuestionDataType.INTEGER}
+    supported_validator_data_types: ClassVar[set[QuestionDataType]] = {QuestionDataType.INTEGER}
 
     _key: ManagedExpressionsEnum = name
 
@@ -200,7 +202,8 @@ class GreaterThan(ManagedExpression):
 @register_managed_expression
 class LessThan(ManagedExpression):
     name: ClassVar[ManagedExpressionsEnum] = ManagedExpressionsEnum.LESS_THAN
-    question_data_types: ClassVar[set[QuestionDataType]] = {QuestionDataType.INTEGER}
+    supported_condition_data_types: ClassVar[set[QuestionDataType]] = {QuestionDataType.INTEGER}
+    supported_validator_data_types: ClassVar[set[QuestionDataType]] = {QuestionDataType.INTEGER}
 
     _key: ManagedExpressionsEnum = name
 
@@ -253,7 +256,8 @@ class LessThan(ManagedExpression):
 @register_managed_expression
 class Between(ManagedExpression):
     name: ClassVar[ManagedExpressionsEnum] = ManagedExpressionsEnum.BETWEEN
-    question_data_types: ClassVar[set[QuestionDataType]] = {QuestionDataType.INTEGER}
+    supported_condition_data_types: ClassVar[set[QuestionDataType]] = {QuestionDataType.INTEGER}
+    supported_validator_data_types: ClassVar[set[QuestionDataType]] = {QuestionDataType.INTEGER}
 
     _key: ManagedExpressionsEnum = name
 

--- a/app/developers/deliver_routes.py
+++ b/app/developers/deliver_routes.py
@@ -48,7 +48,7 @@ from app.common.data.types import (
     SubmissionModeEnum,
 )
 from app.common.expressions.forms import build_managed_expression_form
-from app.common.expressions.registry import get_managed_expressions_for_question_type
+from app.common.expressions.registry import get_managed_validators_by_data_type
 from app.common.forms import GenericSubmitForm
 from app.common.helpers.collections import SubmissionHelper
 from app.deliver_grant_funding.forms import (
@@ -616,7 +616,7 @@ def edit_question(
         question=question,
         form=wt_form,
         confirm_deletion_form=confirm_deletion_form if "delete" in request.args else None,
-        managed_validation_available=get_managed_expressions_for_question_type(question.data_type),
+        managed_validation_available=get_managed_validators_by_data_type(question.data_type),
     )
 
 

--- a/tests/integration/common/expressions/test_registry.py
+++ b/tests/integration/common/expressions/test_registry.py
@@ -1,6 +1,7 @@
 from app.common.data.types import QuestionDataType
 from app.common.expressions.registry import (
-    get_managed_expressions_for_question_type,
+    get_managed_conditions_by_data_type,
+    get_managed_validators_by_data_type,
     get_registered_data_types,
     get_supported_form_questions,
 )
@@ -11,7 +12,8 @@ class TestManagedExpressions:
         unsupported_question_type = QuestionDataType.TEXT_SINGLE_LINE
 
         # because we're using a defaultdict we should make sure reading empty values can't change the logic
-        assert get_managed_expressions_for_question_type(unsupported_question_type) == []
+        assert get_managed_conditions_by_data_type(unsupported_question_type) == []
+        assert get_managed_validators_by_data_type(unsupported_question_type) == []
         assert unsupported_question_type not in get_registered_data_types()
 
     def test_get_supported_form_questions_filters_question_types(self, factories):


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-667

## 📝 Description
At the moment, any managed expression we create will be available as both a condition and a validator. This is fine for integer questions, where that makes sense. But once we add radios, we might allow branching of questions based on specific choices, but there is no reason to try to 'validate' that a specific choice was selected. The nature of radios+checkboxes does this already.

## 🧪 Testing
test conditons and validation pages for all question types:
- you should be able to add conditions to all questions, if an integer question exists in the same form
- you should be able to add validation to integer question types only

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [-] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested
