### PR TITLE
Add the 'view task' page

### DIFF
--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/change_form_name.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/change_form_name.html
@@ -1,30 +1,32 @@
 {% extends "deliver_grant_funding/grant_base.html" %}
-{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/breadcrumbs/macro.html" import govukBreadcrumbs %}
 
 {% set page_title = "Tasks" %}
 {% set active_item_identifier = "reports" %}
 
 {% block beforeContent %}
   {{
-    govukBackLink({
-      "text": "Back",
-      "href": url_for('deliver_grant_funding.list_report_tasks', grant_id=grant.id, report_id=db_form.section.collection_id),
+    govukBreadcrumbs(params={
+      "items": [
+        {"text": "Reports", "href": url_for("deliver_grant_funding.list_reports", grant_id=grant.id)},
+        {"text": db_form.section.collection.name, "href": url_for("deliver_grant_funding.list_report_tasks", grant_id=grant.id, report_id=db_form.section.collection_id)},
+        {"text": db_form.title, "href": url_for("deliver_grant_funding.list_task_questions", grant_id=grant.id, form_id=db_form.id)},
+        {"text": "Task name"},
+      ],
     })
   }}
-{% endblock %}
+{% endblock beforeContent %}
 
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-l">{{ db_form.title }}</span>
-      <h1 class="govuk-heading-l">Manage task</h1>
       <form method="post" novalidate>
         {{ form.csrf_token }}
-        {{ form.title(params={"label": {"text": "Task name"} }) }}
+        {{ form.title(params={"label": {"text": "Update task name", "isPageHeading": true, "classes": "govuk-label--l"} }) }}
 
         <div class="govuk-button-group">
           {{ form.submit(params={"text": "Update task name"}) }}
-          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for("deliver_grant_funding.list_report_tasks", grant_id=db_form.section.collection.grant_id, report_id=db_form.section.collection_id) }}">Cancel</a>
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for("deliver_grant_funding.list_task_questions", grant_id=grant.id, form_id=db_form.id) }}">Cancel</a>
         </div>
       </form>
     </div>

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_report_tasks.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_report_tasks.html
@@ -58,7 +58,7 @@
         {% set rows = [] %}
         {% for form in report.forms %}
           {% set taskHtml %}
-            <a class="govuk-link govuk-link--no-visited-state" href="#">{{ form.title }}</a>
+            <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.list_task_questions', grant_id=grant.id, form_id=form.id) }}">{{ form.title }}</a>
           {% endset %}
           {% set questionsHtml %}
             {{ form.questions | length }}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_task_questions.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_task_questions.html
@@ -1,0 +1,112 @@
+{% extends "deliver_grant_funding/grant_base.html" %}
+{% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
+{% from "govuk_frontend_jinja/components/breadcrumbs/macro.html" import govukBreadcrumbs %}
+{% from "govuk_frontend_jinja/components/tag/macro.html" import govukTag %}
+{% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
+
+{% set page_title = "Reports" %}
+{% set active_item_identifier = "reports" %}
+{% set grant_admin = authorisation_helper.is_grant_admin(grant.id, current_user) %}
+
+{% block beforeContent %}
+  {{
+    govukBreadcrumbs(params={
+      "items": [
+        {"text": "Reports", "href": url_for("deliver_grant_funding.list_reports", grant_id=grant.id)},
+        {"text": db_form.section.collection.name, "href": url_for("deliver_grant_funding.list_report_tasks", grant_id=grant.id, report_id=db_form.section.collection_id)},
+        {"text": db_form.title},
+      ],
+    })
+  }}
+{% endblock beforeContent %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if delete_form %}
+        {% set banner_html %}
+          <p class="govuk-body govuk-!-font-weight-bold">Are you sure you want to delete this task?</p>
+          <form method="post" novalidate>
+            {{ delete_form.csrf_token }}
+            <div class="govuk-button-group govuk-!-margin-bottom-0">
+              {{ delete_form.confirm_deletion(params={"text": "Yes, delete this task", "classes": "govuk-button--warning govuk-!-margin-bottom-0"}) }}
+              <a class="govuk-link govuk-link--no-visited-state govuk-!-margin-bottom-0" href="{{ url_for('deliver_grant_funding.list_task_questions', grant_id=grant.id, form_id=db_form.id) }}">Cancel</a>
+            </div>
+          </form>
+        {% endset %}
+
+        {{ govukNotificationBanner(params={"role": "alert", "titleText": "Important", "classes": "", "html": banner_html}) }}
+      {% endif %}
+
+      <h1 class="govuk-heading-l">{{ db_form.title }}</h1>
+    </div>
+    <div class="govuk-grid-column-one-third govuk-!-text-align-right">
+      <button class="govuk-button govuk-button--secondary" disabled>Preview task</button>
+    </div>
+  </div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <h2 class="govuk-heading-m govuk-!-margin-top-5">Questions</h2>
+      {% if not db_form.questions %}
+        <p class="govuk-body">This task has no questions.</p>
+      {% else %}
+        {% set rows = [] %}
+        {% for question in db_form.questions %}
+          {% set keyHtml %}
+            {% if grant_admin %}
+              {# TODO: link it up #}
+              {{ question.text }}
+            {% else %}
+              {{ question.text }}
+            {% endif %}
+            {% if question.conditions %}
+              {{
+                govukTag({
+                  "text": "Conditional",
+                  "classes": "govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-top-1",
+                })
+              }}
+            {% endif %}
+          {% endset %}
+
+          {% set actions = [] %}
+          {% if grant_admin and db_form.questions|length > 1 %}
+            {# TODO: implement this #}
+            {#
+            {% do actions.append({"text": "Move up", "visuallyHiddenText": db_form.title, "href": url_for('deliver_grant_funding.move_question', grant_id=grant.id, question_id=question.id, direction='up'), "classes": "govuk-link--no-visited-state" ~ (" move-up-down-link-hidden" if loop.first else ""), "attributes": {"aria-hidden": true} if loop.first else {} }) %}
+            {% do actions.append({"text": "Move down", "visuallyHiddenText": db_form.title, "href": url_for('deliver_grant_funding.move_question', grant_id=grant.id, question_id=question.id, direction='down'), "classes": "govuk-link--no-visited-state" ~ (" move-up-down-link-hidden" if loop.last else ""), "attributes": {"aria-hidden": true} if loop.last else {} }) %}
+            #}
+          {% endif %}
+          {%
+            do rows.append(
+            {
+              "key": {"html": keyHtml, "classes": "govuk-!-font-weight-regular govuk-!-width-one-half"},
+              "value": {"text": question.data_type, "classes": "govuk-!-width-one-third" if not actions else ""},
+              "actions": {
+                "items": actions,
+              } if actions else {},
+            })
+          %}
+        {% endfor %}
+
+        {{
+          govukSummaryList({
+            "rows": rows
+          })
+        }}
+      {% endif %}
+
+      {# TODO: add a[nother] question #}
+    </div>
+    {% if grant_admin %}
+      <div class="govuk-grid-column-full">
+        <h2 class="govuk-heading-m govuk-!-margin-top-5">Manage</h2>
+
+        <ul class="govuk-list govuk-list--spaced">
+          <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for("deliver_grant_funding.change_form_name", grant_id=grant.id, form_id=db_form.id) }}">Change task name</a></li>
+          <li><a class="govuk-link govuk-link--no-visited-state" href="?delete">Delete task</a></li>
+        </ul>
+      </div>
+    {% endif %}
+  </div>
+{% endblock content %}

--- a/tests/unit/test_all_routes_access.py
+++ b/tests/unit/test_all_routes_access.py
@@ -73,6 +73,7 @@ routes_with_expected_member_only_access = [
     "deliver_grant_funding.grant_details",
     "deliver_grant_funding.list_reports",
     "deliver_grant_funding.list_report_tasks",
+    "deliver_grant_funding.list_task_questions",
 ]
 routes_with_expected_access_grant_funding_logged_in_access = [
     "developers.access.start_submission_redirect",


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-743

## 📝 Description
Adds a page to the Reports tab that lets users:

- see the questions in that task 
- links off to the 'change task name' page 
- delete the task altogether

For now, we don't have any add/edit/view question pages, so the question texts aren't linked. But eventually they'll link off there.

This page will also let a form designer reorder questions (move them up/down). We'll add support for this separately.

**To be added in future tickets/PRs**: move up/down links, previewing the report, adding/editing questions

## 📸 Show the thing (screenshots, gifs)

### Grant admin
<img width="1034" height="1005" alt="image" src="https://github.com/user-attachments/assets/8326ee86-5681-4808-9b55-320f84721c47" />

### Grant team member
<img width="1026" height="838" alt="image" src="https://github.com/user-attachments/assets/206b068a-b167-4095-8cd9-aea7a04af0b1" />


## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [x] Edge cases and error conditions are tested