### PR TITLE
WIP Allow the email question type to check for a certain domain

### DIFF
--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-018_add_url_type
+019_has_domain_validator

--- a/app/common/data/migrations/versions/019_has_domain_validator.py
+++ b/app/common/data/migrations/versions/019_has_domain_validator.py
@@ -1,0 +1,35 @@
+"""adds domain validator
+
+Revision ID: 019_has_domain_validator
+Revises: 018_add_url_type
+Create Date: 2025-07-15 18:11:10.440547
+
+"""
+
+from alembic import op
+from alembic_postgresql_enum import TableReference
+
+revision = "019_has_domain_validator"
+down_revision = "018_add_url_type"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.sync_enum_values(  # ty: ignore[unresolved-attribute]
+        enum_schema="public",
+        enum_name="managed_expression_enum",
+        new_values=["GREATER_THAN", "LESS_THAN", "BETWEEN", "IS_YES", "IS_NO", "ANY_OF", "HAS_DOMAIN"],
+        affected_columns=[TableReference(table_schema="public", table_name="expression", column_name="managed_name")],
+        enum_values_to_rename=[],
+    )
+
+
+def downgrade() -> None:
+    op.sync_enum_values(  # ty: ignore[unresolved-attribute]
+        enum_schema="public",
+        enum_name="managed_expression_enum",
+        new_values=["GREATER_THAN", "LESS_THAN", "BETWEEN", "IS_YES", "IS_NO", "ANY_OF"],
+        affected_columns=[TableReference(table_schema="public", table_name="expression", column_name="managed_name")],
+        enum_values_to_rename=[],
+    )

--- a/app/common/data/types.py
+++ b/app/common/data/types.py
@@ -85,6 +85,7 @@ class ManagedExpressionsEnum(enum.StrEnum):
     IS_YES = "Yes"
     IS_NO = "No"
     ANY_OF = "Any of"
+    HAS_DOMAIN = "From the domain"
 
 
 class FormRunnerState(enum.StrEnum):

--- a/tests/integration/common/expressions/test_managed.py
+++ b/tests/integration/common/expressions/test_managed.py
@@ -5,7 +5,7 @@ import pytest
 from app.common.data.interfaces.collections import get_question_by_id
 from app.common.data.models import Expression
 from app.common.expressions import evaluate
-from app.common.expressions.managed import AnyOf, Between, GreaterThan, IsNo, IsYes, LessThan
+from app.common.expressions.managed import AnyOf, Between, GreaterThan, HasDomain, IsNo, IsYes, LessThan
 from app.types import TRadioItem
 
 
@@ -122,4 +122,17 @@ class TestIsNoExpression:
     )
     def test_evaluate(self, answer: str, expected_result: bool):
         expr = IsNo(question_id=uuid.uuid4())
+        assert evaluate(Expression(statement=expr.statement, context={expr.safe_qid: answer})) is expected_result
+
+
+class TestHasDomainExpression:
+    @pytest.mark.parametrize(
+        "domain, answer, expected_result",
+        (
+            ("communities.gov.uk", "first.last@communities.gov.uk", True),
+            ("communities.gov.uk", "first.last@example.gov.uk", False),
+        ),
+    )
+    def test_evaluate(self, domain: str, answer: str, expected_result: bool):
+        expr = HasDomain(question_id=uuid.uuid4(), domain=domain)
         assert evaluate(Expression(statement=expr.statement, context={expr.safe_qid: answer})) is expected_result

--- a/tests/integration/common/expressions/test_registry.py
+++ b/tests/integration/common/expressions/test_registry.py
@@ -39,7 +39,7 @@ class TestManagedExpressions:
         assert get_supported_form_questions(valid_question) == [second_question]
 
     def test_new_managed_expressions_added(self):
-        assert len(_registry_by_expression_enum) == 6, (
+        assert len(_registry_by_expression_enum) == 7, (
             "If you've added a new managed expression, update this test and add"
             "suitable tests in `tests/integration/common/expressions/test_managed.py`"
         )


### PR DESCRIPTION
## 🎫 Ticket
WIP

## 📝 Description
Currently just a thought experiment trying out how much needs to be added to hook up a new expression for a new question type.

This works both as a validator to ensure the question is being answered with an email address from a certain domain and as a method of branching - only showing certain questions if a previous answer is from a given domain.

If people think this is interesting then we can make it merge-able - just one call to make about if a generic "includes" is sufficient or if we'd want to prove whats needed to set a custom simpleeval function to ensure the domain part of the email address specifically is correct.

## 📸 Show the thing (screenshots, gifs)

<img width="518" height="753" alt="funding communities gov localhost_8080_developers_deliver_submissions_d9fdde55-fc7d-4ef7-8347-46e5f36dc646_b51759ce-0690-49d1-9a0f-d6f34eda28f0_source=check-your-answers" src="https://github.com/user-attachments/assets/f220ff31-5211-48c9-8fd8-a9b1355685ef" />

<img width="518" height="793" alt="funding communities gov localhost_8080_developers_deliver_submissions_d9fdde55-fc7d-4ef7-8347-46e5f36dc646_b51759ce-0690-49d1-9a0f-d6f34eda28f0_source=check-your-answers (1)" src="https://github.com/user-attachments/assets/1a89fa34-35fa-4dfb-a397-56281899f7c6" />

<img width="518" height="753" alt="funding communities gov localhost_8080_developers_deliver_submissions_d9fdde55-fc7d-4ef7-8347-46e5f36dc646_b51759ce-0690-49d1-9a0f-d6f34eda28f0_source=check-your-answers (2)" src="https://github.com/user-attachments/assets/826328a4-1831-4c3d-ab97-79b99ccd0b4d" />


