### PR TITLE
FSPT-720 create monitoring reports

### DIFF
--- a/app/deliver_grant_funding/forms.py
+++ b/app/deliver_grant_funding/forms.py
@@ -339,3 +339,13 @@ class GrantAddUserForm(FlaskForm):
                 return False
 
         return True
+
+
+class SetUpReportForm(FlaskForm):
+    name = StringField(
+        "What is the name of the monitoring report?",
+        widget=GovTextInput(),
+        validators=[DataRequired("Enter a name for the monitoring report")],
+    )
+
+    submit = SubmitField("Continue and set up report", widget=GovSubmitInput())

--- a/app/deliver_grant_funding/routes/reports.py
+++ b/app/deliver_grant_funding/routes/reports.py
@@ -1,12 +1,17 @@
 from uuid import UUID
 
-from flask import render_template
+from flask import redirect, render_template, url_for
 from flask.typing import ResponseReturnValue
 
 from app.common.auth.decorators import has_grant_role
+from app.common.data import interfaces
+from app.common.data.interfaces.collections import create_collection
+from app.common.data.interfaces.exceptions import DuplicateValueError
 from app.common.data.interfaces.grants import get_grant
-from app.common.data.types import RoleEnum
+from app.common.data.types import CollectionType, RoleEnum
+from app.deliver_grant_funding.forms import SetUpReportForm
 from app.deliver_grant_funding.routes import deliver_grant_funding_blueprint
+from app.extensions import auto_commit_after_request
 
 
 @deliver_grant_funding_blueprint.route("/grant/<uuid:grant_id>/reports", methods=["GET"])
@@ -14,3 +19,27 @@ from app.deliver_grant_funding.routes import deliver_grant_funding_blueprint
 def list_reports(grant_id: UUID) -> ResponseReturnValue:
     grant = get_grant(grant_id, with_all_collections=True)
     return render_template("deliver_grant_funding/reports/list_reports.html", grant=grant)
+
+
+@deliver_grant_funding_blueprint.route("/grant/<uuid:grant_id>/set-up-report", methods=["GET", "POST"])
+@has_grant_role(RoleEnum.ADMIN)
+@auto_commit_after_request
+def set_up_report(grant_id: UUID) -> ResponseReturnValue:
+    grant = get_grant(grant_id)
+    form = SetUpReportForm()
+    if form.validate_on_submit():
+        assert form.name.data
+        try:
+            create_collection(
+                name=form.name.data,
+                user=interfaces.user.get_current_user(),
+                grant=grant,
+                type_=CollectionType.MONITORING_REPORT,
+            )
+            # TODO: Redirect to the 'view collection' page when we've added it.
+            return redirect(url_for("deliver_grant_funding.list_reports", grant_id=grant_id))
+
+        except DuplicateValueError:
+            form.name.errors.append("A report with this name already exists")  # type: ignore[attr-defined]
+
+    return render_template("deliver_grant_funding/reports/set_up_report.html", grant=grant, form=form)

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_reports.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_reports.html
@@ -29,10 +29,10 @@
                 <br />
                 Tasks are groups of questions with a common theme
               {% else %}
-                <a class="govuk-link govuk-link--no-visited-state" href="#">{{ report.tasks | length }} tasks<span class="govuk-visually-hidden"> in report for {{ report.name }}</span></a>
+                <a class="govuk-link govuk-link--no-visited-state" href="#">{{ report.forms | length }} tasks<span class="govuk-visually-hidden"> in report for {{ report.name }}</span></a>
               {% endif %}
             {% else %}
-              <a class="govuk-link govuk-link--no-visited-state" href="#">{{ report.tasks | length }} tasks<span class="govuk-visually-hidden"> in report for {{ report.name }}</span></a>
+              <a class="govuk-link govuk-link--no-visited-state" href="#">{{ report.forms | length }} tasks<span class="govuk-visually-hidden"> in report for {{ report.name }}</span></a>
             {% endif %}
           {% endset %}
 
@@ -64,7 +64,7 @@
           govukButton({
             "text": "Add a monitoring report" if not grant.reports else "Add another monitoring report",
             "classes": "" if not grant.reports else "govuk-button--secondary",
-            "href": "#"
+            "href": url_for('deliver_grant_funding.set_up_report', grant_id=grant.id)
           })
         }}
       {% endif %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/set_up_report.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/set_up_report.html
@@ -1,0 +1,21 @@
+{% extends "deliver_grant_funding/grant_base.html" %}
+
+{% set page_title = "Reports" %}
+{% set active_item_identifier = "reports" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l">{{ grant.name }}</span>
+      <form method="post" novalidate>
+        {{ form.csrf_token }}
+        {{ form.name(params={"label": {"isPageHeading": true, "classes": "govuk-label--l"} }) }}
+
+        <div class="govuk-button-group">
+          {{ form.submit }}
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for("deliver_grant_funding.list_reports", grant_id=grant.id) }}">Cancel</a>
+        </div>
+      </form>
+    </div>
+  </div>
+{% endblock content %}

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -5,7 +5,8 @@ from _pytest.fixtures import FixtureRequest
 from bs4 import BeautifulSoup
 from flask import url_for
 
