### PR TITLE
Export as CSV from the reports tab

### DIFF
--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -388,6 +388,7 @@ class CollectionHelper:
         ]
 
     def generate_csv_content_for_all_submissions(self) -> str:
+        # TODO: make me generate rows (yield) rather than hold everything in memory
         metadata_headers = ["Submission reference", "Created by", "Created at"]
         question_headers = {
             question.id: f"[{question.form.title}] {question.name}"

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_submissions.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_submissions.html
@@ -36,7 +36,7 @@
         {{
           govukButton({
             "text": "Export as CSV",
-            "href": "#",
+            "href": url_for("deliver_grant_funding.export_report_submissions", grant_id=grant.id, report_id=report.id, submission_mode=submission_mode, export_format='csv'),
             "classes": "govuk-button--secondary govuk-!-margin-bottom-2",
             "disabled": true
           })

--- a/tests/unit/test_all_routes_access.py
+++ b/tests/unit/test_all_routes_access.py
@@ -81,6 +81,7 @@ routes_with_expected_member_only_access = [
     "deliver_grant_funding.check_your_answers",
     "deliver_grant_funding.list_submissions",
     "deliver_grant_funding.view_submission",
+    "deliver_grant_funding.export_report_submissions",
 ]
 
 routes_with_expected_access_grant_funding_logged_in_access = [


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
Adds an initial pass of exporting a CSV of all submissions to the reports tab. This endpoint is not really optimised at all - we'll have to keep an eye on it as the number of submissions/etc grows. 