### PR TITLE
Improving performance on the generate CSV function

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,27 @@ uv run flask developers export-grants
 
 Then commit the change, create a PR and get it merged. Developer environments will sync the changes automatically when their app starts up again.
 
+### Seeding for performance testing
+
+If you need a large amount of submissions in a grant to test performance, you can use the
+`seed-grants-many-submissions` command:
+
+```bash
+uv run flask developers seed-grants-many-submissions
+```
+
+This creates 2 grants with 100 submissions each - one with conditional questions, one with one question of each existing type in the database. The responses use the
+`Faker` module to generate random answers.
+
+Using this in conjunction with the flask debug toolbar allows you to see the number and timing of queries for operations in the tool.
+
+For routes that don't result in a template render, eg Export to CSV, hack that route to return any template after generating the csv, and then the flask debug toolbar still shows you the performance data.
+
+The following tests are skipped, but were also developed to help test performance. They are skipped at the moment because the factory setup caches the data, so there are actually no wueries executed when generating the CSV file. TODO: See if we can clear out the session between factory creation and CSV export to stop this happening.
+
+- tests.integration.common.helpers.test_collections::test_multiple_submission_export_non_conditional
+- tests.integration.common.helpers.test_collections::test_multiple_submission_export_conditional
+
 
 # IDE setup
 

--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -105,7 +105,7 @@ def get_all_submissions_with_mode_for_collection_with_full_schema(
             .selectinload(Section.forms)
             .selectinload(Form.questions)
             .selectinload(Question.expressions),
-            joinedload(Submission.events),
+            selectinload(Submission.events),
             joinedload(Submission.created_by),
         )
     ).unique()

--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -23,7 +23,10 @@ from app.common.collections.types import (
     YesNoAnswer,
 )
 from app.common.data import interfaces
-from app.common.data.interfaces.collections import get_submission
+from app.common.data.interfaces.collections import (
+    get_all_submissions_with_mode_for_collection_with_full_schema,
+    get_submission,
+)
 from app.common.data.models_user import User
 from app.common.data.types import (
     QuestionDataType,
@@ -346,12 +349,7 @@ class CollectionHelper:
         self.collection = collection
         self.submission_mode = submission_mode
         self.submissions = [
-            s
-            for s in (
-                collection.test_submissions
-                if submission_mode == SubmissionModeEnum.TEST
-                else collection.live_submissions
-            )
+            s for s in (get_all_submissions_with_mode_for_collection_with_full_schema(collection.id, submission_mode))
         ]
         self.submission_helpers = {s.id: SubmissionHelper(s) for s in self.submissions}
 

--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -3,7 +3,7 @@ import uuid
 from datetime import datetime
 from io import StringIO
 from itertools import chain
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, List, Optional
 from uuid import UUID
 
 from immutabledict import immutabledict
@@ -345,6 +345,11 @@ class SubmissionHelper:
 
 
 class CollectionHelper:
+    collection: "Collection"
+    submission_mode: SubmissionModeEnum
+    submissions: List["Submission"]
+    submission_helpers: dict[UUID, SubmissionHelper]
+
     def __init__(self, collection: "Collection", submission_mode: SubmissionModeEnum):
         self.collection = collection
         self.submission_mode = submission_mode

--- a/tests/models.py
+++ b/tests/models.py
@@ -263,17 +263,17 @@ class _CollectionFactory(SQLAlchemyModelFactory):
         def _create_submission(mode: SubmissionModeEnum, count: int = 0) -> None:
             for _ in range(count):
                 response_data: dict[str, Any] = {
-                    str(q1.id): Integer(faker.Faker().random_int(min=0, max=60)).get_value_for_submission()
+                    str(q1.id): IntegerAnswer(faker.Faker().random_int(min=0, max=60)).get_value_for_submission()  # ty: ignore[missing-argument]
                 }
-                response_data[str(q2.id)] = YesNo(random.choice([True, False])).get_value_for_submission()
+                response_data[str(q2.id)] = YesNoAnswer(random.choice([True, False])).get_value_for_submission()  # ty: ignore[missing-argument]
 
-                response_data[str(q3.id)] = TextSingleLine(faker.Faker().word()).get_value_for_submission()
+                response_data[str(q3.id)] = TextSingleLineAnswer(faker.Faker().word()).get_value_for_submission()  # ty: ignore[missing-argument]
                 item_choice = faker.Faker().random_int(min=0, max=2)
-                response_data[str(q4.id)] = SingleChoiceFromList(
+                response_data[str(q4.id)] = SingleChoiceFromListAnswer(
                     key=q4.data_source.items[item_choice].key, label=q4.data_source.items[item_choice].label
                 ).get_value_for_submission()
 
-                response_data[str(q5.id)] = TextSingleLine(faker.Faker().word()).get_value_for_submission()
+                response_data[str(q5.id)] = TextSingleLineAnswer(faker.Faker().word()).get_value_for_submission()  # ty: ignore[missing-argument]
 
                 _SubmissionFactory.create(
                     collection=obj,

--- a/tests/models.py
+++ b/tests/models.py
@@ -10,10 +10,9 @@ for transactional isolation.
 import datetime
 import random
 import secrets
-from typing import Any
+from typing import Any, cast
 from uuid import uuid4
 
-import factory
 import factory.fuzzy
 import faker
 from factory.alchemy import SQLAlchemyModelFactory
@@ -41,8 +40,9 @@ from app.common.data.models import (
 )
 from app.common.data.models_user import Invitation, MagicLink, User, UserRole
 from app.common.data.types import QuestionDataType, SubmissionEventKey, SubmissionModeEnum, SubmissionStatusEnum
-from app.common.expressions.managed import GreaterThan
+from app.common.expressions.managed import AnyOf, GreaterThan
 from app.extensions import db
+from app.types import TRadioItem
 
 
 def _required() -> None:
@@ -203,6 +203,87 @@ class _CollectionFactory(SQLAlchemyModelFactory):
         if live:
             _create_submission(SubmissionModeEnum.LIVE, complete_question_2=True)
             _create_submission(SubmissionModeEnum.LIVE, complete_question_2=False)
+
+    @factory.post_generation  # type: ignore
+    def create_completed_submissions_conditional_question_random(  # type: ignore
+        obj: Collection,
+        create,
+        extracted,
+        test: int = 0,
+        live: int = 0,
+        **kwargs,
+    ) -> None:
+        if not live and not test:
+            return
+
+        section = _SectionFactory.create(collection=obj)
+        form = _FormFactory.create(section=section, title="Export test form", slug="export-test-form")
+
+        # Create a conditional branch of questions
+        q1 = _QuestionFactory.create(
+            name="Number of cups of tea",
+            form=form,
+            data_type=QuestionDataType.INTEGER,
+            text="How many cups of tea do you drink in a week?",
+        )
+        q2 = _QuestionFactory.create(
+            name="Buy teabags in bulk",
+            form=form,
+            data_type=QuestionDataType.YES_NO,
+            text="Do you buy teabags in bulk?",
+            expressions=[
+                Expression.from_managed(GreaterThan(question_id=q1.id, minimum_value=30), _UserFactory.create())
+            ],
+        )
+        q3 = _QuestionFactory.create(
+            name="Favourite dunking biscuit",
+            form=form,
+            data_type=QuestionDataType.TEXT_SINGLE_LINE,
+            text="What is your favourite biscuit to dunk?",
+        )
+        q4 = _QuestionFactory.create(
+            name="Favourite brand of teabags",
+            form=form,
+            data_type=QuestionDataType.RADIOS,
+            text="What is your favourite brand of teabags?",
+        )
+        q5 = _QuestionFactory.create(
+            name="Favourite brand of teabags (Other)",
+            form=form,
+            data_type=QuestionDataType.TEXT_SINGLE_LINE,
+            text="What is your favourite brand of teabags (Other)?",
+            expressions=[
+                Expression.from_managed(
+                    AnyOf(question_id=q4.id, items=[cast(TRadioItem, ({"key": "other", "label": "Other"}))]),
+                    _UserFactory.create(),
+                )
+            ],
+        )
+
+        def _create_submission(mode: SubmissionModeEnum, count: int = 0) -> None:
+            for _ in range(count):
+                response_data: dict[str, Any] = {
+                    str(q1.id): Integer(faker.Faker().random_int(min=0, max=60)).get_value_for_submission()
+                }
+                response_data[str(q2.id)] = YesNo(random.choice([True, False])).get_value_for_submission()
+
+                response_data[str(q3.id)] = TextSingleLine(faker.Faker().word()).get_value_for_submission()
+                item_choice = faker.Faker().random_int(min=0, max=2)
+                response_data[str(q4.id)] = SingleChoiceFromList(
+                    key=q4.data_source.items[item_choice].key, label=q4.data_source.items[item_choice].label
+                ).get_value_for_submission()
+
+                response_data[str(q5.id)] = TextSingleLine(faker.Faker().word()).get_value_for_submission()
+
+                _SubmissionFactory.create(
+                    collection=obj,
+                    mode=mode,
+                    data=response_data,
+                    status=SubmissionStatusEnum.COMPLETED,
+                )
+
+        _create_submission(SubmissionModeEnum.TEST, test)
+        _create_submission(SubmissionModeEnum.LIVE, live)
 
     @factory.post_generation  # type: ignore
     def create_completed_submissions_each_question_type(  # type: ignore


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-693

## 📝 Description
This ticket was to see if we had any potential performance issues with the generate CSV function. On invesigation, we were creating one query per submission when generating the csv output. With the changes in this ticket it is down to one query to generate the csv content for any number of submissions.

- README contains information on a new seeding command that creates collections with 100 submissions - this number can be changed if we need more for something
- Using any kind of performance testing plugin or instrumentation was out of scope for this work
- Adds 2 new unit tests that are now skipped - I used these to generate initial timings before making any changes, but they are no longer useful in their current state because the factory has cached all the data, so they don't generate any queries.

The conclusions that we have reduced the number of queries is based on the approach mentioned in the README file - we hacked the export csv endpoint to render a template, and then used the information in the flask debug toolbar.

## 🧪 Testing
This can be tested using the approach detailed in the README and the flask debug toolbar. Also tested before and after the change on a huddle with @MarcUsher and @samuelhwilliams as witnesses of the improvement 🙂 

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [ ] PR title and description provide sufficient context for reviewers
- [ ] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- [x] No N+1 query problems introduced
- [ ] Any new DB queries include appropriate where clauses based on the user's permissions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
