### PR TITLE
FSPT-685: Pull data source item choices for expressions from DB

### DIFF
--- a/app/common/expressions/__init__.py
+++ b/app/common/expressions/__init__.py
@@ -167,7 +167,13 @@ def _evaluate_expression_with_context(expression: "Expression", context: Express
     """
     if context is None:
         context = ExpressionContext()
-    context.expression_context = immutabledict(expression.context or {})
+
+    # This section isn't lovely but as the context will be an immutable dict we need to add our data_source variable
+    # before this is created and then pop it out afterwards to not duplicate the info in the database
+    expression_context = (expression.context or {}) | {
+        "data_source": [reference.data_source_item.key for reference in expression.data_source_item_references]
+    }
+    context.expression_context = immutabledict(expression_context)
 
     evaluator = simpleeval.EvalWithCompoundTypes(names=context)  # type: ignore[no-untyped-call]
 

--- a/app/developers/data/grants.json
+++ b/app/developers/data/grants.json
@@ -21,11 +21,6 @@
           "data_source_item_id": "819b2684-b5d9-4141-b397-e657121d9e5e",
           "expression_id": "4c912286-fe91-4299-bad9-dc177509032f",
           "id": "c802c0ba-40a7-4a7f-8413-fb16385f3fd1"
-        },
-        {
-          "data_source_item_id": "181c333c-725c-487b-aa4a-1ccf24a4e36d",
-          "expression_id": "70e7b389-5d94-4b0f-8eb5-f2f7140175b7",
-          "id": "79a573b8-ccae-4423-b6df-a80d34df1e0a"
         }
       ],
       "data_source_items": [
@@ -450,20 +445,6 @@
           "order": 5
         },
         {
-          "data_source_id": "91c2b73d-dc7c-4680-9a49-d2c0ecef11bc",
-          "id": "181c333c-725c-487b-aa4a-1ccf24a4e36d",
-          "key": "yes",
-          "label": "Yes",
-          "order": 0
-        },
-        {
-          "data_source_id": "91c2b73d-dc7c-4680-9a49-d2c0ecef11bc",
-          "id": "a30d4652-756d-41ff-a63e-3bc0da8a9ae7",
-          "key": "no",
-          "label": "No",
-          "order": 1
-        },
-        {
           "data_source_id": "2936076d-8f1b-47b6-acb4-06290564e8b8",
           "id": "9245d18d-c238-44c4-ae61-1e4ca23bd950",
           "key": "1",
@@ -640,10 +621,6 @@
           "question_id": "591f6895-0b97-4cdb-ab12-63da263551a4"
         },
         {
-          "id": "91c2b73d-dc7c-4680-9a49-d2c0ecef11bc",
-          "question_id": "f57fd753-6657-4681-8847-69278300134d"
-        },
-        {
           "id": "2936076d-8f1b-47b6-acb4-06290564e8b8",
           "question_id": "aead29df-25ba-4f46-ba0f-5f0617c14996"
         },
@@ -779,19 +756,13 @@
         },
         {
           "context": {
-            "items": [
-              {
-                "key": "yes",
-                "label": "Yes"
-              }
-            ],
-            "question_id": "f57fd753-6657-4681-8847-69278300134d"
+            "question_id": "897480b2-794d-416b-a827-2f4f2e8f5843"
           },
           "created_by_id": "9ab212ee-6716-4921-b6a2-61a684bf2fe3",
-          "id": "70e7b389-5d94-4b0f-8eb5-f2f7140175b7",
-          "managed_name": "Any of",
+          "id": "327ce841-a7ee-4ac3-b0be-f0d791b0f89e",
+          "managed_name": "Yes",
           "question_id": "677b317f-37cd-456c-905f-f3324f905e4a",
-          "statement": "q_f57fd75366574681884769278300134d in data_source",
+          "statement": "q_897480b2794d416ba8272f4f2e8f5843 is True",
           "type": "CONDITION"
         },
         {
@@ -844,36 +815,36 @@
         },
         {
           "id": "9cf64797-461d-467c-8834-470051899da7",
-          "order": 0,
-          "section_id": "73112adc-8ab9-4e7c-8634-987b0508c307",
+          "order": 1,
+          "section_id": "93f068c3-1ed0-41a6-b89d-930c96bd690e",
           "slug": "programme-progress",
           "title": "Programme progress"
         },
         {
           "id": "1482f2ef-9cbe-4e75-b8f0-4362f65822de",
-          "order": 1,
-          "section_id": "73112adc-8ab9-4e7c-8634-987b0508c307",
+          "order": 2,
+          "section_id": "93f068c3-1ed0-41a6-b89d-930c96bd690e",
           "slug": "outputs-and-outcomes",
           "title": "Outputs and outcomes"
         },
         {
           "id": "e34e4d79-6b02-4b08-b719-412c026a7c20",
-          "order": 2,
-          "section_id": "73112adc-8ab9-4e7c-8634-987b0508c307",
+          "order": 3,
+          "section_id": "93f068c3-1ed0-41a6-b89d-930c96bd690e",
           "slug": "main-risk-to-delivery",
           "title": "Main risk to delivery"
         },
         {
           "id": "8506d7ef-2421-40d5-b120-daf870e09968",
-          "order": 0,
-          "section_id": "edd318d2-64c9-4fac-bfbd-b4b7126fc395",
+          "order": 4,
+          "section_id": "93f068c3-1ed0-41a6-b89d-930c96bd690e",
           "slug": "spend-in-the-last-reporting-period",
           "title": "Spend in the last reporting period"
         },
         {
           "id": "e2546f96-3655-483b-8531-0bbfd49a2631",
-          "order": 1,
-          "section_id": "edd318d2-64c9-4fac-bfbd-b4b7126fc395",
+          "order": 5,
+          "section_id": "93f068c3-1ed0-41a6-b89d-930c96bd690e",
           "slug": "estimated-future-spend",
           "title": "Estimated future spend"
         }
@@ -1161,14 +1132,14 @@
           "text": "Who is the risk owner?"
         },
         {
-          "data_type": "Select one from a list of choices",
+          "data_type": "Yes or no",
           "form_id": "e34e4d79-6b02-4b08-b719-412c026a7c20",
           "hint": "",
-          "id": "f57fd753-6657-4681-8847-69278300134d",
+          "id": "897480b2-794d-416b-a827-2f4f2e8f5843",
           "name": "risk to life",
           "order": 5,
           "presentation_options": {
-            "last_data_source_item_is_distinct_from_others": null
+            "last_data_source_item_is_distinct_from_others": false
           },
           "slug": "is-there-a-risk-to-life",
           "text": "Is there a risk to life?"
@@ -1375,24 +1346,8 @@
           "collection_version": 1,
           "id": "93f068c3-1ed0-41a6-b89d-930c96bd690e",
           "order": 0,
-          "slug": "your-organisation",
-          "title": "Your organisation"
-        },
-        {
-          "collection_id": "4e8f04f8-57c2-0399-464b-e62ff96b684a",
-          "collection_version": 1,
-          "id": "73112adc-8ab9-4e7c-8634-987b0508c307",
-          "order": 1,
-          "slug": "programme-information",
-          "title": "Programme information"
-        },
-        {
-          "collection_id": "4e8f04f8-57c2-0399-464b-e62ff96b684a",
-          "collection_version": 1,
-          "id": "edd318d2-64c9-4fac-bfbd-b4b7126fc395",
-          "order": 2,
-          "slug": "finances",
-          "title": "Finances"
+          "slug": "tasks",
+          "title": "Tasks"
         }
       ]
     },
@@ -1428,9 +1383,9 @@
         },
         {
           "id": "6ba3aac0-b30b-0b4d-06a6-84ed632f4f84",
-          "order": 0,
-          "section_id": "b08331e5-7567-0d0b-e30f-b5f11272ea39",
-          "slug": "form-5",
+          "order": 2,
+          "section_id": "5ddd7671-d127-0bfb-b955-a870ce1f82cc",
+          "slug": "public-feedback-on-picnic-areas",
           "title": "Public Feedback on Picnic Areas"
         }
       ],
@@ -1502,16 +1457,8 @@
           "collection_version": 1,
           "id": "5ddd7671-d127-0bfb-b955-a870ce1f82cc",
           "order": 0,
-          "slug": "park-overview",
-          "title": "Park Overview"
-        },
-        {
-          "collection_id": "157b21fd-4d7e-0dfe-0e4a-0b8d0d35353b",
-          "collection_version": 1,
-          "id": "b08331e5-7567-0d0b-e30f-b5f11272ea39",
-          "order": 1,
-          "slug": "feedback",
-          "title": "Feedback"
+          "slug": "tasks",
+          "title": "Tasks"
         }
       ]
     },
@@ -1540,16 +1487,16 @@
         },
         {
           "id": "7ebb5886-bbc3-14b7-38fa-e16a09e053f7",
-          "order": 0,
-          "section_id": "e420512f-0a96-0b55-8a6d-b64605f54bb1",
-          "slug": "form-7",
+          "order": 1,
+          "section_id": "24be7d83-09b5-53aa-0984-0070fd5c902a",
+          "slug": "usage-statistics",
           "title": "Usage Statistics"
         },
         {
           "id": "08b95b3e-2ac8-234a-4c1d-666a9694e549",
-          "order": 1,
-          "section_id": "e420512f-0a96-0b55-8a6d-b64605f54bb1",
-          "slug": "form-8",
+          "order": 2,
+          "section_id": "24be7d83-09b5-53aa-0984-0070fd5c902a",
+          "slug": "maintenance-notes",
           "title": "Maintenance Notes"
         }
       ],
@@ -1647,16 +1594,8 @@
           "collection_version": 1,
           "id": "24be7d83-09b5-53aa-0984-0070fd5c902a",
           "order": 0,
-          "slug": "playground-overview",
-          "title": "Playground Overview"
-        },
-        {
-          "collection_id": "920d3faf-c082-b34a-1cec-6d8db9a72dea",
-          "collection_version": 1,
-          "id": "e420512f-0a96-0b55-8a6d-b64605f54bb1",
-          "order": 1,
-          "slug": "usage-maintenance",
-          "title": "Usage & Maintenance"
+          "slug": "tasks",
+          "title": "Tasks"
         }
       ]
     }
@@ -1687,7 +1626,7 @@
       "azure_ad_subject_id": "40e16bf9d02fa7f67c6bb767b197e544",
       "email": "sclark@test.communities.gov.uk",
       "id": "9ab212ee-6716-4921-b6a2-61a684bf2fe3",
-      "last_logged_in_at_utc": "Mon, 14 Jul 2025 10:00:46 GMT",
+      "last_logged_in_at_utc": "Thu, 24 Jul 2025 11:19:04 GMT",
       "name": "Willie Brown"
     }
   ]

--- a/app/developers/data/grants.json
+++ b/app/developers/data/grants.json
@@ -15,7 +15,17 @@
         {
           "data_source_item_id": "ec7bcf8a-d271-4ede-8f9b-7a3f7eff742e",
           "expression_id": "a360e91c-9bf9-4097-a97b-985f9879e8e5",
-          "id": "a78fa3e8-0dd8-46b5-b0ea-0b74dac58826"
+          "id": "57e12230-a356-467b-b605-201a58c4aed0"
+        },
+        {
+          "data_source_item_id": "819b2684-b5d9-4141-b397-e657121d9e5e",
+          "expression_id": "4c912286-fe91-4299-bad9-dc177509032f",
+          "id": "c802c0ba-40a7-4a7f-8413-fb16385f3fd1"
+        },
+        {
+          "data_source_item_id": "181c333c-725c-487b-aa4a-1ccf24a4e36d",
+          "expression_id": "70e7b389-5d94-4b0f-8eb5-f2f7140175b7",
+          "id": "79a573b8-ccae-4423-b6df-a80d34df1e0a"
         }
       ],
       "data_source_items": [
@@ -669,7 +679,7 @@
           "id": "a360e91c-9bf9-4097-a97b-985f9879e8e5",
           "managed_name": "Any of",
           "question_id": "77cd348d-e2ee-4c98-ba6a-0a699670bdcc",
-          "statement": "q_826587e0a1034e8fbdf0d9024f2c4607 in {'data-certifier-eg-section-151-officer'}",
+          "statement": "q_826587e0a1034e8fbdf0d9024f2c4607 in data_source",
           "type": "CONDITION"
         },
         {
@@ -686,7 +696,7 @@
           "id": "4c912286-fe91-4299-bad9-dc177509032f",
           "managed_name": "Any of",
           "question_id": "17a224fa-7731-44f4-9b93-35e14f7f6de8",
-          "statement": "q_826587e0a1034e8fbdf0d9024f2c4607 in {'none-of-the-above'}",
+          "statement": "q_826587e0a1034e8fbdf0d9024f2c4607 in data_source",
           "type": "CONDITION"
         },
         {
@@ -781,7 +791,7 @@
           "id": "70e7b389-5d94-4b0f-8eb5-f2f7140175b7",
           "managed_name": "Any of",
           "question_id": "677b317f-37cd-456c-905f-f3324f905e4a",
-          "statement": "q_f57fd75366574681884769278300134d in {'yes'}",
+          "statement": "q_f57fd75366574681884769278300134d in data_source",
           "type": "CONDITION"
         },
         {
@@ -924,7 +934,7 @@
           "name": "kind of data certifier",
           "order": 3,
           "presentation_options": {
-            "last_data_source_item_is_distinct_from_others": null
+            "last_data_source_item_is_distinct_from_others": false
           },
           "slug": "what-kind-of-data-certifier-is-the-lead-contact",
           "text": "What kind of data certifier is the lead contact?"
@@ -1171,7 +1181,7 @@
           "name": "management of risk to life",
           "order": 6,
           "presentation_options": {
-            "last_data_source_item_is_distinct_from_others": null
+            "last_data_source_item_is_distinct_from_others": false
           },
           "slug": "how-are-you-managing-the-risk-to-life",
           "text": "How are you managing the risk to life?"

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -765,7 +765,7 @@ class TestExpressions:
         assert len(from_db.expressions) == 1
         assert from_db.expressions[0].type == ExpressionType.CONDITION
         assert from_db.expressions[0].managed_name == ManagedExpressionsEnum.ANY_OF
-        assert q0.safe_qid and items[0].key and items[1].key in from_db.expressions[0].statement
+        assert q0.safe_qid in from_db.expressions[0].statement
 
         assert len(from_db.expressions[0].data_source_item_references) == 2
         assert from_db.expressions[0].data_source_item_references[0].data_source_item_id == q0.data_source.items[0].id
@@ -843,7 +843,7 @@ class TestExpressions:
         assert len(from_db.expressions) == 1
         assert from_db.expressions[0].type == ExpressionType.CONDITION
         assert from_db.expressions[0].managed_name == ManagedExpressionsEnum.ANY_OF
-        assert q0.safe_qid and items[2].key in from_db.expressions[0].statement
+        assert q0.safe_qid in from_db.expressions[0].statement
 
         assert len(from_db.expressions[0].data_source_item_references) == 1
         assert from_db.expressions[0].data_source_item_references[0].data_source_item_id == q0.data_source.items[2].id

--- a/tests/models.py
+++ b/tests/models.py
@@ -47,7 +47,7 @@ from app.common.data.types import (
     SubmissionModeEnum,
     SubmissionStatusEnum,
 )
-from app.common.expressions.managed import AnyOf, BaseDataSourceManagedExpression, GreaterThan
+from app.common.expressions.managed import AnyOf, GreaterThan
 from app.constants import DEFAULT_SECTION_NAME
 from app.extensions import db
 from app.types import TRadioItem
@@ -534,14 +534,11 @@ class _QuestionFactory(SQLAlchemyModelFactory):
         for expression in extracted:
             expression.question_id = self.id
 
-            if (
-                isinstance(expression.managed, BaseDataSourceManagedExpression)
-                and expression.managed.referenced_question.data_source
-            ):
+            if expression.managed.referenced_question.data_source:
                 # Longwindedly doing this via ORM to avoid additional DB queries when we switch the data export
                 # performance tests back on
                 all_referenced_question_data_source_items = expression.managed.referenced_question.data_source.items
-                expression_referenced_data_source_items = expression.managed.referenced_data_source_items
+                expression_referenced_data_source_items = expression.managed.items
                 referenced_items = [
                     item
                     for item in all_referenced_question_data_source_items


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-685

## 📝 Description
When setting up a managed expression for a question with a data source, we copy the information about the referenced options into the context of the expression. We also then copy+hardcode the option keys in the expression statement.

This change makes us dynamically reference the data source items through the DB relationships instead, preventing some copying and keeping things in sync better.

## 📸 Show the thing (screenshots, gifs)
No viz changes

## 🧪 Testing
- Add some conditions that rely on a radio questions
- Save the conditions
- Check the Expression in the DB to see it's referring to `data_source` and that the data source items are not referenced in the context

## 📋 Developer Checklist

### Review Readiness
- [X] PR title and description provide sufficient context for reviewers
- [X] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- [X] No N+1 query problems introduced
- [X] Any new DB queries include appropriate where clauses based on the user's permissions

### Testing
- [X] I have tested this change and it meets the acceptance criteria for the ticket
- [X] I need the reviewer(s) to pull and run this change locally
- ~[ ] New (non-developer) functionality has appropriate unit and integration tests~
- [X] End-to-end tests have been updated (if applicable)
- [X] Edge cases and error conditions are tested

## 📚 Additional Notes
