### PR TITLE
FSPT-673: Track data source choices in expressions

### DIFF
--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-018_add_url_type
+019_add_data_source_item_ref

--- a/app/common/data/migrations/versions/019_add_data_source_item_ref.py
+++ b/app/common/data/migrations/versions/019_add_data_source_item_ref.py
@@ -1,0 +1,39 @@
+"""Add DataSourceItemReference table
+
+Revision ID: 019_add_data_source_item_ref
+Revises: 018_add_url_type
+Create Date: 2025-07-16 08:25:37.365949
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "019_add_data_source_item_ref"
+down_revision = "018_add_url_type"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "data_source_item_reference",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("created_at_utc", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at_utc", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.Column("data_source_item_id", sa.Uuid(), nullable=False),
+        sa.Column("expression_id", sa.Uuid(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["data_source_item_id"],
+            ["data_source_item.id"],
+            name=op.f("fk_data_source_item_reference_data_source_item_id_data_source_item"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["expression_id"], ["expression.id"], name=op.f("fk_data_source_item_reference_expression_id_expression")
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_data_source_item_reference")),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("data_source_item_reference")

--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -325,6 +325,10 @@ class Expression(BaseModel):
     created_by_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("user.id"))
     created_by: Mapped[User] = relationship("User")
 
+    data_source_item_references: Mapped[list["DataSourceItemReference"]] = relationship(
+        "DataSourceItemReference", back_populates="expression", cascade="all, delete-orphan"
+    )
+
     __table_args__ = (
         Index(
             "uq_type_validation_unique_key",
@@ -393,8 +397,21 @@ class DataSourceItem(BaseModel):
     label: Mapped[str]
 
     data_source: Mapped[DataSource] = relationship("DataSource", back_populates="items", uselist=False)
+    references: Mapped[list["DataSourceItemReference"]] = relationship(
+        "DataSourceItemReference", back_populates="data_source_item"
+    )
 
     __table_args__ = (
         UniqueConstraint("data_source_id", "order", name="uq_data_source_id_order", deferrable=True),
         UniqueConstraint("data_source_id", "key", name="uq_data_source_id_key"),
     )
+
+
+class DataSourceItemReference(BaseModel):
+    __tablename__ = "data_source_item_reference"
+
+    data_source_item_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("data_source_item.id"))
+    expression_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("expression.id"))
+
+    data_source_item: Mapped[DataSourceItem] = relationship("DataSourceItem", back_populates="references")
+    expression: Mapped[Expression] = relationship("Expression", back_populates="data_source_item_references")

--- a/app/common/expressions/managed.py
+++ b/app/common/expressions/managed.py
@@ -360,8 +360,15 @@ class Between(ManagedExpression):
         )
 
 
+class BaseDataSourceManagedExpression(ManagedExpression):
+    @property
+    @abc.abstractmethod  # todo: decorator does nothing here because ABCMeta cant be used
+    def referenced_data_source_items(self) -> list["TRadioItem"]:
+        raise NotImplementedError
+
+
 @register_managed_expression
-class AnyOf(ManagedExpression):
+class AnyOf(BaseDataSourceManagedExpression):
     name: ClassVar[ManagedExpressionsEnum] = ManagedExpressionsEnum.ANY_OF
     supported_condition_data_types: ClassVar[set[QuestionDataType]] = {QuestionDataType.RADIOS}
     supported_validator_data_types: ClassVar[set[QuestionDataType]] = {}  # type: ignore[assignment]
@@ -420,6 +427,10 @@ class AnyOf(ManagedExpression):
             question_id=question.id,
             items=items,  # ty: ignore[unresolved-attribute]
         )
+
+    @property
+    def referenced_data_source_items(self) -> list["TRadioItem"]:
+        return self.items
 
 
 @register_managed_expression

--- a/app/developers/data/grants.json
+++ b/app/developers/data/grants.json
@@ -13,6 +13,15 @@
           "version": 1
         }
       ],
+      "data_source_item_references": [
+        {
+          "created_at_utc": "Mon, 21 Jul 2025 15:02:07 GMT",
+          "data_source_item_id": "ec7bcf8a-d271-4ede-8f9b-7a3f7eff742e",
+          "expression_id": "a360e91c-9bf9-4097-a97b-985f9879e8e5",
+          "id": "a78fa3e8-0dd8-46b5-b0ea-0b74dac58826",
+          "updated_at_utc": "Mon, 21 Jul 2025 15:02:07 GMT"
+        }
+      ],
       "data_source_items": [
         {
           "created_at_utc": "Mon, 14 Jul 2025 10:01:21 GMT",
@@ -1227,6 +1236,7 @@
           "version": 1
         }
       ],
+      "data_source_item_references": [],
       "data_source_items": [],
       "data_sources": [],
       "expressions": [],
@@ -1355,6 +1365,7 @@
           "version": 1
         }
       ],
+      "data_source_item_references": [],
       "data_source_items": [],
       "data_sources": [],
       "expressions": [],
@@ -1497,15 +1508,6 @@
   ],
   "users": [
     {
-      "azure_ad_subject_id": "40e16bf9d02fa7f67c6bb767b197e544",
-      "created_at_utc": "Thu, 03 Jul 2025 15:18:06 GMT",
-      "email": "sclark@test.communities.gov.uk",
-      "id": "9ab212ee-6716-4921-b6a2-61a684bf2fe3",
-      "last_logged_in_at_utc": "Mon, 14 Jul 2025 10:00:46 GMT",
-      "name": "Willie Brown",
-      "updated_at_utc": "Mon, 14 Jul 2025 10:00:46 GMT"
-    },
-    {
       "azure_ad_subject_id": "mDLVWMQVmvxRxPNKpKUFODrcU",
       "created_at_utc": "Thu, 03 Jul 2025 14:37:06 GMT",
       "email": "johnsonlori@test.communities.gov.uk",
@@ -1513,6 +1515,15 @@
       "last_logged_in_at_utc": "Thu, 03 Jul 2025 14:37:06 GMT",
       "name": "Margaret Ballard",
       "updated_at_utc": "Thu, 03 Jul 2025 14:37:06 GMT"
+    },
+    {
+      "azure_ad_subject_id": "40e16bf9d02fa7f67c6bb767b197e544",
+      "created_at_utc": "Thu, 03 Jul 2025 15:18:06 GMT",
+      "email": "sclark@test.communities.gov.uk",
+      "id": "9ab212ee-6716-4921-b6a2-61a684bf2fe3",
+      "last_logged_in_at_utc": "Mon, 14 Jul 2025 10:00:46 GMT",
+      "name": "Willie Brown",
+      "updated_at_utc": "Mon, 14 Jul 2025 10:00:46 GMT"
     },
     {
       "azure_ad_subject_id": "GLLNgipKjLFCQjLaXVVeUjNyH",

--- a/app/developers/deliver_routes.py
+++ b/app/developers/deliver_routes.py
@@ -12,6 +12,7 @@ from app.common.auth.decorators import is_platform_admin
 from app.common.collections.runner import DGFFormRunner
 from app.common.data import interfaces
 from app.common.data.interfaces.collections import (
+    DataSourceItemReferenceDependencyException,
     DependencyOrderException,
     create_collection,
     create_form,
@@ -618,6 +619,19 @@ def edit_question(
         except DuplicateValueError as e:
             field_with_error: Field = getattr(wt_form, e.field_name)
             field_with_error.errors.append(f"{field_with_error.name.capitalize()} already in use")  # type:ignore[attr-defined]
+        except DataSourceItemReferenceDependencyException as e:
+            for flash_context in e.as_flash_contexts():
+                flash(flash_context, FlashMessageType.DATA_SOURCE_ITEM_DEPENDENCY_ERROR.value)  # type: ignore[arg-type]
+            return redirect(
+                url_for(
+                    "developers.deliver.edit_question",
+                    grant_id=grant_id,
+                    collection_id=collection_id,
+                    section_id=section_id,
+                    form_id=form_id,
+                    question_id=question_id,
+                )
+            )
 
     return render_template(
         "developers/deliver/edit_question.html",

--- a/app/developers/templates/developers/deliver/edit_question.html
+++ b/app/developers/templates/developers/deliver/edit_question.html
@@ -37,9 +37,11 @@
         {% endif %}
       {% endwith %}
 
-      {% with flashes = get_flashed_messages(category_filter=[enum.flash_message_type.DEPENDENCY_ORDER_ERROR.value]) %}
+      {% with flashes = get_flashed_messages(category_filter=[enum.flash_message_type.DEPENDENCY_ORDER_ERROR.value, enum.flash_message_type.DATA_SOURCE_ITEM_DEPENDENCY_ERROR.value]) %}
         {% if flashes %}
-          {{ dependency_banner(flashes[0], grant.id, collection.id, section.id, db_form.id) }}
+          {% for error in flashes %}
+            {{ dependency_banner(error, grant.id, collection.id, section.id, db_form.id) }}
+          {% endfor %}
         {% endif %}
       {% endwith %}
 

--- a/app/developers/templates/developers/deliver/macros/dependency_banner.html
+++ b/app/developers/templates/developers/deliver/macros/dependency_banner.html
@@ -16,6 +16,9 @@
       Depends on the answer to:
       <a class="govuk-notification-banner__link" href="{{ depends_on_link }}">{{ error.depends_on_question_text }}</a>
     </p>
+    {% if "depends_on_items_text" in error %}
+      <p class="govuk-body govuk-!-font-weight-bold">Depends on the options: {{ error.depends_on_items_text }}</p>
+    {% endif %}
   {% endset %}
 
   {{ govukNotificationBanner(params={"role": "alert", "titleText": "Warning", "classes": "app-notification-banner--destructive", "html": banner_html}) }}

--- a/app/types.py
+++ b/app/types.py
@@ -14,6 +14,7 @@ NOT_PROVIDED = TNotProvided.token
 
 class FlashMessageType(StrEnum):
     DEPENDENCY_ORDER_ERROR = "dependency_order_error"
+    DATA_SOURCE_ITEM_DEPENDENCY_ERROR = "data_source_item_dependency_error"
     SUBMISSION_TESTING_COMPLETE = "submission_testing_complete"
     QUESTION_CREATED = "question_created"
 

--- a/tests/integration/common/helpers/test_collections.py
+++ b/tests/integration/common/helpers/test_collections.py
@@ -628,6 +628,15 @@ class TestCollectionHelper:
     @pytest.mark.skip(reason="performance")
     @pytest.mark.parametrize("num_test_submissions", [1, 2, 3, 5, 12, 60, 100, 500])
     def test_multiple_submission_export_conditional(self, factories, track_sql_queries, num_test_submissions):
+        """
+        As with the test above, this test create a collection with a number of test submissions, then times how long it
+        takes to generate the CSV content for all submissions. It also tracks the number of SQL queries made and their
+        total duration.
+
+        It is skipped as now we have improved the performance of the queries to generate the CSV file, the test doesn't
+        record any queries as everything is already cached by the factory. Leaving it in the code for reference and
+        future use. See 'Seeding for performance testing' in the README for more details.
+        """
         factory_start = datetime.now()
         collection = factories.collection.create(
             create_completed_submissions_conditional_question_random__test=num_test_submissions


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-673

## 📝 Description
Adds a DataSourceItemReference table so we can track when a data source item is used in a conditional managed expression and prevent the form designer from deleting/changing options on which other questions depend.

If a form designer tries to delete options on which other questions depend, flashes one or more messages to the user to indicate a) which questions depend on one or more options they tried to delete and b) which options they tried to delete that question depends on. Flashes one 'message' for each question that fits these criteria.

## 📸 Show the thing (screenshots, gifs)
<img width="1018" height="1091" alt="image" src="https://github.com/user-attachments/assets/078076d0-bbc9-4bf9-bbde-c0214c87c509" />

## 🧪 Testing
- Create a flow with a radios question and then one or more questions which depend on one or more of those radio options
- Edit the original radios question and try to delete some or all of the options which have been used in managed expressions
- Get a flash error message for each question which depends on one or more of the options you tried to delete or change, along with each relevant option you tried to delete or change
- Try to delete the original radios question and get the usual error that other questions depend on that question

## 📋 Developer Checklist

### Review Readiness
- [X] PR title and description provide sufficient context for reviewers
- [X] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- [X] No N+1 query problems introduced
- [X] Any new DB queries include appropriate where clauses based on the user's permissions

### Testing
- [X] I have tested this change and it meets the acceptance criteria for the ticket
- [ ] I need the reviewer(s) to pull and run this change locally
- [X] New (non-developer) functionality has appropriate unit and integration tests
- ~[ ] End-to-end tests have been updated (if applicable)~
- [X] Edge cases and error conditions are tested

## 📚 Additional Notes

