### PR TITLE
Small content tweaks for developer pages

### DIFF
--- a/app/developers/deliver_routes.py
+++ b/app/developers/deliver_routes.py
@@ -483,7 +483,7 @@ def add_question(grant_id: UUID, collection_id: UUID, section_id: UUID, form_id:
             assert wt_form.hint.data is not None
             assert wt_form.name.data is not None
 
-            create_question(
+            question = create_question(
                 form=form,
                 text=wt_form.text.data,
                 hint=wt_form.hint.data,
@@ -495,11 +495,12 @@ def add_question(grant_id: UUID, collection_id: UUID, section_id: UUID, form_id:
             )
             return redirect(
                 url_for(
-                    "developers.deliver.manage_form",
+                    "developers.deliver.edit_question",
                     grant_id=grant_id,
                     collection_id=collection_id,
                     section_id=section_id,
                     form_id=form_id,
+                    question_id=question.id,
                 )
             )
         except DuplicateValueError as e:

--- a/app/developers/templates/developers/deliver/_render_managed_expression_form.html
+++ b/app/developers/templates/developers/deliver/_render_managed_expression_form.html
@@ -1,4 +1,4 @@
-{% macro render_managed_expression_form(form, label_html) %}
+{% macro render_managed_expression_form(form, label_html, submit_label) %}
   <form method="post" novalidate>
     {{ form.csrf_token }}
 
@@ -15,6 +15,6 @@
       })
     }}
 
-    {{ form.submit }}
+    {{ form.submit(params={"text": submit_label}) }}
   </form>
 {% endmacro %}

--- a/app/developers/templates/developers/deliver/add_question_condition_select_condition_type.html
+++ b/app/developers/templates/developers/deliver/add_question_condition_select_condition_type.html
@@ -32,7 +32,7 @@
           <span class="govuk-visually-hidden">to {{ depends_on_question.text }}</span>
           is
         {% endset %}
-        {{ render_managed_expression_form(form, label_html=label_html) }}
+        {{ render_managed_expression_form(form, label_html=label_html, submit_label="Add condition") }}
       {% else %}
         <p class="govuk-body">This question cannot be used a condition.</p>
       {% endif %}

--- a/app/developers/templates/developers/deliver/edit_question.html
+++ b/app/developers/templates/developers/deliver/edit_question.html
@@ -62,7 +62,7 @@
               {{ form.data_source_items }}
             {% endif %}
 
-            {{ form.submit }}
+            {{ form.submit(params={"text": "Save"}) }}
           </form>
 
           <div class="govuk-form-group">

--- a/app/developers/templates/developers/deliver/manage_question_condition_select_condition_type.html
+++ b/app/developers/templates/developers/deliver/manage_question_condition_select_condition_type.html
@@ -53,7 +53,7 @@
           <span class="govuk-visually-hidden">to {{ depends_on_question.text }}</span>
           is
         {% endset %}
-        {{ render_managed_expression_form(form, label_html=label_html) }}
+        {{ render_managed_expression_form(form, label_html=label_html, submit_label=submit_label) }}
       {% else %}
         <p class="govuk-body">This question cannot be used a condition.</p>
       {% endif %}

--- a/app/developers/templates/developers/deliver/manage_question_validation.html
+++ b/app/developers/templates/developers/deliver/manage_question_validation.html
@@ -55,7 +55,7 @@
           <span class="govuk-visually-hidden">“{{ question.text }}”</span>
           must be
         {% endset %}
-        {{ render_managed_expression_form(form, label_html=label_html) }}
+        {{ render_managed_expression_form(form, label_html=label_html, submit_label=submit_label) }}
 
         {% if expression %}
           <div class="govuk-grid-row govuk-!-margin-top-7">

--- a/tests/e2e/developer_pages.py
+++ b/tests/e2e/developer_pages.py
@@ -462,8 +462,21 @@ class AddQuestionDetailsPage(GrantDevelopersBasePage):
     def fill_data_source_items(self, items: list[str]) -> None:
         self.page.get_by_role("textbox", name="List of options").fill("\n".join(items))
 
-    def click_submit(self) -> ManageFormPage:
+    def click_submit(self) -> "EditQuestionPage":
         self.page.get_by_role("button", name="Submit").click()
+        edit_question_page = EditQuestionPage(
+            self.page,
+            self.domain,
+            grant_name=self.grant_name,
+            collection_name=self.collection_name,
+            section_title=self.section_title,
+            form_name=self.form_name,
+        )
+        expect(edit_question_page.heading).to_be_visible()
+        return edit_question_page
+
+    def click_back(self) -> ManageFormPage:
+        self.page.get_by_role("link", name="Back").click()
         manage_form_page = ManageFormPage(
             self.page,
             self.domain,

--- a/tests/e2e/test_developer_journey.py
+++ b/tests/e2e/test_developer_journey.py
@@ -65,8 +65,8 @@ def create_question(
         assert data_source_items
         question_details_page.fill_data_source_items(data_source_items)
 
-    manage_form_page = question_details_page.click_submit()
-    manage_form_page.check_question_exists(question_text)
+    question_details_page.click_submit()
+    question_details_page.click_back()
 
     created_questions_to_test.append(
         {

--- a/tests/integration/deliver_grant_funding/test_routes.py
+++ b/tests/integration/deliver_grant_funding/test_routes.py
@@ -731,11 +731,12 @@ def test_add_text_question_post(authenticated_platform_admin_client, factories, 
     )
     assert result.status_code == 302
     assert result.location == url_for(
-        "developers.deliver.manage_form",
+        "developers.deliver.edit_question",
         grant_id=form.section.collection.grant.id,
         collection_id=form.section.collection.id,
         section_id=form.section.id,
         form_id=form.id,
+        question_id=db_session.query(Question).first().id,
     )
 
     form_from_db = db_session.scalars(select(Form).where(Form.id == form.id)).one()


### PR DESCRIPTION
- Redirect to 'edit question' page after adding a question, so that you can add conditions/validation.
- Tweak primary button labels on some pages (eg update question)