### PR TITLE
Refer to 'reports' instead of 'collections'

### DIFF
--- a/app/deliver_grant_funding/forms.py
+++ b/app/deliver_grant_funding/forms.py
@@ -153,8 +153,8 @@ class GrantContactForm(GrantSetupForm):
 
 class CollectionForm(GrantSetupForm):
     name = StringField(
-        "What is the name of the collection?",
-        validators=[DataRequired("Enter a collection name")],
+        "What is the name of this monitoring report?",
+        validators=[DataRequired("Enter a monitoring report name")],
         filters=[strip_string_if_not_empty],
         widget=GovTextInput(),
     )

--- a/app/developers/templates/developers/deliver/add_collection.html
+++ b/app/developers/templates/developers/deliver/add_collection.html
@@ -19,11 +19,11 @@
       <form method="post" novalidate>
         {{ form.csrf_token }}
         {{ form.grant_id }}
-        {{ form.name (params={"label": {"isPageHeading": true, "classes": "govuk-label--l" }})
-        }}
+        <span class="govuk-caption-l">{{ grant.name }}</span>
+        {{ form.name (params={"label": {"isPageHeading": true, "classes": "govuk-label--l" }}) }}
         {{
           form.submit(params={
-              "text": "Set up collection"
+              "text": "Continue and set up report"
           })
         }}
       </form>

--- a/app/developers/templates/developers/deliver/grant_developers.html
+++ b/app/developers/templates/developers/deliver/grant_developers.html
@@ -30,10 +30,10 @@
   </div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <h2 class="govuk-heading-m govuk-!-margin-top-4">Collections</h2>
+      <h2 class="govuk-heading-m govuk-!-margin-top-4">Reports</h2>
 
       {% if not grant.collections %}
-        <p class="govuk-body">This grant has no collections.</p>
+        <p class="govuk-body">This grant has no monitoring reports.</p>
       {% else %}
         {% for collection in grant.collections %}
           {% set collection_link %}
@@ -49,23 +49,36 @@
               sections
             {% endtrans %}
           {% endset %}
-          {% set submissions_text %}
+          {% set submissionsText %}
+            Review
             {% trans count=collection.test_submissions | length %}
               {{ count }}
               test submission {% pluralize %}
               {{ count }}
               test submissions
             {% endtrans %}
+            <span class="govuk-visually-hidden">for {{ collection.name }}</span>
+          {% endset %}
+
+
+          {% set submissionsHtml %}
+            <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for("developers.deliver.list_submissions_for_collection", collection_id=collection.id, submission_mode=enum.submission_mode.TEST) }}"> {{ submissionsText }} </a>
           {% endset %}
 
 
           {% set formSectionsAndTasksText %}
-            {% if collection.has_non_default_sections %}
-              {{ collection.sections | length }}
-              {% trans count=collection.sections|length %}section{% pluralize %}sections{% endtrans %},
+            {% if collection.forms | length == 0 %}
+              <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for("developers.deliver.add_form", grant_id=grant.id, collection_id=collection.id, section_id=collection.sections[0].id) }}"
+                >Add tasks <span class="govuk-visually-hidden">to {{ collection.name }}</span></a
+              >
+              to create your report
+              <br />
+              Tasks are groups of questions with a common theme
+            {% else %}
+              <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for("developers.deliver.manage_collection_tasks", grant_id=grant.id, collection_id=collection.id) }}"
+                >Build form <span class="govuk-visually-hidden">for {{ collection.name }}</span></a
+              >
             {% endif %}
-            {{ collection.forms | length }}
-            {% trans count=collection.forms|length %}task{% pluralize %}tasks{% endtrans %}
           {% endset %}
 
           {{
@@ -80,28 +93,14 @@
               },
               "rows": [
                 {
-                  "key": {"text": "Form"},
+                  "key": {"text": "Report"},
                   "value": {"text": formSectionsAndTasksText},
-                  "actions": {
-                    "items": [
-                      {"text": "Build form", "visuallyHiddenText": collection.title, "href": url_for("developers.deliver.manage_collection_tasks", grant_id=grant.id, collection_id=collection.id), "classes": "govuk-link--no-visited-state" },
-                    ],
-                  },
                 },
                 {
                   "key": {"text": "Submissions"},
-                  "value":{"text": submissions_text},
-                  "actions": {
-                    "items": [
-                      {
-                        "href": url_for("developers.deliver.list_submissions_for_collection", collection_id=collection.id, submission_mode=enum.submission_mode.TEST),
-                        "text": "View",
-                        "classes": "govuk-link govuk-link--no-visited-state"
-                      }
-                    ]
-                  }
+                  "value":{"html": submissionsHtml},
                 },
-                {"key": {"text": "Created by"}, "value": {"text": collection.created_by.name ~ " on " ~ format_date(collection.created_at_utc)} },
+                {"key": {"text": "Created by"}, "value": {"text": collection.created_by.email} },
                 {"key": {"text": "Last updated"}, "value": {"text": format_date(collection.updated_at_utc)} },
               ],
             })
