### PR TITLE
FSPT-684: Enhance radios to autocomplete on >x items

### DIFF
--- a/app/assets/main.js
+++ b/app/assets/main.js
@@ -1,2 +1,13 @@
 import { initAll } from 'govuk-frontend'
+import accessibleAutocomplete from 'accessible-autocomplete'
+
 initAll()
+
+for (let el of document.querySelectorAll("[data-accessible-autocomplete]")) {
+    accessibleAutocomplete.enhanceSelectElement({
+        selectElement: el,
+        showAllValues: true,
+        confirmOnBlur: false,
+        displayMenu: "overlay",
+    });
+}

--- a/app/assets/main.scss
+++ b/app/assets/main.scss
@@ -171,3 +171,13 @@ $app-destructive-link-active-colour: $govuk-text-colour;
     background-color: #f47738;
     color: white;
 }
+
+// Fix for GOV.UK Accessible Autocomplete arrown ot being visible: https://github.com/alphagov/accessible-autocomplete/issues/351
+.autocomplete__wrapper {
+    z-index: 1;
+}
+
+.autocomplete__dropdown-arrow-down {
+  z-index: 1 !important;
+  pointer-events: none;
+}

--- a/app/assets/main.scss
+++ b/app/assets/main.scss
@@ -5,6 +5,7 @@ $govuk-assets-path: "/static/assets/";
 $govuk-brand-colour: #00625e;
 
 @import "../../node_modules/govuk-frontend/dist/govuk";
