### PR TITLE
BAU: remove 'latest' tre-agging 

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -65,14 +65,9 @@ jobs:
           ECR_IMAGE_URI="$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$REPO_NAME:$IMAGE_TAG"
           echo "::add-mask::$ECR_IMAGE_URI"
 
-          LATEST_TAG=""
-          if [ "${{ github.ref_name }}" == "main" ]; then
-            LATEST_TAG="--tag $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$REPO_NAME:latest"
-          fi
-
           uv export --format requirements-txt --no-hashes > requirements.txt
 
-          pack build "$ECR_IMAGE_URI" $LATEST_TAG \
+          pack build "$ECR_IMAGE_URI" \
             --builder paketobuildpacks/builder-jammy-full \
             --publish
 


### PR DESCRIPTION
## 🎫 Ticket
BAU fix after https://github.com/communitiesuk/funding-service/pull/494 for error in https://github.com/communitiesuk/funding-service/actions/runs/16446086664/job/46478346214

## 📝 Description
Remove latest tagging as we now rely solely on git sha based tags and re-tagging latest breaks tagging immutability

## 🧪 Testing
Have tested on branch: https://github.com/communitiesuk/funding-service/actions/runs/16446824280

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [ ] PR title and description provide sufficient context for reviewers
- [ ] Commits are logical, self-contained, and have clear descriptions

## 📚 Additional Notes
<!-- Any additional context, concerns, or considerations for reviewers -->
