### PR TITLE
Help form designers test+stop testing

### DIFF
--- a/.idea/funding-service.iml
+++ b/.idea/funding-service.iml
@@ -2,8 +2,8 @@
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/app" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/.venv" />
     </content>
     <orderEntry type="jdk" jdkName="uv (funding-service)" jdkType="Python SDK" />

--- a/app/assets/main.scss
+++ b/app/assets/main.scss
@@ -157,19 +157,17 @@ $app-destructive-link-active-colour: $govuk-text-colour;
 }
 
 .app-test-data-banner {
+    position: relative;
     text-align: center;
-    border-top: 5px solid #f47738;
-    z-index: 10;
-    margin-bottom: -29px !important;  // 29px hardcoded sorry; dont think we can calculate this
+    background-color: govuk-colour("orange");
+    padding: 15px 20px;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
 }
 
 .app-test-data-banner__tag {
-    position: relative;
-    display: inline-block;
-    padding: 2px;
-    padding-right: 8px;
-    padding-left: 8px;
-    background-color: #f47738;
     color: white;
 }
 
@@ -181,4 +179,8 @@ $app-destructive-link-active-colour: $govuk-text-colour;
 .autocomplete__dropdown-arrow-down {
   z-index: 1 !important;
   pointer-events: none;
+}
+.app-test-data-banner__action {
+  position: absolute;
+  right: 20px;
 }

--- a/app/common/templates/common/macros/collections.html
+++ b/app/common/templates/common/macros/collections.html
@@ -2,11 +2,11 @@
 {% from "govuk_frontend_jinja/components/task-list/macro.html" import govukTaskList %}
 {% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
 {% from "common/macros/status.html" import status with context %}
-{% from "common/partials/mhclg-test-banner.html" import mhclgTestBanner %}
+{% from "common/partials/mhclg-test-banner.html" import mhclgStopTestingBanner %}
 
 {% macro collection_before(runner) %}
   {% if runner.submission.is_test %}
-    {{ mhclgTestBanner("Test submission") }}
+    {{ mhclgStopTestingBanner(runner) }}
   {% endif %}
   {{ govukBackLink({ "text": "Back", "href": runner.back_url }) }}
 {% endmacro %}

--- a/app/common/templates/common/partials/mhclg-test-banner.html
+++ b/app/common/templates/common/partials/mhclg-test-banner.html
@@ -5,3 +5,19 @@
     </div>
   </div>
 {% endmacro %}
+
+{% macro mhclgStopTestingBanner(runner) %}
+  <div class="app-test-data-banner govuk-body govuk-!-margin-bottom-0">
+    <div class="app-test-data-banner__tag">
+      <strong>Test submission</strong>
+    </div>
+    <div class="app-test-data-banner__action">
+      {% set test_submission_source = 'task' if 'test_submission_form_id' in session else 'form' %}
+      <strong
+        ><a class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0" href="{{ url_for('deliver_grant_funding.return_from_test_submission', collection_id=runner.submission.collection.id) }}"
+          >Return to {{ test_submission_source }} builder</a
+        ></strong
+      >
+    </div>
+  </div>
+{% endmacro %}

--- a/app/developers/helpers.py
+++ b/app/developers/helpers.py
@@ -1,0 +1,38 @@
+from typing import TYPE_CHECKING, Optional
+
+from flask import redirect, session, url_for
+from flask.typing import ResponseReturnValue
+
+from app.common.data import interfaces
+from app.common.data.interfaces.collections import create_submission
+from app.common.data.interfaces.temporary import delete_submissions_created_by_user
+from app.common.data.types import SubmissionModeEnum
+from app.common.helpers.collections import SubmissionHelper
+
+if TYPE_CHECKING:
+    from app.common.data.models import Collection, Form
+
+
+def start_testing_submission(collection: "Collection", form: Optional["Form"] = None) -> ResponseReturnValue:
+    user = interfaces.user.get_current_user()
+    delete_submissions_created_by_user(grant_id=collection.grant_id, created_by_id=user.id)
+    submission = create_submission(collection=collection, created_by=user, mode=SubmissionModeEnum.TEST)
+    helper = SubmissionHelper(submission)
+
+    # Pop this if it exists; sanity check for not terminating a session correctly
+    session.pop("test_submission_form_id", None)
+    if form:
+        question = helper.get_first_question_for_form(form)
+        if not question:
+            raise RuntimeError("Form with no question")
+
+        session["test_submission_form_id"] = form.id
+        return redirect(
+            url_for(
+                "developers.deliver.ask_a_question",
+                submission_id=helper.submission.id,
+                question_id=question.id,
+            )
+        )
+
+    return redirect(url_for("developers.deliver.submission_tasklist", submission_id=helper.submission.id))

--- a/app/developers/templates/developers/deliver/collection_tasklist.html
+++ b/app/developers/templates/developers/deliver/collection_tasklist.html
@@ -1,5 +1,5 @@
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
-{% from "common/partials/mhclg-test-banner.html" import mhclgTestBanner %}
+{% from "common/partials/mhclg-test-banner.html" import mhclgStopTestingBanner %}
 {% from "common/macros/status.html" import status with context %}
 {% from "common/macros/collections.html" import collection_tasklist with context %}
 {% extends "developers/deliver/access_grant_funding_base.html" %}
@@ -10,7 +10,7 @@
 
 {% block beforeContent %}
   {% if runner.submission.is_test %}
-    {{ mhclgTestBanner("Test submission") }}
+    {{ mhclgStopTestingBanner(runner) }}
   {% endif %}
   {# the top level back behaviour is likely context specific #}
   {{

--- a/app/developers/templates/developers/deliver/manage_collection.html
+++ b/app/developers/templates/developers/deliver/manage_collection.html
@@ -18,6 +18,13 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      {% with errors = get_flashed_messages(category_filter=[enum.flash_message_type.SUBMISSION_TESTING_COMPLETE.value]) %}
+        {% if errors %}
+          {{ govukNotificationBanner(params={"titleText": "Testing complete", "text": errors[0]}) }}
+        {% endif %}
+        {% set errors = None %}
+      {% endwith %}
+
       {% if delete_collection %}
         {% set banner_html %}
           <p class="govuk-body govuk-!-font-weight-bold">Are you sure you want to delete this collection?</p>

--- a/app/developers/templates/developers/deliver/manage_form.html
+++ b/app/developers/templates/developers/deliver/manage_form.html
@@ -1,9 +1,9 @@
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "govuk_frontend_jinja/components/tag/macro.html" import govukTag %}
-{% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
 {% from "common/macros/move-up-down-table.html" import moveUpDownTable %}
 {% from "developers/deliver/macros/dependency_banner.html" import dependency_banner %}
+{% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
 {% extends "deliver_grant_funding/grant_base.html" %}
 
 {% set page_title = collection.name ~ " - " ~ grant.name %}
@@ -21,6 +21,13 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      {% with errors = get_flashed_messages(category_filter=[enum.flash_message_type.SUBMISSION_TESTING_COMPLETE.value]) %}
+        {% if errors %}
+          {{ govukNotificationBanner(params={"titleText": "Testing complete", "text": errors[0]}) }}
+        {% endif %}
+        {% set errors = None %}
+      {% endwith %}
+
       {% with errors = get_flashed_messages(category_filter=[enum.flash_message_type.DEPENDENCY_ORDER_ERROR.value]) %}
         {% if errors %}
           {% set error = errors[0] %}
@@ -28,12 +35,12 @@
         {% endif %}
       {% endwith %}
 
-      {% if form %}
+      {% if delete_form %}
         {% set banner_html %}
           <p class="govuk-body govuk-!-font-weight-bold">Are you sure you want to delete this task?</p>
           <form method="post" novalidate>
-            {{ form.csrf_token }}
-            {{ form.confirm_deletion(params={"classes": "govuk-button--warning govuk-!-margin-bottom-0"}) }}
+            {{ delete_form.csrf_token }}
+            {{ delete_form.confirm_deletion(params={"classes": "govuk-button--warning govuk-!-margin-bottom-0"}) }}
           </form>
         {% endset %}
 
@@ -45,11 +52,20 @@
         {{ db_form.title }}
       </h1>
     </div>
+    <div class="govuk-grid-column-one-third govuk-!-text-align-right">
+      <form method="post" novalidate>
+        {{ form.csrf_token }}
+        {{ form.submit(params={"text": "Test this task", "classes": "govuk-button--secondary" if not collection.sections else "", "disabled": db_form.questions | length == 0}) }}
+      </form>
+    </div>
   </div>
   <div class="govuk-grid-row govuk-!-margin-top-5">
-    <div class="govuk-grid-column-full">
+    <div class="govuk-grid-column-two-thirds">
       <h2 class="govuk-heading-m">Questions</h2>
-
+    </div>
+  </div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       {% set table_rows = [] %}
       {% for question in db_form.questions %}
         {% set question_link %}
@@ -101,7 +117,7 @@
         })
       }}
       <p class="govuk-body">
-        <a class="govuk-button govuk-button--warning" href="{{ url_for('developers.deliver.manage_form', grant_id=grant.id, collection_id=collection.id, section_id=section.id, form_id=db_form.id, delete='') }}">Delete this task</a>
+        <a class="govuk-link app-link--destructive" href="{{ url_for('developers.deliver.manage_form', grant_id=grant.id, collection_id=collection.id, section_id=section.id, form_id=db_form.id, delete='') }}">Delete this task</a>
       </p>
     </div>
   </div>

--- a/app/types.py
+++ b/app/types.py
@@ -14,6 +14,7 @@ NOT_PROVIDED = TNotProvided.token
 
 class FlashMessageType(Enum):
     DEPENDENCY_ORDER_ERROR = "dependency_order_error"
+    SUBMISSION_TESTING_COMPLETE = "submission_testing_complete"
 
 
 TRadioItem = TypedDict("TRadioItem", {"key": str, "label": str})

--- a/tests/unit/common/collections/test_runner.py
+++ b/tests/unit/common/collections/test_runner.py
@@ -80,7 +80,7 @@ class TestFormRunner:
         runner.to_url(FormRunnerState.CHECK_YOUR_ANSWERS, form=second_form)
         check_answers_mock.assert_called_once_with(runner, question, second_form, None)
 
-    def test_next_url(self, factories):
+    def test_next_url(self, factories, app):
         question = factories.question.build()
         second_question = factories.question.build(form=question.form)
         submission = factories.submission.build(collection=question.form.section.collection)

--- a/tests/unit/test_all_routes_access.py
+++ b/tests/unit/test_all_routes_access.py
@@ -86,6 +86,7 @@ routes_with_no_expected_access_restrictions = [
     "auth.sso_sign_in",
     "auth.sso_get_token",
     "auth.sign_out",
+    "deliver_grant_funding.return_from_test_submission",  # the target endpoints have auth
     "static",
     "healthcheck.healthcheck",
     "index",


### PR DESCRIPTION
Good for first review/feedback/"do we want this" - needs tests/tweaking for final review

## 🎫 Ticket
BAU

## 📝 Description
Adds a button on individual 'manage form/task' pages so that form designers can jump straight into testing an individual form. This is easy while we have no cross-form interactions; we'll have to think through how we might facilitate this in a world where there are dependencies _between_ forms.

It also increases the height+visibility of the 'testing banner', and adds a button to any of the form runner pages so that a form designer can bail out of the testing journey. The theory is that a form designer is looking to test a very specific behaviour, and as soon as they've done that they'll want to get back to tweaking/editing the form configuration itself. We shouldn't force them to do an awkward multi-back nav, or complete an entire form/submission.

Note: the flash message when testing is 'complete' don't feel very nice. I feel like you need _something_ to explain the unusual navigation, but can't think of something that looks/feels good, so this is very much just a bad attempt.

## 📸 Show the thing (screenshots, gifs)
![2025-07-17 10 33 35](https://github.com/user-attachments/assets/6663a4cc-3b35-4bb4-a2c5-85db4d0e222e)

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [-] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested