### PR TITLE
FSPT-724: manage tasks in a report

### DIFF
--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_report_tasks.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_report_tasks.html
@@ -55,7 +55,7 @@
           {% endset %}
           {% set actions = [] %}
           {% if grant_admin %}
-            {% do actions.append({"text": "Manage", "visuallyHiddenText": form.title, "href": "#", "classes": "govuk-link--no-visited-state"}) %}
+            {% do actions.append({"text": "Manage", "visuallyHiddenText": form.title, "href": url_for('deliver_grant_funding.manage_form', grant_id=grant.id, form_id=form.id), "classes": "govuk-link--no-visited-state"}) %}
           {% else %}
             {# Append some empty actions in order to keep the layout visually the same - might need to think about this more when we have examples #}
             {% do actions.append({}) %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/manage_form.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/manage_form.html
@@ -1,0 +1,56 @@
+{% extends "deliver_grant_funding/grant_base.html" %}
+{% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+
+{% set page_title = "Tasks" %}
+{% set active_item_identifier = "reports" %}
+
+{% block beforeContent %}
+  {{
+    govukBackLink({
+      "text": "Back",
+      "href": url_for('deliver_grant_funding.list_report_tasks', grant_id=grant.id, report_id=db_form.section.collection_id),
+    })
+  }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if delete_form %}
+        {% set banner_html %}
+          <p class="govuk-body govuk-!-font-weight-bold">Are you sure you want to delete this task?</p>
+          <form method="post" novalidate>
+            {{ delete_form.csrf_token }}
+            <div class="govuk-button-group govuk-!-margin-bottom-0">
+              {{ delete_form.confirm_deletion(params={"text": "Yes, delete this task", "classes": "govuk-button--warning govuk-!-margin-bottom-0"}) }}
+              <a class="govuk-link govuk-link--no-visited-state govuk-!-margin-bottom-0" href="{{ url_for('deliver_grant_funding.manage_form', grant_id=grant.id, form_id=db_form.id) }}">Cancel</a>
+            </div>
+          </form>
+        {% endset %}
+
+        {{ govukNotificationBanner(params={"role": "alert", "titleText": "Important", "classes": "app-notification-banner--destructive", "html": banner_html}) }}
+      {% endif %}
+
+      <span class="govuk-caption-l">{{ db_form.title }}</span>
+      <h1 class="govuk-heading-l">Manage task</h1>
+      <form method="post" novalidate>
+        {{ form.csrf_token }}
+        {{ form.title(params={"label": {"text": "Task name"} }) }}
+
+        <div class="govuk-button-group">
+          {{ form.submit(params={"text": "Update task name"}) }}
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for("deliver_grant_funding.list_report_tasks", grant_id=db_form.section.collection.grant_id, report_id=db_form.section.collection_id) }}">Cancel</a>
+        </div>
+      </form>
+
+      {% if not db_form.live_submissions %}
+        <h2 class="govuk-heading-m govuk-!-margin-top-7">Delete task</h2>
+        <p class="govuk-body">
+          If this task is no longer needed, you can delete it.<br /><br />
+          <a class="govuk-link govuk-link--no-visited-state app-link--destructive" href="{{ url_for("deliver_grant_funding.manage_form", grant_id=grant.id, form_id=db_form.id, delete='') }}">Delete task</a>
+        </p>
+      {% endif %}
+    </div>
+  </div>
+{% endblock content %}

--- a/tests/unit/test_all_routes_access.py
+++ b/tests/unit/test_all_routes_access.py
@@ -66,6 +66,7 @@ routes_with_expected_grant_admin_only_access = [
     "deliver_grant_funding.set_up_report",
     "deliver_grant_funding.manage_report",
     "deliver_grant_funding.add_task",
+    "deliver_grant_funding.manage_form",
 ]
 routes_with_expected_member_only_access = [
     "deliver_grant_funding.list_users_for_grant",


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-724

## 📝 Description
Adds and links up a page where you can "manage" a form - rename and delete it. This lines up with the "manage report" page that lets you do the same functions.

This page is available to grant admins and above only, and only when there are no live submissions against the report yet. We want to consider report schemas immutable once submissions have started to come in against them, and plan future work to adding versioning that will let changes be made if need be.

## 📸 Show the thing (screenshots, gifs)
![2025-08-01 15 39 19](https://github.com/user-attachments/assets/b904deff-4825-4449-a21a-03147fa1f6e3)

## 🧪 Testing

1. Login as platform admin
2. Go to https://funding.communities.gov.localhost:8080/grant/caf0ce3f-5175-f69c-66a9-41e2c2245845/report/4e8f04f8-57c2-0399-464b-e62ff96b684a
3. Click one of the manage links - rename and/or delete a task
4. Use the developers tab to become a grant team member
5. Re-visit those pages - the "Manage" links have disappeared; visiting the URL directly is a 403

## 📋 Developer Checklist

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- [x] No N+1 query problems introduced
- [x] Any new DB queries include appropriate where clauses based on the user's permissions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [x] Edge cases and error conditions are tested