@@ -111,8 +110,8 @@
 
       {{
         govukButton({
-          "text": "Add collection",
-          "classes": "govuk-button--secondary",
+          "text": "Add a monitoring report" if not grant.collections else "Add another monitoring report",
+          "classes": "" if not grant.collections else "govuk-button--secondary",
           "href": url_for("developers.deliver.setup_collection", grant_id = grant.id)
         })
       }}

--- a/app/developers/templates/developers/deliver/manage_collection.html
+++ b/app/developers/templates/developers/deliver/manage_collection.html
@@ -19,7 +19,7 @@
     <div class="govuk-grid-column-two-thirds">
       {% if delete_collection %}
         {% set banner_html %}
-          <p class="govuk-body govuk-!-font-weight-bold">Are you sure you want to delete this collection?</p>
+          <p class="govuk-body govuk-!-font-weight-bold">Are you sure you want to delete this report?</p>
           <form method="post" novalidate>
             {{ confirm_deletion_form.csrf_token }}
             {{ confirm_deletion_form.confirm_deletion(params={"classes": "govuk-button--warning govuk-!-margin-bottom-0"}) }}
@@ -29,11 +29,11 @@
         {{ govukNotificationBanner(params={"role": "alert", "titleText": "Warning", "classes": "app-notification-banner--destructive", "html": banner_html}) }}
       {% endif %}
 
-      <h1 class="govuk-heading-l">Manage collection</h1>
+      <h1 class="govuk-heading-l">Manage report</h1>
 
       <form method="post" novalidate>
         {{ form.csrf_token }}
-        {{ form.name(params={"label": {"text": "Collection name"} }) }}
+        {{ form.name(params={"label": {"text": "Report name"} }) }}
         {{ form.submit(params={"text": "Save"}) }}
       </form>
     </div>
@@ -43,7 +43,7 @@
       <div class="govuk-grid-row govuk-!-margin-top-7">
         <div class="govuk-grid-column-two-thirds">
           <p class="govuk-body">
-            <a class="govuk-link app-link--destructive" href="{{ url_for('developers.deliver.manage_collection', grant_id=grant.id, collection_id=collection.id, delete='') }}">Delete this collection</a>
+            <a class="govuk-link app-link--destructive" href="{{ url_for('developers.deliver.manage_collection', grant_id=grant.id, collection_id=collection.id, delete='') }}">Delete report</a>
           </p>
         </div>
       </div>

--- a/app/developers/templates/developers/deliver/manage_collection_tasks.html
+++ b/app/developers/templates/developers/deliver/manage_collection_tasks.html
@@ -27,7 +27,7 @@
 
       {% if delete_collection %}
         {% set banner_html %}
-          <p class="govuk-body govuk-!-font-weight-bold">Are you sure you want to delete this collection?</p>
+          <p class="govuk-body govuk-!-font-weight-bold">Are you sure you want to delete this report?</p>
           <form method="post" novalidate>
             {{ confirm_deletion_form.csrf_token }}
             {{ confirm_deletion_form.confirm_deletion(params={"classes": "govuk-button--warning govuk-!-margin-bottom-0"}) }}
@@ -53,7 +53,7 @@
     <div class="govuk-grid-column-one-third govuk-!-text-align-right">
       <form method="post" novalidate>
         {{ form.csrf_token }}
-        {{ form.submit(params={"text": "Preview this form", "classes": "" if testThisFormIsPrimaryAction else "govuk-button--secondary"}) }}
+        {{ form.submit(params={"text": "Preview report", "classes": "" if testThisFormIsPrimaryAction else "govuk-button--secondary"}) }}
       </form>
     </div>
   </div>

--- a/app/developers/templates/developers/deliver/manage_form_questions.html
+++ b/app/developers/templates/developers/deliver/manage_form_questions.html
@@ -42,7 +42,7 @@
     <div class="govuk-grid-column-one-third govuk-!-text-align-right">
       <form method="post" novalidate>
         {{ form.csrf_token }}
-        {{ form.submit(params={"text": "Preview this task", "classes": "govuk-button--secondary" if not db_form.questions else "", "disabled": db_form.questions | length == 0}) }}
+        {{ form.submit(params={"text": "Preview task", "classes": "govuk-button--secondary" if not db_form.questions else "", "disabled": db_form.questions | length == 0}) }}
       </form>
     </div>
   </div>

--- a/tests/e2e/developer_pages.py
+++ b/tests/e2e/developer_pages.py
@@ -6,6 +6,7 @@ from playwright.sync_api import Locator, Page, expect
 
 from app.common.data.types import ManagedExpressionsEnum, QuestionDataType
 from app.common.expressions.managed import GreaterThan, LessThan, ManagedExpression
+from app.constants import DEFAULT_SECTION_NAME
 
 if TYPE_CHECKING:
     from tests.e2e.pages import AllGrantsPage
@@ -39,7 +40,9 @@ class GrantDevelopersPage(GrantDevelopersBasePage):
         self.manage_collections_link = self.page.get_by_role("link", name="Manage")
         self.delete_link = page.get_by_role("link", name="Delete this grant")
         self.confirm_delete = page.get_by_role("button", name="Confirm deletion")
