### PR TITLE
Make dependency error banners red again

### DIFF
--- a/app/assets/main.scss
+++ b/app/assets/main.scss
@@ -179,3 +179,12 @@ $app-destructive-link-active-colour: $govuk-text-colour;
 .move-up-down-link-hidden {
   visibility: hidden;
 }
+
+.app-notification-banner--destructive {
+  border-color: $govuk-error-colour;
+  background-color: $govuk-error-colour;
+
+  .app-notification-banner__link {
+    @include govuk-link-style-error;
+  }
+}

--- a/app/developers/templates/developers/deliver/macros/dependency_banner.html
+++ b/app/developers/templates/developers/deliver/macros/dependency_banner.html
@@ -21,5 +21,5 @@
     {% endif %}
   {% endset %}
 
-  {{ govukNotificationBanner(params={"role": "alert", "titleText": "Warning", "classes": "", "html": banner_html}) }}
+  {{ govukNotificationBanner(params={"role": "alert", "titleText": "Warning", "classes": "app-notification-banner--destructive", "html": banner_html}) }}
 {% endmacro %}


### PR DESCRIPTION
Meant to remove this for the 'delete [thing]' popups, but not the error message banners

| Before | After |
|---|---|
| <img width="710" height="364" alt="image" src="https://github.com/user-attachments/assets/8f22b7b2-c53f-468a-8c6a-43bf043b02fa" /> | <img width="721" height="357" alt="image" src="https://github.com/user-attachments/assets/4083d6d2-7457-412b-a26d-f4be51c200cb" /> |