### PR TITLE
FSPT-727: Add 'Specifically' managed expression for Checkboxes questions

### DIFF
--- a/app/common/collections/types.py
+++ b/app/common/collections/types.py
@@ -127,8 +127,8 @@ class MultipleChoiceFromListAnswer(SubmissionAnswerBaseModel):
     def get_value_for_form(self) -> list[str]:
         return [choice["key"] for choice in self.choices]
 
-    def get_value_for_expression(self) -> list[str]:
-        return [choice["key"] for choice in self.choices]
+    def get_value_for_expression(self) -> set[str]:
+        return {choice["key"] for choice in self.choices}
 
     def get_value_for_text_export(self) -> str:
         return "\n".join(choice["label"] for choice in self.choices)

--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-023_add_checkbox_question_type
+024_add_specifically_mgd_exp

--- a/app/common/data/migrations/versions/024_add_specifically_mgd_exp.py
+++ b/app/common/data/migrations/versions/024_add_specifically_mgd_exp.py
@@ -1,0 +1,35 @@
+"""Add specifically managed expression
+
+Revision ID: 024_add_specifically_mgd_exp
+Revises: 023_add_checkbox_question_type
+Create Date: 2025-08-01 15:55:52.482930
+
+"""
+
+from alembic import op
+from alembic_postgresql_enum import TableReference
+
+revision = "024_add_specifically_mgd_exp"
+down_revision = "023_add_checkbox_question_type"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.sync_enum_values(  # ty: ignore[unresolved-attribute]
+        enum_schema="public",
+        enum_name="managed_expression_enum",
+        new_values=["GREATER_THAN", "LESS_THAN", "BETWEEN", "IS_YES", "IS_NO", "ANY_OF", "SPECIFICALLY"],
+        affected_columns=[TableReference(table_schema="public", table_name="expression", column_name="managed_name")],
+        enum_values_to_rename=[],
+    )
+
+
+def downgrade() -> None:
+    op.sync_enum_values(  # ty: ignore[unresolved-attribute]
+        enum_schema="public",
+        enum_name="managed_expression_enum",
+        new_values=["GREATER_THAN", "LESS_THAN", "BETWEEN", "IS_YES", "IS_NO", "ANY_OF"],
+        affected_columns=[TableReference(table_schema="public", table_name="expression", column_name="managed_name")],
+        enum_values_to_rename=[],
+    )

--- a/app/common/data/types.py
+++ b/app/common/data/types.py
@@ -105,6 +105,7 @@ class ManagedExpressionsEnum(enum.StrEnum):
     IS_YES = "Yes"
     IS_NO = "No"
     ANY_OF = "Any of"
+    SPECIFICALLY = "Specifically"
 
 
 class FormRunnerState(enum.StrEnum):

--- a/app/common/templates/common/partials/answers/multiple_choice_from_list.html
+++ b/app/common/templates/common/partials/answers/multiple_choice_from_list.html
@@ -1,4 +1,4 @@
-<ul class="govuk-list govuk-list--bullet">
+<ul data-testid="answer-{{ question.text }}" class="govuk-list govuk-list--bullet">
   {% for choice in answer["choices"] %}
     <li data-testid="{{ choice['label'] }}-{{ question.text }}">{{ choice["label"] }}</li>
   {% endfor %}

--- a/app/developers/data/grants.json
+++ b/app/developers/data/grants.json
@@ -17,6 +17,11 @@
           "data_source_item_id": "ec7bcf8a-d271-4ede-8f9b-7a3f7eff742e",
           "expression_id": "a360e91c-9bf9-4097-a97b-985f9879e8e5",
           "id": "a78fa3e8-0dd8-46b5-b0ea-0b74dac58826"
+        },
+        {
+          "data_source_item_id": "625963b4-06f8-44fe-bcc6-afde03b20040",
+          "expression_id": "28687a63-37b5-44f6-94a6-aa81d6310b7d",
+          "id": "d4ddbbcd-0c2b-4533-ab57-f2efccb9a6a0"
         }
       ],
       "data_source_items": [
@@ -734,6 +739,21 @@
         },
         {
           "context": {
+            "item": {
+              "key": "none-of-the-above",
+              "label": "None of the above"
+            },
+            "question_id": "e5ef3248-6c32-4554-b4a7-4d286cdb3f6a"
+          },
+          "created_by_id": "78371bda-d2e5-4113-8cee-3daad6dd55ab",
+          "id": "28687a63-37b5-44f6-94a6-aa81d6310b7d",
+          "managed_name": "Specifically",
+          "question_id": "233960c6-2eac-4bef-bccd-0f0bee3a94e8",
+          "statement": "'none-of-the-above' in q_e5ef32486c324554b4a74d286cdb3f6a",
+          "type": "CONDITION"
+        },
+        {
+          "context": {
             "question_id": "d99b94c3-66fa-4449-b4c4-ac5a2caeb8c9"
           },
           "created_by_id": "9ab212ee-6716-4921-b6a2-61a684bf2fe3",
@@ -1017,6 +1037,19 @@
           },
           "slug": "on-which-days-of-the-week-is-the-lead-contact-based-in-london",
           "text": "On which days of the week is the lead contact based in London?"
+        },
+        {
+          "data_type": "Yes or no",
+          "form_id": "615f5183-f056-42c4-acd1-23d25db5f9a3",
+          "hint": "",
+          "id": "233960c6-2eac-4bef-bccd-0f0bee3a94e8",
+          "name": "lead contact works remotely",
+          "order": 8,
+          "presentation_options": {
+            "last_data_source_item_is_distinct_from_others": false
+          },
+          "slug": "does-the-lead-contact-work-remotely",
+          "text": "Does the lead contact work remotely?"
         },
         {
           "data_type": "Multiple lines of text",
@@ -1692,6 +1725,13 @@
       "id": "1d652fdb-31df-479c-a39d-55300834eb8e",
       "last_logged_in_at_utc": "Thu, 03 Jul 2025 14:37:06 GMT",
       "name": "Christy Peck"
+    },
+    {
+      "azure_ad_subject_id": "789779cf9692b89ab3fd5e4d725e44c5",
+      "email": "nancy45@test.communities.gov.uk",
+      "id": "78371bda-d2e5-4113-8cee-3daad6dd55ab",
+      "last_logged_in_at_utc": "Mon, 04 Aug 2025 09:36:18 GMT",
+      "name": "Leah Hobbs"
     },
     {
       "azure_ad_subject_id": "40e16bf9d02fa7f67c6bb767b197e544",

--- a/tests/e2e/developer_pages.py
+++ b/tests/e2e/developer_pages.py
@@ -657,7 +657,10 @@ class QuestionPage(GrantDevelopersBasePage):
         self.continue_button = page.get_by_role("button", name="Continue")
 
     def respond_to_question(self, question_type: QuestionDataType, answer: str) -> None:
-        if question_type == QuestionDataType.YES_NO or question_type == QuestionDataType.RADIOS:
+        if question_type == QuestionDataType.CHECKBOXES:
+            for choice in answer:
+                self.page.get_by_role("checkbox", name=choice).click()
+        elif question_type == QuestionDataType.YES_NO or question_type == QuestionDataType.RADIOS:
             # once we start having multiple of these on a page - enjoy the refactor =]
             accessible_autocomplete = self.page.query_selector("[data-accessible-autocomplete]")
             if accessible_autocomplete:

--- a/tests/integration/common/expressions/test_registry.py
+++ b/tests/integration/common/expressions/test_registry.py
@@ -39,7 +39,7 @@ class TestManagedExpressions:
         assert get_supported_form_questions(valid_question) == [second_question]
 
     def test_new_managed_expressions_added(self):
-        assert len(_registry_by_expression_enum) == 6, (
+        assert len(_registry_by_expression_enum) == 7, (
             "If you've added a new managed expression, update this test and add"
             "suitable tests in `tests/integration/common/expressions/test_managed.py`"
         )

--- a/tests/integration/common/helpers/test_collections.py
+++ b/tests/integration/common/helpers/test_collections.py
@@ -269,7 +269,7 @@ class TestSubmissionHelper:
                         "q_d696aebc49d24170a92fb6ef42994298": "my-key",
                         "q_d696aebc49d24170a92fb6ef42994299": "name@example.com",
                         "q_d696aebc49d24170a92fb6ef4299429a": "https://example.com",
-                        "q_d696aebc49d24170a92fb6ef4299429b": ["cheddar", "stilton"],
+                        "q_d696aebc49d24170a92fb6ef4299429b": {"cheddar", "stilton"},
                     }
                 )
             )

--- a/tests/integration/developers/test_deliver_routes.py
+++ b/tests/integration/developers/test_deliver_routes.py
@@ -1,6 +1,5 @@
 import csv
 from io import StringIO
-from typing import cast
 
 from bs4 import BeautifulSoup
 from flask import url_for
@@ -11,7 +10,6 @@ from app.common.data.models import Collection, Expression, Form, Grant, Question
 from app.common.data.types import ExpressionType
 from app.common.expressions.managed import AnyOf
 from app.deliver_grant_funding.forms import CollectionForm, FormForm, QuestionForm, QuestionTypeForm, SectionForm
-from app.types import TRadioItem
 from tests.utils import get_h1_text, get_h2_text, get_soup_text
 
 
@@ -638,13 +636,10 @@ def test_edit_question_post_raises_referenced_data_items_exception(
                 AnyOf(
                     question_id=referenced_question.id,
                     items=[
-                        cast(
-                            TRadioItem,
-                            {
-                                "key": referenced_question.data_source.items[0].key,
-                                "label": referenced_question.data_source.items[0].label,
-                            },
-                        )
+                        {
+                            "key": referenced_question.data_source.items[0].key,
+                            "label": referenced_question.data_source.items[0].label,
+                        }
                     ],
                 ),
                 factories.user.create(),


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-727

## 📝 Description

👉  [First PR adding checkboxes](https://github.com/communitiesuk/funding-service/pull/575)

Adds support for a new managed expression type, `Specifically`, for use with Checkbox questions. 

This can be used for conditional routing to allow the form designer to select exactly one option from a list the list of data source items from a checkbox question type - if the user selects that option (singly or amongst other selected options) then the expression evaluates to True and the conditional question is shown.

_NB. Yes, 'Specifically' is not a nice name for it, I agree, but having spent more time than I should have thinking about it I couldn't come up with an alternative that worked as well - `OneOf` suggests that it could be one or more of the subset of options, `Exactly` suggests mathematical equality._

## 📸 Show the thing (screenshots, gifs)
### Add condition on Checkboxes question type and show routing
![2025-08-04 11 51 53](https://github.com/user-attachments/assets/df1fb0d7-8ff4-4e61-9835-9bc73e5f16ee)

### Show expected errors when trying to delete options/question that is referenced in conditions
![2025-08-04 11 57 56](https://github.com/user-attachments/assets/9fe468b6-b6fc-41e2-a49e-f40740bbb0db)


## 🧪 Testing
- Add a checkbox question type
- Add a subsequent question (any type)
- Add a condition to the subsequent question targeting the checkbox question type and select one of the data list options for the condition
- Test the form and check that the routing works as expected (should display the conditional question if the user selects only the specified option or selects it as part of a number of checkbox choices)
- Try to edit the original question and delete the option on which the condition relies and see that you get an error
- Try to delete the original question and see that you get an error that other questions depend on it

## 📋 Developer Checklist

### Review Readiness
- [X] PR title and description provide sufficient context for reviewers
- [X] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- ~[ ] No N+1 query problems introduced~
- ~[ ] Any new DB queries include appropriate where clauses based on the user's permissions~

### Testing
- [X] I have tested this change and it meets the acceptance criteria for the ticket
- [X] I need the reviewer(s) to pull and run this change locally
- [X] New (non-developer) functionality has appropriate unit and integration tests
- [X] End-to-end tests have been updated (if applicable)
- [X] Edge cases and error conditions are tested

## 📚 Additional Notes