-from tests.utils import page_has_link
+from app.deliver_grant_funding.forms import SetUpReportForm
+from tests.utils import AnyStringMatching, page_has_button, page_has_error, page_has_link
 
 
 class TestListReports:
@@ -32,7 +33,7 @@ class TestListReports:
         assert client.grant.name in soup.text
 
         expected_links = [
-            ("Add a monitoring report", "#"),
+            ("Add a monitoring report", AnyStringMatching(r"/grant/[a-z0-9-]{36}/set-up-report")),
         ]
         for expected_link in expected_links:
             button = page_has_link(soup, expected_link[0])
@@ -63,7 +64,7 @@ class TestListReports:
         assert grant.name in soup.text
 
         expected_links = [
-            ("Add another monitoring report", "#"),
+            ("Add another monitoring report", AnyStringMatching(r"/grant/[a-z0-9-]{36}/set-up-report")),
             ("Add tasks", "#"),
             ("Manage", "#"),
         ]
@@ -73,3 +74,72 @@ class TestListReports:
 
             if can_edit:
                 assert link.get("href") == expected_link[1]
+
+
+class TestSetUpReport:
+    def test_404(self, authenticated_grant_member_client):
+        response = authenticated_grant_member_client.get(
+            url_for("deliver_grant_funding.set_up_report", grant_id=uuid.uuid4())
+        )
+        assert response.status_code == 404
+
+    @pytest.mark.parametrize(
+        "client_fixture, can_access",
+        (
+            ("authenticated_grant_member_client", False),
+            ("authenticated_grant_admin_client", True),
+        ),
+    )
+    def test_get(self, request: FixtureRequest, client_fixture: str, can_access: bool, factories):
+        client = request.getfixturevalue(client_fixture)
+        factories.collection.create(grant=client.grant)
+
+        response = client.get(url_for("deliver_grant_funding.set_up_report", grant_id=client.grant.id))
+
+        if not can_access:
+            assert response.status_code == 403
+        else:
+            assert response.status_code == 200
+            soup = BeautifulSoup(response.data, "html.parser")
+            assert page_has_button(soup, "Continue and set up report")
+
+    @pytest.mark.parametrize(
+        "client_fixture, can_access",
+        (
+            ("authenticated_grant_member_client", False),
+            ("authenticated_grant_admin_client", True),
+        ),
+    )
+    def test_post(self, request: FixtureRequest, client_fixture: str, can_access: bool, factories, db_session):
+        client = request.getfixturevalue(client_fixture)
+        assert len(client.grant.reports) == 0
+
+        form = SetUpReportForm(data={"name": "Test monitoring report"})
+        response = client.post(
+            url_for("deliver_grant_funding.set_up_report", grant_id=client.grant.id),
+            data=form.data,
+            follow_redirects=False,
+        )
+
+        if not can_access:
+            assert response.status_code == 403
+        else:
+            assert response.status_code == 302
+            assert response.location == AnyStringMatching("/grant/[a-z0-9-]{36}/reports")
+
+            assert len(client.grant.reports) == 1
+            assert client.grant.reports[0].name == "Test monitoring report"
+            assert client.grant.reports[0].created_by == client.user
+
+    def test_post_duplicate_report_name(self, authenticated_grant_admin_client, factories):
+        factories.collection.create(grant=authenticated_grant_admin_client.grant, name="Monitoring report")
+
+        form = SetUpReportForm(data={"name": "Monitoring report"})
+        response = authenticated_grant_admin_client.post(
+            url_for("deliver_grant_funding.set_up_report", grant_id=authenticated_grant_admin_client.grant.id),
+            data=form.data,
+        )
+        soup = BeautifulSoup(response.data, "html.parser")
+
+        assert response.status_code == 200
+        assert page_has_error(soup, "A report with this name already exists")

--- a/tests/unit/test_all_routes_access.py
+++ b/tests/unit/test_all_routes_access.py
@@ -63,6 +63,7 @@ routes_with_expected_grant_admin_only_access = [
     "deliver_grant_funding.grant_change_name",
     "deliver_grant_funding.grant_change_description",
     "deliver_grant_funding.grant_change_contact",
+    "deliver_grant_funding.set_up_report",
 ]
 routes_with_expected_member_only_access = [
     "deliver_grant_funding.list_users_for_grant",


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-720

## 📝 Description
Adds a page to the 'Reports' tab where grant admins and above can create a monitoring report for the current grant.

@Kateharries - please can I get content/can you check content for the error message if a report already exists with the name they enter?

## 📸 Show the thing (screenshots, gifs)
![2025-07-28 22 57 49](https://github.com/user-attachments/assets/28c13b00-26b5-4afb-82e8-d5ed0c5024a0)

## 🧪 Testing
<!-- Describe how you've tested this change, and how a reviewer can test it -->

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- [x] No N+1 query problems introduced
- [x] Any new DB queries include appropriate where clauses based on the user's permissions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested