### PR TITLE
Make alembic-postgresql-enum a core dependency

### DIFF
--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-021_add_collection_type
+022_force_migrations

--- a/app/common/data/migrations/versions/022_force_migrations.py
+++ b/app/common/data/migrations/versions/022_force_migrations.py
@@ -1,0 +1,20 @@
+"""force db migrations on deployment
+
+Revision ID: 022_force_migrations
+Revises: 021_add_collection_type
+Create Date: 2025-07-29 09:08:42.517034
+
+"""
+
+revision = "022_force_migrations"
+down_revision = "021_add_collection_type"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ readme = "README.md"
 requires-python = "==3.13.5"
 dependencies = [
     "alembic-utils==0.8.8",
+    "alembic-postgresql-enum==1.8.0",
     "babel==2.17.0",
     "flask==3.1.1",
     "flask-babel==4.0.0",
@@ -61,7 +62,6 @@ dev = [
     "types-boto3==1.39.14",
     "freezegun==1.5.3",
     "import-linter==2.3",
-    "alembic-postgresql-enum==1.8.0",
     "ty==0.0.1a16",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -518,6 +518,7 @@ name = "funding-service"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "alembic-postgresql-enum" },
     { name = "alembic-utils" },
     { name = "babel" },
     { name = "flask" },
@@ -547,7 +548,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "alembic-postgresql-enum" },
     { name = "beautifulsoup4" },
     { name = "boto3" },
     { name = "debugpy" },
@@ -579,6 +579,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "alembic-postgresql-enum", specifier = "==1.8.0" },
     { name = "alembic-utils", specifier = "==0.8.8" },
     { name = "babel", specifier = "==2.17.0" },
     { name = "flask", specifier = "==3.1.1" },
@@ -608,7 +609,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "alembic-postgresql-enum", specifier = "==1.8.0" },
     { name = "beautifulsoup4", specifier = "==4.13.4" },
     { name = "boto3", specifier = "==1.39.14" },
     { name = "debugpy", specifier = "==1.8.15" },


### PR DESCRIPTION
We use this dependency to generate DB migrations for changes to enum types. I thought we'd only need this as a dev dependency to generate the migration, but we've just had an error on deployment after removing dev dependencies from the deployed package.

This is because we import it in `env.py`, which is loaded when running database migrations.