### PR TITLE
Add a new email question type

### DIFF
--- a/app/common/collections/forms.py
+++ b/app/common/collections/forms.py
@@ -7,14 +7,14 @@ from govuk_frontend_wtf.wtforms_widgets import GovRadioInput, GovSubmitInput, Go
 from immutabledict import immutabledict
 from wtforms import Field, Form, RadioField
 from wtforms.fields.numeric import IntegerField
-from wtforms.fields.simple import StringField, SubmitField
-from wtforms.validators import DataRequired, InputRequired, Optional, ValidationError
+from wtforms.fields.simple import EmailField, StringField, SubmitField
+from wtforms.validators import DataRequired, Email, InputRequired, Optional, ValidationError
 
 from app.common.data.models import Expression, Question
 from app.common.data.types import QuestionDataType, immutable_json_flat_scalars
 from app.common.expressions import ExpressionContext, evaluate
 
-_accepted_fields = StringField | IntegerField | RadioField
+_accepted_fields = EmailField | StringField | IntegerField | RadioField
 
 
 # FIXME: Ideally this would do an intersection between FlaskForm and QuestionFormProtocol, but type hinting in
@@ -110,6 +110,16 @@ def build_question_form(question: Question, expression_context: ExpressionContex
 
     field: _accepted_fields
     match question.data_type:
+        case QuestionDataType.EMAIL:
+            field = EmailField(
+                label=question.text,
+                description=question.hint or "",
+                widget=GovTextInput(),
+                validators=[
+                    DataRequired(f"Enter the {question.name}"),
+                    Email(message="Enter an email address in the correct format, like name@example.com"),
+                ],
+            )
         case QuestionDataType.TEXT_SINGLE_LINE:
             field = StringField(
                 label=question.text,

--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-016_add_yes_no_question
+017_add_email_question_type

--- a/app/common/data/migrations/versions/017_add_email_question_type.py
+++ b/app/common/data/migrations/versions/017_add_email_question_type.py
@@ -1,0 +1,35 @@
+"""add email question type
+
+Revision ID: 017_add_email_question_type
+Revises: 016_add_yes_no_question
+Create Date: 2025-07-15 15:37:51.281946
+
+"""
+
+from alembic import op
+from alembic_postgresql_enum import TableReference
+
+revision = "017_add_email_question_type"
+down_revision = "016_add_yes_no_question"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.sync_enum_values(  # ty: ignore[unresolved-attribute]
+        enum_schema="public",
+        enum_name="question_data_type_enum",
+        new_values=["EMAIL", "TEXT_SINGLE_LINE", "TEXT_MULTI_LINE", "INTEGER", "YES_NO", "RADIOS"],
+        affected_columns=[TableReference(table_schema="public", table_name="question", column_name="data_type")],
+        enum_values_to_rename=[],
+    )
+
+
+def downgrade() -> None:
+    op.sync_enum_values(  # ty: ignore[unresolved-attribute]
+        enum_schema="public",
+        enum_name="question_data_type_enum",
+        new_values=["TEXT_SINGLE_LINE", "TEXT_MULTI_LINE", "INTEGER", "YES_NO", "RADIOS"],
+        affected_columns=[TableReference(table_schema="public", table_name="question", column_name="data_type")],
+        enum_values_to_rename=[],
+    )

--- a/app/common/data/types.py
+++ b/app/common/data/types.py
@@ -41,6 +41,7 @@ class AuthMethodEnum(str, enum.Enum):
 class QuestionDataType(enum.StrEnum):
     # If adding values here, also update QuestionTypeForm
     # and manually create a migration to update question_type_enum in the db
+    EMAIL = "An email address"
     TEXT_SINGLE_LINE = "A single line of text"
     TEXT_MULTI_LINE = "Multiple lines of text"
     INTEGER = "A whole number"

--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -332,7 +332,7 @@ def _form_data_to_question_type(
     answer = form.get_answer_to_question(question)
 
     match question.data_type:
-        case QuestionDataType.TEXT_SINGLE_LINE:
+        case QuestionDataType.TEXT_SINGLE_LINE | QuestionDataType.EMAIL:
             return TextSingleLine(answer)
         case QuestionDataType.TEXT_MULTI_LINE:
             return TextMultiLine(answer)
@@ -351,7 +351,7 @@ def _deserialise_question_type(
     question: "Question", serialised_data: str | int | float | bool
 ) -> TextSingleLine | TextMultiLine | Integer | YesNo | SingleChoiceFromList:
     match question.data_type:
-        case QuestionDataType.TEXT_SINGLE_LINE:
+        case QuestionDataType.TEXT_SINGLE_LINE | QuestionDataType.EMAIL:
             return TypeAdapter(TextSingleLine).validate_python(serialised_data)
         case QuestionDataType.TEXT_MULTI_LINE:
             return TypeAdapter(TextMultiLine).validate_python(serialised_data)

--- a/app/common/templates/common/macros/collections.html
+++ b/app/common/templates/common/macros/collections.html
@@ -22,7 +22,7 @@
     {# We want the caption outside of the <h> element to keep things more concise and understandable to screenreader users #}
     {# So we just manually add the caption here. #}
     <span class="govuk-caption-l">{{ question.form.title }}</span>
-    {% if question.data_type == enum.question_type.TEXT_SINGLE_LINE or question.data_type == enum.question_type.TEXT_MULTI_LINE %}
+    {% if question.data_type == enum.question_type.TEXT_SINGLE_LINE or question.data_type == enum.question_type.TEXT_MULTI_LINE or question.data_type == enum.question_type.EMAIL %}
       {{ form.render_question(question, params={"label": {"classes": "govuk-label--l", "isPageHeading": true} }) }}
     {% elif question.data_type == enum.question_type.INTEGER %}
       {{ form.render_question(question, params={"label": {"classes": "govuk-label--l", "isPageHeading": true}, "inputmode": "numeric", "spellcheck": false }) }}

--- a/app/developers/data/grants.json
+++ b/app/developers/data/grants.json
@@ -773,16 +773,16 @@
           "updated_at_utc": "Thu, 03 Jul 2025 15:41:42 GMT"
         },
         {
-          "created_at_utc": "Thu, 03 Jul 2025 15:41:54 GMT",
-          "data_type": "A single line of text",
+          "created_at_utc": "Tue, 15 Jul 2025 15:35:11 GMT",
+          "data_type": "An email address",
           "form_id": "615f5183-f056-42c4-acd1-23d25db5f9a3",
           "hint": "",
-          "id": "82a0b8ec-7474-4e82-a53d-e3e24f584623",
+          "id": "b51759ce-0690-49d1-9a0f-d6f34eda28f0",
           "name": "lead contact email",
           "order": 1,
           "slug": "what-is-the-email-address-of-the-lead-contact-for-this-programme",
           "text": "What is the email address of the lead contact for this programme?",
-          "updated_at_utc": "Thu, 03 Jul 2025 15:41:54 GMT"
+          "updated_at_utc": "Tue, 15 Jul 2025 15:35:27 GMT"
         },
         {
           "created_at_utc": "Mon, 14 Jul 2025 10:01:21 GMT",
@@ -794,7 +794,7 @@
           "order": 2,
           "slug": "what-is-the-role-of-the-lead-contact-for-this-programme",
           "text": "What is the role of the lead contact for this programme?",
-          "updated_at_utc": "Mon, 14 Jul 2025 10:01:21 GMT"
+          "updated_at_utc": "Tue, 15 Jul 2025 15:35:14 GMT"
         },
         {
           "created_at_utc": "Mon, 14 Jul 2025 10:01:40 GMT",
@@ -806,7 +806,7 @@
           "order": 3,
           "slug": "what-kind-of-data-certifier-is-the-lead-contact",
           "text": "What kind of data certifier is the lead contact?",
-          "updated_at_utc": "Mon, 14 Jul 2025 10:01:40 GMT"
+          "updated_at_utc": "Tue, 15 Jul 2025 15:35:13 GMT"
         },
         {
           "created_at_utc": "Thu, 03 Jul 2025 15:44:52 GMT",
@@ -1485,15 +1485,6 @@
   ],
   "users": [
     {
-      "azure_ad_subject_id": "40e16bf9d02fa7f67c6bb767b197e544",
-      "created_at_utc": "Thu, 03 Jul 2025 15:18:06 GMT",
-      "email": "sclark@test.communities.gov.uk",
-      "id": "9ab212ee-6716-4921-b6a2-61a684bf2fe3",
-      "last_logged_in_at_utc": "Mon, 14 Jul 2025 10:00:46 GMT",
-      "name": "Willie Brown",
-      "updated_at_utc": "Mon, 14 Jul 2025 10:00:46 GMT"
-    },
-    {
       "azure_ad_subject_id": "mDLVWMQVmvxRxPNKpKUFODrcU",
       "created_at_utc": "Thu, 03 Jul 2025 14:37:06 GMT",
       "email": "johnsonlori@test.communities.gov.uk",
@@ -1501,6 +1492,15 @@
       "last_logged_in_at_utc": "Thu, 03 Jul 2025 14:37:06 GMT",
       "name": "Margaret Ballard",
       "updated_at_utc": "Thu, 03 Jul 2025 14:37:06 GMT"
+    },
+    {
+      "azure_ad_subject_id": "40e16bf9d02fa7f67c6bb767b197e544",
+      "created_at_utc": "Thu, 03 Jul 2025 15:18:06 GMT",
+      "email": "sclark@test.communities.gov.uk",
+      "id": "9ab212ee-6716-4921-b6a2-61a684bf2fe3",
+      "last_logged_in_at_utc": "Mon, 14 Jul 2025 10:00:46 GMT",
+      "name": "Willie Brown",
+      "updated_at_utc": "Mon, 14 Jul 2025 10:00:46 GMT"
     },
     {
       "azure_ad_subject_id": "GLLNgipKjLFCQjLaXVVeUjNyH",

--- a/tests/e2e/test_developer_journey.py
+++ b/tests/e2e/test_developer_journey.py
@@ -20,6 +20,7 @@ class _QuestionResponse:
 
 
 question_text_by_type: dict[QuestionDataType, str] = {
+    QuestionDataType.EMAIL: "Enter an email address",
     QuestionDataType.TEXT_SINGLE_LINE: "Enter a single line of text",
     QuestionDataType.TEXT_MULTI_LINE: "Enter a few lines of text",
     QuestionDataType.INTEGER: "Enter a number",
@@ -29,6 +30,10 @@ question_text_by_type: dict[QuestionDataType, str] = {
 
 
 question_response_data_by_type: dict[QuestionDataType, list[_QuestionResponse]] = {
+    QuestionDataType.EMAIL: [
+        _QuestionResponse("not-an-email", "Enter an email address in the correct format, like name@example.com"),
+        _QuestionResponse("name@example.com"),
+    ],
     QuestionDataType.TEXT_SINGLE_LINE: [_QuestionResponse("E2E question text single line")],
     QuestionDataType.TEXT_MULTI_LINE: [_QuestionResponse("E2E question text multi line\nwith a second line")],
     QuestionDataType.INTEGER: [
@@ -154,6 +159,7 @@ def test_create_and_preview_collection(
 
         # Add a question of each type
         manage_form_page = section_detail_page.click_manage_form(form_name)
+        create_question(QuestionDataType.EMAIL, manage_form_page)
         create_question(QuestionDataType.TEXT_SINGLE_LINE, manage_form_page)
         create_question(QuestionDataType.TEXT_MULTI_LINE, manage_form_page)
         create_question(QuestionDataType.INTEGER, manage_form_page)

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -280,59 +280,30 @@ def test_get_question(db_session, factories):
 
 
 class TestCreateQuestion:
-    def test_text_single_line(self, db_session, factories):
+    @pytest.mark.parametrize(
+        "question_type",
+        [
+            QuestionDataType.TEXT_SINGLE_LINE,
+            QuestionDataType.EMAIL,
+            QuestionDataType.TEXT_MULTI_LINE,
+            QuestionDataType.INTEGER,
+        ],
+    )
+    def test_simple_types(self, db_session, factories, question_type):
         form = factories.form.create()
         question = create_question(
             form=form,
             text="Test Question",
             hint="Test Hint",
             name="Test Question Name",
-            data_type=QuestionDataType.TEXT_SINGLE_LINE,
+            data_type=question_type,
         )
         assert question is not None
         assert question.id is not None
         assert question.text == "Test Question"
         assert question.hint == "Test Hint"
         assert question.name == "Test Question Name"
-        assert question.data_type == QuestionDataType.TEXT_SINGLE_LINE
-        assert question.order == 0
-        assert question.slug == "test-question"
-        assert question.data_source is None
-
-    def test_text_multi_line(self, db_session, factories):
-        form = factories.form.create()
-        question = create_question(
-            form=form,
-            text="Test Question",
-            hint="Test Hint",
-            name="Test Question Name",
-            data_type=QuestionDataType.TEXT_MULTI_LINE,
-        )
-        assert question is not None
-        assert question.id is not None
-        assert question.text == "Test Question"
-        assert question.hint == "Test Hint"
-        assert question.name == "Test Question Name"
-        assert question.data_type == QuestionDataType.TEXT_MULTI_LINE
-        assert question.order == 0
-        assert question.slug == "test-question"
-        assert question.data_source is None
-
-    def test_integer(self, db_session, factories):
-        form = factories.form.create()
-        question = create_question(
-            form=form,
-            text="Test Question",
-            hint="Test Hint",
-            name="Test Question Name",
-            data_type=QuestionDataType.INTEGER,
-        )
-        assert question is not None
-        assert question.id is not None
-        assert question.text == "Test Question"
-        assert question.hint == "Test Hint"
-        assert question.name == "Test Question Name"
-        assert question.data_type == QuestionDataType.INTEGER
+        assert question.data_type == question_type
         assert question.order == 0
         assert question.slug == "test-question"
         assert question.data_source is None
@@ -378,18 +349,27 @@ class TestCreateQuestion:
         assert [item.key for item in question.data_source.items] == ["one", "two", "three"]
 
     def test_break_if_new_question_types_added(self):
-        assert len(QuestionDataType) == 5, "Add a new test above if adding a new question type"
+        assert len(QuestionDataType) == 6, "Add a new test above if adding a new question type"
 
 
 class TestUpdateQuestion:
-    def test_text_single_line(self, db_session, factories):
+    @pytest.mark.parametrize(
+        "question_type",
+        [
+            QuestionDataType.TEXT_SINGLE_LINE,
+            QuestionDataType.EMAIL,
+            QuestionDataType.TEXT_MULTI_LINE,
+            QuestionDataType.INTEGER,
+        ],
+    )
+    def test_simple_types(self, db_session, factories, question_type):
         form = factories.form.create()
         question = create_question(
             form=form,
             text="Test Question",
             hint="Test Hint",
             name="Test Question Name",
-            data_type=QuestionDataType.TEXT_SINGLE_LINE,
+            data_type=question_type,
         )
         assert question is not None
         assert question.data_source is None
@@ -404,59 +384,9 @@ class TestUpdateQuestion:
         assert updated_question.text == "Updated Question"
         assert updated_question.hint == "Updated Hint"
         assert updated_question.name == "Updated Question Name"
-        assert updated_question.data_type == QuestionDataType.TEXT_SINGLE_LINE
+        assert updated_question.data_type == question_type
         assert updated_question.slug == "updated-question"
         assert updated_question.data_source is None
-
-    def test_text_multi_line(self, db_session, factories):
-        form = factories.form.create()
-        question = create_question(
-            form=form,
-            text="Test Question",
-            hint="Test Hint",
-            name="Test Question Name",
-            data_type=QuestionDataType.TEXT_MULTI_LINE,
-        )
-        assert question is not None
-        assert question.data_source is None
-
-        updated_question = update_question(
-            question=question,
-            text="Updated Question",
-            hint="Updated Hint",
-            name="Updated Question Name",
-        )
-
-        assert updated_question.text == "Updated Question"
-        assert updated_question.hint == "Updated Hint"
-        assert updated_question.name == "Updated Question Name"
-        assert updated_question.data_type == QuestionDataType.TEXT_MULTI_LINE
-        assert updated_question.slug == "updated-question"
-        assert updated_question.data_source is None
-
-    def test_integer(self, db_session, factories):
-        form = factories.form.create()
-        question = create_question(
-            form=form,
-            text="Test Question",
-            hint="Test Hint",
-            name="Test Question Name",
-            data_type=QuestionDataType.INTEGER,
-        )
-        assert question is not None
-
-        updated_question = update_question(
-            question=question,
-            text="Updated Question",
-            hint="Updated Hint",
-            name="Updated Question Name",
-        )
-
-        assert updated_question.text == "Updated Question"
-        assert updated_question.hint == "Updated Hint"
-        assert updated_question.name == "Updated Question Name"
-        assert updated_question.data_type == QuestionDataType.INTEGER
-        assert updated_question.slug == "updated-question"
 
     def test_yes_no(self, db_session, factories):
         form = factories.form.create()
@@ -520,7 +450,7 @@ class TestUpdateQuestion:
         assert db_session.get(DataSourceItem, item_ids[1]) is None
 
     def test_break_if_new_question_types_added(self):
-        assert len(QuestionDataType) == 5, "Add a new test above if adding a new question type"
+        assert len(QuestionDataType) == 6, "Add a new test above if adding a new question type"
 
 
 def test_move_question_up_down(db_session, factories):

--- a/tests/integration/common/helpers/test_collections.py
+++ b/tests/integration/common/helpers/test_collections.py
@@ -87,7 +87,7 @@ class TestSubmissionHelper:
             assert helper.form_data == {}
 
         def test_with_submission_data(self, factories):
-            assert len(QuestionDataType) == 5, "Update this test if adding new questions"
+            assert len(QuestionDataType) == 6, "Update this test if adding new questions"
 
             form = factories.form.build()
             form_two = factories.form.build(section=form.section)
@@ -114,6 +114,11 @@ class TestSubmissionHelper:
                 data_source__items__key="my-key",
                 data_source__items__label="My label",
             )
+            q6 = factories.question.build(
+                form=form,
+                id=uuid.UUID("d696aebc-49d2-4170-a92f-b6ef42994299"),
+                data_type=QuestionDataType.EMAIL,
+            )
 
             submission = factories.submission.build(
                 collection=form.section.collection,
@@ -123,6 +128,7 @@ class TestSubmissionHelper:
                     str(q3.id): Integer(50).get_value_for_submission(),
                     str(q4.id): YesNo(True).get_value_for_submission(),  # ty: ignore[missing-argument]
                     str(q5.id): SingleChoiceFromList(key="my-key", label="My label").get_value_for_submission(),
+                    str(q6.id): TextSingleLine("name@example.com").get_value_for_submission(),
                 },
             )
             helper = SubmissionHelper(submission)
@@ -133,6 +139,7 @@ class TestSubmissionHelper:
                 "q_d696aebc49d24170a92fb6ef42994296": 50,
                 "q_d696aebc49d24170a92fb6ef42994297": True,
                 "q_d696aebc49d24170a92fb6ef42994298": "my-key",
+                "q_d696aebc49d24170a92fb6ef42994299": "name@example.com",
             }
 
     class TestExpressionContext:
@@ -149,7 +156,7 @@ class TestSubmissionHelper:
             assert helper.expression_context == ExpressionContext()
 
         def test_with_submission_data(self, factories):
-            assert len(QuestionDataType) == 5, "Update this test if adding new questions"
+            assert len(QuestionDataType) == 6, "Update this test if adding new questions"
 
             form = factories.form.build()
             form_two = factories.form.build(section=form.section)
@@ -176,6 +183,11 @@ class TestSubmissionHelper:
                 data_source__items__key="my-key",
                 data_source__items__label="My label",
             )
+            q6 = factories.question.build(
+                form=form,
+                id=uuid.UUID("d696aebc-49d2-4170-a92f-b6ef42994299"),
+                data_type=QuestionDataType.EMAIL,
+            )
             submission = factories.submission.build(
                 collection=form.section.collection,
                 data={
@@ -184,6 +196,7 @@ class TestSubmissionHelper:
                     str(q3.id): Integer(50).get_value_for_submission(),
                     str(q4.id): YesNo(True).get_value_for_submission(),  # ty: ignore[missing-argument]
                     str(q5.id): SingleChoiceFromList(key="my-key", label="My label").get_value_for_submission(),
+                    str(q6.id): TextSingleLine("name@example.com").get_value_for_submission(),
                 },
             )
             helper = SubmissionHelper(submission)
@@ -196,6 +209,7 @@ class TestSubmissionHelper:
                         "q_d696aebc49d24170a92fb6ef42994296": 50,
                         "q_d696aebc49d24170a92fb6ef42994297": True,
                         "q_d696aebc49d24170a92fb6ef42994298": "my-key",
+                        "q_d696aebc49d24170a92fb6ef42994299": "name@example.com",
                     }
                 )
             )

--- a/tests/integration/test_fixtures.py
+++ b/tests/integration/test_fixtures.py
@@ -124,7 +124,7 @@ def test_collection_factory_completed_submissions(db_session, factories):
     assert len(collection_from_db.live_submissions) == 2
 
     answers_dict = collection._submissions[0].data
-    assert len(answers_dict) == 5
+    assert len(answers_dict) == 6
 
     for submission in collection_from_db.test_submissions:
         helper = SubmissionHelper(submission)

--- a/tests/models.py
+++ b/tests/models.py
@@ -151,7 +151,7 @@ class _CollectionFactory(SQLAlchemyModelFactory):
         form = _FormFactory.create(section=section)
 
         # Assertion to remind us to add more question types here when we start supporting them
-        assert len(QuestionDataType) == 5, "If you have added a new question type, please update this factory."
+        assert len(QuestionDataType) == 6, "If you have added a new question type, please update this factory."
 
         # Create a question of each supported type
         q1 = _QuestionFactory.create(form=form, data_type=QuestionDataType.TEXT_SINGLE_LINE, text="What is your name?")
@@ -159,6 +159,7 @@ class _CollectionFactory(SQLAlchemyModelFactory):
         q3 = _QuestionFactory.create(form=form, data_type=QuestionDataType.INTEGER, text="What is your age?")
         q4 = _QuestionFactory.create(form=form, data_type=QuestionDataType.YES_NO, text="Do you like cheese?")
         q5 = _QuestionFactory.create(form=form, data_type=QuestionDataType.RADIOS, text="What is the best option?")
+        q6 = _QuestionFactory.create(form=form, data_type=QuestionDataType.EMAIL, text="What is your email address?")
 
         for _ in range(0, test):
             _SubmissionFactory.create(
@@ -172,6 +173,7 @@ class _CollectionFactory(SQLAlchemyModelFactory):
                     str(q5.id): SingleChoiceFromList(
                         key=q5.data_source.items[0].key, label=q5.data_source.items[0].label
                     ).get_value_for_submission(),
+                    str(q6.id): TextSingleLine(faker.Faker().email()).get_value_for_submission(),
                 },
                 status=SubmissionStatusEnum.COMPLETED,
             )
@@ -187,6 +189,7 @@ class _CollectionFactory(SQLAlchemyModelFactory):
                     str(q5.id): SingleChoiceFromList(
                         key=q5.data_source.items[0].key, label=q5.data_source.items[0].label
                     ).get_value_for_submission(),
+                    str(q6.id): TextSingleLine(faker.Faker().email()).get_value_for_submission(),
                 },
                 status=SubmissionStatusEnum.COMPLETED,
             )

--- a/tests/unit/common/collections/test_forms.py
+++ b/tests/unit/common/collections/test_forms.py
@@ -9,8 +9,8 @@ from govuk_frontend_wtf.wtforms_widgets import GovRadioInput, GovTextArea, GovTe
 from werkzeug.datastructures import MultiDict
 from wtforms.fields.choices import RadioField
 from wtforms.fields.numeric import IntegerField
-from wtforms.fields.simple import StringField
-from wtforms.validators import DataRequired, InputRequired
+from wtforms.fields.simple import EmailField, StringField
+from wtforms.validators import DataRequired, Email, InputRequired
 
 from app import create_app
 from app.common.collections.forms import build_question_form
@@ -72,7 +72,7 @@ class TestBuildQuestionForm:
         assert hasattr(form, "submit")
 
     def test_the_next_test_exhausts_QuestionDataType(self):
-        assert len(QuestionDataType) == 5, (
+        assert len(QuestionDataType) == 6, (
             "If this test breaks, tweak the number and update `test_expected_field_types` accordingly."
         )
 
@@ -84,6 +84,7 @@ class TestBuildQuestionForm:
             (QuestionDataType.INTEGER, IntegerField, GovTextInput, [InputRequired]),
             (QuestionDataType.YES_NO, RadioField, GovRadioInput, [InputRequired]),
             (QuestionDataType.RADIOS, RadioField, GovRadioInput, []),
+            (QuestionDataType.EMAIL, EmailField, GovTextInput, [DataRequired, Email]),
         ),
     )
     def test_expected_field_types(
@@ -98,5 +99,5 @@ class TestBuildQuestionForm:
         assert isinstance(question_field.widget, expected_widget)
         assert question_field.label.text == "Question text"
         assert question_field.description == "Question hint"
-        for validator in expected_validators:
-            assert isinstance(question_field.validators[0], validator)
+        for i, validator in enumerate(expected_validators):
+            assert isinstance(question_field.validators[i], validator)


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
Adds a new question type for email addresses. This is similar to the 'single line of text', but automatically includes validation for an email address-like format, which should save form designers time from manually having to set up this validation.

This ended up being easier than adding a managed expression/validation for 'Email' that could be applied to the single line of text data type.

Updates the developer e2e test to run through an email question as well. Also updates the seeded/example grant.

## 📸 Show the thing (screenshots, gifs)
![2025-07-15 16 33 52](https://github.com/user-attachments/assets/41474b67-be0b-4ece-93a0-9d8890d26c88)


## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [ ] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested