### PR TITLE
FSPT-605 Add group pages and macros

### DIFF
--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -26,7 +26,6 @@ from app.common.data.models import (
 from app.common.data.models_user import User
 from app.common.data.types import (
     CollectionType,
-    ComponentType,
     ExpressionType,
     QuestionDataType,
     QuestionPresentationOptions,
@@ -83,7 +82,8 @@ def get_collection(
                 joinedload(Collection.sections)
                 .joinedload(Section.forms)
                 .selectinload(Form._all_components)
-                .selectinload(Component.components.and_(Component.type == ComponentType.GROUP)),
+                # .selectinload(Component.components.and_(Component.type == ComponentType.GROUP)),
+                .selectinload(Component.components),
                 # eagerly populate the forms top level components - this is a redundant query but
                 # leaves as much as possible with the ORM
                 joinedload(Collection.sections).joinedload(Section.forms).selectinload(Form.components),
@@ -433,7 +433,7 @@ def create_question(
     hint: str,
     name: str,
     data_type: QuestionDataType,
-    parent: Optional[Group] = None,
+    parent: Optional[Component] = None,
     items: list[str] | None = None,
     presentation_options: QuestionPresentationOptions | None = None,
 ) -> Question:

--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -488,8 +488,13 @@ def create_group(form: Form, *, text: str, name: Optional[str] = None, parent: O
     return group
 
 
+# todo: rename
 def get_question_by_id(question_id: UUID) -> Question:
     return db.session.get_one(Question, question_id)
+
+
+def get_component_by_id(component_id: UUID) -> Component:
+    return db.session.get_one(Component, component_id)
 
 
 class FlashableException(Protocol):

--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -326,6 +326,10 @@ class Component(BaseModel):
     def container(self) -> Union["Group", "Form"]:
         return self.parent or self.form
 
+    @property
+    def is_group(self) -> bool:
+        return isinstance(self, Group)
+
     __table_args__ = (
         UniqueConstraint("order", "parent_id", "form_id", name="uq_component_order_form", deferrable=True),
         UniqueConstraint("slug", "form_id", name="uq_component_slug_form"),

--- a/app/common/templates/common/macros/move-up-down-table.html
+++ b/app/common/templates/common/macros/move-up-down-table.html
@@ -1,6 +1,6 @@
 {# todo: I think all of this can be accomplished by overriding some design system classes #}
 {#       which would allow us to use the standard summary list macro with a few style changes #}
-{% macro moveUpDownTable(table_rows) %}
+{% macro table(table_rows) %}
   <dl class="govuk-summary-list app-move-up-down-table">
     {% for row in table_rows %}
       <div class="govuk-summary-list__row app-move-up-down-table__row">
@@ -39,4 +39,54 @@
       </div>
     {% endfor %}
   </dl>
+{% endmacro %}
+
+{# knows how to diplay a summary card or flat list of components #}
+{% macro moveUpDownTable(table_rows, component=None) %}
+  {% if component.is_group %}
+    <div class="govuk-summary-card">
+      <div class="govuk-summary-card__title-wrapper">
+        <h2 class="govuk-summary-card__title">
+          {{ component.name }}
+          {% if component.conditions %}
+            {{
+              govukTag({
+                "text": "Conditional",
+                "classes": "govuk-tag--pink govuk-!-margin-left-1",
+              })
+            }}
+          {% endif %}
+        </h2>
+        <ul class="govuk-summary-card__actions">
+          <li class="govuk-summary-card__action">
+            <a class="app-link-button" href="#">Manage group</a>
+          </li>
+          <li class="govuk-summary-card__action">
+            {# todo: this is based on the template context again, there's a way of generically passing down context #}
+            {% if component == db_form.components | first %}
+              <span class="govuk-body app-move-up-down-table__action--disabled">Move up</span>
+            {% else %}
+              <form method="POST" action="{{ url_for('developers.deliver.move_question', grant_id = grant.id, collection_id = collection.id, section_id = section.id, form_id=db_form.id, question_id=component.id, direction = 'up') }}">
+                <button type="submit" class="app-link-button">Move up</button>
+              </form>
+            {% endif %}
+          </li>
+          <li class="govuk-summary-card__action">
+            {% if component == db_form.components | last %}
+              <span class="govuk-body app-move-up-down-table__action--disabled">Move down</span>
+            {% else %}
+              <form method="POST" action="{{ url_for('developers.deliver.move_question', grant_id = grant.id, collection_id = collection.id, section_id = section.id, form_id=db_form.id, question_id=component.id, direction = 'down') }}">
+                <button type="submit" class="app-link-button">Move down</button>
+              </form>
+            {% endif %}
+          </li>
+        </ul>
+      </div>
+
+      {# todo: actions etc. should be calculated here not in the top level template #}
+      <div class="govuk-summary-card__content">{{ table(table_rows) }}</div>
+    </div>
+  {% else %}
+    {{ table(table_rows) }}
+  {% endif %}
 {% endmacro %}

--- a/app/common/templates/common/macros/move-up-down-table.html
+++ b/app/common/templates/common/macros/move-up-down-table.html
@@ -1,6 +1,6 @@
 {# todo: I think all of this can be accomplished by overriding some design system classes #}
 {#       which would allow us to use the standard summary list macro with a few style changes #}
-{% macro table(table_rows) %}
+{% macro table(table_rows, component=None) %}
   <dl class="govuk-summary-list app-move-up-down-table">
     {% for row in table_rows %}
       <div class="govuk-summary-list__row app-move-up-down-table__row">
@@ -38,10 +38,30 @@
         </dd>
       </div>
     {% endfor %}
+
+    {% if component %}
+      {% set form = component.form %}
+      {% set section = form.section %}
+      {% set collection = section.collection %}
+      {% set grant = collection.grant %}
+      {% set link %}
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('developers.deliver.choose_question_type', grant_id=grant.id, collection_id=collection.id, section_id=section.id, form_id=form.id, parent=component.id) }}">
+          Add question
+        </a>
+      {% endset %}
+
+      {% if table_rows %}
+        <div class="govuk-summary-list__row app-move-up-down-table__row">
+          <dt class="govuk-summary-list__value">{{ link }}</dt>
+        </div>
+      {% else %}
+        <p class="govuk-body">{{ link }}</p>
+      {% endif %}
+    {% endif %}
   </dl>
 {% endmacro %}
 
-{# knows how to diplay a summary card or flat list of components #}
+{# knows how to display a summary card or flat list of components #}
 {% macro moveUpDownTable(table_rows, component=None) %}
   {% if component.is_group %}
     {% set form = component.form %}
@@ -66,7 +86,7 @@
             <a class="app-link-button" href="#">Manage group</a>
           </li>
           <li class="govuk-summary-card__action">
-            {% if component == component.contained_by.components | first %}
+            {% if component == component.container.components | first %}
               <span class="govuk-body app-move-up-down-table__action--disabled">Move up</span>
             {% else %}
               <form method="POST" action="{{ url_for('developers.deliver.move_question', grant_id = grant.id, collection_id = collection.id, section_id = section.id, form_id=form.id, question_id=component.id, direction = 'up') }}">
@@ -75,7 +95,7 @@
             {% endif %}
           </li>
           <li class="govuk-summary-card__action">
-            {% if component == component.contained_by.components | last %}
+            {% if component == component.container.components | last %}
               <span class="govuk-body app-move-up-down-table__action--disabled">Move down</span>
             {% else %}
               <form method="POST" action="{{ url_for('developers.deliver.move_question', grant_id = grant.id, collection_id = collection.id, section_id = section.id, form_id=form.id, question_id=component.id, direction = 'down') }}">
@@ -87,7 +107,7 @@
       </div>
 
       {# todo: actions etc. should be calculated here not in the top level template #}
-      <div class="govuk-summary-card__content">{{ table(table_rows) }}</div>
+      <div class="govuk-summary-card__content">{{ table(table_rows, component) }}</div>
     </div>
   {% else %}
     {{ table(table_rows) }}

--- a/app/common/templates/common/macros/move-up-down-table.html
+++ b/app/common/templates/common/macros/move-up-down-table.html
@@ -44,6 +44,10 @@
 {# knows how to diplay a summary card or flat list of components #}
 {% macro moveUpDownTable(table_rows, component=None) %}
   {% if component.is_group %}
+    {% set form = component.form %}
+    {% set section = form.section %}
+    {% set collection = section.collection %}
+    {% set grant = collection.grant %}
     <div class="govuk-summary-card">
       <div class="govuk-summary-card__title-wrapper">
         <h2 class="govuk-summary-card__title">
@@ -62,20 +66,19 @@
             <a class="app-link-button" href="#">Manage group</a>
           </li>
           <li class="govuk-summary-card__action">
-            {# todo: this is based on the template context again, there's a way of generically passing down context #}
-            {% if component == db_form.components | first %}
+            {% if component == component.contained_by.components | first %}
               <span class="govuk-body app-move-up-down-table__action--disabled">Move up</span>
             {% else %}
-              <form method="POST" action="{{ url_for('developers.deliver.move_question', grant_id = grant.id, collection_id = collection.id, section_id = section.id, form_id=db_form.id, question_id=component.id, direction = 'up') }}">
+              <form method="POST" action="{{ url_for('developers.deliver.move_question', grant_id = grant.id, collection_id = collection.id, section_id = section.id, form_id=form.id, question_id=component.id, direction = 'up') }}">
                 <button type="submit" class="app-link-button">Move up</button>
               </form>
             {% endif %}
           </li>
           <li class="govuk-summary-card__action">
-            {% if component == db_form.components | last %}
+            {% if component == component.contained_by.components | last %}
               <span class="govuk-body app-move-up-down-table__action--disabled">Move down</span>
             {% else %}
-              <form method="POST" action="{{ url_for('developers.deliver.move_question', grant_id = grant.id, collection_id = collection.id, section_id = section.id, form_id=db_form.id, question_id=component.id, direction = 'down') }}">
+              <form method="POST" action="{{ url_for('developers.deliver.move_question', grant_id = grant.id, collection_id = collection.id, section_id = section.id, form_id=form.id, question_id=component.id, direction = 'down') }}">
                 <button type="submit" class="app-link-button">Move down</button>
               </form>
             {% endif %}

--- a/app/deliver_grant_funding/forms.py
+++ b/app/deliver_grant_funding/forms.py
@@ -209,6 +209,16 @@ class QuestionTypeForm(FlaskForm):
     submit = SubmitField(widget=GovSubmitInput())
 
 
+class GroupForm(FlaskForm):
+    name = StringField(
+        "Group name",
+        validators=[DataRequired("Enter the group name")],
+        filters=[strip_string_if_not_empty],
+        widget=GovTextInput(),
+    )
+    submit = SubmitField(widget=GovSubmitInput())
+
+
 class QuestionForm(FlaskForm):
     text = StringField(
         "What is the question?",

--- a/app/deliver_grant_funding/forms.py
+++ b/app/deliver_grant_funding/forms.py
@@ -11,7 +11,7 @@ from govuk_frontend_wtf.wtforms_widgets import (
     GovTextArea,
     GovTextInput,
 )
-from wtforms import Field
+from wtforms import Field, HiddenField
 from wtforms.fields.choices import RadioField
 from wtforms.fields.simple import BooleanField, StringField, SubmitField, TextAreaField
 from wtforms.validators import DataRequired, Email, Optional, ValidationError
@@ -205,6 +205,10 @@ class QuestionTypeForm(FlaskForm):
         validators=[DataRequired("Select a question type")],
         widget=GovRadioInput(),
         name="question type",
+    )
+    parent = HiddenField(
+        "Parent",
+        description="The parent this question will belong to. If not set the question belongs to the form directly",
     )
     submit = SubmitField(widget=GovSubmitInput())
 

--- a/app/developers/templates/developers/deliver/add_group.html
+++ b/app/developers/templates/developers/deliver/add_group.html
@@ -1,0 +1,29 @@
+{% extends "deliver_grant_funding/grant_base.html" %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+
+{% set page_title = "Add a group - " ~ db_form.title %}
+{% set active_item_identifier = "developers" %}
+
+{% block beforeContent %}
+  {# todo: when nested this will either go back to the parent or the form #}
+  {{
+    govukBackLink({
+        "text": "Back",
+        "href": url_for("developers.deliver.manage_form_questions", grant_id = grant.id, collection_id=collection.id, section_id=section.id, form_id=db_form.id, back_link="manage_section")
+    })
+  }}
+{% endblock beforeContent %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">Add Group</h1>
+
+      <form method="post" novalidate>
+        {{ form.csrf_token }}
+        {{ form.name }}
+        {{ form.submit(params={"text": "Add group"}) }}
+      </form>
+    </div>
+  </div>
+{% endblock content %}

--- a/app/developers/templates/developers/deliver/macros/component_table.html
+++ b/app/developers/templates/developers/deliver/macros/component_table.html
@@ -1,0 +1,74 @@
+{% from "common/macros/move-up-down-table.html" import moveUpDownTable with context %}
+{# todo: the historic logic is weirdly split out between the template and a macro, move all #}
+{#       of the presentation decisions into the macro (including links etc.) #}
+
+{# todo: an accurate question count - I think that could be dervied from form_db.questions | length for now #}
+{% macro component_table(components) %}
+
+  {# we put any components that aren't already grouped together into a top level group to let us use a uniform #}
+  {# component and not have conditional logic that opens tags and we can't guarantee will close them later #}
+
+  {# todo: we probably shouldn't call these "groups" as that could also refer to the group component #}
+
+  {% if components %}
+    <p class="govuk-body">This task has {% trans count=db_form.questions | length %}{{ count }} question{% pluralize %}{{ count }} questions{% endtrans %}.</p>
+
+    {% set groups = [] %}
+
+    {% for component in components %}
+      {% if component.is_group %}
+        {% do groups.append(component) %}
+      {% else %}
+        {# if the last entry was already a group or doesn't exist, we should start a new one #}
+        {% if not groups or (groups | last).is_group %}
+          {% do groups.append([ component ]) %}
+        {% else %}
+          {% do (groups | last).append(component) %}
+        {% endif %}
+      {% endif %}
+    {% endfor %}
+
+    {% for group in groups %}
+      {# we treat flat components and grouped up components differently so we keep track of that #}
+      {% set table_components = group.components if group.is_group else group %}
+      {% set table_rows = [] %}
+      {% for component in table_components %}
+        {% set question_link %}
+          <a
+            class="govuk-link govuk-link--no-visited-state"
+            href="{{ url_for('developers.deliver.edit_question', grant_id = grant.id, collection_id = collection.id, section_id = section.id, form_id=db_form.id, question_id=component.id) }}">
+            {{ component.text }}
+          </a>
+          {% if component.conditions %}
+            {{
+              govukTag({
+              "text": "Conditional",
+              "classes": "govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-top-1",
+              })
+            }}
+          {% endif %}
+        {% endset %}
+        {%
+          do table_rows.append({
+            "html": question_link,
+            "actions":[{
+                "text":"Move up",
+                "href": url_for('developers.deliver.move_question', grant_id = grant.id, collection_id = collection.id, section_id = section.id, form_id=db_form.id, question_id=component.id, direction = 'up'),"disabled": component == db_form.components | first,
+                "post": True
+                }, {
+                "href": url_for('developers.deliver.move_question', grant_id = grant.id, collection_id = collection.id, section_id = section.id, form_id=db_form.id, question_id=component.id, direction = 'down'),
+                "post": True,
+                "text": "Move down","disabled": component == db_form.components | last
+                }
+            ]
+          })
+        %}
+      {% endfor %}
+
+      {# fixme: the styling for the border top and tag spacing look broken on tablet and mobile #}
+      {{ moveUpDownTable(table_rows, group) }}
+    {% endfor %}
+  {% else %}
+    <p class="govuk-body">This task has no questions.</p>
+  {% endif %}
+{% endmacro %}

--- a/app/developers/templates/developers/deliver/macros/component_table.html
+++ b/app/developers/templates/developers/deliver/macros/component_table.html
@@ -1,3 +1,4 @@
+{% from "govuk_frontend_jinja/components/tag/macro.html" import govukTag %}
 {% from "common/macros/move-up-down-table.html" import moveUpDownTable %}
 
 {# todo: the historic logic is weirdly split out between the template and a macro, move all #}
@@ -49,12 +50,12 @@
           "html": question_link,
           "actions":[{
               "text":"Move up",
-              "href": url_for('developers.deliver.move_question', grant_id = grant.id, collection_id = collection.id, section_id = section.id, form_id=form.id, question_id=component.id, direction = 'up'),"disabled": component == component.contained_by.components | first,
+              "href": url_for('developers.deliver.move_question', grant_id = grant.id, collection_id = collection.id, section_id = section.id, form_id=form.id, question_id=component.id, direction = 'up'),"disabled": component == component.container.components | first,
               "post": True
               }, {
               "href": url_for('developers.deliver.move_question', grant_id = grant.id, collection_id = collection.id, section_id = section.id, form_id=form.id, question_id=component.id, direction = 'down'),
               "post": True,
-              "text": "Move down","disabled": component == component.contained_by.components | last
+              "text": "Move down","disabled": component == component.container.components | last
               }
           ]
         })

--- a/app/developers/templates/developers/deliver/macros/component_table.html
+++ b/app/developers/templates/developers/deliver/macros/component_table.html
@@ -1,74 +1,67 @@
-{% from "common/macros/move-up-down-table.html" import moveUpDownTable with context %}
+{% from "common/macros/move-up-down-table.html" import moveUpDownTable %}
+
 {# todo: the historic logic is weirdly split out between the template and a macro, move all #}
 {#       of the presentation decisions into the macro (including links etc.) #}
+{% macro component_table(parent) %}
+  {% set table_sections = [] %}
 
-{# todo: an accurate question count - I think that could be dervied from form_db.questions | length for now #}
-{% macro component_table(components) %}
-
-  {# we put any components that aren't already grouped together into a top level group to let us use a uniform #}
+  {# we put any components that aren't already grouped together into top level sections to let us use a uniform #}
   {# component and not have conditional logic that opens tags and we can't guarantee will close them later #}
-
-  {# todo: we probably shouldn't call these "groups" as that could also refer to the group component #}
-
-  {% if components %}
-    <p class="govuk-body">This task has {% trans count=db_form.questions | length %}{{ count }} question{% pluralize %}{{ count }} questions{% endtrans %}.</p>
-
-    {% set groups = [] %}
-
-    {% for component in components %}
-      {% if component.is_group %}
-        {% do groups.append(component) %}
+  {% for component in parent.components %}
+    {% if component.is_group %}
+      {% do table_sections.append(component) %}
+    {% else %}
+      {# if the last entry was already a group or doesn't exist, we should start a new one #}
+      {% if not table_sections or (table_sections | last).is_group %}
+        {% do table_sections.append([ component ]) %}
       {% else %}
-        {# if the last entry was already a group or doesn't exist, we should start a new one #}
-        {% if not groups or (groups | last).is_group %}
-          {% do groups.append([ component ]) %}
-        {% else %}
-          {% do (groups | last).append(component) %}
-        {% endif %}
+        {% do (table_sections | last).append(component) %}
       {% endif %}
+    {% endif %}
+  {% endfor %}
+
+  {% for section in table_sections %}
+    {# we treat flat components and grouped up components differently so we keep track of that #}
+    {% set components = section.components if section.is_group else section %}
+    {% set table_rows = [] %}
+    {% for component in components %}
+      {% set form = component.form %}
+      {% set section = form.section %}
+      {% set collection = section.collection %}
+      {% set grant = collection.grant %}
+
+
+      {% set question_link %}
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('developers.deliver.edit_question', grant_id = grant.id, collection_id = collection.id, section_id = section.id, form_id=form.id, question_id=component.id) }}">
+          {{ component.text }}
+        </a>
+        {% if component.conditions %}
+          {{
+            govukTag({
+            "text": "Conditional",
+            "classes": "govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-top-1",
+            })
+          }}
+        {% endif %}
+      {% endset %}
+      {%
+        do table_rows.append({
+          "html": question_link,
+          "actions":[{
+              "text":"Move up",
+              "href": url_for('developers.deliver.move_question', grant_id = grant.id, collection_id = collection.id, section_id = section.id, form_id=form.id, question_id=component.id, direction = 'up'),"disabled": component == component.contained_by.components | first,
+              "post": True
+              }, {
+              "href": url_for('developers.deliver.move_question', grant_id = grant.id, collection_id = collection.id, section_id = section.id, form_id=form.id, question_id=component.id, direction = 'down'),
+              "post": True,
+              "text": "Move down","disabled": component == component.contained_by.components | last
+              }
+          ]
+        })
+      %}
     {% endfor %}
 
-    {% for group in groups %}
-      {# we treat flat components and grouped up components differently so we keep track of that #}
-      {% set table_components = group.components if group.is_group else group %}
-      {% set table_rows = [] %}
-      {% for component in table_components %}
-        {% set question_link %}
-          <a
-            class="govuk-link govuk-link--no-visited-state"
-            href="{{ url_for('developers.deliver.edit_question', grant_id = grant.id, collection_id = collection.id, section_id = section.id, form_id=db_form.id, question_id=component.id) }}">
-            {{ component.text }}
-          </a>
-          {% if component.conditions %}
-            {{
-              govukTag({
-              "text": "Conditional",
-              "classes": "govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-top-1",
-              })
-            }}
-          {% endif %}
-        {% endset %}
-        {%
-          do table_rows.append({
-            "html": question_link,
-            "actions":[{
-                "text":"Move up",
-                "href": url_for('developers.deliver.move_question', grant_id = grant.id, collection_id = collection.id, section_id = section.id, form_id=db_form.id, question_id=component.id, direction = 'up'),"disabled": component == db_form.components | first,
-                "post": True
-                }, {
-                "href": url_for('developers.deliver.move_question', grant_id = grant.id, collection_id = collection.id, section_id = section.id, form_id=db_form.id, question_id=component.id, direction = 'down'),
-                "post": True,
-                "text": "Move down","disabled": component == db_form.components | last
-                }
-            ]
-          })
-        %}
-      {% endfor %}
-
-      {# fixme: the styling for the border top and tag spacing look broken on tablet and mobile #}
-      {{ moveUpDownTable(table_rows, group) }}
-    {% endfor %}
-  {% else %}
-    <p class="govuk-body">This task has no questions.</p>
-  {% endif %}
+    {# fixme: the styling for the border top and tag spacing look broken on tablet and mobile #}
+    {{ moveUpDownTable(table_rows, section) }}
+  {% endfor %}
 {% endmacro %}

--- a/app/developers/templates/developers/deliver/manage_form_questions.html
+++ b/app/developers/templates/developers/deliver/manage_form_questions.html
@@ -4,7 +4,7 @@
 {% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
 
 {# todo: ideally this just passes in what it needs but this gets us going for now #}
-{% from "developers/deliver/macros/component_table.html" import component_table with context %}
+{% from "developers/deliver/macros/component_table.html" import component_table %}
 {% extends "deliver_grant_funding/grant_base.html" %}
 
 {% set page_title = collection.name ~ " - " ~ grant.name %}
@@ -53,7 +53,12 @@
     </div>
   </div>
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">{{ component_table(db_form.components) }}</div>
+    {% if db_form.components %}
+      <p class="govuk-body">This task has {% trans count=db_form.questions | length %}{{ count }} question{% pluralize %}{{ count }} questions{% endtrans %}.</p>
+      <div class="govuk-grid-column-full">{{ component_table(db_form) }}</div>
+    {% else %}
+      <p class="govuk-body">This task has no questions.</p>
+    {% endif %}
   </div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/developers/templates/developers/deliver/manage_form_questions.html
+++ b/app/developers/templates/developers/deliver/manage_form_questions.html
@@ -1,9 +1,10 @@
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
-{% from "govuk_frontend_jinja/components/tag/macro.html" import govukTag %}
-{% from "common/macros/move-up-down-table.html" import moveUpDownTable %}
 {% from "developers/deliver/macros/dependency_banner.html" import dependency_banner %}
 {% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
+
+{# todo: ideally this just passes in what it needs but this gets us going for now #}
+{% from "developers/deliver/macros/component_table.html" import component_table with context %}
 {% extends "deliver_grant_funding/grant_base.html" %}
 
 {% set page_title = collection.name ~ " - " ~ grant.name %}
@@ -52,57 +53,28 @@
     </div>
   </div>
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      {% set table_rows = [] %}
-      {% for question in db_form.questions %}
-        {% set question_link %}
-          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('developers.deliver.edit_question', grant_id = grant.id, collection_id = collection.id, section_id = section.id, form_id=db_form.id, question_id=question.id) }}">
-            {{ question.text }}
-          </a>
-          {% if question.conditions %}
-            {{
-              govukTag({
-                "text": "Conditional",
-                "classes": "govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-top-1",
-              })
-            }}
-          {% endif %}
-        {% endset %}
-        {%
-          do table_rows.append({
-            "html": question_link,
-            "actions":[{
-                "text":"Move up",
-                "href": url_for('developers.deliver.move_question', grant_id = grant.id, collection_id = collection.id, section_id = section.id, form_id=db_form.id, question_id=question.id, direction = 'up'),"disabled":(loop.index <= 1),
-                "post": True
-              }, {
-                "href": url_for('developers.deliver.move_question', grant_id = grant.id, collection_id = collection.id, section_id = section.id, form_id=db_form.id, question_id=question.id, direction = 'down'),
-                "post": True,
-                "text": "Move down","disabled":(loop.index >= db_form.questions | length)
-              }
-            ]
-          })
-        %}
-      {% endfor %}
-
-      {% if db_form.questions %}
-        <p class="govuk-body">This task has {% trans count=db_form.questions | length %}{{ count }} question{% pluralize %}{{ count }} questions{% endtrans %}.</p>
-        {# fixme: the styling for the border top and tag spacing look broken on tablet and mobile #}
-        {{ moveUpDownTable(table_rows) }}
-      {% else %}
-        <p class="govuk-body">This task has no questions.</p>
-      {% endif %}
-    </div>
+    <div class="govuk-grid-column-full">{{ component_table(db_form.components) }}</div>
   </div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      {{
-        govukButton({
-            "text": "Add question",
-            "classes": "govuk-button--secondary" if db_form.questions else '',
-            "href": url_for("developers.deliver.choose_question_type", grant_id=grant.id, collection_id=collection.id, section_id=section.id, form_id=db_form.id),
-        })
-      }}
+      <div class="govuk-button-group">
+        {{
+          govukButton({
+              "text": "Add question",
+              "classes": "govuk-button--secondary" if db_form.questions else '',
+              "href": url_for("developers.deliver.choose_question_type", grant_id=grant.id, collection_id=collection.id, section_id=section.id, form_id=db_form.id),
+          })
+        }}
+
+        {# for now this is only shown on the manage form page #}
+        {{
+          govukButton({
+            "text": "Add group",
+            "classes": "govuk-button--secondary",
+            "href": url_for("developers.deliver.add_group", grant_id=grant.id, collection_id=collection.id, section_id=section.id, form_id=db_form.id)
+          })
+        }}
+      </div>
     </div>
   </div>
   <div class="govuk-grid-row govuk-!-margin-top-5">

--- a/app/developers/templates/developers/deliver/manage_form_questions.html
+++ b/app/developers/templates/developers/deliver/manage_form_questions.html
@@ -53,12 +53,14 @@
     </div>
   </div>
   <div class="govuk-grid-row">
-    {% if db_form.components %}
-      <p class="govuk-body">This task has {% trans count=db_form.questions | length %}{{ count }} question{% pluralize %}{{ count }} questions{% endtrans %}.</p>
-      <div class="govuk-grid-column-full">{{ component_table(db_form) }}</div>
-    {% else %}
-      <p class="govuk-body">This task has no questions.</p>
-    {% endif %}
+    <div class="govuk-grid-column-full">
+      {% if db_form.components %}
+        <p class="govuk-body">This task has {% trans count=db_form.questions | length %}{{ count }} question{% pluralize %}{{ count }} questions{% endtrans %}.</p>
+        {{ component_table(db_form) }}
+      {% else %}
+        <p class="govuk-body">This task has no questions.</p>
+      {% endif %}
+    </div>
   </div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/tests/unit/test_all_routes_access.py
+++ b/tests/unit/test_all_routes_access.py
@@ -36,6 +36,7 @@ routes_with_expected_platform_admin_only_access = [
     "developers.deliver.manage_form",
     "developers.deliver.choose_question_type",
     "developers.deliver.add_question",
+    "developers.deliver.add_group",
     "developers.deliver.move_question",
     "developers.deliver.edit_question",
     "developers.deliver.add_question_condition_select_question",


### PR DESCRIPTION
Updates the question table to include appropriately rendering groups as
summary cards.

This commit also adds the "add group" handler and tweaks the interface
actions for moving components to make sure they work generically with
both questions and groups.


https://github.com/user-attachments/assets/56946b97-28cf-4911-b842-1bbc79392c7e

