### PR TITLE
FSPT-727: Add and update tests for report previews

### DIFF
--- a/tests/integration/deliver_grant_funding/routes/test_runner.py
+++ b/tests/integration/deliver_grant_funding/routes/test_runner.py
@@ -1,0 +1,477 @@
+import pytest
+from _pytest.fixtures import FixtureRequest
+from bs4 import BeautifulSoup
+from flask import url_for
+
+from app.common.data.types import ExpressionType, SubmissionModeEnum
+
+
+class TestSubmissionTasklist:
+    @pytest.mark.parametrize(
+        "client_fixture, can_preview",
+        (
+            ("authenticated_no_role_client", False),
+            ("authenticated_grant_member_client", True),
+            ("authenticated_grant_admin_client", True),
+        ),
+    )
+    def test_get_submission_tasklist(self, request: FixtureRequest, client_fixture: str, can_preview: bool, factories):
+        client = request.getfixturevalue(client_fixture)
+        grant = getattr(client, "grant", None) or factories.grant.create()
+        question = factories.question.create(form__title="Colour information", form__section__collection__grant=grant)
+        submission = factories.submission.create(collection=question.form.section.collection, created_by=client.user)
+
+        response = client.get(
+            url_for(
+                "deliver_grant_funding.submission_tasklist",
+                grant_id=grant.id,
+                submission_id=submission.id,
+            )
+        )
+        if not can_preview:
+            assert response.status_code == 403
+        else:
+            assert response.status_code == 200
+            soup = BeautifulSoup(response.data, "html.parser")
+            assert "Colour information" in soup.text
+            assert "Not started" in soup.text
+
+    @pytest.mark.parametrize(
+        "client_fixture",
+        (
+            ("authenticated_no_role_client"),
+            ("authenticated_grant_member_client"),
+            ("authenticated_grant_admin_client"),
+        ),
+    )
+    def test_get_other_users_submission_tasklist_403s(self, request: FixtureRequest, client_fixture: str, factories):
+        client = request.getfixturevalue(client_fixture)
+        grant = getattr(client, "grant", None) or factories.grant.create()
+        question = factories.question.create(form__title="Colour information", form__section__collection__grant=grant)
+
+        generic_user = factories.user.create()
+        generic_submission = factories.submission.create(
+            collection=question.form.section.collection, created_by=generic_user
+        )
+
+        response = client.get(
+            url_for(
+                "deliver_grant_funding.submission_tasklist",
+                grant_id=grant.id,
+                submission_id=generic_submission.id,
+            )
+        )
+        assert response.status_code == 403
+
+    @pytest.mark.parametrize(
+        "client_fixture, can_preview",
+        (
+            ("authenticated_no_role_client", False),
+            ("authenticated_grant_member_client", True),
+            ("authenticated_grant_admin_client", True),
+        ),
+    )
+    def test_post_submission_tasklist_test(
+        self, request: FixtureRequest, client_fixture: str, can_preview: bool, factories
+    ):
+        client = request.getfixturevalue(client_fixture)
+        grant = getattr(client, "grant", None) or factories.grant.create()
+        question = factories.question.create(form__title="Colour information", form__section__collection__grant=grant)
+        submission_data = {str(question.id): "test answer"}
+        submission = factories.submission.create(
+            collection=question.form.section.collection, created_by=client.user, data=submission_data
+        )
+        factories.submission_event.create(created_by=client.user, submission=submission, form=question.form)
+
+        with client.session_transaction() as session:
+            session["test_submission_form_id"] = question.form.id
+
+        response = client.post(
+            url_for(
+                "deliver_grant_funding.submission_tasklist",
+                grant_id=grant.id,
+                submission_id=submission.id,
+                form_id=question.form.id,
+            ),
+            data={"submit": True},
+            follow_redirects=False,
+        )
+        if not can_preview:
+            assert response.status_code == 403
+        else:
+            assert response.status_code == 302
+            expected_location = url_for(
+                "deliver_grant_funding.return_from_test_submission",
+                collection_id=question.form.section.collection.id,
+                finished=1,
+            )
+            assert response.location == expected_location
+
+    @pytest.mark.parametrize(
+        "client_fixture, can_preview",
+        (
+            ("authenticated_no_role_client", False),
+            ("authenticated_grant_member_client", True),
+            ("authenticated_grant_admin_client", True),
+        ),
+    )
+    def test_post_submission_tasklist_live(
+        self, request: FixtureRequest, client_fixture: str, can_preview: bool, factories
+    ):
+        client = request.getfixturevalue(client_fixture)
+        grant = getattr(client, "grant", None) or factories.grant.create()
+        question = factories.question.create(form__title="Colour information", form__section__collection__grant=grant)
+        submission_data = {str(question.id): "test answer"}
+        submission = factories.submission.create(
+            collection=question.form.section.collection,
+            mode=SubmissionModeEnum.LIVE,
+            created_by=client.user,
+            data=submission_data,
+        )
+        factories.submission_event.create(created_by=client.user, submission=submission, form=question.form)
+
+        response = client.post(
+            url_for(
+                "deliver_grant_funding.submission_tasklist",
+                grant_id=grant.id,
+                submission_id=submission.id,
+                form_id=question.form.id,
+            ),
+            data={"submit": True},
+            follow_redirects=False,
+        )
+        if not can_preview:
+            assert response.status_code == 403
+        else:
+            assert response.status_code == 302
+            expected_location = url_for(
+                "deliver_grant_funding.list_report_tasks",
+                grant_id=grant.id,
+                report_id=submission.collection.id,
+            )
+            assert response.location == expected_location
+
+
+class TestAskAQuestion:
+    @pytest.mark.parametrize(
+        "client_fixture, can_preview",
+        (
+            ("authenticated_no_role_client", False),
+            ("authenticated_grant_member_client", True),
+            ("authenticated_grant_admin_client", True),
+        ),
+    )
+    def test_get_ask_a_question(self, request: FixtureRequest, client_fixture: str, can_preview: bool, factories):
+        client = request.getfixturevalue(client_fixture)
+        grant = getattr(client, "grant", None) or factories.grant.create()
+        question = factories.question.create(
+            text="What's your favourite colour?",
+            form__title="Colour information",
+            form__section__collection__grant=grant,
+        )
+        submission = factories.submission.create(collection=question.form.section.collection, created_by=client.user)
+
+        response = client.get(
+            url_for(
+                "deliver_grant_funding.ask_a_question",
+                grant_id=grant.id,
+                submission_id=submission.id,
+                question_id=question.id,
+            )
+        )
+        if not can_preview:
+            assert response.status_code == 403
+        else:
+            assert response.status_code == 200
+            soup = BeautifulSoup(response.data, "html.parser")
+            assert "What's your favourite colour?" in soup.text
+
+    @pytest.mark.parametrize(
+        "client_fixture",
+        (
+            ("authenticated_no_role_client"),
+            ("authenticated_grant_member_client"),
+            ("authenticated_grant_admin_client"),
+        ),
+    )
+    def test_get_other_users_ask_a_question_403s(self, request: FixtureRequest, client_fixture: str, factories):
+        client = request.getfixturevalue(client_fixture)
+        grant = getattr(client, "grant", None) or factories.grant.create()
+        question = factories.question.create(
+            text="What's your favourite colour?",
+            form__title="Colour information",
+            form__section__collection__grant=grant,
+        )
+
+        generic_user = factories.user.create()
+        generic_submission = factories.submission.create(
+            collection=question.form.section.collection, created_by=generic_user
+        )
+
+        response = client.get(
+            url_for(
+                "deliver_grant_funding.ask_a_question",
+                grant_id=grant.id,
+                submission_id=generic_submission.id,
+                question_id=question.id,
+            )
+        )
+        assert response.status_code == 403
+
+    def test_get_ask_a_question_with_failing_condition_redirects(self, authenticated_grant_admin_client, factories):
+        grant = authenticated_grant_admin_client.grant
+        user = authenticated_grant_admin_client.user
+        question = factories.question.create(form__section__collection__grant=grant)
+        submission = factories.submission.create(collection=question.form.section.collection, created_by=user)
+
+        response = authenticated_grant_admin_client.get(
+            url_for(
+                "deliver_grant_funding.ask_a_question",
+                grant_id=grant.id,
+                submission_id=submission.id,
+                question_id=question.id,
+            ),
+        )
+        assert response.status_code == 200
+
+        # the question should no longer be accessible
+        factories.expression.create(question=question, type=ExpressionType.CONDITION, statement="False")
+
+        response = authenticated_grant_admin_client.get(
+            url_for(
+                "deliver_grant_funding.ask_a_question",
+                grant_id=grant.id,
+                submission_id=submission.id,
+                question_id=question.id,
+            ),
+        )
+        assert response.status_code == 302
+        assert response.location == url_for(
+            "deliver_grant_funding.check_your_answers",
+            grant_id=grant.id,
+            submission_id=submission.id,
+            form_id=question.form.id,
+        )
+
+    @pytest.mark.parametrize(
+        "client_fixture, can_preview",
+        (
+            ("authenticated_no_role_client", False),
+            ("authenticated_grant_member_client", True),
+            ("authenticated_grant_admin_client", True),
+        ),
+    )
+    def test_post_ask_a_question(self, request: FixtureRequest, client_fixture: str, can_preview: bool, factories):
+        client = request.getfixturevalue(client_fixture)
+        grant = getattr(client, "grant", None) or factories.grant.create()
+        question = factories.question.create(
+            text="What's your favourite colour?",
+            order=0,
+            form__title="Colour information",
+            form__section__collection__grant=grant,
+        )
+        question_2 = factories.question.create(
+            text="What's your least favourite colour?",
+            order=1,
+            form=question.form,
+        )
+        submission = factories.submission.create(collection=question.form.section.collection, created_by=client.user)
+
+        # Redirect to next question on successful post
+        response = client.post(
+            url_for(
+                "deliver_grant_funding.ask_a_question",
+                grant_id=grant.id,
+                submission_id=submission.id,
+                question_id=question.id,
+            ),
+            data={"submit": True, question.safe_qid: "Blue"},
+            follow_redirects=False,
+        )
+        if not can_preview:
+            assert response.status_code == 403
+        else:
+            assert response.status_code == 302
+            expected_location = url_for(
+                "deliver_grant_funding.ask_a_question",
+                grant_id=grant.id,
+                submission_id=submission.id,
+                question_id=question_2.id,
+            )
+            assert response.location == expected_location
+
+        # Redirect to check your answers on successful post
+        response = client.post(
+            url_for(
+                "deliver_grant_funding.ask_a_question",
+                grant_id=grant.id,
+                submission_id=submission.id,
+                question_id=question_2.id,
+            ),
+            data={"submit": True, question_2.safe_qid: "Orange"},
+            follow_redirects=False,
+        )
+        if not can_preview:
+            assert response.status_code == 403
+        else:
+            assert response.status_code == 302
+            expected_location = url_for(
+                "deliver_grant_funding.check_your_answers",
+                grant_id=grant.id,
+                submission_id=submission.id,
+                form_id=question.form.id,
+            )
+            assert response.location == expected_location
+
+
+class TestCheckYourAnswers:
+    @pytest.mark.parametrize(
+        "client_fixture, can_preview",
+        (
+            ("authenticated_no_role_client", False),
+            ("authenticated_grant_member_client", True),
+            ("authenticated_grant_admin_client", True),
+        ),
+    )
+    def test_get_check_your_answers(self, request: FixtureRequest, client_fixture: str, can_preview: bool, factories):
+        client = request.getfixturevalue(client_fixture)
+        grant = getattr(client, "grant", None) or factories.grant.create()
+        question = factories.question.create(
+            text="What's your favourite colour?",
+            form__title="Colour information",
+            form__section__collection__grant=grant,
+        )
+        submission = factories.submission.create(collection=question.form.section.collection, created_by=client.user)
+
+        response = client.get(
+            url_for(
+                "deliver_grant_funding.check_your_answers",
+                grant_id=grant.id,
+                submission_id=submission.id,
+                form_id=question.form.id,
+            )
+        )
+        if not can_preview:
+            assert response.status_code == 403
+        else:
+            assert response.status_code == 200
+            soup = BeautifulSoup(response.data, "html.parser")
+            assert "Check your answers" in soup.text
+            assert "What's your favourite colour?" in soup.text
+            assert "Colour information" in soup.text
+
+    @pytest.mark.parametrize(
+        "client_fixture",
+        (
+            ("authenticated_no_role_client"),
+            ("authenticated_grant_member_client"),
+            ("authenticated_grant_admin_client"),
+        ),
+    )
+    def test_get_other_users_check_your_answers_403s(self, request: FixtureRequest, client_fixture: str, factories):
+        client = request.getfixturevalue(client_fixture)
+        grant = getattr(client, "grant", None) or factories.grant.create()
+        question = factories.question.create(
+            text="What's your favourite colour?",
+            form__title="Colour information",
+            form__section__collection__grant=grant,
+        )
+
+        generic_user = factories.user.create()
+        generic_submission = factories.submission.create(
+            collection=question.form.section.collection, created_by=generic_user
+        )
+
+        response = client.get(
+            url_for(
+                "deliver_grant_funding.check_your_answers",
+                grant_id=grant.id,
+                submission_id=generic_submission.id,
+                form_id=question.form.id,
+            )
+        )
+        assert response.status_code == 403
+
+    @pytest.mark.parametrize(
+        "client_fixture, can_preview",
+        (
+            ("authenticated_no_role_client", False),
+            ("authenticated_grant_member_client", True),
+            ("authenticated_grant_admin_client", True),
+        ),
+    )
+    def test_post_check_your_answers_complete_form(
+        self, request: FixtureRequest, client_fixture: str, can_preview: bool, factories
+    ):
+        client = request.getfixturevalue(client_fixture)
+        grant = getattr(client, "grant", None) or factories.grant.create()
+        question = factories.question.create(
+            text="What's your favourite colour?",
+            form__title="Colour information",
+            form__section__collection__grant=grant,
+        )
+        submission = factories.submission.create(collection=question.form.section.collection, created_by=client.user)
+
+        response = client.post(
+            url_for(
+                "deliver_grant_funding.check_your_answers",
+                grant_id=grant.id,
+                submission_id=submission.id,
+                form_id=question.form.id,
+            ),
+            follow_redirects=False,
+        )
+        if not can_preview:
+            assert response.status_code == 403
+        else:
+            assert response.status_code == 302
+            expected_location = url_for(
+                "deliver_grant_funding.submission_tasklist",
+                grant_id=grant.id,
+                submission_id=submission.id,
+                form_id=question.form.id,
+            )
+            assert response.location == expected_location
+
+    @pytest.mark.parametrize(
+        "client_fixture, can_preview",
+        (
+            ("authenticated_no_role_client", False),
+            ("authenticated_grant_member_client", True),
+            ("authenticated_grant_admin_client", True),
+        ),
+    )
+    def test_post_check_your_answers_complete_test_preview(
+        self, request: FixtureRequest, client_fixture: str, can_preview: bool, factories
+    ):
+        client = request.getfixturevalue(client_fixture)
+        grant = getattr(client, "grant", None) or factories.grant.create()
+        question = factories.question.create(
+            text="What's your favourite colour?",
+            form__title="Colour information",
+            form__section__collection__grant=grant,
+        )
+        submission = factories.submission.create(collection=question.form.section.collection, created_by=client.user)
+
+        with client.session_transaction() as session:
+            session["test_submission_form_id"] = question.form.id
+
+        response = client.post(
+            url_for(
+                "deliver_grant_funding.check_your_answers",
+                grant_id=grant.id,
+                submission_id=submission.id,
+                form_id=question.form.id,
+            ),
+            follow_redirects=False,
+        )
+        if not can_preview:
+            assert response.status_code == 403
+        else:
+            assert response.status_code == 302
+            expected_location = url_for(
+                "deliver_grant_funding.return_from_test_submission",
+                collection_id=question.form.section.collection.id,
+                finished=1,
+            )
+            assert response.location == expected_location

--- a/tests/integration/deliver_grant_funding/test_helpers.py
+++ b/tests/integration/deliver_grant_funding/test_helpers.py
@@ -1,0 +1,47 @@
+from app.common.data.models import (
+    Submission,
+    SubmissionEvent,
+)
+from app.common.data.types import (
+    SubmissionModeEnum,
+)
+from app.deliver_grant_funding.helpers import start_testing_submission
+from tests.utils import AnyStringMatching
+
+
+def test_start_testing_submission(authenticated_grant_admin_client, db_session, factories):
+    user = authenticated_grant_admin_client.user
+    collection = factories.collection.create(create_completed_submissions_each_question_type__test=1)
+
+    for submission in collection.test_submissions:
+        submission.created_by = user
+        factories.submission_event.create(submission=submission, created_by=submission.created_by)
+
+    old_test_submissions_from_db = db_session.query(Submission).where(Submission.mode == SubmissionModeEnum.TEST).all()
+    old_submission_events_from_db = db_session.query(SubmissionEvent).all()
+
+    assert len(old_test_submissions_from_db) == 1
+    assert len(old_submission_events_from_db) == 1
+
+    # Test that old submissions are deleted and you get redirected to the preview tasklist
+    response = start_testing_submission(collection=collection)
+    assert response.status_code == 302
+    assert response.location == AnyStringMatching("/grant/[a-z0-9-]{36}/submissions/[a-z0-9-]{36}")
+    test_submissions_from_db = db_session.query(Submission).where(Submission.mode == SubmissionModeEnum.TEST).all()
+    assert len(test_submissions_from_db) == 1
+    assert test_submissions_from_db[0].id is not old_test_submissions_from_db[0].id
+
+    # When passing a form, test that old submissions are deleted and you get redirected to the specific
+    # ask a question preview
+    form = collection.forms[0]
+    response = start_testing_submission(collection=collection, form=form)
+    assert response.status_code == 302
+    assert response.location == AnyStringMatching("/grant/[a-z0-9-]{36}/submissions/[a-z0-9-]{36}/[a-z0-9-]{36}")
+    second_test_submissions_from_db = (
+        db_session.query(Submission).where(Submission.mode == SubmissionModeEnum.TEST).all()
+    )
+    assert len(second_test_submissions_from_db) == 1
+    assert second_test_submissions_from_db[0].id not in [
+        old_test_submissions_from_db[0].id,
+        test_submissions_from_db[0].id,
+    ]

--- a/tests/integration/developers/test_deliver_routes.py
+++ b/tests/integration/developers/test_deliver_routes.py
@@ -562,7 +562,9 @@ def test_accessing_question_page_with_failing_condition_redirects(
     authenticated_platform_admin_client, factories, templates_rendered
 ):
     question = factories.question.create()
-    submission = factories.submission.create(collection=question.form.section.collection)
+    submission = factories.submission.create(
+        collection=question.form.section.collection, created_by=authenticated_platform_admin_client.user
+    )
 
     response = authenticated_platform_admin_client.get(
         url_for("developers.deliver.ask_a_question", submission_id=submission.id, question_id=question.id),

--- a/tests/models.py
+++ b/tests/models.py
@@ -679,6 +679,7 @@ class _SubmissionEventFactory(SQLAlchemyModelFactory):
     id = factory.LazyFunction(uuid4)
     key = SubmissionEventKey.FORM_RUNNER_FORM_COMPLETED
     submission = factory.SubFactory(_SubmissionFactory)
+    form = factory.SubFactory(_FormFactory)
     created_by = factory.SubFactory(_UserFactory)
 
 


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-725

## 📝 Description
We merged in the `preview report` functionality from the reports tab in order to be able to demo it at FS Show & Tell - we were confident in the functionality working for FS Admins and Grant Team members as it was essentially a lift & shift of the existing form runner preview functionality which exists for the Developers journey and Access Grant Funding.

However now that we've now moved this core functionality into the reports tab, which will be used by Grant Team members, we need some more robust testing on these routes and helper methods than we had before, and also need to secure the preview routes to only allow users to preview a submission they've created.

See comments from Sam on the first PR 👉 https://github.com/communitiesuk/funding-service/pull/594

## 📸 Show the thing (screenshots, gifs)
No screenshots (only zuul) - it's just a lot of of tests with no UI changes

## 🧪 Testing
Adding lotsa tests baby!
But also you can try creating some test submissions with a few different users locally and then URL hack to try and preview these when logged in as a different user - you should 403 for each of the preview report stages (submission tasklist, ask a question, check your answers).

## 📋 Developer Checklist

### Review Readiness
- [X] PR title and description provide sufficient context for reviewers
- [X] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- ~[ ] No N+1 query problems introduced~
- [X] Any new DB queries include appropriate where clauses based on the user's permissions

### Testing
- [X] I have tested this change and it meets the acceptance criteria for the ticket
- [X] I need the reviewer(s) to pull and run this change locally
- [X] New (non-developer) functionality has appropriate unit and integration tests
- ~[ ] End-to-end tests have been updated (if applicable)~
- [X] Edge cases and error conditions are tested

## 📚 Additional Notes
