### PR TITLE
BAUF Fixup flakey auto complete test

### DIFF
--- a/tests/e2e/developer_pages.py
+++ b/tests/e2e/developer_pages.py
@@ -638,6 +638,11 @@ class QuestionPage(GrantDevelopersBasePage):
             # once we start having multiple of these on a page - enjoy the refactor =]
             accessible_autocomplete = self.page.query_selector("[data-accessible-autocomplete]")
             if accessible_autocomplete:
+                # there is a few ms of delay during the call to "enhanceSelectElement" which allows the select
+                # being progressively enhanced to be selected before its complete as playwright will act immediately
+                # on the role being available - this causes the test to fail particularly when there is network latency.
+                # Wait for the full input + options to be loaded before using it
+                expect(self.page.locator("[class='autocomplete__wrapper']")).to_be_attached()
                 element = self.page.get_by_role("combobox")
                 element.click()
                 element.fill(answer)


### PR DESCRIPTION
We've only seen one instance of network latency causing the progressive enhancement of the select component to fail but lets get ahead of it and keep flakiness to 0 while we're building.

## 🧪 Testing
Including latency on network requests locally guarantees the select will be clicked before the JS has fully processed, including this snippet and running tests on main should be guaranteed to fail. Running them then on this branch should be guaranteed to succeed.

```python
# tests/e2e/conftest.py
def authenticated_browser_sso():
  client = page.context.new_cdp_session(page)

  # download and upload bandwidth set high to "uncap" but they're required
  # all thats needed is a bit of latency
  client.send("Network.emulateNetworkConditions", {
    "offline": False,
    "latency": 500,
    "downloadThroughput": 5000000,
    "uploadThroughput": 5000000,
  })

  #...
```

```bash
uv run pytest --e2e tests/e2e/test_developer_journey.py::test_create_and_preview_collection --video=on
```