### PR TITLE
BAU: Fix data source item dependency exception

### DIFF
--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -479,6 +479,7 @@ def raise_if_data_source_item_reference_dependency(
             data_source_item_dependency_map[dependent_question].add(data_source_item)
 
     if data_source_item_dependency_map:
+        db.session.rollback()
         raise DataSourceItemReferenceDependencyException(
             "You cannot delete or change an option that other questions depend on.",
             question_being_edited=question,

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -607,6 +607,7 @@ def test_raise_if_data_source_item_reference_dependency(db_session, factories):
         name="Test Question Name",
         data_type=QuestionDataType.RADIOS,
         items=["option 1", "option 2", "option 3"],
+        presentation_options=QuestionPresentationOptions(last_data_source_item_is_distinct_from_others=True),
     )
     items = referenced_question.data_source.items
     anyof_expression = AnyOf(
@@ -623,6 +624,7 @@ def test_raise_if_data_source_item_reference_dependency(db_session, factories):
     assert referenced_question == error.value.question_being_edited
     assert len(error.value.data_source_item_dependency_map) == 1
     assert dependent_question in error.value.data_source_item_dependency_map.keys()
+    assert referenced_question.presentation_options.last_data_source_item_is_distinct_from_others is True
 
 
 def test_update_submission_data(db_session, factories):


### PR DESCRIPTION
## 🎫 Ticket
BAU - lil bugfix

## 📝 Description
When you try to delete data source items on which another question depended on, we raised an error. However, with interfaces using other interfaces using other interfaces, the way in which this error was raised was wrong as it would preserve the original data source items but not rollback any other changes made to the form, as when the exception was raised it wasn't in a try/except block or using what would eventually be a base IntegrityError (but rather raising pre-emptively so as to have the context needed to build useful error messages).

We might want to take a look at where certain interfaces/which interfaces try to flush changes and raise exceptions so that this can be consistent and we don't end up with issues like this happening again - happy to shelve this PR if that's something we want to do now for this instance, or if we want to do a fuller sweep.

## 📸 Show the thing (screenshots, gifs)
![2025-07-24 09 48 30](https://github.com/user-attachments/assets/1325b4c0-cc36-4f20-a182-a98e5564b41f)

## 🧪 Testing
- Add a radios question with a 'None of the above' type option, and a question which depends on that 'None of the above'
- Edit the original question and try to untick the final answer option
- Get the correct error message and see that the rest of the question details (including the ticked 'final answer option' and original final answer wording) are preserved

## 📋 Developer Checklist

### Review Readiness
- [X] PR title and description provide sufficient context for reviewers
- [X] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- ~[ ] No N+1 query problems introduced~
- ~[ ] Any new DB queries include appropriate where clauses based on the user's permissions~

### Testing
- [X] I have tested this change and it meets the acceptance criteria for the ticket
- ~[ ] I need the reviewer(s) to pull and run this change locally~
- [X] New (non-developer) functionality has appropriate unit and integration tests
- ~[ ] End-to-end tests have been updated (if applicable)~
- [X] Edge cases and error conditions are tested

## 📚 Additional Notes
<!-- Any additional context, concerns, or considerations for reviewers -->
