### PR TITLE
Fixup for ty 0.0.1a16

### DIFF
--- a/app/common/expressions/__init__.py
+++ b/app/common/expressions/__init__.py
@@ -185,7 +185,6 @@ def _evaluate_expression_with_context(expression: "Expression", context: Express
             ast.Compare,
             ast.Subscript,
             ast.Attribute,
-            ast.Index,
             ast.Slice,
             ast.Constant,
             ast.Call,


### PR DESCRIPTION
Renovate [bumped ty](https://github.com/communitiesuk/funding-service/pull/561). Because we only have it as an optional check, it got automerged even though ty started failing.

This applies the required fix - `ast.Index` is now deprecated. We don't use it in expressions currently anyway, so can drop it out.