### PR TITLE
FSPT-686: Add "Yes/No" question

### DIFF
--- a/app/common/collections/forms.py
+++ b/app/common/collections/forms.py
@@ -131,6 +131,15 @@ def build_question_form(question: Question, expression_context: ExpressionContex
                 widget=GovTextInput(),
                 validators=[InputRequired(f"Enter the {question.name}")],
             )
+        case QuestionDataType.YES_NO:
+            field = RadioField(
+                label=question.text,
+                description=question.hint or "",
+                widget=GovRadioInput(),
+                choices=[(1, "Yes"), (0, "No")],
+                validators=[InputRequired("Select yes or no")],
+                coerce=lambda val: bool(int(val)),
+            )
         case QuestionDataType.RADIOS:
             field = RadioField(
                 label=question.text,

--- a/app/common/collections/types.py
+++ b/app/common/collections/types.py
@@ -37,6 +37,24 @@ TextMultiLine = SubmissionAnswerRootModel[str]
 Integer = SubmissionAnswerRootModel[int]
 
 
+class YesNo(SubmissionAnswerRootModel[bool]):
+    @property
+    def _render_answer_template(self) -> str:
+        return "common/partials/answers/yes_no.html"
+
+    def get_value_for_submission(self) -> bool:
+        return cast(bool, self.model_dump(mode="json"))
+
+    def get_value_for_form(self) -> bool:
+        return self.root
+
+    def get_value_for_expression(self) -> bool:
+        return self.root
+
+    def get_value_for_text_export(self) -> str:
+        return "Yes" if self.root else "No"
+
+
 class SingleChoiceFromList(BaseModel):
     key: str
     label: str

--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-015_any_of_radios
+016_add_yes_no_question

--- a/app/common/data/migrations/versions/016_add_yes_no_question.py
+++ b/app/common/data/migrations/versions/016_add_yes_no_question.py
@@ -1,0 +1,49 @@
+"""add yes/no question
+
+Revision ID: 016_add_yes_no_question
+Revises: 015_any_of_radios
+Create Date: 2025-07-15 11:36:58.587172
+
+"""
+
+from alembic import op
+from alembic_postgresql_enum import TableReference
+
+revision = "016_add_yes_no_question"
+down_revision = "015_any_of_radios"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.sync_enum_values(  # ty: ignore[unresolved-attribute]
+        enum_schema="public",
+        enum_name="question_data_type_enum",
+        new_values=["TEXT_SINGLE_LINE", "TEXT_MULTI_LINE", "INTEGER", "YES_NO", "RADIOS"],
+        affected_columns=[TableReference(table_schema="public", table_name="question", column_name="data_type")],
+        enum_values_to_rename=[],
+    )
+    op.sync_enum_values(  # ty: ignore[unresolved-attribute]
+        enum_schema="public",
+        enum_name="managed_expression_enum",
+        new_values=["GREATER_THAN", "LESS_THAN", "BETWEEN", "IS_YES", "IS_NO", "ANY_OF"],
+        affected_columns=[TableReference(table_schema="public", table_name="expression", column_name="managed_name")],
+        enum_values_to_rename=[],
+    )
+
+
+def downgrade() -> None:
+    op.sync_enum_values(  # ty: ignore[unresolved-attribute]
+        enum_schema="public",
+        enum_name="managed_expression_enum",
+        new_values=["GREATER_THAN", "LESS_THAN", "BETWEEN", "ANY_OF"],
+        affected_columns=[TableReference(table_schema="public", table_name="expression", column_name="managed_name")],
+        enum_values_to_rename=[],
+    )
+    op.sync_enum_values(  # ty: ignore[unresolved-attribute]
+        enum_schema="public",
+        enum_name="question_data_type_enum",
+        new_values=["TEXT_SINGLE_LINE", "TEXT_MULTI_LINE", "INTEGER", "RADIOS"],
+        affected_columns=[TableReference(table_schema="public", table_name="question", column_name="data_type")],
+        enum_values_to_rename=[],
+    )

--- a/app/common/data/types.py
+++ b/app/common/data/types.py
@@ -44,6 +44,7 @@ class QuestionDataType(enum.StrEnum):
     TEXT_SINGLE_LINE = "A single line of text"
     TEXT_MULTI_LINE = "Multiple lines of text"
     INTEGER = "A whole number"
+    YES_NO = "Yes or no"
     RADIOS = "Select one from a list of choices"
 
     @staticmethod
@@ -80,6 +81,8 @@ class ManagedExpressionsEnum(enum.StrEnum):
     GREATER_THAN = "Greater than"
     LESS_THAN = "Less than"
     BETWEEN = "Between"
+    IS_YES = "Yes"
+    IS_NO = "No"
     ANY_OF = "Any of"
 
 

--- a/app/common/expressions/managed.py
+++ b/app/common/expressions/managed.py
@@ -422,6 +422,80 @@ class AnyOf(ManagedExpression):
         )
 
 
