### PR TITLE
FSPT-728: move up/down for tasks and questions

### DIFF
--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_report_tasks.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_report_tasks.html
@@ -75,8 +75,8 @@
           {% endset %}
           {% set actions = [] %}
           {% if grant_admin and report.forms|length > 1 %}
-            {% do actions.append({"text": "Move up", "visuallyHiddenText": form.title, "href": "#", "classes": "govuk-link--no-visited-state" ~ (" move-up-down-link-hidden" if loop.first else ""), "attributes": {"aria-hidden": true} if loop.first else {} }) %}
-            {% do actions.append({"text": "Move down", "visuallyHiddenText": form.title, "href": "#", "classes": "govuk-link--no-visited-state" ~ (" move-up-down-link-hidden" if loop.last else ""), "attributes": {"aria-hidden": true} if loop.last else {} }) %}
+            {% do actions.append({"text": "Move up", "visuallyHiddenText": form.title, "href": url_for('deliver_grant_funding.move_task', grant_id=grant.id, form_id=form.id, direction='up'), "classes": "govuk-link--no-visited-state" ~ (" move-up-down-link-hidden" if loop.first else ""), "attributes": {"aria-hidden": true} if loop.first else {} }) %}
+            {% do actions.append({"text": "Move down", "visuallyHiddenText": form.title, "href": url_for('deliver_grant_funding.move_task', grant_id=grant.id, form_id=form.id, direction='down'), "classes": "govuk-link--no-visited-state" ~ (" move-up-down-link-hidden" if loop.last else ""), "attributes": {"aria-hidden": true} if loop.last else {} }) %}
           {% else %}
             {# Append some empty actions in order to keep the layout visually the same - might need to think about this more when we have examples #}
             {% do actions.append({}) %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_task_questions.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_task_questions.html
@@ -3,6 +3,7 @@
 {% from "govuk_frontend_jinja/components/breadcrumbs/macro.html" import govukBreadcrumbs %}
 {% from "govuk_frontend_jinja/components/tag/macro.html" import govukTag %}
 {% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
+{% from "developers/deliver/macros/dependency_banner.html" import dependency_banner %}
 
 {% set page_title = "Reports" %}
 {% set active_item_identifier = "reports" %}
@@ -44,6 +45,12 @@
         {{ govukNotificationBanner(params={"role": "alert", "titleText": "Important", "classes": "", "html": banner_html}) }}
       {% endif %}
 
+      {% with flashes = get_flashed_messages(category_filter=[enum.flash_message_type.DEPENDENCY_ORDER_ERROR.value]) %}
+        {% if flashes %}
+          {{ dependency_banner(flashes[0], grant.id, db_form.section.collection.id, db_form.section.id, db_form.id) }}
+        {% endif %}
+      {% endwith %}
+
       <h1 class="govuk-heading-l">{{ db_form.title }}</h1>
     </div>
     <div class="govuk-grid-column-one-third govuk-!-text-align-right">
@@ -80,11 +87,8 @@
 
           {% set actions = [] %}
           {% if grant_admin and db_form.questions|length > 1 %}
-            {# TODO: implement this #}
-            {#
             {% do actions.append({"text": "Move up", "visuallyHiddenText": db_form.title, "href": url_for('deliver_grant_funding.move_question', grant_id=grant.id, question_id=question.id, direction='up'), "classes": "govuk-link--no-visited-state" ~ (" move-up-down-link-hidden" if loop.first else ""), "attributes": {"aria-hidden": true} if loop.first else {} }) %}
             {% do actions.append({"text": "Move down", "visuallyHiddenText": db_form.title, "href": url_for('deliver_grant_funding.move_question', grant_id=grant.id, question_id=question.id, direction='down'), "classes": "govuk-link--no-visited-state" ~ (" move-up-down-link-hidden" if loop.last else ""), "attributes": {"aria-hidden": true} if loop.last else {} }) %}
-            #}
           {% endif %}
           {%
             do rows.append(

--- a/app/developers/templates/developers/deliver/macros/dependency_banner.html
+++ b/app/developers/templates/developers/deliver/macros/dependency_banner.html
@@ -2,6 +2,7 @@
 
 {# todo: its not nice that we have to pass around so much contexts - we shouldnt need this much to route #}
 {% macro dependency_banner(error, grant_id, collection_id, section_id, form_id) %}
+  {# TODO: point these at deliver_grant_funding endpoints when we build them #}
   {% set question_link = url_for("developers.deliver.edit_question", grant_id=grant_id, collection_id=collection_id, section_id=section_id, form_id=form_id, question_id=error.question_id) %}
   {% set depends_on_link = url_for("developers.deliver.edit_question", grant_id=grant_id, collection_id=collection_id, section_id=section_id, form_id=form_id, question_id=error.depends_on_question_id) %}
 
@@ -21,5 +22,5 @@
     {% endif %}
   {% endset %}
 
-  {{ govukNotificationBanner(params={"role": "alert", "titleText": "Warning", "classes": "app-notification-banner--destructive", "html": banner_html}) }}
+  {{ govukNotificationBanner(params={"role": "alert", "titleText": "Error", "classes": "app-notification-banner--destructive", "html": banner_html}) }}
 {% endmacro %}

--- a/tests/integration/developers/test_deliver_routes.py
+++ b/tests/integration/developers/test_deliver_routes.py
@@ -669,7 +669,7 @@ def test_edit_question_post_raises_referenced_data_items_exception(
     assert result.status_code == 200
 
     soup = BeautifulSoup(result.data, "html.parser")
-    assert get_h2_text(soup) == "Warning"
+    assert get_h2_text(soup) == "Error"
     assert "You cannot delete or change an option that other questions depend on" in get_soup_text(soup, "p")
     assert f"Depends on the options: {referenced_question.data_source.items[0].label}" in [
         p.text for p in soup.find_all("p")

--- a/tests/unit/test_all_routes_access.py
+++ b/tests/unit/test_all_routes_access.py
@@ -67,6 +67,8 @@ routes_with_expected_grant_admin_only_access = [
     "deliver_grant_funding.change_report_name",
     "deliver_grant_funding.add_task",
     "deliver_grant_funding.change_form_name",
+    "deliver_grant_funding.move_task",
+    "deliver_grant_funding.move_question",
 ]
 routes_with_expected_member_only_access = [
     "deliver_grant_funding.list_users_for_grant",


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-728

## 📝 Description
Adds/enables functionality for moving tasks and questions up and down in the list.

## 📸 Show the thing (screenshots, gifs)
![2025-08-06 19 25 44](https://github.com/user-attachments/assets/deee0d12-5959-43e9-878d-ac3e21ae2b8e)


## 🧪 Testing
- Move some tasks and questions up and down :)

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [x] Edge cases and error conditions are tested