### PR TITLE
BAU: Fix flash message tuple unpacking

### DIFF
--- a/app/developers/templates/developers/deliver/edit_question.html
+++ b/app/developers/templates/developers/deliver/edit_question.html
@@ -23,7 +23,7 @@
     <div class="govuk-grid-column-two-thirds">
       {% with errors = get_flashed_messages(category_filter=[enum.flash_message_type.DEPENDENCY_ORDER_ERROR.value]) %}
         {% if errors %}
-          {% set type, error = errors[0] %}
+          {% set error = errors[0] %}
           {{ dependency_banner(error, grant.id, collection.id, section.id, db_form.id) }}
         {% endif %}
       {% endwith %}

--- a/app/developers/templates/developers/deliver/manage_form.html
+++ b/app/developers/templates/developers/deliver/manage_form.html
@@ -23,7 +23,7 @@
     <div class="govuk-grid-column-two-thirds">
       {% with errors = get_flashed_messages(category_filter=[enum.flash_message_type.DEPENDENCY_ORDER_ERROR.value]) %}
         {% if errors %}
-          {% set type, error = errors[0] %}
+          {% set error = errors[0] %}
           {{ dependency_banner(error, grant.id, collection.id, section.id, db_form.id) }}
         {% endif %}
       {% endwith %}


### PR DESCRIPTION
## 🎫 Ticket
BAU 

## 📝 Description
In a couple of places where we called Flask's `get_flashed_messages` we're expecting the errors to come back as tuples to unpack them with `type, error` but the errors are only coming back as strings as we're not passing 'with_categories=True'. 

As for now we only have one category and are not using the `type`, we should be able to safely remove this and just deal with the error contents as a single string to avoid a Flask error when the flash messages try to render.

## 📸 Show the thing (screenshots, gifs)
No screenshot needed, the error renders as normal, just stops a blue Flask error screen.

## 🧪 Testing
Prompt one of these flash errors (eg. try to move a conditional question above the question on which it depends, or edit and delete a question that another question depends on). Previously it would give a Flask error, now it renders the flash message correctly.

## 📋 Developer Checklist

### Review Readiness
- [X] PR title and description provide sufficient context for reviewers
- [X] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- [X] No N+1 query problems introduced
- [X] Any new DB queries include appropriate where clauses based on the user's permissions

### Testing
- [X] I have tested this change and it meets the acceptance criteria for the ticket
- ~[ ] I need the reviewer(s) to pull and run this change locally~
- ~[ ] New (non-developer) functionality has appropriate unit and integration tests~
- ~[ ] End-to-end tests have been updated (if applicable)~
- [X] Edge cases and error conditions are tested

## 📚 Additional Notes

