### PR TITLE
Committing existing ruff.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -232,7 +232,8 @@ $RECYCLE.BIN/
 flask_session
 
 # IntelliJ
-.idea
+.idea/*
+!.idea/ruff.xml
 
 # Mac files
 .bash_profile

--- a/.gitignore
+++ b/.gitignore
@@ -234,6 +234,9 @@ flask_session
 # IntelliJ
 .idea/*
 !.idea/ruff.xml
+!.run/Template Python tests.run.xml
+!.idea/modules.xml
+!.idea/funding-service.iml
 
 # Mac files
 .bash_profile

--- a/.idea/funding-service.iml
+++ b/.idea/funding-service.iml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/app" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/.venv" />
+    </content>
+    <orderEntry type="jdk" jdkName="uv (funding-service)" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="PLAIN" />
+    <option name="myDocStringFormat" value="Plain" />
+  </component>
+  <component name="TemplatesService">
+    <option name="TEMPLATE_CONFIGURATION" value="Jinja2" />
+    <option name="TEMPLATE_FOLDERS">
+      <list>
+        <option value="$MODULE_DIR$/stubs/sso/templates" />
+        <option value="$MODULE_DIR$/app/common/templates" />
+        <option value="$MODULE_DIR$/app/developers/templates" />
+        <option value="$MODULE_DIR$/app/deliver_grant_funding/templates" />
+        <option value="$MODULE_DIR$/app/access_grant_funding/templates" />
+      </list>
+    </option>
+  </component>
+  <component name="TestRunnerService">
+    <option name="PROJECT_TEST_RUNNER" value="py.test" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/funding-service.iml" filepath="$PROJECT_DIR$/.idea/funding-service.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/ruff.xml
+++ b/.idea/ruff.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RuffConfigService">
+    <option name="enableLsp" value="false" />
+    <option name="runRuffOnSave" value="true" />
+    <option name="useRuffFormat" value="true" />
+    <option name="useRuffServer" value="true" />
+  </component>
+</project>

--- a/.run/Template Python tests.run.xml
+++ b/.run/Template Python tests.run.xml
@@ -1,0 +1,21 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="true" type="tests" factoryName="py.test">
+    <module name="funding-service" />
+    <option name="ENV_FILES" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <option name="SDK_HOME" value="" />
+    <option name="SDK_NAME" value="uv (funding-service)" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="IS_MODULE_SDK" value="false" />
+    <option name="ADD_CONTENT_ROOTS" value="false" />
+    <option name="ADD_SOURCE_ROOTS" value="false" />
+    <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
+    <option name="_new_keywords" value="&quot;&quot;" />
+    <option name="_new_parameters" value="&quot;&quot;" />
+    <option name="_new_additionalArguments" value="&quot;&quot;" />
+    <option name="_new_target" value="&quot;&quot;" />
+    <option name="_new_targetType" value="&quot;PATH&quot;" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/README.md
+++ b/README.md
@@ -100,3 +100,20 @@ uv run flask developers export-grants
 ```
 
 Then commit the change, create a PR and get it merged. Developer environments will sync the changes automatically when their app starts up again.
+
+
+# IDE setup
+
+## PyCharm
+
+- If you need a license for PyCharm Pro, contact your line manager.
+
+### Ruff
+
+To enable ruff format on save and linting in PyCharm, you need to install the [Ruff plugin](https://plugins.jetbrains.com/plugin/20574-ruff).
+
+The ruff config file is committed to git at `.idea/ruff.xml` so should be picked up automatically once you install the plugin.
+
+### Unit Tests
+
+The configuration for running unit tests is also committed to git. You should just be able to right click a test file or directory, or use the little green triangle icons on a source file, to run and debug tests.


### PR DESCRIPTION
## 📝 Description
Adding the following pycharm config files to git for standardisation and sharing:
- .idea/funding-service.iml - categorises directories as different types of source root
- .idea/modules.xml - lists the moduels in this project and maps to the funding-service.iml above
- .idea/ruff.xml - config for ruff integration
- .run/Template Python tests.run.xml - default template run configuration for the unit tests
