### PR TITLE
Make data source item keys case insensitive

### DIFF
--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-024_add_specifically_mgd_exp
+025_ds_item_key_case_insensitive

--- a/app/common/data/migrations/versions/025_ds_item_key_case_insensitive.py
+++ b/app/common/data/migrations/versions/025_ds_item_key_case_insensitive.py
@@ -1,0 +1,26 @@
+"""make data source item keys case insensitive
+
+Revision ID: 025_ds_item_key_case_insensitive
+Revises: 024_add_specifically_mgd_exp
+Create Date: 2025-08-07 15:05:03.406920
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "025_ds_item_key_case_insensitive"
+down_revision = "024_add_specifically_mgd_exp"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("data_source_item", schema=None) as batch_op:
+        batch_op.alter_column("key", existing_type=sa.VARCHAR(), type_=postgresql.CITEXT(), existing_nullable=False)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("data_source_item", schema=None) as batch_op:
+        batch_op.alter_column("key", existing_type=postgresql.CITEXT(), type_=sa.VARCHAR(), existing_nullable=False)

--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -461,7 +461,7 @@ class DataSourceItem(BaseModel):
 
     data_source_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("data_source.id"))
     order: Mapped[int]
-    key: Mapped[str]
+    key: Mapped[CIStr]
     label: Mapped[str]
 
     data_source: Mapped[DataSource] = relationship("DataSource", back_populates="items", uselist=False)


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
It is very unlikely (and probably a mistake) if someone enters two data source items with just case differences.