### PR TITLE
Lift tasks out of summary card

### DIFF
--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_report_tasks.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_report_tasks.html
@@ -44,7 +44,7 @@
 
       <h1 class="govuk-heading-l">
         <span class="govuk-caption-l">{{ report.name }}</span>
-        Monitoring report tasks
+        Tasks
       </h1>
     </div>
     <div class="govuk-grid-column-one-third govuk-!-text-align-right">
@@ -60,7 +60,7 @@
         <p class="govuk-body">This monitoring report has no tasks.</p>
         {% if grant_admin %}
           <p class="govuk-body">
-            <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.add_task', grant_id=grant.id, report_id=report.id) }}"> Add a task </a>
+            <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.add_task', grant_id=grant.id, report_id=report.id) }}">Add a task</a>
           </p>
         {% endif %}
       {% else %}
@@ -96,17 +96,13 @@
 
         {{
           govukSummaryList({
-            "card": {
-              "title": {"text": "Tasks"},
-              "actions": {
-                "items": [
-                  {"text": "Add another task", "href": url_for("deliver_grant_funding.add_task", grant_id=grant.id, report_id=report.id), "classes": "govuk-link--no-visited-state"}
-                ] if grant_admin else [],
-               }
-            },
             "rows": rows
           })
         }}
+      {% endif %}
+
+      {% if grant_admin %}
+        <a class="govuk-button govuk-button--secondary" href="{{ url_for('deliver_grant_funding.add_task', grant_id=grant.id, report_id=report.id) }}">Add another task</a>
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
We're no longer allowing multiple sections in a report, based on our current understanding of reporting needs. Given this, we can just use a summary list component rather than a summary card (which is aimed at showing multiple similar lists on the page).


## 📸 Show the thing (screenshots, gifs)

### Before
<img width="1036" height="799" alt="image" src="https://github.com/user-attachments/assets/de9aaee4-d9f5-4397-8dfc-0b483da1c0b4" />


### After
<img width="1060" height="769" alt="image" src="https://github.com/user-attachments/assets/bd9607a8-19c4-448b-8ffc-30f8901f759d" />
