### PR TITLE
Fix submission status on 'list submissions' page

### DIFF
--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -31,7 +31,6 @@ from app.common.data.types import (
     QuestionPresentationOptions,
     SubmissionEventKey,
     SubmissionModeEnum,
-    SubmissionStatusEnum,
 )
 from app.common.expressions.managed import BaseDataSourceManagedExpression
 from app.common.utils import slugify
@@ -168,7 +167,6 @@ def create_submission(*, collection: Collection, created_by: User, mode: Submiss
         created_by=created_by,
         mode=mode,
         data={},
-        status=SubmissionStatusEnum.NOT_STARTED,
     )
     db.session.add(submission)
     db.session.flush()

--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-027_add_group_type
+028_remove_submission_status

--- a/app/common/data/migrations/versions/028_remove_submission_status.py
+++ b/app/common/data/migrations/versions/028_remove_submission_status.py
@@ -1,0 +1,38 @@
+"""remove submission status
+
+Revision ID: 028_remove_submission_status
+Revises: 027_add_group_type
+Create Date: 2025-08-08 10:41:55.178484
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "028_remove_submission_status"
+down_revision = "027_add_group_type"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("submission", schema=None) as batch_op:
+        batch_op.drop_column("status")
+
+    sa.Enum("NOT_STARTED", "IN_PROGRESS", "COMPLETED", name="submission_status_enum").drop(op.get_bind())
+
+
+def downgrade() -> None:
+    sa.Enum("NOT_STARTED", "IN_PROGRESS", "COMPLETED", name="submission_status_enum").create(op.get_bind())
+    with op.batch_alter_table("submission", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "status",
+                postgresql.ENUM(
+                    "NOT_STARTED", "IN_PROGRESS", "COMPLETED", name="submission_status_enum", create_type=False
+                ),
+                autoincrement=False,
+                nullable=False,
+            )
+        )

--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -19,7 +19,6 @@ from app.common.data.types import (
     QuestionPresentationOptions,
     SubmissionEventKey,
     SubmissionModeEnum,
-    SubmissionStatusEnum,
     json_flat_scalars,
     json_scalars,
 )
@@ -140,9 +139,6 @@ class Submission(BaseModel):
     data: Mapped[json_scalars] = mapped_column(mutable_json_type(dbtype=JSONB, nested=True))  # type: ignore[no-untyped-call]
     mode: Mapped[SubmissionModeEnum] = mapped_column(
         SqlEnum(SubmissionModeEnum, name="submission_mode_enum", validate_strings=True)
-    )
-    status: Mapped[SubmissionStatusEnum] = mapped_column(
-        SqlEnum(SubmissionStatusEnum, name="submission_status_enum", validate_strings=True)
     )
 
     # TODO: generated and persisted human readable references for submissions

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_submissions.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_submissions.html
@@ -45,19 +45,21 @@
     </div>
     <div class="govuk-grid-column-full">
       {% set rows=[] %}
-      {% for submission in helper.submissions %}
+      {% for submission_helper in helper.submission_helpers.values() %}
         {# TODO: We should show the organisation/recipient name instead of the user's email address #}
         {% set link_to_submission %}
-          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.view_submission', grant_id=grant.id, submission_id=submission.id) }}" data-submission-link>{{ submission.created_by.email }}</a>
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.view_submission', grant_id=grant.id, submission_id=submission_helper.submission.id) }}" data-submission-link>
+            {{ submission_helper.submission.created_by.email }}
+          </a>
         {% endset %}
         {%
           do rows.append([
             {
               "html": link_to_submission,
             }, {
-              "html": status(submission.status)
+              "html": status(submission_helper.status)
             }, {
-              "text": format_date_short(submission.updated_at_utc)
+              "text": format_date_short(submission_helper.submission.updated_at_utc)
             }
           ])
         %}

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -796,7 +796,11 @@ class TestListSubmissions:
         assert "No submissions found for this monitoring report" in response.text
 
     def test_based_on_submission_mode(self, authenticated_grant_member_client, factories, db_session):
-        report = factories.collection.create(grant=authenticated_grant_member_client.grant, name="Test Report")
+        report = factories.collection.create(
+            grant=authenticated_grant_member_client.grant,
+            name="Test Report",
+            create_completed_submissions_each_question_type__test=1,
+        )
         factories.submission.create(
             collection=report, mode=SubmissionModeEnum.TEST, created_by__email="submitter-test@recipient.org"
         )
@@ -830,6 +834,11 @@ class TestListSubmissions:
         live_recipient_link = page_has_link(live_soup, "submitter-live@recipient.org")
         assert test_recipient_link.get("href") == AnyStringMatching("/grant/[a-z0-9-]{36}/submission/[a-z0-9-]{36}")
         assert live_recipient_link.get("href") == AnyStringMatching("/grant/[a-z0-9-]{36}/submission/[a-z0-9-]{36}")
+
+        test_submission_tags = test_soup.select(".govuk-tag")
+        live_submission_tags = live_soup.select(".govuk-tag")
+        assert [tag.text.strip() for tag in test_submission_tags] == ["In progress", "Not started"]
+        assert [tag.text.strip() for tag in live_submission_tags] == ["Not started"]
 
 
 class TestExportReportSubmissions:

--- a/tests/models.py
+++ b/tests/models.py
@@ -47,7 +47,6 @@ from app.common.data.types import (
     QuestionPresentationOptions,
     SubmissionEventKey,
     SubmissionModeEnum,
-    SubmissionStatusEnum,
 )
 from app.common.expressions.managed import AnyOf, BaseDataSourceManagedExpression, GreaterThan, Specifically
 from app.constants import DEFAULT_SECTION_NAME
@@ -219,7 +218,6 @@ class _CollectionFactory(SQLAlchemyModelFactory):
                 collection=obj,
                 mode=mode,
                 data=response_data,
-                status=SubmissionStatusEnum.COMPLETED,
             )
 
         if test:
@@ -341,7 +339,6 @@ class _CollectionFactory(SQLAlchemyModelFactory):
                     collection=obj,
                     mode=mode,
                     data=response_data,
-                    status=SubmissionStatusEnum.COMPLETED,
                 )
 
         _create_submission(SubmissionModeEnum.TEST, test)
@@ -445,7 +442,6 @@ class _CollectionFactory(SQLAlchemyModelFactory):
                             ]
                         ).get_value_for_submission(),
                     },
-                    status=SubmissionStatusEnum.COMPLETED,
                 )
 
         _create_submission_of_type(SubmissionModeEnum.TEST, test)
@@ -493,7 +489,6 @@ class _SubmissionFactory(SQLAlchemyModelFactory):
     id = factory.LazyFunction(uuid4)
     mode = SubmissionModeEnum.TEST
     data = factory.LazyFunction(dict)
-    status = SubmissionStatusEnum.NOT_STARTED
 
     created_by_id = factory.LazyAttribute(lambda o: o.created_by.id)
     created_by = factory.SubFactory(_UserFactory)


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
This was showing the 'status' field of the Submission DB model, rather than the generated status from the submission helper.

We also remove the 'status' column from the Submission table, since this isn't actually used everywhere. For now, we dynamically determine the status based on submission events and form data.

## Screenshots

| Before | After |
|---|---|
| <img width="999" height="401" alt="image" src="https://github.com/user-attachments/assets/035cda9d-6f80-4e64-a033-61b3fdeee33e" /> | <img width="1006" height="427" alt="image" src="https://github.com/user-attachments/assets/cf8289f5-36b9-495b-b0f8-e9a64e3839ae" /> |

## 🧪 Testing
Check the 'list/view submissions' pages in the reports tab.

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested