### PR TITLE
Add types to split collections

### DIFF
--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -23,6 +23,7 @@ from app.common.data.models import (
 )
 from app.common.data.models_user import User
 from app.common.data.types import (
+    CollectionType,
     ExpressionType,
     QuestionDataType,
     QuestionPresentationOptions,
@@ -40,8 +41,8 @@ if TYPE_CHECKING:
     from app.common.expressions.managed import ManagedExpression
 
 
-def create_collection(*, name: str, user: User, grant: Grant, version: int = 1) -> Collection:
-    collection = Collection(name=name, created_by=user, grant=grant, version=version, slug=slugify(name))
+def create_collection(*, name: str, user: User, grant: Grant, version: int = 1, type_: CollectionType) -> Collection:
+    collection = Collection(name=name, created_by=user, grant=grant, version=version, slug=slugify(name), type=type_)
     db.session.add(collection)
 
     try:

--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-020_add_question_options
+021_add_collection_type

--- a/app/common/data/migrations/versions/021_add_collection_type.py
+++ b/app/common/data/migrations/versions/021_add_collection_type.py
@@ -1,0 +1,36 @@
+"""add collection types
+
+Revision ID: 021_add_collection_type
+Revises: 020_add_question_options
+Create Date: 2025-07-28 18:38:08.362357
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import text
+
+revision = "021_add_collection_type"
+down_revision = "020_add_question_options"
+branch_labels = None
+depends_on = None
+
+collection_type_enum = sa.Enum("MONITORING_REPORT", name="collection_type")
+
+
+def upgrade() -> None:
+    collection_type_enum.create(op.get_bind())
+    with op.batch_alter_table("collection", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("type", collection_type_enum, nullable=True))
+
+    op.execute(text("UPDATE collection SET type='MONITORING_REPORT' WHERE type IS NULL"))
+
+    with op.batch_alter_table("collection", schema=None) as batch_op:
+        batch_op.alter_column("type", nullable=False, existing_nullable=True)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("collection", schema=None) as batch_op:
+        batch_op.drop_column("type")
+
+    collection_type_enum.drop(op.get_bind())

--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -11,6 +11,7 @@ from sqlalchemy_json import mutable_json_type
 from app.common.data.base import BaseModel, CIStr
 from app.common.data.models_user import Invitation, User
 from app.common.data.types import (
+    CollectionType,
     ExpressionType,
     ManagedExpressionsEnum,
     QuestionDataType,
@@ -54,6 +55,10 @@ class Grant(BaseModel):
         viewonly=True,
     )
 
+    @property
+    def reports(self) -> list["Collection"]:
+        return [collection for collection in self.collections if collection.type == CollectionType.MONITORING_REPORT]
+
 
 class Organisation(BaseModel):
     __tablename__ = "organisation"
@@ -70,6 +75,8 @@ class Collection(BaseModel):
     # NOTE: The ID provided by the BaseModel should *NOT CHANGE* when incrementing the version. That part is a stable
     #       identifier for linked collection/versioning.
     version: Mapped[int] = mapped_column(default=1, primary_key=True)
+
+    type: Mapped[CollectionType] = mapped_column(SqlEnum(CollectionType, name="collection_type", validate_strings=True))
 
     # Name will be superseded by domain specific application contexts but allows us to
     # try out different collections and scenarios

--- a/app/common/data/types.py
+++ b/app/common/data/types.py
@@ -88,6 +88,10 @@ class SubmissionEventKey(enum.StrEnum):
     SUBMISSION_SUBMITTED = "Submission submitted"
 
 
+class CollectionType(enum.StrEnum):
+    MONITORING_REPORT = "monitoring report"
+
+
 class ExpressionType(enum.StrEnum):
     CONDITION = "CONDITION"
     VALIDATION = "VALIDATION"

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_reports.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_reports.html
@@ -17,11 +17,10 @@
   </div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      {% if not grant.collections %}
+      {% if not grant.reports %}
         <p class="govuk-body">This grant has no monitoring reports.</p>
       {% else %}
-        {# TODO: Add a `reports` property to the grant which filters this down based on a (to be added) CollectionType enum #}
-        {% for report in grant.collections %}
+        {% for report in grant.reports %}
           {% set formSectionsAndTasksText %}
             {% if grant_admin %}
               {% if report.forms | length == 0 %}
@@ -63,8 +62,8 @@
       {% if grant_admin %}
         {{
           govukButton({
-            "text": "Add a monitoring report" if not grant.collections else "Add another monitoring report",
-            "classes": "" if not grant.collections else "govuk-button--secondary",
+            "text": "Add a monitoring report" if not grant.reports else "Add another monitoring report",
+            "classes": "" if not grant.reports else "govuk-button--secondary",
             "href": "#"
           })
         }}

--- a/app/developers/data/grants.json
+++ b/app/developers/data/grants.json
@@ -8,6 +8,7 @@
           "id": "4e8f04f8-57c2-0399-464b-e62ff96b684a",
           "name": "Report on cheeseboards in parks",
           "slug": "report-on-cheeseboards-in-parks",
+          "type": "monitoring report",
           "version": 1
         }
       ],
@@ -1354,6 +1355,7 @@
           "id": "157b21fd-4d7e-0dfe-0e4a-0b8d0d35353b",
           "name": "Report on picnic areas in parks",
           "slug": "report-on-picnic-areas-in-parks",
+          "type": "monitoring report",
           "version": 1
         }
       ],
@@ -1465,6 +1467,7 @@
           "id": "920d3faf-c082-b34a-1cec-6d8db9a72dea",
           "name": "Report on playgrounds in parks",
           "slug": "report-on-playgrounds-in-parks",
+          "type": "monitoring report",
           "version": 1
         }
       ],
@@ -1621,7 +1624,7 @@
       "azure_ad_subject_id": "40e16bf9d02fa7f67c6bb767b197e544",
       "email": "sclark@test.communities.gov.uk",
       "id": "9ab212ee-6716-4921-b6a2-61a684bf2fe3",
-      "last_logged_in_at_utc": "Mon, 14 Jul 2025 10:00:46 GMT",
+      "last_logged_in_at_utc": "Mon, 28 Jul 2025 21:50:10 GMT",
       "name": "Willie Brown"
     }
   ]

--- a/app/developers/deliver_routes.py
+++ b/app/developers/deliver_routes.py
@@ -44,6 +44,7 @@ from app.common.data.interfaces.temporary import (
     delete_section,
 )
 from app.common.data.types import (
+    CollectionType,
     ExpressionType,
     FormRunnerState,
     QuestionDataType,
@@ -117,7 +118,7 @@ def setup_collection(grant_id: UUID) -> ResponseReturnValue:
         try:
             assert form.name.data is not None
             user = interfaces.user.get_current_user()
-            create_collection(name=form.name.data, user=user, grant=grant)
+            create_collection(name=form.name.data, user=user, grant=grant, type_=CollectionType.MONITORING_REPORT)
             return redirect(url_for("developers.deliver.grant_developers", grant_id=grant_id))
         except DuplicateValueError as e:
             field_with_error: Field = getattr(form, e.field_name)

--- a/app/developers/templates/developers/deliver/grant_developers.html
+++ b/app/developers/templates/developers/deliver/grant_developers.html
@@ -38,10 +38,10 @@
     <div class="govuk-grid-column-full">
       <h2 class="govuk-heading-m govuk-!-margin-top-4">Reports</h2>
 
-      {% if not grant.collections %}
+      {% if not grant.reports %}
         <p class="govuk-body">This grant has no monitoring reports.</p>
       {% else %}
-        {% for collection in grant.collections %}
+        {% for collection in grant.reports %}
           {% set collection_link %}
             <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('developers.deliver.manage_collection_tasks', grant_id=grant.id, collection_id=collection.id) }}">{{ collection.name }}</a>
           {% endset %}
@@ -116,8 +116,8 @@
 
       {{
         govukButton({
-          "text": "Add a monitoring report" if not grant.collections else "Add another monitoring report",
-          "classes": "" if not grant.collections else "govuk-button--secondary",
+          "text": "Add a monitoring report" if not grant.reports else "Add another monitoring report",
+          "classes": "" if not grant.reports else "govuk-button--secondary",
           "href": url_for("developers.deliver.setup_collection", grant_id = grant.id)
         })
       }}

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -39,6 +39,7 @@ from app.common.data.interfaces.collections import (
 from app.common.data.interfaces.exceptions import DuplicateValueError
 from app.common.data.models import Collection, DataSourceItem, Expression
 from app.common.data.types import (
+    CollectionType,
     ExpressionType,
     ManagedExpressionsEnum,
     QuestionDataType,
@@ -79,7 +80,7 @@ class TestCreateCollection:
     def test_create_collection(self, db_session, factories):
         g = factories.grant.create()
         u = factories.user.create()
-        collection = create_collection(name="test collection", user=u, grant=g)
+        collection = create_collection(name="test collection", user=u, grant=g, type_=CollectionType.MONITORING_REPORT)
         assert collection is not None
         assert collection.id is not None
         assert collection.slug == "test-collection"
@@ -92,26 +93,28 @@ class TestCreateCollection:
         u = factories.user.create()
 
         # Check collection created initially
-        create_collection(name="test_collection", user=u, grant=grants[0])
+        create_collection(name="test_collection", user=u, grant=grants[0], type_=CollectionType.MONITORING_REPORT)
 
         # Check same name in a different grant is allowed
-        collection_same_name_different_grant = create_collection(name="test_collection", user=u, grant=grants[1])
+        collection_same_name_different_grant = create_collection(
+            name="test_collection", user=u, grant=grants[1], type_=CollectionType.MONITORING_REPORT
+        )
         assert collection_same_name_different_grant.id is not None
 
         # Check same name in the same grant is allowed with a different version
         collection_same_name_different_version = create_collection(
-            name="test_collection", user=u, grant=grants[0], version=2
+            name="test_collection", user=u, grant=grants[0], version=2, type_=CollectionType.MONITORING_REPORT
         )
         assert collection_same_name_different_version.id is not None
 
         # Check same name in the same grant is not allowed with the same version
         with pytest.raises(DuplicateValueError):
-            create_collection(name="test_collection", user=u, grant=grants[0])
+            create_collection(name="test_collection", user=u, grant=grants[0], type_=CollectionType.MONITORING_REPORT)
 
     def test_creates_default_section(self, db_session, factories):
         g = factories.grant.create()
         u = factories.user.create()
-        collection = create_collection(name="test collection", user=u, grant=g)
+        collection = create_collection(name="test collection", user=u, grant=g, type_=CollectionType.MONITORING_REPORT)
         assert collection.has_non_default_sections is False
         assert len(collection.sections) == 1
         assert collection.sections[0].title == "Tasks"

--- a/tests/models.py
+++ b/tests/models.py
@@ -41,6 +41,7 @@ from app.common.data.models import (
 )
 from app.common.data.models_user import Invitation, MagicLink, User, UserRole
 from app.common.data.types import (
+    CollectionType,
     QuestionDataType,
     QuestionPresentationOptions,
     SubmissionEventKey,
@@ -144,6 +145,7 @@ class _CollectionFactory(SQLAlchemyModelFactory):
     id = factory.LazyFunction(uuid4)
     name = factory.Sequence(lambda n: "Collection %d" % n)
     slug = factory.Sequence(lambda n: "collection-%d" % n)
+    type = CollectionType.MONITORING_REPORT
 
     created_by_id = factory.LazyAttribute(lambda o: o.created_by.id)
     created_by = factory.SubFactory(_UserFactory)


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-719

## 📝 Description
We expect to have multiple kinds of collection focused on specific funding domains, such as applications, monitoring reports and maybe prospectuses. This will let us filter appropriately to get just the collections we're interested in.