+@import "../../node_modules/accessible-autocomplete";
 
 .app-\!-no-wrap {
     white-space: nowrap;

--- a/app/common/forms/fields.py
+++ b/app/common/forms/fields.py
@@ -1,0 +1,16 @@
+from typing import Any
+
+from govuk_frontend_wtf.wtforms_widgets import GovSelect
+from wtforms import Field
+
+
+class MHCLGAccessibleAutocomplete(GovSelect):
+    is_accessible_autocomplete: bool = True
+
+    def __call__(self, field: Field, **kwargs: Any) -> Any:
+        # Set `data-accessible-autocomplete` on select field, which our JS will pick up and enhance automatically.
+        params = kwargs.get("params", {})
+        attributes = params.get("attributes", {})
+        attributes.setdefault("data-accessible-autocomplete", "1")
+        params["attributes"] = attributes
+        return super().__call__(field, **kwargs)

--- a/app/common/forms/fields.py
+++ b/app/common/forms/fields.py
@@ -7,6 +7,8 @@ from wtforms import Field
 class MHCLGAccessibleAutocomplete(GovSelect):
     is_accessible_autocomplete: bool = True
 
+    template = "common/fields/accessible-autocomplete.html"
+
     def __call__(self, field: Field, **kwargs: Any) -> Any:
         # Set `data-accessible-autocomplete` on select field, which our JS will pick up and enhance automatically.
         params = kwargs.get("params", {})

--- a/app/common/templates/common/base.html
+++ b/app/common/templates/common/base.html
@@ -13,6 +13,7 @@
     <script type="module" src="{{ vite_asset('@vite/client') }}"></script>
   {% endif %}
   <link rel="stylesheet" href="{{ vite_asset('app/assets/main.scss') }}" type="text/css" />
+  <link nonce="{{ cspNonce }}" rel="stylesheet" href="{{ url_for('static', filename='assets/accessible-autocomplete/accessible-autocomplete.min.css') }}" type="text/css" />
 {% endblock head %}
 
 {% block header %}
@@ -54,6 +55,24 @@
 
 {% block bodyEnd %}
   <script type="module" src="{{ vite_asset('app/assets/main.js') }}"></script>
+  <script type="module" src="{{ url_for('static', filename='assets/accessible-autocomplete/accessible-autocomplete.min.js') }}"></script>
+  <script nonce="{{ cspNonce }}">
+    // Wait for the script to load
+    window.addEventListener("load", function () {
+      if (typeof accessibleAutocomplete !== "undefined") {
+        for (let el of document.querySelectorAll("[data-accessible-autocomplete]")) {
+          accessibleAutocomplete.enhanceSelectElement({
+            selectElement: el,
+            showAllValues: true,
+            confirmOnBlur: false,
+            displayMenu: "overlay",
+          });
+        }
+      } else {
+        console.error("accessibleAutocomplete is not available");
+      }
+    });
+  </script>
 {% endblock %}
 
 {% block footer %}

--- a/app/common/templates/common/base.html
+++ b/app/common/templates/common/base.html
@@ -13,7 +13,6 @@
     <script type="module" src="{{ vite_asset('@vite/client') }}"></script>
   {% endif %}
   <link rel="stylesheet" href="{{ vite_asset('app/assets/main.scss') }}" type="text/css" />
-  <link nonce="{{ cspNonce }}" rel="stylesheet" href="{{ url_for('static', filename='assets/accessible-autocomplete/accessible-autocomplete.min.css') }}" type="text/css" />
 {% endblock head %}
 
 {% block header %}
@@ -55,24 +54,6 @@
 
 {% block bodyEnd %}
   <script type="module" src="{{ vite_asset('app/assets/main.js') }}"></script>
-  <script type="module" src="{{ url_for('static', filename='assets/accessible-autocomplete/accessible-autocomplete.min.js') }}"></script>
-  <script nonce="{{ cspNonce }}">
-    // Wait for the script to load
-    window.addEventListener("load", function () {
-      if (typeof accessibleAutocomplete !== "undefined") {
-        for (let el of document.querySelectorAll("[data-accessible-autocomplete]")) {
-          accessibleAutocomplete.enhanceSelectElement({
-            selectElement: el,
-            showAllValues: true,
-            confirmOnBlur: false,
-            displayMenu: "overlay",
-          });
-        }
-      } else {
-        console.error("accessibleAutocomplete is not available");
-      }
-    });
-  </script>
 {% endblock %}
 
 {% block footer %}

--- a/app/common/templates/common/fields/accessible-autocomplete.html
+++ b/app/common/templates/common/fields/accessible-autocomplete.html
@@ -1,0 +1,3 @@
+{% from 'govuk_frontend_jinja/components/select/macro.html' import govukSelect %}
+
+<div class="govuk-body">{{ govukSelect(params) }}</div>

--- a/app/common/templates/common/macros/collections.html
+++ b/app/common/templates/common/macros/collections.html
@@ -29,7 +29,15 @@
     {% elif question.data_type == enum.question_type.YES_NO %}
       {{ form.render_question(question, params={"fieldset": {"legend": {"text": question.text, "classes": "govuk-fieldset__legend--l", "isPageHeading": true} }, "classes": "govuk-radios--inline" }) }}
     {% elif question.data_type == enum.question_type.RADIOS %}
-      {{ form.render_question(question, params={"fieldset": {"legend": {"text": question.text, "classes": "govuk-fieldset__legend--l", "isPageHeading": true} } }) }}
+      {% if form.get_question_field(question).widget.is_accessible_autocomplete %}
+        {#
+          `govuk-!-width-full` override here to line up with the default width of the accessible autocomplete component. We could potentially do something smarter, like copy the class
+          from here to the enhanced autocomplete, but leaving that for a future increment.
+        #}
+        {{ form.render_question(question, params={"label": {"text": question.text, "classes": "govuk-fieldset__legend--l", "isPageHeading": true}, "classes": "govuk-!-width-full" }) }}
+      {% else %}
+        {{ form.render_question(question, params={"fieldset": {"legend": {"text": question.text, "classes": "govuk-fieldset__legend--l", "isPageHeading": true} } }) }}
+      {% endif %}
     {% endif %}
 
     {{ form.submit }}

--- a/app/config.py
+++ b/app/config.py
@@ -252,6 +252,9 @@ class _SharedConfig(_BaseConfig):
     # Service Desk
     SERVICE_DESK_URL: str = "https://mhclgdigital.atlassian.net/servicedesk/customer/portal/5"
 
+    # Form rendering options
+    ENHANCE_RADIOS_TO_AUTOCOMPLETE_AFTER_X_ITEMS: int = 20
+
     # Grant setup
     GGIS_TEAM_EMAIL: str = "ggis@communities.gov.uk"
     PIPELINE_GRANTS_SCHEME_FORM_URL: str = "https://forms.office.com.mcas.ms/pages/responsepage.aspx?id=EGg0v32c3kOociSi7zmVqBUKhC0CqZtGmIj1YcYa53xUNTFRWkRXQ1ZJUEJMOTg1UllGWEpCNDQ4NSQlQCN0PWcu&route=shorturl"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "funding-service",
       "version": "1.0.0",
       "dependencies": {
+        "accessible-autocomplete": "^3.0.1",
         "govuk-frontend": "5.9.0"
       },
       "devDependencies": {
@@ -1039,6 +1040,20 @@
       "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/accessible-autocomplete": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/accessible-autocomplete/-/accessible-autocomplete-3.0.1.tgz",
+      "integrity": "sha512-xMshgc2LT5addvvfCTGzIkRrvhbOFeylFSnSMfS/PdjvvvElZkakCwxO3/yJYBWyi1hi3tZloqOJQ5kqqJtH4g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "preact": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "preact": {
+          "optional": true
+        }
+      }
     },
     "node_modules/anymatch": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -8,12 +8,13 @@
     "build": "vite build"
   },
   "dependencies": {
+    "accessible-autocomplete": "^3.0.1",
     "govuk-frontend": "5.9.0"
   },
   "devDependencies": {
-    "sass": "1.89.2",
     "prettier": "3.6.2",
     "prettier-plugin-jinja-template": "2.1.0",
+    "sass": "1.89.2",
     "vite": "6.3.5",
     "vite-plugin-static-copy": "3.1.1"
   }

--- a/tests/e2e/developer_pages.py
+++ b/tests/e2e/developer_pages.py
@@ -635,7 +635,15 @@ class QuestionPage(GrantDevelopersBasePage):
 
     def respond_to_question(self, question_type: QuestionDataType, answer: str) -> None:
         if question_type == QuestionDataType.YES_NO or question_type == QuestionDataType.RADIOS:
-            self.page.get_by_role("radio", name=answer).click()
+            # once we start having multiple of these on a page - enjoy the refactor =]
+            accessible_autocomplete = self.page.query_selector("[data-accessible-autocomplete]")
+            if accessible_autocomplete:
+                element = self.page.get_by_role("combobox")
+                element.click()
+                element.fill(answer)
+                element.press("Enter")
+            else:
+                self.page.get_by_role("radio", name=answer).click()
         else:
             self.page.get_by_role("textbox", name=self.question_name).fill(answer)
 

--- a/tests/e2e/test_developer_journey.py
+++ b/tests/e2e/test_developer_journey.py
@@ -169,6 +169,8 @@ def test_create_and_preview_collection(
         create_question(QuestionDataType.INTEGER, manage_form_page)
         create_question(QuestionDataType.YES_NO, manage_form_page)
         create_question(QuestionDataType.RADIOS, manage_form_page, ["option 1", "option 2", "option 3"])
+        # radios gets enhanced to autocomplete >x options
+        create_question(QuestionDataType.RADIOS, manage_form_page, [f"option {x}" for x in range(25)])
         create_question(QuestionDataType.URL, manage_form_page)
 
         add_validation(

--- a/vite.config.js
+++ b/vite.config.js
@@ -37,10 +37,6 @@ export default defineConfig({
           dest: "./assets",
         },
         {
-          src: "node_modules/accessible-autocomplete/dist/*",
-          dest: "./assets/accessible-autocomplete",
-        },
-        {
           src: "app/assets/images",
           dest: "./assets"
         }

--- a/vite.config.js
+++ b/vite.config.js
@@ -15,7 +15,7 @@ export default defineConfig({
         /assets\/images\/.*\.svg$/,
       ],
     },
-    emptyOutDir: true
+    emptyOutDir: true,
   },
   css: {
     preprocessorOptions: {
@@ -35,6 +35,10 @@ export default defineConfig({
         {
           src: "node_modules/govuk-frontend/dist/govuk/assets/*",
           dest: "./assets",
+        },
+        {
+          src: "node_modules/accessible-autocomplete/dist/*",
+          dest: "./assets/accessible-autocomplete",
         },
         {
           src: "app/assets/images",


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-684

## 📝 Description
When a form designer creates a radios/"choose one" question, they can enter any number of options for the radios.

Presenting a form-filler with a list of potentially hundreds of options is a bad experience. When we go over some number of options - chosen in this case to be 20 - we will instead render a select field and try to enhance it into a GOV.UK Accessible Autocomplete component, which provides a searchable text field.

https://alphagov.github.io/accessible-autocomplete/

We do this using progressive enhancemene, so if the JS fails for any reason the user can still use the input as a standard dropdown. Not much better than radios (probably worse!) - but still technically usable. We expect all of our users to be on work devices with JS enabled+available.

## 📸 Very contrived show the thing (screenshots, gifs)
![2025-07-17 08 18 16](https://github.com/user-attachments/assets/777fda59-b90d-4bb0-be62-865d818b7431)

## 🧪 Testing
<!-- Describe how you've tested this change, and how a reviewer can test it -->

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [ ] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [ ] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [x] Edge cases and error conditions are tested