### PR TITLE
Remove some context from condition/validation pages

### DIFF
--- a/app/developers/templates/developers/deliver/_add_question_condition_context.html
+++ b/app/developers/templates/developers/deliver/_add_question_condition_context.html
@@ -1,18 +1,4 @@
 {% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
-
-{{
-  govukSummaryList({
-    "rows": [{
-      "key": { "text": "Collection" },
-      "value": { "text": question.form.section.collection.name },
-    }, {
-      "key": { "text": "Form" },
-      "value": { "text": question.form.title },
-    }],
-    "classes": "app-!-border-top-line"
-  })
-}}
-
 <h2 class="govuk-heading-m">Condition</h2>
 {{
   govukSummaryList({

--- a/app/developers/templates/developers/deliver/manage_question_validation.html
+++ b/app/developers/templates/developers/deliver/manage_question_validation.html
@@ -36,9 +36,6 @@
       {{
         govukSummaryList({
           "rows": [{
-            "key": { "text": "Collection" },
-            "value": { "text": question.form.section.collection.name },
-          }, {
             "key": { "text": "Form" },
             "value": { "text": question.form.title },
           }, {


### PR DESCRIPTION
Removes some context from the 'add condition' and 'add validation' pages which felt a little bit confusing/redundant.