### PR TITLE
Flash message after creating a question

### DIFF
--- a/app/developers/deliver_routes.py
+++ b/app/developers/deliver_routes.py
@@ -493,6 +493,7 @@ def add_question(grant_id: UUID, collection_id: UUID, section_id: UUID, form_id:
                 if question_data_type_enum == QuestionDataType.RADIOS and wt_form.data_source_items.data is not None
                 else None,
             )
+            flash("Question created", FlashMessageType.QUESTION_CREATED)
             return redirect(
                 url_for(
                     "developers.deliver.edit_question",

--- a/app/developers/templates/developers/deliver/edit_question.html
+++ b/app/developers/templates/developers/deliver/edit_question.html
@@ -21,6 +21,23 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      {% with errors = get_flashed_messages(category_filter=[enum.flash_message_type.QUESTION_CREATED]) %}
+        {% if errors %}
+          {% set error = errors[0] %}
+          {% set question_created_content %}
+            <a class="govuk-notification-banner__link" href="{{ url_for('developers.deliver.manage_form', grant_id=grant.id, collection_id=collection.id, section_id=section.id, form_id=db_form.id) }}">Return to the task</a>
+            to create other questions, or stay here to add conditions and validation to this question.
+          {% endset %}
+          {{
+            govukNotificationBanner({
+              "titleText": error,
+              "html": question_created_content,
+              "type": "success"
+            })
+          }}
+        {% endif %}
+      {% endwith %}
+
       {% with errors = get_flashed_messages(category_filter=[enum.flash_message_type.DEPENDENCY_ORDER_ERROR.value]) %}
         {% if errors %}
           {% set error = errors[0] %}

--- a/app/types.py
+++ b/app/types.py
@@ -1,4 +1,4 @@
-from enum import Enum
+from enum import Enum, StrEnum
 from typing import Literal, TypedDict
 
 LogFormats = Literal["plaintext", "json"]
@@ -12,9 +12,10 @@ class TNotProvided(Enum):
 NOT_PROVIDED = TNotProvided.token
 
 
-class FlashMessageType(Enum):
+class FlashMessageType(StrEnum):
     DEPENDENCY_ORDER_ERROR = "dependency_order_error"
     SUBMISSION_TESTING_COMPLETE = "submission_testing_complete"
+    QUESTION_CREATED = "question_created"
 
 
 TRadioItem = TypedDict("TRadioItem", {"key": str, "label": str})


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
We used to redirect back to the 'manage form(task)' page after adding a question. Quite often, though, a form designer will want to add conditions or validation to that same question, which means they then have to find the question again and click back into it.

This felt annoying, so I changed the redirect to the 'edit question' page. But that page is very visually similar to the 'add question' page, which can make it feel like the 'add question' didn't quite work.

This attempts to mitigate some of that confusion by adding a flash message that directs the user to the next actions:

- go back to the form/task page if you're done
- add conditions/validation to this question if you need it

This isn't perfect - ideally I think we'd want either a very brief 'add question' page, eg only the question text - or for the add+edit pages to be identical (allowing you to set up conditions+validation before clicking 'create' at all). Both of those are technically bigger changes, so this is intended as a short-term patch to help until the full designs are in.

## 📸 Show the thing (screenshots, gifs)
![2025-07-18 07 22 20](https://github.com/user-attachments/assets/97089f72-ad11-4d49-a9ff-6acfc0bb8cf6)



## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [-] I need the reviewer(s) to pull and run this change locally
- [-] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are testederations for reviewers -->
