### PR TITLE
FSPT-723: create 'add task' page

### DIFF
--- a/app/deliver_grant_funding/forms.py
+++ b/app/deliver_grant_funding/forms.py
@@ -349,3 +349,12 @@ class SetUpReportForm(FlaskForm):
     )
 
     submit = SubmitField("Continue and set up report", widget=GovSubmitInput())
+
+
+class AddTaskForm(FlaskForm):
+    title = StringField(
+        "Task name",
+        widget=GovTextInput(),
+        validators=[DataRequired("Enter a name for the task")],
+    )
+    submit = SubmitField("Add task", widget=GovSubmitInput())

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/add_task.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/add_task.html
@@ -1,0 +1,36 @@
+{% extends "deliver_grant_funding/grant_base.html" %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+
+{% set page_title = "Reports" %}
+{% set active_item_identifier = "reports" %}
+
+{% block beforeContent %}
+  {{
+    govukBackLink({
+      "text": "Back",
+      "href": url_for('deliver_grant_funding.list_reports', grant_id=grant.id),
+    })
+  }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l">{{ grant.name }}</span>
+      <h1 class="govuk-heading-l">What is the name of the task?</h1>
+      <p class="govuk-body">Use tasks to group related questions together. This helps the person completing the form to focus on one topic or ‘task’ at a time.</p>
+
+      {# TODO/NOTE FOR CONTENT: SHOULD WE LIST THE EXISTING TASK NAMES HERE? #}
+
+      <form method="post" novalidate>
+        {{ form.csrf_token }}
+        {{ form.title(params={"label": {"classes": "govuk-visually-hidden"} }) }}
+
+        <div class="govuk-button-group">
+          {{ form.submit }}
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for("deliver_grant_funding.list_reports", grant_id=grant.id) }}">Cancel</a>
+        </div>
+      </form>
+    </div>
+  </div>
+{% endblock content %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_reports.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_reports.html
@@ -24,7 +24,7 @@
           {% set formSectionsAndTasksText %}
             {% if grant_admin %}
               {% if report.forms | length == 0 %}
-                <a class="govuk-link govuk-link--no-visited-state" href="#">Add tasks<span class="govuk-visually-hidden"> to {{ report.name }}</span></a>
+                <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.add_task', grant_id=grant.id, report_id=report.id) }}">Add tasks<span class="govuk-visually-hidden"> to {{ report.name }}</span></a>
                 to create your report
                 <br />
                 Tasks are groups of questions with a common theme

--- a/tests/unit/test_all_routes_access.py
+++ b/tests/unit/test_all_routes_access.py
@@ -65,6 +65,7 @@ routes_with_expected_grant_admin_only_access = [
     "deliver_grant_funding.grant_change_contact",
     "deliver_grant_funding.set_up_report",
     "deliver_grant_funding.manage_report",
+    "deliver_grant_funding.add_task",
 ]
 routes_with_expected_member_only_access = [
     "deliver_grant_funding.list_users_for_grant",


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-723 - part 1

## 📝 Description
Create, and hook up (for a report with 0 tasks), the 'add task' page. This takes the name for a task and creates the task in the report.

For now, it returns the user back to the 'list reports' page. The following patch will add a 'list tasks in a report' dashboard-style page, and 'add task' will then redirect there instead.

## 📸 Show the thing (screenshots, gifs)
![2025-07-30 14 54 20](https://github.com/user-attachments/assets/dcb23793-bca7-46ba-9dc4-97ef5acd9325)



## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- [x] No N+1 query problems introduced
- [x] Any new DB queries include appropriate where clauses based on the user's permissions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [x] Edge cases and error conditions are tested