+@register_managed_expression
+class IsYes(ManagedExpression):
+    name: ClassVar[ManagedExpressionsEnum] = ManagedExpressionsEnum.IS_YES
+    supported_condition_data_types: ClassVar[set[QuestionDataType]] = {QuestionDataType.YES_NO}
+    supported_validator_data_types: ClassVar[set[QuestionDataType]] = {}  # type: ignore[assignment]
+
+    _key: ManagedExpressionsEnum = name
+
+    question_id: UUID
+
+    @property
+    def description(self) -> str:
+        return "is yes"
+
+    @property
+    def message(self) -> str:
+        return "The answer is “yes”"
+
+    @property
+    def statement(self) -> str:
+        return f"{self.safe_qid} is True"
+
+    @staticmethod
+    def get_form_fields(
+        expression: TOptional["Expression"] = None, referenced_question: TOptional["Question"] = None
+    ) -> dict[str, "Field"]:
+        return {}
+
+    @staticmethod
+    def update_validators(form: "_ManagedExpressionForm") -> None:
+        pass
+
+    @staticmethod
+    def build_from_form(form: "_ManagedExpressionForm", question: "Question") -> "IsYes":
+        return IsYes(question_id=question.id)
+
+
+@register_managed_expression
+class IsNo(ManagedExpression):
+    name: ClassVar[ManagedExpressionsEnum] = ManagedExpressionsEnum.IS_NO
+    supported_condition_data_types: ClassVar[set[QuestionDataType]] = {QuestionDataType.YES_NO}
+    supported_validator_data_types: ClassVar[set[QuestionDataType]] = {}  # type: ignore[assignment]
+
+    _key: ManagedExpressionsEnum = name
+
+    question_id: UUID
+
+    @property
+    def description(self) -> str:
+        return "is no"
+
+    @property
+    def message(self) -> str:
+        return "The answer is “no”"
+
+    @property
+    def statement(self) -> str:
+        return f"{self.safe_qid} is False"
+
+    @staticmethod
+    def get_form_fields(
+        expression: TOptional["Expression"] = None, referenced_question: TOptional["Question"] = None
+    ) -> dict[str, "Field"]:
+        return {}
+
+    @staticmethod
+    def update_validators(form: "_ManagedExpressionForm") -> None:
+        pass
+
+    @staticmethod
+    def build_from_form(form: "_ManagedExpressionForm", question: "Question") -> "IsNo":
+        return IsNo(question_id=question.id)
+
+
 def get_managed_expression(expression: "Expression") -> ManagedExpression:
     if not expression.managed_name:
         raise ValueError(f"Expression {expression.id} is not a managed expression.")

--- a/app/common/templates/common/macros/collections.html
+++ b/app/common/templates/common/macros/collections.html
@@ -26,6 +26,8 @@
       {{ form.render_question(question, params={"label": {"classes": "govuk-label--l", "isPageHeading": true} }) }}
     {% elif question.data_type == enum.question_type.INTEGER %}
       {{ form.render_question(question, params={"label": {"classes": "govuk-label--l", "isPageHeading": true}, "inputmode": "numeric", "spellcheck": false }) }}
+    {% elif question.data_type == enum.question_type.YES_NO %}
+      {{ form.render_question(question, params={"fieldset": {"legend": {"text": question.text, "classes": "govuk-fieldset__legend--l", "isPageHeading": true} }, "classes": "govuk-radios--inline" }) }}
     {% elif question.data_type == enum.question_type.RADIOS %}
       {{ form.render_question(question, params={"fieldset": {"legend": {"text": question.text, "classes": "govuk-fieldset__legend--l", "isPageHeading": true} } }) }}
     {% endif %}

--- a/app/common/templates/common/partials/answers/yes_no.html
+++ b/app/common/templates/common/partials/answers/yes_no.html
@@ -1,0 +1,1 @@
+<span data-testid="answer-{{ question.text }}">{{ "Yes" if answer.root else "No" }}</span>

--- a/app/developers/data/grants.json
+++ b/app/developers/data/grants.json
@@ -540,6 +540,19 @@
         },
         {
           "context": {
+            "question_id": "d99b94c3-66fa-4449-b4c4-ac5a2caeb8c9"
+          },
+          "created_at_utc": "Tue, 15 Jul 2025 12:01:33 GMT",
+          "created_by_id": "9ab212ee-6716-4921-b6a2-61a684bf2fe3",
+          "id": "fac76323-0d53-427f-ad85-2522a33c77e4",
+          "managed_name": "Yes",
+          "question_id": "6e42d5ac-1475-4e3a-89f0-39c9ab1ac2d1",
+          "statement": "q_d99b94c366fa4449b4c4ac5a2caeb8c9 is True",
+          "type": "CONDITION",
+          "updated_at_utc": "Tue, 15 Jul 2025 12:01:33 GMT"
+        },
+        {
+          "context": {
             "inclusive": true,
             "minimum_value": 0,
             "question_id": "46068ea5-7e83-476e-91f4-71e87a1cc1a0"
@@ -818,6 +831,30 @@
           "slug": "describe-the-main-success-that-your-programme-had-in-the-last-reporting-period",
           "text": "Describe the main success that your programme had in the last reporting period",
           "updated_at_utc": "Thu, 03 Jul 2025 17:33:32 GMT"
+        },
+        {
+          "created_at_utc": "Tue, 15 Jul 2025 12:01:18 GMT",
+          "data_type": "Yes or no",
+          "form_id": "9cf64797-461d-467c-8834-470051899da7",
+          "hint": "",
+          "id": "d99b94c3-66fa-4449-b4c4-ac5a2caeb8c9",
+          "name": "any failures to report",
+          "order": 2,
+          "slug": "do-you-have-any-failures-to-report",
+          "text": "Do you have any failures to report?",
+          "updated_at_utc": "Tue, 15 Jul 2025 12:01:18 GMT"
+        },
+        {
+          "created_at_utc": "Tue, 15 Jul 2025 12:01:28 GMT",
+          "data_type": "Multiple lines of text",
+          "form_id": "9cf64797-461d-467c-8834-470051899da7",
+          "hint": "",
+          "id": "6e42d5ac-1475-4e3a-89f0-39c9ab1ac2d1",
+          "name": "failure details",
+          "order": 3,
+          "slug": "detail-the-failures-that-you-want-us-to-know-about",
+          "text": "Detail the failures that you want us to know about",
+          "updated_at_utc": "Tue, 15 Jul 2025 12:01:28 GMT"
         },
         {
           "created_at_utc": "Thu, 03 Jul 2025 15:54:17 GMT",

--- a/tests/e2e/developer_pages.py
+++ b/tests/e2e/developer_pages.py
@@ -607,7 +607,7 @@ class QuestionPage(GrantDevelopersBasePage):
         self.continue_button = page.get_by_role("button", name="Continue")
 
     def respond_to_question(self, question_type: QuestionDataType, answer: str) -> None:
-        if question_type == QuestionDataType.RADIOS:
+        if question_type == QuestionDataType.YES_NO or question_type == QuestionDataType.RADIOS:
             self.page.get_by_role("radio", name=answer).click()
         else:
             self.page.get_by_role("textbox", name=self.question_name).fill(answer)

--- a/tests/e2e/test_developer_journey.py
+++ b/tests/e2e/test_developer_journey.py
@@ -23,6 +23,7 @@ question_text_by_type: dict[QuestionDataType, str] = {
     QuestionDataType.TEXT_SINGLE_LINE: "Enter a single line of text",
     QuestionDataType.TEXT_MULTI_LINE: "Enter a few lines of text",
     QuestionDataType.INTEGER: "Enter a number",
+    QuestionDataType.YES_NO: "Yes or no",
     QuestionDataType.RADIOS: "Select one from a list of options",
 }
 
@@ -35,6 +36,7 @@ question_response_data_by_type: dict[QuestionDataType, list[_QuestionResponse]] 
         _QuestionResponse("101", "The answer must be less than or equal to 100"),
         _QuestionResponse("100"),
     ],
+    QuestionDataType.YES_NO: [_QuestionResponse("Yes")],
     QuestionDataType.RADIOS: [_QuestionResponse("option 2")],
 }
 
@@ -155,6 +157,7 @@ def test_create_and_preview_collection(
         create_question(QuestionDataType.TEXT_SINGLE_LINE, manage_form_page)
         create_question(QuestionDataType.TEXT_MULTI_LINE, manage_form_page)
         create_question(QuestionDataType.INTEGER, manage_form_page)
+        create_question(QuestionDataType.YES_NO, manage_form_page)
         create_question(QuestionDataType.RADIOS, manage_form_page, ["option 1", "option 2", "option 3"])
 
         add_validation(

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -337,6 +337,25 @@ class TestCreateQuestion:
         assert question.slug == "test-question"
         assert question.data_source is None
 
+    def test_yes_no(self, db_session, factories):
+        form = factories.form.create()
+        question = create_question(
+            form=form,
+            text="Test Question",
+            hint="Test Hint",
+            name="Test Question Name",
+            data_type=QuestionDataType.YES_NO,
+        )
+        assert question is not None
+        assert question.id is not None
+        assert question.text == "Test Question"
+        assert question.hint == "Test Hint"
+        assert question.name == "Test Question Name"
+        assert question.data_type == QuestionDataType.YES_NO
+        assert question.order == 0
+        assert question.slug == "test-question"
+        assert question.data_source is None
+
     def test_radios(self, db_session, factories):
         form = factories.form.create()
         question = create_question(
@@ -359,7 +378,7 @@ class TestCreateQuestion:
         assert [item.key for item in question.data_source.items] == ["one", "two", "three"]
 
     def test_break_if_new_question_types_added(self):
-        assert len(QuestionDataType) == 4, "Add a new test above if adding a new question type"
+        assert len(QuestionDataType) == 5, "Add a new test above if adding a new question type"
 
 
 class TestUpdateQuestion:
@@ -439,6 +458,30 @@ class TestUpdateQuestion:
         assert updated_question.data_type == QuestionDataType.INTEGER
         assert updated_question.slug == "updated-question"
 
+    def test_yes_no(self, db_session, factories):
+        form = factories.form.create()
+        question = create_question(
+            form=form,
+            text="Test Question",
+            hint="Test Hint",
+            name="Test Question Name",
+            data_type=QuestionDataType.YES_NO,
+        )
+        assert question is not None
+
+        updated_question = update_question(
+            question=question,
+            text="Updated Question",
+            hint="Updated Hint",
+            name="Updated Question Name",
+        )
+
+        assert updated_question.text == "Updated Question"
+        assert updated_question.hint == "Updated Hint"
+        assert updated_question.name == "Updated Question Name"
+        assert updated_question.data_type == QuestionDataType.YES_NO
+        assert updated_question.slug == "updated-question"
+
     def test_radios(self, db_session, factories):
         form = factories.form.create()
         question = create_question(
@@ -477,7 +520,7 @@ class TestUpdateQuestion:
         assert db_session.get(DataSourceItem, item_ids[1]) is None
 
     def test_break_if_new_question_types_added(self):
-        assert len(QuestionDataType) == 4, "Add a new test above if adding a new question type"
+        assert len(QuestionDataType) == 5, "Add a new test above if adding a new question type"
 
 
 def test_move_question_up_down(db_session, factories):

--- a/tests/integration/common/expressions/test_managed.py
+++ b/tests/integration/common/expressions/test_managed.py
@@ -5,7 +5,7 @@ import pytest
 from app.common.data.interfaces.collections import get_question_by_id
 from app.common.data.models import Expression
 from app.common.expressions import evaluate
-from app.common.expressions.managed import AnyOf, Between, GreaterThan, LessThan
+from app.common.expressions.managed import AnyOf, Between, GreaterThan, IsNo, IsYes, LessThan
 from app.types import TRadioItem
 
 
@@ -96,4 +96,30 @@ class TestAnyOfExpression:
     )
     def test_evaluate(self, items: list[TRadioItem], answer: str, expected_result: bool):
         expr = AnyOf(question_id=uuid.uuid4(), items=items)
+        assert evaluate(Expression(statement=expr.statement, context={expr.safe_qid: answer})) is expected_result
+
+
+class TestIsYesExpression:
+    @pytest.mark.parametrize(
+        "answer, expected_result",
+        (
+            (True, True),
+            (False, False),
+        ),
+    )
+    def test_evaluate(self, answer: str, expected_result: bool):
+        expr = IsYes(question_id=uuid.uuid4())
+        assert evaluate(Expression(statement=expr.statement, context={expr.safe_qid: answer})) is expected_result
+
+
+class TestIsNoExpression:
+    @pytest.mark.parametrize(
+        "answer, expected_result",
+        (
+            (True, False),
+            (False, True),
+        ),
+    )
+    def test_evaluate(self, answer: str, expected_result: bool):
+        expr = IsNo(question_id=uuid.uuid4())
         assert evaluate(Expression(statement=expr.statement, context={expr.safe_qid: answer})) is expected_result

--- a/tests/integration/common/expressions/test_registry.py
+++ b/tests/integration/common/expressions/test_registry.py
@@ -39,7 +39,7 @@ class TestManagedExpressions:
         assert get_supported_form_questions(valid_question) == [second_question]
 
     def test_new_managed_expressions_added(self):
-        assert len(_registry_by_expression_enum) == 4, (
+        assert len(_registry_by_expression_enum) == 6, (
             "If you've added a new managed expression, update this test and add"
             "suitable tests in `tests/integration/common/expressions/test_managed.py`"
         )

--- a/tests/integration/common/helpers/test_collections.py
+++ b/tests/integration/common/helpers/test_collections.py
@@ -4,7 +4,7 @@ import pytest
 from immutabledict import immutabledict
 
 from app.common.collections.forms import build_question_form
-from app.common.collections.types import Integer, SingleChoiceFromList, TextMultiLine, TextSingleLine
+from app.common.collections.types import Integer, SingleChoiceFromList, TextMultiLine, TextSingleLine, YesNo
 from app.common.data.types import QuestionDataType, SubmissionStatusEnum
 from app.common.expressions import ExpressionContext
 from app.common.helpers.collections import SubmissionHelper
@@ -87,7 +87,7 @@ class TestSubmissionHelper:
             assert helper.form_data == {}
 
         def test_with_submission_data(self, factories):
-            assert len(QuestionDataType) == 4, "Update this test if adding new questions"
+            assert len(QuestionDataType) == 5, "Update this test if adding new questions"
 
             form = factories.form.build()
             form_two = factories.form.build(section=form.section)
@@ -105,8 +105,11 @@ class TestSubmissionHelper:
                 form=form_two, id=uuid.UUID("d696aebc-49d2-4170-a92f-b6ef42994296"), data_type=QuestionDataType.INTEGER
             )
             q4 = factories.question.build(
+                form=form_two, id=uuid.UUID("d696aebc-49d2-4170-a92f-b6ef42994297"), data_type=QuestionDataType.YES_NO
+            )
+            q5 = factories.question.build(
                 form=form_two,
-                id=uuid.UUID("d696aebc-49d2-4170-a92f-b6ef42994297"),
+                id=uuid.UUID("d696aebc-49d2-4170-a92f-b6ef42994298"),
                 data_type=QuestionDataType.RADIOS,
                 data_source__items__key="my-key",
                 data_source__items__label="My label",
@@ -118,7 +121,8 @@ class TestSubmissionHelper:
                     str(q1.id): TextSingleLine("answer").get_value_for_submission(),
                     str(q2.id): TextMultiLine("answer\nthis").get_value_for_submission(),
                     str(q3.id): Integer(50).get_value_for_submission(),
-                    str(q4.id): SingleChoiceFromList(key="my-key", label="My label").get_value_for_submission(),
+                    str(q4.id): YesNo(True).get_value_for_submission(),  # ty: ignore[missing-argument]
+                    str(q5.id): SingleChoiceFromList(key="my-key", label="My label").get_value_for_submission(),
                 },
             )
             helper = SubmissionHelper(submission)
@@ -127,7 +131,8 @@ class TestSubmissionHelper:
                 "q_d696aebc49d24170a92fb6ef42994294": "answer",
                 "q_d696aebc49d24170a92fb6ef42994295": "answer\nthis",
                 "q_d696aebc49d24170a92fb6ef42994296": 50,
-                "q_d696aebc49d24170a92fb6ef42994297": "my-key",
+                "q_d696aebc49d24170a92fb6ef42994297": True,
+                "q_d696aebc49d24170a92fb6ef42994298": "my-key",
             }
 
     class TestExpressionContext:
@@ -144,7 +149,7 @@ class TestSubmissionHelper:
             assert helper.expression_context == ExpressionContext()
 
         def test_with_submission_data(self, factories):
-            assert len(QuestionDataType) == 4, "Update this test if adding new questions"
+            assert len(QuestionDataType) == 5, "Update this test if adding new questions"
 
             form = factories.form.build()
             form_two = factories.form.build(section=form.section)
@@ -162,8 +167,11 @@ class TestSubmissionHelper:
                 form=form_two, id=uuid.UUID("d696aebc-49d2-4170-a92f-b6ef42994296"), data_type=QuestionDataType.INTEGER
             )
             q4 = factories.question.build(
+                form=form_two, id=uuid.UUID("d696aebc-49d2-4170-a92f-b6ef42994297"), data_type=QuestionDataType.YES_NO
+            )
+            q5 = factories.question.build(
                 form=form_two,
-                id=uuid.UUID("d696aebc-49d2-4170-a92f-b6ef42994297"),
+                id=uuid.UUID("d696aebc-49d2-4170-a92f-b6ef42994298"),
                 data_type=QuestionDataType.RADIOS,
                 data_source__items__key="my-key",
                 data_source__items__label="My label",
@@ -174,7 +182,8 @@ class TestSubmissionHelper:
                     str(q1.id): TextSingleLine("answer").get_value_for_submission(),
                     str(q2.id): TextMultiLine("answer\nthis").get_value_for_submission(),
                     str(q3.id): Integer(50).get_value_for_submission(),
-                    str(q4.id): SingleChoiceFromList(key="my-key", label="My label").get_value_for_submission(),
+                    str(q4.id): YesNo(True).get_value_for_submission(),  # ty: ignore[missing-argument]
+                    str(q5.id): SingleChoiceFromList(key="my-key", label="My label").get_value_for_submission(),
                 },
             )
             helper = SubmissionHelper(submission)
@@ -185,7 +194,8 @@ class TestSubmissionHelper:
                         "q_d696aebc49d24170a92fb6ef42994294": "answer",
                         "q_d696aebc49d24170a92fb6ef42994295": "answer\nthis",
                         "q_d696aebc49d24170a92fb6ef42994296": 50,
-                        "q_d696aebc49d24170a92fb6ef42994297": "my-key",
+                        "q_d696aebc49d24170a92fb6ef42994297": True,
+                        "q_d696aebc49d24170a92fb6ef42994298": "my-key",
                     }
                 )
             )

--- a/tests/integration/test_fixtures.py
+++ b/tests/integration/test_fixtures.py
@@ -124,7 +124,7 @@ def test_collection_factory_completed_submissions(db_session, factories):
     assert len(collection_from_db.live_submissions) == 2
 
     answers_dict = collection._submissions[0].data
-    assert len(answers_dict) == 4
+    assert len(answers_dict) == 5
 
     for submission in collection_from_db.test_submissions:
         helper = SubmissionHelper(submission)

--- a/tests/models.py
+++ b/tests/models.py
@@ -8,6 +8,7 @@ for transactional isolation.
 """
 
 import datetime
+import random
 import secrets
 from typing import Any
 from uuid import uuid4
@@ -18,7 +19,7 @@ import faker
 from factory.alchemy import SQLAlchemyModelFactory
 from flask import url_for
 
-from app.common.collections.types import Integer, SingleChoiceFromList, TextMultiLine, TextSingleLine
+from app.common.collections.types import Integer, SingleChoiceFromList, TextMultiLine, TextSingleLine, YesNo
 from app.common.data.models import (
     Collection,
     DataSource,
@@ -150,13 +151,14 @@ class _CollectionFactory(SQLAlchemyModelFactory):
         form = _FormFactory.create(section=section)
 
         # Assertion to remind us to add more question types here when we start supporting them
-        assert len(QuestionDataType) == 4, "If you have added a new question type, please update this factory."
+        assert len(QuestionDataType) == 5, "If you have added a new question type, please update this factory."
 
         # Create a question of each supported type
         q1 = _QuestionFactory.create(form=form, data_type=QuestionDataType.TEXT_SINGLE_LINE, text="What is your name?")
         q2 = _QuestionFactory.create(form=form, data_type=QuestionDataType.TEXT_MULTI_LINE, text="What is your quest?")
         q3 = _QuestionFactory.create(form=form, data_type=QuestionDataType.INTEGER, text="What is your age?")
-        q4 = _QuestionFactory.create(form=form, data_type=QuestionDataType.RADIOS, text="What is the best option?")
+        q4 = _QuestionFactory.create(form=form, data_type=QuestionDataType.YES_NO, text="Do you like cheese?")
+        q5 = _QuestionFactory.create(form=form, data_type=QuestionDataType.RADIOS, text="What is the best option?")
 
         for _ in range(0, test):
             _SubmissionFactory.create(
@@ -166,8 +168,9 @@ class _CollectionFactory(SQLAlchemyModelFactory):
                     str(q1.id): TextSingleLine(faker.Faker().name()).get_value_for_submission(),
                     str(q2.id): TextMultiLine("\n".join(faker.Faker().sentences(nb=3))).get_value_for_submission(),
                     str(q3.id): Integer(faker.Faker().random_number(2)).get_value_for_submission(),
-                    str(q4.id): SingleChoiceFromList(
-                        key=q4.data_source.items[0].key, label=q4.data_source.items[0].label
+                    str(q4.id): YesNo(random.choice([True, False])).get_value_for_submission(),  # ty: ignore[missing-argument]
+                    str(q5.id): SingleChoiceFromList(
+                        key=q5.data_source.items[0].key, label=q5.data_source.items[0].label
                     ).get_value_for_submission(),
                 },
                 status=SubmissionStatusEnum.COMPLETED,
@@ -180,8 +183,9 @@ class _CollectionFactory(SQLAlchemyModelFactory):
                     str(q1.id): TextSingleLine(faker.Faker().name()).get_value_for_submission(),
                     str(q2.id): TextMultiLine("\n".join(faker.Faker().sentences(nb=3))).get_value_for_submission(),
                     str(q3.id): Integer(faker.Faker().random_number(2)).get_value_for_submission(),
-                    str(q4.id): SingleChoiceFromList(
-                        key=q4.data_source.items[0].key, label=q4.data_source.items[0].label
+                    str(q4.id): YesNo(random.choice([True, False])).get_value_for_submission(),  # ty: ignore[missing-argument]
+                    str(q5.id): SingleChoiceFromList(
+                        key=q5.data_source.items[0].key, label=q5.data_source.items[0].label
                     ).get_value_for_submission(),
                 },
                 status=SubmissionStatusEnum.COMPLETED,

--- a/tests/unit/common/collections/test_forms.py
+++ b/tests/unit/common/collections/test_forms.py
@@ -72,7 +72,7 @@ class TestBuildQuestionForm:
         assert hasattr(form, "submit")
 
     def test_the_next_test_exhausts_QuestionDataType(self):
-        assert len(QuestionDataType) == 4, (
+        assert len(QuestionDataType) == 5, (
             "If this test breaks, tweak the number and update `test_expected_field_types` accordingly."
         )
 
@@ -82,6 +82,7 @@ class TestBuildQuestionForm:
             (QuestionDataType.TEXT_SINGLE_LINE, StringField, GovTextInput, [DataRequired]),
             (QuestionDataType.TEXT_MULTI_LINE, StringField, GovTextArea, [DataRequired]),
             (QuestionDataType.INTEGER, IntegerField, GovTextInput, [InputRequired]),
+            (QuestionDataType.YES_NO, RadioField, GovRadioInput, [InputRequired]),
             (QuestionDataType.RADIOS, RadioField, GovRadioInput, []),
         ),
     )

--- a/tests/unit/common/collections/test_types.py
+++ b/tests/unit/common/collections/test_types.py
@@ -1,25 +1,26 @@
 import pytest
 
-from app.common.collections.types import Integer, TextMultiLine, TextSingleLine
+from app.common.collections.types import Integer, TextMultiLine, TextSingleLine, YesNo
 
 
 @pytest.mark.parametrize(
-    "model, data",
+    "model, data, expected_text_export",
     (
-        (TextSingleLine, "hello"),
-        (TextMultiLine, "hello\nthere"),
-        (Integer, 5),
+        (TextSingleLine, "hello", "hello"),
+        (TextMultiLine, "hello\nthere", "hello\nthere"),
+        (Integer, 5, "5"),
+        (YesNo, True, "Yes"),
     ),
 )
 class TestSubmissionAnswerRootModels:
-    def test_get_value_for_submission(self, model, data):
+    def test_get_value_for_submission(self, model, data, expected_text_export):
         assert model(data).get_value_for_submission() == data
 
-    def test_get_value_for_form(self, model, data):
+    def test_get_value_for_form(self, model, data, expected_text_export):
         assert model(data).get_value_for_form() == data
 
-    def test_get_value_for_expression(self, model, data):
+    def test_get_value_for_expression(self, model, data, expected_text_export):
         assert model(data).get_value_for_expression() == data
 
-    def test_get_value_for_text_export(self, model, data):
-        assert model(data).get_value_for_text_export() == str(data)
+    def test_get_value_for_text_export(self, model, data, expected_text_export):
+        assert model(data).get_value_for_text_export() == expected_text_export


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-686

## 📝 Description
We’ve added support for radio questions to the service, allowing users to define any list of options. But we expect that, very often, form designers will want to add a simple “yes” / “no” question type. This is such a common use-case that we think it’s worth building a specific question type just for this specific type of radio question.

This implementation does not use the 'data source' implementation of other radio question. It felt like the options were either:

1. Have a single platform-level data source for yes/no that all questions of this type use.
2. Create a new yes/no data source for each question.

Option 1 hits on some functionality we don't have yet, so would have increased scope quite a bit. Option 2 would definitely be fine but also feels a tiny bit wasteful (absolutely negligible though).

Neither of the options feel fundamentally better than just having a hard-coded yes/no question that processes the information in a distinct way (treating it as a boolean rather than a string yes/no).

Also updates our seeded grant to include a yes/no question with a dependent question.

## 📸 Show the thing (screenshots, gifs)
![2025-07-15 12 28 43](https://github.com/user-attachments/assets/4e5da921-472b-4f2c-a3c4-070120c3362f)


## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [ ] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested