### PR TITLE
Fix references for none of the above

### DIFF
--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -345,7 +345,7 @@ class Question(BaseModel, SafeQidMixin):
         ):
             return self.data_source.items[-1].label
 
-        return None
+        return "None of the above"
 
     __table_args__ = (
         UniqueConstraint("order", "form_id", name="uq_question_order_form", deferrable=True),

--- a/app/developers/data/grants.json
+++ b/app/developers/data/grants.json
@@ -16,12 +16,17 @@
         {
           "data_source_item_id": "ec7bcf8a-d271-4ede-8f9b-7a3f7eff742e",
           "expression_id": "a360e91c-9bf9-4097-a97b-985f9879e8e5",
-          "id": "a78fa3e8-0dd8-46b5-b0ea-0b74dac58826"
+          "id": "c98f8f94-c698-42f4-8748-efd4b7fc0fd0"
+        },
+        {
+          "data_source_item_id": "819b2684-b5d9-4141-b397-e657121d9e5e",
+          "expression_id": "4c912286-fe91-4299-bad9-dc177509032f",
+          "id": "b5d8b403-90f0-422e-b696-4bebb79e2912"
         },
         {
           "data_source_item_id": "625963b4-06f8-44fe-bcc6-afde03b20040",
           "expression_id": "28687a63-37b5-44f6-94a6-aa81d6310b7d",
-          "id": "d4ddbbcd-0c2b-4533-ab57-f2efccb9a6a0"
+          "id": "63c275ff-a415-4aa3-a00a-bfafad6efb07"
         }
       ],
       "data_source_items": [

--- a/tests/integration/common/data/test_models.py
+++ b/tests/integration/common/data/test_models.py
@@ -50,14 +50,14 @@ class TestQuestionModel:
             data_type=QuestionDataType.RADIOS,
             presentation_options=QuestionPresentationOptions(last_data_source_item_is_distinct_from_others=False),
         )
-        other_question = factories.question.create()
+        other_question = factories.question.create(data_type=QuestionDataType.TEXT_MULTI_LINE)
 
         assert question.data_source_items == "Option 0\nOption 1\nOption 2"
         assert other_question.data_source_items is None
 
         assert question.separate_option_if_no_items_match is False
         assert other_question.separate_option_if_no_items_match is None
-        assert question.none_of_the_above_item_text is None
+        assert question.none_of_the_above_item_text == "None of the above"
         assert other_question.none_of_the_above_item_text is None
 
     def test_data_source_items_last_item_is_distinct(self, factories):


### PR DESCRIPTION
And re-export them

We were not getting the dependency error banners for "none of the above", and that value was not being pre-populated as default for the "none of the above" option.