-        self.add_collection_button = self.page.get_by_role("button", name="Add collection")
+        self.add_collection_button = self.page.get_by_role("button", name="Add a monitoring report").or_(
+            self.page.get_by_role("button", name="Add another monitoring report")
+        )
         self.summary_row_submissions = page.locator("div.govuk-summary-list__row").filter(
             has=page.get_by_text("Submissions")
         )
@@ -62,8 +65,20 @@ class GrantDevelopersPage(GrantDevelopersBasePage):
     def check_collection_exists(self, collection_name: str) -> None:
         expect(self.page.get_by_role("heading", name=collection_name)).to_be_visible()
 
-    def click_manage_form(self, collection_name: str, grant_name: str) -> CollectionDetailPage:
-        self.page.get_by_role("link", name=f"Build form ({collection_name})").click()
+    def click_add_task(self, collection_name: str, grant_name: str) -> SelectTaskTypePage:
+        self.page.get_by_role("link", name=f"Add tasks to {collection_name}").click()
+        form_type_page = SelectTaskTypePage(
+            self.page,
+            self.domain,
+            grant_name=grant_name,
+            collection_name=collection_name,
+            section_title=DEFAULT_SECTION_NAME,
+        )
+        expect(form_type_page.heading).to_be_visible()
+        return form_type_page
+
+    def click_build_form(self, collection_name: str, grant_name: str) -> CollectionDetailPage:
+        self.page.get_by_role("link", name=f"Build form for {collection_name}").click()
         collection_detail_page = CollectionDetailPage(
             self.page, self.domain, grant_name=grant_name, collection_name=collection_name
         )
@@ -83,14 +98,14 @@ class AddCollectionPage(GrantDevelopersBasePage):
             page,
             domain,
             grant_name=grant_name,
-            heading=page.get_by_role("heading", name="What is the name of the collection?"),
+            heading=page.get_by_role("heading", name="What is the name of this monitoring report?"),
         )
 
     def fill_in_collection_name(self, name: str) -> None:
-        self.page.get_by_role("textbox", name="What is the name of the collection?").fill(name)
+        self.page.get_by_role("textbox", name="What is the name of this monitoring report?").fill(name)
 
     def click_submit(self, grant_name: str) -> GrantDevelopersPage:
-        self.page.get_by_role("button", name="Set up collection").click()
+        self.page.get_by_role("button", name="Set up report").click()
         developers_page = GrantDevelopersPage(self.page, self.domain, grant_name=grant_name)
         expect(developers_page.heading).to_be_visible()
         return developers_page
@@ -111,7 +126,7 @@ class CollectionDetailPage(GrantDevelopersBasePage):
             heading=page.get_by_role("heading", name=collection_name),
         )
         self.collection_name = collection_name
-        self.test_form_button = self.page.get_by_role("button", name="Preview this form")
+        self.test_form_button = self.page.get_by_role("button", name="Preview report")
         self.add_section_button = self.page.get_by_role(
             "link", name="Split the form into sections of related tasks"
         ).or_(self.page.get_by_role("link", name="Add another section to the form"))

--- a/tests/e2e/test_developer_journey.py
+++ b/tests/e2e/test_developer_journey.py
@@ -138,7 +138,7 @@ def navigate_to_collection_detail_page(
     all_grants_page.navigate()
     grant_dashboard_page = all_grants_page.click_grant(grant_name)
     developers_page = grant_dashboard_page.click_developers(grant_name)
-    collection_detail_page = developers_page.click_manage_form(grant_name=grant_name, collection_name=collection_name)
+    collection_detail_page = developers_page.click_build_form(grant_name=grant_name, collection_name=collection_name)
     return collection_detail_page
 
 
@@ -176,12 +176,9 @@ def test_create_and_preview_collection(
         developers_page = add_collection_page.click_submit(new_grant_name)
         developers_page.check_collection_exists(new_collection_name)
 
-        collection_detail_page = developers_page.click_manage_form(
-            collection_name=new_collection_name, grant_name=new_grant_name
-        )
+        form_type_page = developers_page.click_add_task(collection_name=new_collection_name, grant_name=new_grant_name)
 
         # Add a new form
-        form_type_page = collection_detail_page.click_add_form(DEFAULT_SECTION_NAME)
         form_type_page.click_add_empty_task()
         form_details_page = form_type_page.click_continue()
         form_name = f"E2E form {uuid.uuid4()}"

--- a/tests/integration/deliver_grant_funding/test_routes.py
+++ b/tests/integration/deliver_grant_funding/test_routes.py
@@ -288,7 +288,7 @@ def test_create_collection_get(authenticated_platform_admin_client, factories, t
     assert result.status_code == 200
 
     soup = BeautifulSoup(result.data, "html.parser")
-    assert get_h1_text(soup) == "What is the name of the collection?"
+    assert get_h1_text(soup) == "What is the name of this monitoring report?"
 
 
 def test_create_collection_post(authenticated_platform_admin_client, factories, db_session):


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
Tweak content on the developer pages to refer to monitoring reports instead of generic collections.