### PR TITLE
Start adding the 'Reports' tab

### DIFF
--- a/app/common/auth/authorisation_helper.py
+++ b/app/common/auth/authorisation_helper.py
@@ -30,6 +30,8 @@ class AuthorisationHelper:
     def is_grant_admin(grant_id: UUID, user: User | AnonymousUserMixin) -> bool:
         if isinstance(user, AnonymousUserMixin):
             return False
+        if AuthorisationHelper.is_platform_admin(user=user):
+            return True
         return any(
             role.role == RoleEnum.ADMIN and role.organisation_id is None and role.grant_id == grant_id
             for role in user.roles

--- a/app/common/auth/decorators.py
+++ b/app/common/auth/decorators.py
@@ -1,5 +1,6 @@
 import functools
-from typing import Callable
+import uuid
+from typing import Callable, cast
 
 from flask import abort, current_app, redirect, request, session, url_for
 from flask.typing import ResponseReturnValue
@@ -144,7 +145,7 @@ def has_grant_role[**P](
             if AuthorisationHelper.is_platform_admin(user=user):
                 return func(*args, **kwargs)
 
-            if "grant_id" not in kwargs or (grant_id := kwargs["grant_id"]) is None:
+            if "grant_id" not in kwargs or (grant_id := cast(uuid.UUID, kwargs["grant_id"])) is None:
                 raise ValueError("Grant ID required.")
 
             # raises a 404 if the grant doesn't exist; more appropriate than 403 on non-existent entity

--- a/app/deliver_grant_funding/routes/__init__.py
+++ b/app/deliver_grant_funding/routes/__init__.py
@@ -2,4 +2,4 @@ from flask import Blueprint
 
 deliver_grant_funding_blueprint = Blueprint(name="deliver_grant_funding", import_name=__name__)
 
-from app.deliver_grant_funding.routes import grant_details, grant_setup, grant_team, misc  # noqa: E402, F401
+from app.deliver_grant_funding.routes import grant_details, grant_setup, grant_team, misc, reports  # noqa: E402, F401

--- a/app/deliver_grant_funding/routes/reports.py
+++ b/app/deliver_grant_funding/routes/reports.py
@@ -1,0 +1,16 @@
+from uuid import UUID
+
+from flask import render_template
+from flask.typing import ResponseReturnValue
+
+from app.common.auth.decorators import has_grant_role
+from app.common.data.interfaces.grants import get_grant
+from app.common.data.types import RoleEnum
+from app.deliver_grant_funding.routes import deliver_grant_funding_blueprint
+
+
+@deliver_grant_funding_blueprint.route("/grant/<uuid:grant_id>/reports", methods=["GET"])
+@has_grant_role(RoleEnum.MEMBER)
+def list_reports(grant_id: UUID) -> ResponseReturnValue:
+    grant = get_grant(grant_id, with_all_collections=True)
+    return render_template("deliver_grant_funding/reports/list_reports.html", grant=grant)

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_base.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_base.html
@@ -11,6 +11,12 @@
           "current": active_item_identifier == "details"
       },
       {
+          "text": "Reports",
+          "key": "reports",
+          "href": url_for("deliver_grant_funding.list_reports", grant_id=grant.id),
+          "current": active_item_identifier == "reports"
+      },
+      {
           "text": "Grant team",
           "key": "grant_users",
           "href": url_for("deliver_grant_funding.list_users_for_grant", grant_id=grant.id),

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_reports.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_reports.html
@@ -1,0 +1,74 @@
+{% extends "deliver_grant_funding/grant_base.html" %}
+{% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
+{% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
+
+{% set page_title = "Reports" %}
+{% set active_item_identifier = "reports" %}
+{% set grant_admin = authorisation_helper.is_grant_admin(grant.id, current_user) %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l">{{ grant.name }}</span>
+        Reports
+      </h1>
+    </div>
+  </div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      {% if not grant.collections %}
+        <p class="govuk-body">This grant has no monitoring reports.</p>
+      {% else %}
+        {# TODO: Add a `reports` property to the grant which filters this down based on a (to be added) CollectionType enum #}
+        {% for report in grant.collections %}
+          {% set formSectionsAndTasksText %}
+            {% if grant_admin %}
+              {% if report.forms | length == 0 %}
+                <a class="govuk-link govuk-link--no-visited-state" href="#">Add tasks<span class="govuk-visually-hidden"> to {{ report.name }}</span></a>
+                to create your report
+                <br />
+                Tasks are groups of questions with a common theme
+              {% else %}
+                <a class="govuk-link govuk-link--no-visited-state" href="#">{{ report.tasks | length }} tasks<span class="govuk-visually-hidden"> in report for {{ report.name }}</span></a>
+              {% endif %}
+            {% else %}
+              <a class="govuk-link govuk-link--no-visited-state" href="#">{{ report.tasks | length }} tasks<span class="govuk-visually-hidden"> in report for {{ report.name }}</span></a>
+            {% endif %}
+          {% endset %}
+
+          {{
+            govukSummaryList({
+            	"card": {
+            		"title": {"text": report.name},
+            		"actions": {
+            			"items": [
+            				{"text": "Manage", "visuallyHiddenText": report.title, "href": "#", "classes": "govuk-link--no-visited-state" },
+            			] if grant_admin else [],
+            		},
+            	},
+            	"rows": [
+            		{
+            			"key": {"text": "Report"},
+            			"value": {"text": formSectionsAndTasksText},
+            		},
+            		{"key": {"text": "Created by"}, "value": {"text": report.created_by.email} },
+            		{"key": {"text": "Last updated"}, "value": {"text": format_date(report.updated_at_utc)} },
+            	],
+            })
+          }}
+        {% endfor %}
+      {% endif %}
+
+      {% if grant_admin %}
+        {{
+          govukButton({
+            "text": "Add a monitoring report" if not grant.collections else "Add another monitoring report",
+            "classes": "" if not grant.collections else "govuk-button--secondary",
+            "href": "#"
+          })
+        }}
+      {% endif %}
+    </div>
+  </div>
+{% endblock content %}

--- a/tests/integration/deliver_grant_funding/routes/test_misc.py
+++ b/tests/integration/deliver_grant_funding/routes/test_misc.py
@@ -35,7 +35,7 @@ class TestListGrants:
         soup = BeautifulSoup(result.data, "html.parser")
 
         nav_items = [item.text.strip() for item in soup.select(".govuk-service-navigation__item")]
-        assert nav_items == ["Grant details", "Grant team"]
+        assert nav_items == ["Grant details", "Reports", "Grant team"]
         assert len(queries) == 3  # 1) select user, 2) select user_role, 3) select grants
 
     def test_list_grants_as_member_with_multiple_grants(

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -1,0 +1,75 @@
+import uuid
+
+import pytest
+from _pytest.fixtures import FixtureRequest
+from bs4 import BeautifulSoup
+from flask import url_for
+
+from tests.utils import page_has_link
+
+
+class TestListReports:
+    def test_404(self, authenticated_grant_member_client):
+        response = authenticated_grant_member_client.get(
+            url_for("deliver_grant_funding.list_reports", grant_id=uuid.uuid4())
+        )
+        assert response.status_code == 404
+
+    @pytest.mark.parametrize(
+        "client_fixture, can_edit",
+        (
+            ("authenticated_grant_member_client", False),
+            ("authenticated_grant_admin_client", True),
+        ),
+    )
+    def test_grant_member_get_no_reports(self, request: FixtureRequest, client_fixture: str, can_edit: bool, factories):
+        client = request.getfixturevalue(client_fixture)
+
+        response = client.get(url_for("deliver_grant_funding.list_reports", grant_id=client.grant.id))
+        assert response.status_code == 200
+
+        soup = BeautifulSoup(response.data, "html.parser")
+        assert client.grant.name in soup.text
+
+        expected_links = [
+            ("Add a monitoring report", "#"),
+        ]
+        for expected_link in expected_links:
+            button = page_has_link(soup, expected_link[0])
+            assert (button is not None) is can_edit
+
+            if can_edit:
+                assert button.get("href") == expected_link[1]
+
+    @pytest.mark.parametrize(
+        "client_fixture, can_edit",
+        (
+            ("authenticated_grant_member_client", False),
+            ("authenticated_grant_admin_client", True),
+            ("authenticated_platform_admin_client", True),
+        ),
+    )
+    def test_grant_member_get_with_reports(
+        self, request: FixtureRequest, client_fixture: str, can_edit: bool, factories
+    ):
+        client = request.getfixturevalue(client_fixture)
+        grant = client.grant or factories.grant.create()
+        factories.collection.create(grant=grant)
+
+        response = client.get(url_for("deliver_grant_funding.list_reports", grant_id=grant.id))
+        assert response.status_code == 200
+
+        soup = BeautifulSoup(response.data, "html.parser")
+        assert grant.name in soup.text
+
+        expected_links = [
+            ("Add another monitoring report", "#"),
+            ("Add tasks", "#"),
+            ("Manage", "#"),
+        ]
+        for expected_link in expected_links:
+            link = page_has_link(soup, expected_link[0])
+            assert (link is not None) is can_edit
+
+            if can_edit:
+                assert link.get("href") == expected_link[1]

--- a/tests/models.py
+++ b/tests/models.py
@@ -425,6 +425,13 @@ class _CollectionFactory(SQLAlchemyModelFactory):
         for _ in range(0, live):
             _SubmissionFactory.create(collection=obj, mode=SubmissionModeEnum.LIVE)
 
+    @factory.post_generation
+    def commit_the_things_to_clean_the_session(self, create, extracted, **kwargs):  # type: ignore
+        # Runs after all of the other post_generation hooks (hopefully) and commits anything created to the DB,
+        # so that our clean-session-tracking logic has a clean session again.
+        if create:
+            _CollectionFactory._meta.sqlalchemy_session_factory().commit()  # type: ignore
+
 
 class _SubmissionFactory(SQLAlchemyModelFactory):
     class Meta:

--- a/tests/unit/common/auth/test_authorisation_helper.py
+++ b/tests/unit/common/auth/test_authorisation_helper.py
@@ -78,6 +78,13 @@ class TestAuthorisationHelper:
         factories.user_role.build(user=user, role=role, grant=grant)
         assert AuthorisationHelper.is_grant_admin(user=user, grant_id=grant.id) is expected
 
+    def test_is_grant_admin_if_platform_admin(self, factories):
+        user = factories.user.build()
+        grant = factories.grant.build()
+        assert AuthorisationHelper.is_grant_admin(user=user, grant_id=grant.id) is False
+        factories.user_role.build(user=user, role=RoleEnum.ADMIN)
+        assert AuthorisationHelper.is_grant_admin(user=user, grant_id=grant.id) is True
+
     @pytest.mark.parametrize(
         "role",
         [

--- a/tests/unit/test_all_routes_access.py
+++ b/tests/unit/test_all_routes_access.py
@@ -67,6 +67,7 @@ routes_with_expected_grant_admin_only_access = [
 routes_with_expected_member_only_access = [
     "deliver_grant_funding.list_users_for_grant",
     "deliver_grant_funding.grant_details",
+    "deliver_grant_funding.list_reports",
 ]
 routes_with_expected_access_grant_funding_logged_in_access = [
     "developers.access.start_submission_redirect",

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -121,3 +121,23 @@ def get_h1_text(soup: BeautifulSoup) -> str:
 
 def get_h2_text(soup: BeautifulSoup) -> str:
     return get_soup_text(soup, "h2")
+
+
+def page_has_link(soup: BeautifulSoup, link_text: str) -> Tag | None:
+    links = soup.select("a")
+
+    for link in links:
+        if link_text in link.text:
+            return link
+
+    return None
+
+
+def page_has_button(soup: BeautifulSoup, button_text: str) -> Tag | None:
+    buttons = soup.select("button")
+
+    for button in buttons:
+        if button_text in button.text:
+            return button
+
+    return None


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-719

## 📝 Description
Adds the first part of the 'Reports' tab, which is where deliver grant funding users will see and manage monitoring reports for a grant. This is intended to serve two types of users currently: form designers (internal to Funding Service), and 'form reviewers' (grant team members). Form designers will use this tab to set up and build out monitoring reports, including configuring the data collection and setting dates for when grant recipients can provide data. Grant team members will use this for a read-only view of the report that has been set up for them, in order to validate that they're happy with it. In the long term we hope that grant team members will be able to build the reports themselves, but we're not aiming at that for MVP.

Currently, none of the links on the page are functional. These will be hooked up by future tickets that add those pages.

A followup PR will add a new column to the `Collection` table to track the 'type' of collection - which for now will just be MONITORING, but could be eg APPLICATION or PROSPECTUS as well.

## 📸 Show the thing (screenshots, gifs)

### Grant members - read only
<img width="1004" height="765" alt="image" src="https://github.com/user-attachments/assets/6734318e-4f0b-4a23-b299-7b1a1da3d37a" />

### Grant admins - read/write
<img width="1006" height="830" alt="image" src="https://github.com/user-attachments/assets/1c25002c-bd99-4472-bbbc-056fe65672be" />

## 🧪 Testing
<!-- Describe how you've tested this change, and how a reviewer can test it -->

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- [x] No N+1 query problems introduced
- [x] Any new DB queries include appropriate where clauses based on the user's permissions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested