### PR TITLE
Allow platform admins to downgrade to grant team members

### DIFF
--- a/app/developers/forms.py
+++ b/app/developers/forms.py
@@ -18,6 +18,10 @@ class ConfirmDeletionForm(FlaskForm):
     confirm_deletion = SubmitField("Confirm deletion", widget=GovSubmitInput())
 
 
+class BecomeGrantTeamMemberForm(FlaskForm):
+    submit = SubmitField("Become grant team member", widget=GovSubmitInput())
+
+
 class ConditionSelectQuestionForm(FlaskForm):
     question = SelectField(
         "Which answer should the condition check?",

--- a/app/developers/templates/developers/deliver/grant_developers.html
+++ b/app/developers/templates/developers/deliver/grant_developers.html
@@ -27,6 +27,12 @@
       </h1>
       <p class="govuk-body">You can try out tech and designs that are work in progress.</p>
     </div>
+    <div class="govuk-grid-column-one-third govuk-!-text-align-right">
+      <form method="post" novalidate>
+        {{ become_grant_team_member_form.csrf_token }}
+        {{ become_grant_team_member_form.submit(params={"classes": "govuk-button--secondary"}) }}
+      </form>
+    </div>
   </div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FSPT-587

This is a very quick and easy change that will allow platform admins (ie us) to quickly and temporarily downgrade our accounts to that of a 'grant team member'. This should make it easy for eg product managers and designers to view the service through a "read only"/reduced permissions role.

It doesn't give us everything we might want for permission permutations (ie someone who's a member of multiple grants) - but it gets us quite a lot for very little effort.

![2025-07-25 22 21 30](https://github.com/user-attachments/assets/886ae897-094e-4eb3-be4b-cedbd0d1ebac)