### PR TITLE
Excluding test files from ty so that the config matches mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,8 +106,8 @@ type = "layers"
 exhaustive = true
 containers = ["app"]
 layers = [
-  "developers",
-  "common : deliver_grant_funding : extensions : healthcheck : services : config : logging : monkeypatch : sentry : types"
+    "developers",
+    "common : deliver_grant_funding : extensions : healthcheck : services : config : logging : monkeypatch : sentry : types"
 ]
 
 [[tool.importlinter.contracts]]
@@ -212,3 +212,6 @@ filterwarnings = [
     "ignore:cannot collect test class 'TestConfig' because it has a __init__ constructor:pytest.PytestCollectionWarning",
     "ignore:datetime\\.datetime\\.utcnow\\(\\) is deprecated and scheduled for removal in a future version*:DeprecationWarning"
 ]
+[tool.ty.src]
+include = ["app", "tests"]
+exclude = ["tests/**/test_*.py"]


### PR DESCRIPTION
Excluding test files (`test_*`) from `ty`, mirroring the setup for mypy