### PR TITLE
Disable sections functionality

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -254,7 +254,12 @@ class _SharedConfig(_BaseConfig):
 
     # Form rendering options
     ENHANCE_RADIOS_TO_AUTOCOMPLETE_AFTER_X_ITEMS: int = 20
-    ENABLE_FORM_SECTIONS_AFTER_X_TASKS: int = 5
+
+    # note: temporarily setting this to a very high value to effectively 'disable' our section functionality;
+    #       there is a feeling that sections are not useful for monitoring reports. This disables sections globally
+    #       but until we are thinking about anything other than monitoring reports, this is a very quick change that
+    #       does what we need.
+    ENABLE_FORM_SECTIONS_AFTER_X_TASKS: int = 1000
     MAX_DATA_SOURCE_ITEMS: int = 100
 
     # Grant setup


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
Effectively disable the ability to split a form into sections. After some discussion with design (@Kateharries) there's a feeling that the evidence doesn't exist for this being useful for monitoring reports. Let's 'turn it off' (by setting the threshold so high it will never be hit in normal use-cases). If we later find out that we do need to have sections again, it's very easy to toggle it back on. If we continue to see no need for it, we can think about removing the code in some later refactor/cleanup. But we'd need a lot of confidence across a lot of use cases for that.