### PR TITLE
FSPT-744: add/edit question+condition+validation pages in reports tab

### DIFF
--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -762,6 +762,16 @@ def delete_form(form: Form) -> None:
     db.session.flush()
 
 
+def delete_question(question: Question) -> None:
+    raise_if_question_has_any_dependencies(question)
+    db.session.delete(question)
+    if question in question.form.questions:
+        question.form.components.remove(question)
+    question.form.components.reorder()
+    db.session.execute(text("SET CONSTRAINTS uq_component_order_form DEFERRED"))
+    db.session.flush()
+
+
 def delete_collection_test_submissions_created_by_user(collection: Collection, created_by_user: User) -> None:
     # We're trying to rely less on ORM relationships and cascades in delete queries so here we explicitly delete all
     # SubmissionEvents related to the `created_by_user`'s test submissions for that collection version, and then

--- a/app/deliver_grant_funding/forms.py
+++ b/app/deliver_grant_funding/forms.py
@@ -11,7 +11,7 @@ from govuk_frontend_wtf.wtforms_widgets import (
     GovTextArea,
     GovTextInput,
 )
-from wtforms import Field, HiddenField
+from wtforms import Field
 from wtforms.fields.choices import RadioField
 from wtforms.fields.simple import BooleanField, StringField, SubmitField, TextAreaField
 from wtforms.validators import DataRequired, Email, Optional, ValidationError
@@ -200,11 +200,10 @@ class FormForm(FlaskForm):
 
 class QuestionTypeForm(FlaskForm):
     question_data_type = RadioField(
-        "What is the type of the question?",
+        "What is the type of question?",
         choices=[(qdt.name, qdt.value) for qdt in QuestionDataType],
         validators=[DataRequired("Select a question type")],
         widget=GovRadioInput(),
-        name="question type",
     )
     parent = HiddenField(
         "Parent",
@@ -240,10 +239,10 @@ class QuestionForm(FlaskForm):
         render_kw={"params": {"rows": 2}},
     )
     name = StringField(
-        "Question name",
-        validators=[DataRequired("Enter the question name")],
+        "Question reference",
+        validators=[DataRequired("Enter the question reference")],
         description=(
-            "A short description of the answer in lower case, for example “risk category” or “contact email address”"
+            "A short name for the answer in lower case, for example “risk category” or “contact email address”"
         ),
         filters=[strip_string_if_not_empty],
         widget=GovTextInput(),

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/macros/dependency_banner.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/macros/dependency_banner.html
@@ -1,0 +1,24 @@
+{% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
+
+{% macro dependency_banner(error) %}
+  {% set question_link = url_for("deliver_grant_funding.edit_question", grant_id=error.grant_id, question_id=error.question_id) %}
+  {% set depends_on_link = url_for("deliver_grant_funding.edit_question", grant_id=error.grant_id, question_id=error.depends_on_question_id) %}
+
+
+  {% set banner_html %}
+    <p class="govuk-body govuk-!-font-weight-bold">{{ error.message }}</p>
+    <p class="govuk-body govuk-!-font-weight-bold">
+      Question:
+      <a class="govuk-notification-banner__link" href="{{ question_link }}">{{ error.question_text }}</a>
+    </p>
+    <p class="govuk-body govuk-!-font-weight-bold">
+      Depends on the answer to:
+      <a class="govuk-notification-banner__link" href="{{ depends_on_link }}">{{ error.depends_on_question_text }}</a>
+    </p>
+    {% if "depends_on_items_text" in error %}
+      <p class="govuk-body govuk-!-font-weight-bold">Depends on the options: {{ error.depends_on_items_text }}</p>
+    {% endif %}
+  {% endset %}
+
+  {{ govukNotificationBanner(params={"role": "alert", "titleText": "Error", "classes": "app-notification-banner--destructive", "html": banner_html}) }}
+{% endmacro %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/_add_question_condition_context.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/_add_question_condition_context.html
@@ -1,0 +1,14 @@
+{% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
+<h2 class="govuk-heading-m">Condition</h2>
+{{
+  govukSummaryList({
+    "rows": [{
+      "key": { "text": "The question" },
+      "value": { "text": question.text },
+    }, {
+      "key": { "text": "Depends on the answer to" },
+      "value": { "text": "(Not selected)" if not depends_on_question else depends_on_question.text },
+    }],
+    "classes": "app-!-border-top-line govuk-!-margin-bottom-8"
+  })
+}}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/_render_managed_expression_form.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/_render_managed_expression_form.html
@@ -1,0 +1,20 @@
+{% macro render_managed_expression_form(form, label_html, submit_label) %}
+  <form method="post" novalidate>
+    {{ form.csrf_token }}
+
+    {{
+      form.type(params={
+      "fieldset": {
+          "legend": {
+          "html": label_html,
+          "classes": "govuk-fieldset__legend--m",
+          "isPageHeading": False
+          },
+      },
+      "items": form.get_managed_expression_radio_conditional_items()
+      })
+    }}
+
+    {{ form.submit(params={"text": submit_label}) }}
+  </form>
+{% endmacro %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/add_question.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/add_question.html
@@ -1,0 +1,52 @@
+{% extends "deliver_grant_funding/grant_base.html" %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
+
+{% set page_title = "Add a question - " ~ db_form.title %}
+{% set active_item_identifier = "reports" %}
+
+{% block beforeContent %}
+  {{
+    govukBackLink({
+        "text": "Back",
+        "href": url_for("developers.deliver.choose_question_type", grant_id = grant.id, collection_id=collection.id, section_id=section.id, form_id=db_form.id, question_data_type=chosen_question_data_type.name, back_link="manage_section")
+    })
+  }}
+{% endblock beforeContent %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">Add question</h1>
+
+      {{
+        govukSummaryList({
+          "rows": [{
+            "key": {"text": "Question type"},
+            "value":{"text": chosen_question_data_type.value},
+            "classes": "govuk-summary-list__row--no-border"
+          }]
+        })
+      }}
+
+      <form method="post" novalidate>
+        {{ form.csrf_token }}
+        {{ form.text }}
+        {{ form.name }}
+        {{ form.hint }}
+
+        {% if chosen_question_data_type in [enum.question_type.RADIOS, enum.question_type.CHECKBOXES] %}
+          {{ form.data_source_items }}
+
+
+          {% set conditionalHtml %}
+            {{ form.none_of_the_above_item_text }}
+          {% endset %}
+          {{ form.separate_option_if_no_items_match(params={"items": [{"conditional": {"html": conditionalHtml} }]}) }}
+        {% endif %}
+
+        {{ form.submit(params={"text": "Add question"}) }}
+      </form>
+    </div>
+  </div>
+{% endblock content %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/add_question_condition_select_question.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/add_question_condition_select_question.html
@@ -1,0 +1,37 @@
+{% extends "deliver_grant_funding/grant_base.html" %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% set active_item_identifier = "reports" %}
+
+{% block pageTitle %}Add a condition - {{ question.name }} - Deliver grant funding{% endblock pageTitle %}
+
+{% block beforeContent %}
+  {{ govukBackLink({ "text": "Back", "href": url_for("deliver_grant_funding.edit_question", grant_id=grant.id, question_id=question.id) }) }}
+{% endblock beforeContent %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">Add a condition</h1>
+
+      {% include "deliver_grant_funding/reports/_add_question_condition_context.html" %}
+
+      {% if not form.question.choices %}
+        <p class="govuk-body">There are no questions in this form that can be used as a condition.</p>
+      {% else %}
+        <form method="post" novalidate>
+          {{ form.csrf_token }}
+          {{
+            form.question(params={
+              "label": {
+                "text": "What answer should the condition check?",
+                "classes": "govuk-label--m",
+                "isPageHeading": false
+              },
+            })
+          }}
+          {{ form.submit }}
+        </form>
+      {% endif %}
+    </div>
+  </div>
+{% endblock content %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/choose_question_type.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/choose_question_type.html
@@ -1,0 +1,28 @@
+{% extends "deliver_grant_funding/grant_base.html" %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+
+{% set page_title = "Add a question - " ~ db_form.title %}
+{% set active_item_identifier = "reports" %}
+
+{% block beforeContent %}
+  {{
+    govukBackLink({
+      "text": "Back",
+      "href": url_for('deliver_grant_funding.list_task_questions', grant_id=grant.id, form_id=db_form.id),
+    })
+  }}
+{% endblock beforeContent %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form method="post" novalidate>
+        {{ form.csrf_token }}
+        {{ form.form_id }}
+
+        {{ form.question_data_type(params={"fieldset": {"legend": {"text": form.question_data_type.label, "isPageHeading": true, "classes": "govuk-fieldset__legend--l"} } }) }}
+        {{ form.submit(params={"text": "Continue"}) }}
+      </form>
+    </div>
+  </div>
+{% endblock content %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/edit_question.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/edit_question.html
@@ -3,7 +3,7 @@
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
 {% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
-{% from "developers/deliver/macros/dependency_banner.html" import dependency_banner %}
+{% from "deliver_grant_funding/macros/dependency_banner.html" import dependency_banner %}
 {% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
 
 {% set page_title = "Edit question - " ~ db_form.title %}
@@ -40,7 +40,7 @@
       {% with flashes = get_flashed_messages(category_filter=[enum.flash_message_type.DEPENDENCY_ORDER_ERROR.value, enum.flash_message_type.DATA_SOURCE_ITEM_DEPENDENCY_ERROR.value]) %}
         {% if flashes %}
           {% for error in flashes %}
-            {{ dependency_banner(error, grant.id, collection.id, section.id, db_form.id) }}
+            {{ dependency_banner(error) }}
           {% endfor %}
         {% endif %}
       {% endwith %}
@@ -105,7 +105,7 @@
 
 
             {% set value_html %}
-              <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('developers.deliver.edit_question_condition', grant_id=grant.id, question_id=question.id, expression_id=condition.id) }}">
+              <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.edit_question_condition', grant_id=grant.id, question_id=question.id, expression_id=condition.id) }}">
                 <span class="govuk-visually-hidden">Change condition for</span>
                 {{ condition.managed.message }}
               </a>
@@ -120,7 +120,7 @@
           {{
             govukButton({
               "text": "Add condition",
-              "href": url_for('developers.deliver.add_question_condition_select_question', grant_id=grant.id, question_id=question.id),
+              "href": url_for('deliver_grant_funding.add_question_condition_select_question', grant_id=grant.id, question_id=question.id),
               "classes": "govuk-button--secondary",
             })
           }}
@@ -139,7 +139,7 @@
                 <span class="govuk-visually-hidden">validation</span>
               {% endset %}
               {% set value_html %}
-                <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('developers.deliver.edit_question_validation', grant_id=grant.id, question_id=question.id, expression_id=validation.id) }}" disabled>
+                <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.edit_question_validation', grant_id=grant.id, question_id=question.id, expression_id=validation.id) }}" disabled>
                   <span class="govuk-visually-hidden">Change validation for</span>
                   {{ validation.managed.message }}
                 </a>
@@ -157,7 +157,7 @@
             {{
               govukButton({
                 "text": "Add more validation" if question.validations else "Add validation",
-                "href": url_for("developers.deliver.add_question_validation", grant_id=grant.id, question_id=question.id),
+                "href": url_for("deliver_grant_funding.add_question_validation", grant_id=grant.id, question_id=question.id),
                 "classes": "govuk-button--secondary govuk-!-margin-bottom-3"
               })
             }}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/edit_question.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/edit_question.html
@@ -1,0 +1,178 @@
+{% extends "deliver_grant_funding/grant_base.html" %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
+{% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
+{% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
+{% from "developers/deliver/macros/dependency_banner.html" import dependency_banner %}
+{% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
+
+{% set page_title = "Edit question - " ~ db_form.title %}
+{% set active_item_identifier = "reports" %}
+
+{% block beforeContent %}
+  {{
+    govukBackLink({
+        "text": "Back",
+        "href": url_for("deliver_grant_funding.list_task_questions", grant_id=grant.id, form_id=db_form.id)
+    })
+  }}
+{% endblock beforeContent %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% with flashes = get_flashed_messages(category_filter=[enum.flash_message_type.QUESTION_CREATED]) %}
+        {% if flashes %}
+          {% set question_created_content %}
+            <a class="govuk-notification-banner__link" href="{{ url_for('deliver_grant_funding.list_task_questions', grant_id=grant.id, form_id=db_form.id) }}">Return to the task</a>
+            to create other questions, or stay here to add conditions and validation to this question.
+          {% endset %}
+          {{
+            govukNotificationBanner({
+              "titleText": flashes[0],
+              "html": question_created_content,
+              "type": "success"
+            })
+          }}
+        {% endif %}
+      {% endwith %}
+
+      {% with flashes = get_flashed_messages(category_filter=[enum.flash_message_type.DEPENDENCY_ORDER_ERROR.value, enum.flash_message_type.DATA_SOURCE_ITEM_DEPENDENCY_ERROR.value]) %}
+        {% if flashes %}
+          {% for error in flashes %}
+            {{ dependency_banner(error, grant.id, collection.id, section.id, db_form.id) }}
+          {% endfor %}
+        {% endif %}
+      {% endwith %}
+
+      {% if confirm_deletion_form %}
+        {% set banner_html %}
+          <p class="govuk-body govuk-!-font-weight-bold">Are you sure you want to delete this question?</p>
+          <form method="post" novalidate>
+            {{ confirm_deletion_form.csrf_token }}
+
+            <span class="govuk-button-group govuk-!-margin-bottom-0">
+              {{ confirm_deletion_form.confirm_deletion(params={"text": "Yes, delete this question", "classes": "govuk-button--warning govuk-!-margin-bottom-0"}) }}
+              <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.edit_question', grant_id=grant.id, question_id=question.id) }}">Cancel</a>
+            </span>
+          </form>
+        {% endset %}
+
+        {{ govukNotificationBanner(params={"role": "alert", "titleText": "Warning", "classes": "", "html": banner_html}) }}
+      {% endif %}
+
+      <h1 class="govuk-heading-l">Edit question</h1>
+      {{
+        govukSummaryList({
+          "rows": [{
+            "key": {"text": "Question type"},
+            "value":{"text": question.data_type.value},
+            "classes": "govuk-summary-list__row--no-border"
+          }]
+        })
+      }}
+      <form method="post" novalidate>
+        {{ form.csrf_token }}
+        {{ form.form_id }}
+        {{ form.question_data_type }}
+        {{ form.text }}
+        {{ form.name }}
+        {{ form.hint }}
+
+        {% if question.data_type in [enum.question_type.RADIOS, enum.question_type.CHECKBOXES] %}
+          {{ form.data_source_items }}
+
+
+          {% set conditionalHtml %}
+            {{ form.none_of_the_above_item_text }}
+          {% endset %}
+          {{ form.separate_option_if_no_items_match(params={"items": [{"conditional": {"html": conditionalHtml} }]}) }}
+        {% endif %}
+
+        <div class="govuk-form-group">
+          <h2 class="govuk-heading-m">Conditions</h2>
+          <p class="govuk-body">Use answers from other questions to decide if your users should be asked this question.</p>
+          {% set rows = [] %}
+          {% for condition in question.conditions %}
+            {% set managed = condition.managed %}
+            {% set depends_on = managed.referenced_question %}
+
+
+            {% set key_html %}
+              {# todo: would users find it useful to be able to link to the question being depended on from here? #}
+              <span>{{ depends_on.text }}</span>
+            {% endset %}
+
+
+            {% set value_html %}
+              <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('developers.deliver.edit_question_condition', grant_id=grant.id, question_id=question.id, expression_id=condition.id) }}">
+                <span class="govuk-visually-hidden">Change condition for</span>
+                {{ condition.managed.message }}
+              </a>
+            {% endset %}
+            {% do rows.append({ "key": { "html": key_html }, "value": { "html": value_html } }) %}
+          {% endfor %}
+
+          {% if rows %}
+            {{ govukSummaryList({ "rows": rows, "classes": "app-tasklist-builder" }) }}
+          {% endif %}
+
+          {{
+            govukButton({
+              "text": "Add condition",
+              "href": url_for('developers.deliver.add_question_condition_select_question', grant_id=grant.id, question_id=question.id),
+              "classes": "govuk-button--secondary",
+            })
+          }}
+        </div>
+        <div class="govuk-form-group">
+          <h2 class="govuk-heading-m">Validations</h2>
+          {% if managed_validation_available %}
+            <p class="govuk-body">Add validation to help users provide the correct answer to the question. The answer will be validated in the order listed.</p>
+            {% set rows = [] %}
+            {% for validation in question.validations %}
+              {% set managed = validation.managed %}
+
+              {# TODO: think more about what info to include in this summary list and how to lay it out #}
+              {% set key_html %}
+                {{ to_ordinal(loop.index) | capitalize }}
+                <span class="govuk-visually-hidden">validation</span>
+              {% endset %}
+              {% set value_html %}
+                <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('developers.deliver.edit_question_validation', grant_id=grant.id, question_id=question.id, expression_id=validation.id) }}" disabled>
+                  <span class="govuk-visually-hidden">Change validation for</span>
+                  {{ validation.managed.message }}
+                </a>
+              {% endset %}
+              {%
+                do rows.append({
+                  "key": { "html": key_html, "classes": "govuk-!-width-one-quarter" },
+                  "value": { "html": value_html },
+                })
+              %}
+            {% endfor %}
+
+            {{ govukSummaryList({ "rows": rows, "classes": "app-tasklist-builder" }) }}
+
+            {{
+              govukButton({
+                "text": "Add more validation" if question.validations else "Add validation",
+                "href": url_for("developers.deliver.add_question_validation", grant_id=grant.id, question_id=question.id),
+                "classes": "govuk-button--secondary govuk-!-margin-bottom-3"
+              })
+            }}
+          {% else %}
+            <p class="govuk-body">Validation is not available for this kind of question.</p>
+          {% endif %}
+        </div>
+
+        {{ form.submit(params={"text": "Save", "classes": "govuk-!-margin-top-3"}) }}
+      </form>
+
+      <h2 class="govuk-heading-m govuk-!-margin-top-5">Question settings</h2>
+      <p class="govuk-body">
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.edit_question', grant_id=grant.id, question_id=question.id, delete='') }}">Delete this question</a>
+      </p>
+    </div>
+  </div>
+{% endblock content %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_task_questions.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_task_questions.html
@@ -70,8 +70,7 @@
         {% for question in db_form.questions %}
           {% set keyHtml %}
             {% if grant_admin %}
-              {# TODO: link it up #}
-              {{ question.text }}
+              <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.edit_question', grant_id=grant.id, question_id=question.id) }}">{{ question.text }}</a>
             {% else %}
               {{ question.text }}
             {% endif %}
@@ -109,7 +108,7 @@
         }}
       {% endif %}
 
-      {# TODO: add a[nother] question #}
+      <a class="govuk-button govuk-button--secondary" href="{{ url_for('deliver_grant_funding.choose_question_type', grant_id=grant.id, form_id=db_form.id) }}">{{ "Add another question" if db_form.questions else "Add a question" }}</a>
     </div>
     {% if grant_admin %}
       <div class="govuk-grid-column-full">

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_task_questions.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_task_questions.html
@@ -3,7 +3,7 @@
 {% from "govuk_frontend_jinja/components/breadcrumbs/macro.html" import govukBreadcrumbs %}
 {% from "govuk_frontend_jinja/components/tag/macro.html" import govukTag %}
 {% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
-{% from "developers/deliver/macros/dependency_banner.html" import dependency_banner %}
+{% from "deliver_grant_funding/macros/dependency_banner.html" import dependency_banner %}
 
 {% set page_title = "Reports" %}
 {% set active_item_identifier = "reports" %}
@@ -47,7 +47,7 @@
 
       {% with flashes = get_flashed_messages(category_filter=[enum.flash_message_type.DEPENDENCY_ORDER_ERROR.value]) %}
         {% if flashes %}
-          {{ dependency_banner(flashes[0], grant.id, db_form.section.collection.id, db_form.section.id, db_form.id) }}
+          {{ dependency_banner(flashes[0]) }}
         {% endif %}
       {% endwith %}
 

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/manage_question_condition_select_condition_type.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/manage_question_condition_select_condition_type.html
@@ -1,0 +1,71 @@
+{% extends "deliver_grant_funding/grant_base.html" %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
+{% from "deliver_grant_funding/reports/_render_managed_expression_form.html" import render_managed_expression_form %}
+
+{% set active_item_identifier = "reports" %}
+
+{% set is_editing = expression %}
+{% set heading = "Edit condition" if is_editing else "Add a condition" %}
+{% set submit_label = "Update condition" if is_editing else "Add condition" %}
+
+{% set back_to_select_question_for_condition = url_for("deliver_grant_funding.add_question_condition_select_question", grant_id=grant.id, question_id=question.id) %}
+{% set back_to_edit_question = url_for("deliver_grant_funding.edit_question", grant_id=grant.id, question_id=question.id) %}
+{% set back_link = back_to_edit_question if is_editing else back_to_select_question_for_condition %}
+
+{% block pageTitle %}
+  Add a condition - {{ question.name }} - Deliver grant funding
+{% endblock pageTitle %}
+
+{% block beforeContent %}
+  {# todo: pressing back here should remember which question you had selected in case you want to just move one up or down in the list #}
+  {#       that would also line up with how the browsers "back" button would work (remembering form options) #}
+  {{ govukBackLink({ "text": "Back", "href": back_link }) }}
+{% endblock beforeContent %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if confirm_deletion_form %}
+        {% set banner_html %}
+          <p class="govuk-body govuk-!-font-weight-bold">Are you sure you want to delete this condition?</p>
+          <form method="post" novalidate>
+            {{ confirm_deletion_form.csrf_token }}
+            <span class="govuk-button-group">
+              {{ confirm_deletion_form.confirm_deletion(params={"text": "Yes, delete this condition", "classes": "govuk-button--warning govuk-!-margin-bottom-0"}) }}
+              <a class="govuk-link govuk-link--no-visited-state govuk-!-margin-bottom-0" href="{{ url_for('deliver_grant_funding.edit_question_condition', grant_id=grant.id, expression_id=expression.id) }}">Cancel</a>
+            </span>
+          </form>
+        {% endset %}
+
+        {{ govukNotificationBanner(params={"role": "alert", "titleText": "Warning", "classes": "", "html": banner_html}) }}
+      {% endif %}
+
+      <h1 class="govuk-heading-l">{{ heading }}</h1>
+
+      {% include "deliver_grant_funding/reports/_add_question_condition_context.html" %}
+
+      {% if form is not none %}
+        {% set label_html %}
+          Only show the question if the answer
+          <span class="govuk-visually-hidden">to {{ depends_on_question.text }}</span>
+          is
+        {% endset %}
+        {{ render_managed_expression_form(form, label_html=label_html, submit_label=submit_label) }}
+      {% else %}
+        <p class="govuk-body">This question cannot be used a condition.</p>
+      {% endif %}
+
+      {% if expression %}
+        <div class="govuk-grid-row govuk-!-margin-top-7">
+          <div class="govuk-grid-column-two-thirds">
+            <h2 class="govuk-heading-m">Condition settings</h2>
+            <p class="govuk-body">
+              <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.edit_question_condition', grant_id=grant.id, expression_id=expression.id, delete='') }}">Delete condition</a>
+            </p>
+          </div>
+        </div>
+      {% endif %}
+    </div>
+  </div>
+{% endblock content %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/manage_question_validation.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/manage_question_validation.html
@@ -1,0 +1,74 @@
+{% extends "deliver_grant_funding/grant_base.html" %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
+{% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
+{% from "deliver_grant_funding/reports/_render_managed_expression_form.html" import render_managed_expression_form %}
+
+{% set active_item_identifier = "reports" %}
+
+{% block pageTitle %}
+  Add validation - {{ question.name }} - Deliver grant funding
+{% endblock pageTitle %}
+
+{% block beforeContent %}
+  {{ govukBackLink({ "text": "Back", "href": url_for("deliver_grant_funding.edit_question", grant_id=grant.id, question_id=question.id) }) }}
+{% endblock beforeContent %}
+
+{% block content %}
+  {% set submit_label = "Edit validation" if expression else "Add validation" %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if confirm_deletion_form %}
+        {% set banner_html %}
+          <p class="govuk-body govuk-!-font-weight-bold">Are you sure you want to delete this validation?</p>
+          <form method="post" novalidate>
+            {{ confirm_deletion_form.csrf_token }}
+
+            <span class="govuk-button-group">
+              {{ confirm_deletion_form.confirm_deletion(params={"text": "Yes, delete this validation", "classes": "govuk-button--warning govuk-!-margin-bottom-0"}) }}
+              <a class="govuk-link govuk-link--no-visited-state govuk-!-margin-bottom-0" href="{{ url_for('deliver_grant_funding.edit_question_validation', grant_id=grant.id, expression_id=expression.id) }}">Cancel</a>
+            </span>
+          </form>
+        {% endset %}
+
+        {{ govukNotificationBanner(params={"role": "alert", "titleText": "Warning", "classes": "", "html": banner_html}) }}
+      {% endif %}
+
+      <h1 class="govuk-heading-l">{{ submit_label }}</h1>
+
+      {{
+        govukSummaryList({
+          "rows": [
+            {"key": {"text": "Form"}, "value": {"text": question.form.title} },
+            {"key": {"text": "Question"}, "value": {"text": question.text} },
+          ],
+          "classes": "app-!-border-top-line"
+        })
+      }}
+
+      {% if form is not none %}
+        {% set label_html %}
+          The answer to the question <span class="govuk-visually-hidden">“{{ question.text }}”</span> must be
+        {% endset %}
+
+        {{ render_managed_expression_form(form, label_html=label_html, submit_label=submit_label) }}
+
+        {% if expression %}
+          <div class="govuk-grid-row govuk-!-margin-top-7">
+            <div class="govuk-grid-column-two-thirds">
+              <h2 class="govuk-heading-m">Validation settings</h2>
+              <p class="govuk-body">
+                <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.edit_question_validation', grant_id=grant.id, question_id=question.id, expression_id=expression.id, delete='') }}"
+                  >Delete validation</a
+                >
+              </p>
+            </div>
+          </div>
+        {% endif %}
+      {% else %}
+        <p class="govuk-body">This question cannot be validated.</p>
+      {% endif %}
+    </div>
+  </div>
+{% endblock content %}

--- a/app/developers/deliver_routes.py
+++ b/app/developers/deliver_routes.py
@@ -60,6 +60,7 @@ from app.common.forms import GenericSubmitForm
 from app.common.helpers.collections import CollectionHelper, SubmissionHelper
 from app.deliver_grant_funding.forms import (
     CollectionForm,
+    ConditionSelectQuestionForm,
     FormForm,
     GroupForm,
     QuestionForm,
@@ -68,7 +69,6 @@ from app.deliver_grant_funding.forms import (
 )
 from app.developers.forms import (
     BecomeGrantTeamMemberForm,
-    ConditionSelectQuestionForm,
     ConfirmDeletionForm,
 )
 from app.developers.helpers import start_testing_submission

--- a/app/developers/forms.py
+++ b/app/developers/forms.py
@@ -5,7 +5,10 @@ from govuk_frontend_wtf.wtforms_widgets import GovSelect, GovSubmitInput
 from wtforms import Field, SelectField, SubmitField, ValidationError
 from wtforms.validators import DataRequired
 
-from app.common.data.interfaces.collections import get_question_by_id, is_component_dependency_order_valid
+from app.common.data.interfaces.collections import (
+    get_question_by_id,
+    is_component_dependency_order_valid,
+)
 from app.common.expressions.registry import get_supported_form_questions
 
 if TYPE_CHECKING:

--- a/tests/e2e/developer_pages.py
+++ b/tests/e2e/developer_pages.py
@@ -453,7 +453,7 @@ class SelectQuestionTypePage(GrantDevelopersBasePage):
             page,
             domain,
             grant_name=grant_name,
-            heading=page.get_by_role("heading", name="What is the type of the question?"),
+            heading=page.get_by_role("heading", name="What is the type of question?"),
         )
         self.section_title = section_title
         self.collection_name = collection_name
@@ -498,7 +498,7 @@ class AddQuestionDetailsPage(GrantDevelopersBasePage):
         self.page.get_by_role("textbox", name="What is the question?").fill(question_text)
 
     def fill_question_name(self, question_name: str) -> None:
-        self.page.get_by_role("textbox", name="Question name").fill(question_name)
+        self.page.get_by_role("textbox", name="Question reference").fill(question_name)
 
     def fill_question_hint(self, question_hint: str) -> None:
         self.page.get_by_role("textbox", name="Question hint").fill(question_hint)

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -255,14 +255,14 @@ def test_move_section_up_down(db_session, factories):
 
 
 class TestGetFormById:
-    def test_get_form(db_session, factories, track_sql_queries):
+    def test_get_form(self, db_session, factories, track_sql_queries):
         form = factories.form.create()
 
         # fetching the form directly
         from_db = get_form_by_id(form_id=form.id)
         assert from_db.id == form.id
 
-    def test_get_form_with_all_questions(db_session, factories, track_sql_queries):
+    def test_get_form_with_all_questions(self, db_session, factories, track_sql_queries):
         form = factories.form.create()
         question_one = factories.question.create(form=form)
         question_two = factories.question.create(form=form)
@@ -634,7 +634,7 @@ class TestUpdateQuestion:
 
         assert question.presentation_options.last_data_source_item_is_distinct_from_others is True
 
-    def test_update_radios_question_options_errors_on_referenced_data_items(db_session, factories):
+    def test_update_radios_question_options_errors_on_referenced_data_items(self, db_session, factories):
         form = factories.form.create()
         user = factories.user.create()
         referenced_question = create_question(
@@ -673,7 +673,7 @@ class TestUpdateQuestion:
             first_dependent_question and second_dependent_question in error.value.data_source_item_dependency_map.keys()
         )
 
-    def test_update_checkboxes_question_options_errors_on_referenced_data_items(db_session, factories):
+    def test_update_checkboxes_question_options_errors_on_referenced_data_items(self, db_session, factories):
         form = factories.form.create()
         user = factories.user.create()
         referenced_question = create_question(
@@ -988,7 +988,7 @@ def test_get_collection_with_full_schema(db_session, factories, track_sql_querie
 
 
 class TestExpressions:
-    def test_add_question_condition(db_session, factories):
+    def test_add_question_condition(self, db_session, factories):
         q0 = factories.question.create()
         question = factories.question.create(form=q0.form)
         user = factories.user.create()
@@ -1011,7 +1011,7 @@ class TestExpressions:
         with pytest.raises(DuplicateValueError):
             add_component_condition(question, user, managed_expression)
 
-    def test_add_radios_question_condition(db_session, factories):
+    def test_add_radios_question_condition(self, db_session, factories):
         q0 = factories.question.create(data_type=QuestionDataType.RADIOS)
         question = factories.question.create(form=q0.form)
         items = q0.data_source.items
@@ -1039,7 +1039,7 @@ class TestExpressions:
         with pytest.raises(DuplicateValueError):
             add_component_condition(question, user, managed_expression)
 
-    def test_add_checkboxes_question_condition(db_session, factories):
+    def test_add_checkboxes_question_condition(self, db_session, factories):
         q0 = factories.question.create(data_type=QuestionDataType.CHECKBOXES)
         question = factories.question.create(form=q0.form)
         items = q0.data_source.items
@@ -1063,7 +1063,7 @@ class TestExpressions:
         with pytest.raises(DuplicateValueError):
             add_component_condition(question, user, managed_expression)
 
-    def test_add_question_condition_blocks_on_order(db_session, factories):
+    def test_add_question_condition_blocks_on_order(self, db_session, factories):
         user = factories.user.create()
         q1 = factories.question.create()
         q2 = factories.question.create(form=q1.form)
@@ -1072,7 +1072,7 @@ class TestExpressions:
             add_component_condition(q1, user, GreaterThan(minimum_value=1000, question_id=q2.id))
         assert str(e.value) == "Cannot add managed condition that depends on a later question"
 
-    def test_add_question_validation(db_session, factories):
+    def test_add_question_validation(self, db_session, factories):
         question = factories.question.create()
         user = factories.user.create()
 
@@ -1091,7 +1091,7 @@ class TestExpressions:
         # check the serialised context lines up with the values in the managed expression
         assert from_db.expressions[0].managed_name == ManagedExpressionsEnum.GREATER_THAN
 
-    def test_update_expression(db_session, factories):
+    def test_update_expression(self, db_session, factories):
         q0 = factories.question.create()
         question = factories.question.create(form=q0.form)
         user = factories.user.create()
@@ -1105,7 +1105,7 @@ class TestExpressions:
 
         assert question.expressions[0].statement == f"{q0.safe_qid} > 5000"
 
-    def test_update_anyof_expression(db_session, factories):
+    def test_update_anyof_expression(self, db_session, factories):
         q0 = factories.question.create(data_type=QuestionDataType.RADIOS)
         question = factories.question.create(form=q0.form)
         items = q0.data_source.items
@@ -1132,7 +1132,7 @@ class TestExpressions:
         assert len(from_db.expressions[0].data_source_item_references) == 1
         assert from_db.expressions[0].data_source_item_references[0].data_source_item_id == q0.data_source.items[2].id
 
-    def test_update_specifically_expression(db_session, factories):
+    def test_update_specifically_expression(self, db_session, factories):
         q0 = factories.question.create(data_type=QuestionDataType.CHECKBOXES)
         question = factories.question.create(form=q0.form)
         items = q0.data_source.items
@@ -1159,7 +1159,7 @@ class TestExpressions:
         assert len(from_db.expressions[0].data_source_item_references) == 1
         assert from_db.expressions[0].data_source_item_references[0].data_source_item_id == q0.data_source.items[1].id
 
-    def test_update_expression_errors_on_validation_overlap(db_session, factories):
+    def test_update_expression_errors_on_validation_overlap(self, db_session, factories):
         question = factories.question.create()
         user = factories.user.create()
         gt_expression = GreaterThan(minimum_value=3000, question_id=question.id)
@@ -1176,7 +1176,7 @@ class TestExpressions:
         with pytest.raises(DuplicateValueError):
             update_question_expression(lt_db_expression, gt_expression)
 
-    def test_remove_expression(db_session, factories):
+    def test_remove_expression(self, db_session, factories):
         qid = uuid.uuid4()
         user = factories.user.create()
         question = factories.question.create(
@@ -1196,13 +1196,13 @@ class TestExpressions:
         with pytest.raises(NoResultFound, match="No row was found when one was required"):
             get_expression(expression_id)
 
-    def test_get_expression(db_session, factories):
+    def test_get_expression(self, db_session, factories):
         expression = factories.expression.create(statement="", type=ExpressionType.VALIDATION)
 
         db_expr = get_expression(expression.id)
         assert db_expr is expression
 
-    def test_get_expression_missing(db_session, factories):
+    def test_get_expression_missing(self, db_session, factories):
         factories.expression.create(statement="", type=ExpressionType.VALIDATION)
 
         with pytest.raises(NoResultFound):
@@ -1239,7 +1239,7 @@ class TestExpressions:
         with pytest.raises(NoResultFound):
             get_expression_by_id(uuid.uuid4())
 
-    def test_get_referenced_data_source_items_by_anyof_managed_expression(db_session, factories):
+    def test_get_referenced_data_source_items_by_anyof_managed_expression(self, db_session, factories):
         referenced_question = factories.question.create(data_type=QuestionDataType.RADIOS)
         items = referenced_question.data_source.items
         managed_expression = AnyOf(
@@ -1250,7 +1250,7 @@ class TestExpressions:
         assert len(referenced_data_source_items) == 2
         assert referenced_data_source_items[0] == referenced_question.data_source.items[0]
 
-    def test_get_referenced_data_source_items_by_specifically_managed_expression(db_session, factories):
+    def test_get_referenced_data_source_items_by_specifically_managed_expression(self, db_session, factories):
         referenced_question = factories.question.create(data_type=QuestionDataType.CHECKBOXES)
         items = referenced_question.data_source.items
         managed_expression = Specifically(

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -7,8 +7,11 @@ from bs4 import BeautifulSoup
 from flask import url_for
 
 from app import QuestionDataType
+from app.common.data import interfaces
 from app.common.data.models import Collection, Form, Question
-from app.common.data.types import SubmissionModeEnum
+from app.common.data.types import ExpressionType, SubmissionModeEnum
+from app.common.expressions.forms import build_managed_expression_form
+from app.common.expressions.managed import IsNo, IsYes
 from app.common.forms import GenericConfirmDeletionForm
 from app.deliver_grant_funding.forms import AddTaskForm, QuestionForm, QuestionTypeForm, SetUpReportForm
 from tests.utils import AnyStringMatching, get_h1_text, get_h2_text, page_has_button, page_has_error, page_has_link
@@ -973,6 +976,912 @@ class TestEditQuestion:
         # If you're a dev and you're looking at this please consider doing a kindness and taking 10 mins to write a nice
         # test here.
         raise AssertionError()
+
+
+class TestAddQuestionConditionSelectQuestion:
+    def test_404(self, authenticated_grant_admin_client):
+        response = authenticated_grant_admin_client.get(
+            url_for(
+                "deliver_grant_funding.add_question_condition_select_question",
+                grant_id=uuid.uuid4(),
+                question_id=uuid.uuid4(),
+            )
+        )
+        assert response.status_code == 404
+
+    @pytest.mark.parametrize(
+        "client_fixture, can_access",
+        (
+            ("authenticated_grant_member_client", False),
+            ("authenticated_grant_admin_client", True),
+        ),
+    )
+    def test_get(self, request, client_fixture, can_access, factories, db_session):
+        client = request.getfixturevalue(client_fixture)
+        report = factories.collection.create(grant=client.grant, name="Test Report")
+        form = factories.form.create(section=report.sections[0], title="Organisation information")
+        question = factories.question.create(
+            form=form,
+            text="My question",
+            name="Question name",
+            hint="Question hint",
+            data_type=QuestionDataType.TEXT_SINGLE_LINE,
+        )
+
+        response = client.get(
+            url_for(
+                "deliver_grant_funding.add_question_condition_select_question",
+                grant_id=client.grant.id,
+                question_id=question.id,
+            )
+        )
+
+        if not can_access:
+            assert response.status_code == 403
+        else:
+            assert response.status_code == 200
+            soup = BeautifulSoup(response.data, "html.parser")
+            assert "There are no questions in this form that can be used as a condition." in soup.text
+
+    @pytest.mark.parametrize(
+        "client_fixture, can_access",
+        (
+            ("authenticated_grant_member_client", False),
+            ("authenticated_grant_admin_client", True),
+        ),
+    )
+    def test_get_with_available_questions(self, request, client_fixture, can_access, factories, db_session):
+        client = request.getfixturevalue(client_fixture)
+        report = factories.collection.create(grant=client.grant, name="Test Report")
+        form = factories.form.create(section=report.sections[0], title="Organisation information")
+
+        factories.question.create(
+            form=form,
+            text="Do you like cheese?",
+            name="cheese question",
+            data_type=QuestionDataType.YES_NO,
+        )
+
+        second_question = factories.question.create(
+            form=form,
+            text="What is your email?",
+            name="email question",
+            data_type=QuestionDataType.EMAIL,
+        )
+
+        response = client.get(
+            url_for(
+                "deliver_grant_funding.add_question_condition_select_question",
+                grant_id=client.grant.id,
+                question_id=second_question.id,
+            )
+        )
+
+        if not can_access:
+            assert response.status_code == 403
+        else:
+            assert response.status_code == 200
+            soup = BeautifulSoup(response.data, "html.parser")
+            assert "What answer should the condition check?" in soup.text
+            assert "Do you like cheese? (cheese question)" in soup.text
+
+    def test_post(self, authenticated_grant_admin_client, factories):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant, name="Test Report")
+        form = factories.form.create(section=report.sections[0], title="Organisation information")
+
+        first_question = factories.question.create(
+            form=form,
+            text="Do you like cheese?",
+            name="cheese question",
+            data_type=QuestionDataType.YES_NO,
+        )
+
+        second_question = factories.question.create(
+            form=form,
+            text="What is your email?",
+            name="email question",
+            data_type=QuestionDataType.EMAIL,
+        )
+
+        response = authenticated_grant_admin_client.post(
+            url_for(
+                "deliver_grant_funding.add_question_condition_select_question",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                question_id=second_question.id,
+            ),
+            data={"question": str(first_question.id)},
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 302
+        assert response.location == AnyStringMatching(
+            rf"/grant/{authenticated_grant_admin_client.grant.id}/question/{second_question.id}/add-condition/{first_question.id}"
+        )
+
+
+class TestAddQuestionCondition:
+    def test_404(self, authenticated_grant_admin_client):
+        response = authenticated_grant_admin_client.get(
+            url_for(
+                "deliver_grant_funding.add_question_condition",
+                grant_id=uuid.uuid4(),
+                question_id=uuid.uuid4(),
+                depends_on_question_id=uuid.uuid4(),
+            )
+        )
+        assert response.status_code == 404
+
+    @pytest.mark.parametrize(
+        "client_fixture, can_access",
+        (
+            ("authenticated_grant_member_client", False),
+            ("authenticated_grant_admin_client", True),
+        ),
+    )
+    def test_get(self, request, client_fixture, can_access, factories, db_session):
+        client = request.getfixturevalue(client_fixture)
+        report = factories.collection.create(grant=client.grant, name="Test Report")
+        form = factories.form.create(section=report.sections[0], title="Organisation information")
+
+        depends_on_question = factories.question.create(
+            form=form,
+            text="Do you like cheese?",
+            name="cheese question",
+            hint="Please select yes or no",
+            data_type=QuestionDataType.YES_NO,
+        )
+
+        target_question = factories.question.create(
+            form=form,
+            text="What is your email?",
+            name="email question",
+            hint="Enter your email",
+            data_type=QuestionDataType.EMAIL,
+        )
+
+        response = client.get(
+            url_for(
+                "deliver_grant_funding.add_question_condition",
+                grant_id=client.grant.id,
+                question_id=target_question.id,
+                depends_on_question_id=depends_on_question.id,
+            )
+        )
+
+        if not can_access:
+            assert response.status_code == 403
+        else:
+            assert response.status_code == 200
+
+    def test_post(self, authenticated_grant_admin_client, factories, db_session):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant, name="Test Report")
+        db_form = factories.form.create(section=report.sections[0], title="Organisation information")
+
+        depends_on_question = factories.question.create(
+            form=db_form,
+            text="Do you like cheese?",
+            name="cheese question",
+            hint="Please select yes or no",
+            data_type=QuestionDataType.YES_NO,
+        )
+
+        target_question = factories.question.create(
+            form=db_form,
+            text="What is your email?",
+            name="email question",
+            hint="Enter your email",
+            data_type=QuestionDataType.EMAIL,
+        )
+
+        assert len(target_question.expressions) == 0
+
+        ConditionForm = build_managed_expression_form(ExpressionType.CONDITION, depends_on_question)
+        form = ConditionForm(data={"type": "Yes"})
+
+        response = authenticated_grant_admin_client.post(
+            url_for(
+                "deliver_grant_funding.add_question_condition",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                question_id=target_question.id,
+                depends_on_question_id=depends_on_question.id,
+            ),
+            data=form.data,
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 302
+        assert response.location == AnyStringMatching(
+            rf"/grant/{authenticated_grant_admin_client.grant.id}/question/{target_question.id}"
+        )
+
+        assert len(target_question.expressions) == 1
+        expression = target_question.expressions[0]
+        assert expression.type == ExpressionType.CONDITION
+        assert expression.managed_name == "Yes"
+        assert expression.managed.referenced_question.id == depends_on_question.id
+
+    def test_post_duplicate_condition(self, authenticated_grant_admin_client, factories, db_session):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant, name="Test Report")
+        db_form = factories.form.create(section=report.sections[0], title="Organisation information")
+
+        depends_on_question = factories.question.create(
+            form=db_form,
+            text="Do you like cheese?",
+            name="cheese question",
+            hint="Please select yes or no",
+            data_type=QuestionDataType.YES_NO,
+        )
+
+        target_question = factories.question.create(
+            form=db_form,
+            text="What is your email?",
+            name="email question",
+            hint="Enter your email",
+            data_type=QuestionDataType.EMAIL,
+        )
+
+        expression = IsYes(question_id=depends_on_question.id, referenced_question=depends_on_question)
+        interfaces.collections.add_component_condition(target_question, interfaces.user.get_current_user(), expression)
+        db_session.commit()
+
+        ConditionForm = build_managed_expression_form(ExpressionType.CONDITION, depends_on_question)
+        form = ConditionForm(data={"type": "Yes"})
+
+        response = authenticated_grant_admin_client.post(
+            url_for(
+                "deliver_grant_funding.add_question_condition",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                question_id=target_question.id,
+                depends_on_question_id=depends_on_question.id,
+            ),
+            data=form.data,
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 200
+        soup = BeautifulSoup(response.data, "html.parser")
+        assert "condition based on this question already exists" in soup.text
+
+
+class TestEditQuestionCondition:
+    def test_404(self, authenticated_grant_admin_client):
+        response = authenticated_grant_admin_client.get(
+            url_for("deliver_grant_funding.edit_question_condition", grant_id=uuid.uuid4(), expression_id=uuid.uuid4())
+        )
+        assert response.status_code == 404
+
+    @pytest.mark.parametrize(
+        "client_fixture, can_access",
+        (
+            ("authenticated_grant_member_client", False),
+            ("authenticated_grant_admin_client", True),
+        ),
+    )
+    def test_get(self, request, client_fixture, can_access, factories, db_session):
+        client = request.getfixturevalue(client_fixture)
+        report = factories.collection.create(grant=client.grant, name="Test Report")
+        db_form = factories.form.create(section=report.sections[0], title="Organisation information")
+        depends_on_question = factories.question.create(
+            form=db_form,
+            text="Do you like cheese?",
+            name="cheese question",
+            data_type=QuestionDataType.YES_NO,
+        )
+        target_question = factories.question.create(
+            form=db_form,
+            text="What is your email?",
+            name="email question",
+            data_type=QuestionDataType.EMAIL,
+        )
+        expression = IsYes(question_id=depends_on_question.id, referenced_question=depends_on_question)
+        interfaces.collections.add_component_condition(target_question, interfaces.user.get_current_user(), expression)
+        db_session.commit()
+
+        expression_id = target_question.expressions[0].id
+
+        response = client.get(
+            url_for(
+                "deliver_grant_funding.edit_question_condition",
+                grant_id=client.grant.id,
+                expression_id=expression_id,
+            )
+        )
+
+        if not can_access:
+            assert response.status_code == 403
+        else:
+            assert response.status_code == 200
+            soup = BeautifulSoup(response.data, "html.parser")
+
+            assert get_h1_text(soup) == "Edit condition"
+
+            assert "The question" in soup.text
+            assert "What is your email?" in soup.text
+
+            assert "Depends on the answer to" in soup.text
+            assert "Do you like cheese?" in soup.text
+
+            yes_radio = soup.find("input", {"type": "radio", "value": "Yes"})
+            no_radio = soup.find("input", {"type": "radio", "value": "No"})
+            assert yes_radio is not None
+            assert no_radio is not None
+            assert yes_radio.get("checked") is not None
+            assert no_radio.get("checked") is None
+
+            assert page_has_button(soup, "Update condition")
+
+            delete_link = page_has_link(soup, "Delete condition")
+            assert delete_link is not None
+
+    def test_get_with_delete_parameter(self, authenticated_grant_admin_client, factories, db_session):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant, name="Test Report")
+        db_form = factories.form.create(section=report.sections[0], title="Organisation information")
+        depends_on_question = factories.question.create(
+            form=db_form,
+            text="Do you like cheese?",
+            name="cheese question",
+            data_type=QuestionDataType.YES_NO,
+        )
+        target_question = factories.question.create(
+            form=db_form,
+            text="What is your email?",
+            name="email question",
+            data_type=QuestionDataType.EMAIL,
+        )
+        expression = IsYes(question_id=depends_on_question.id, referenced_question=depends_on_question)
+        interfaces.collections.add_component_condition(target_question, interfaces.user.get_current_user(), expression)
+        db_session.commit()
+
+        expression_id = target_question.expressions[0].id
+
+        response = authenticated_grant_admin_client.get(
+            url_for(
+                "deliver_grant_funding.edit_question_condition",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                expression_id=expression_id,
+                delete="",
+            )
+        )
+
+        assert response.status_code == 200
+        soup = BeautifulSoup(response.data, "html.parser")
+        assert page_has_button(soup, "Yes, delete this condition")
+
+    def test_post_update_condition(self, authenticated_grant_admin_client, factories, db_session):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant, name="Test Report")
+        db_form = factories.form.create(section=report.sections[0], title="Organisation information")
+        depends_on_question = factories.question.create(
+            form=db_form,
+            text="Do you like cheese?",
+            name="cheese question",
+            data_type=QuestionDataType.YES_NO,
+        )
+        target_question = factories.question.create(
+            form=db_form,
+            text="What is your email?",
+            name="email question",
+            data_type=QuestionDataType.EMAIL,
+        )
+        expression = IsYes(question_id=depends_on_question.id, referenced_question=depends_on_question)
+        interfaces.collections.add_component_condition(target_question, interfaces.user.get_current_user(), expression)
+        db_session.commit()
+
+        expression_id = target_question.expressions[0].id
+        assert target_question.expressions[0].managed_name == "Yes"
+
+        ConditionForm = build_managed_expression_form(
+            ExpressionType.CONDITION, depends_on_question, target_question.expressions[0]
+        )
+        form = ConditionForm(data={"type": "No"})
+
+        response = authenticated_grant_admin_client.post(
+            url_for(
+                "deliver_grant_funding.edit_question_condition",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                expression_id=expression_id,
+            ),
+            data=form.data,
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 302
+        assert response.location == AnyStringMatching(
+            rf"/grant/{authenticated_grant_admin_client.grant.id}/question/{target_question.id}"
+        )
+
+        assert len(target_question.expressions) == 1
+        assert target_question.expressions[0].managed_name == "No"
+
+    def test_post_update_condition_duplicate(self, authenticated_grant_admin_client, factories, db_session):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant, name="Test Report")
+        db_form = factories.form.create(section=report.sections[0], title="Organisation information")
+        depends_on_question = factories.question.create(
+            form=db_form,
+            text="Do you like cheese?",
+            name="cheese question",
+            data_type=QuestionDataType.YES_NO,
+        )
+        target_question = factories.question.create(
+            form=db_form,
+            text="What is your email?",
+            name="email question",
+            data_type=QuestionDataType.EMAIL,
+        )
+        yes_expression = IsYes(question_id=depends_on_question.id, referenced_question=depends_on_question)
+        interfaces.collections.add_component_condition(
+            target_question, interfaces.user.get_current_user(), yes_expression
+        )
+
+        no_expression = IsNo(question_id=depends_on_question.id, referenced_question=depends_on_question)
+        interfaces.collections.add_component_condition(
+            target_question, interfaces.user.get_current_user(), no_expression
+        )
+        db_session.commit()
+
+        assert len(target_question.expressions) == 2
+        yes_expression_id = None
+        for expr in target_question.expressions:
+            if expr.managed_name == "Yes":
+                yes_expression_id = expr.id
+                break
+
+        ConditionForm = build_managed_expression_form(
+            ExpressionType.CONDITION, depends_on_question, target_question.expressions[0]
+        )
+        form = ConditionForm(data={"type": "No"})
+
+        response = authenticated_grant_admin_client.post(
+            url_for(
+                "deliver_grant_funding.edit_question_condition",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                expression_id=yes_expression_id,
+            ),
+            data=form.data,
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 200
+        soup = BeautifulSoup(response.data, "html.parser")
+        assert "condition based on this question already exists" in soup.text
+
+    def test_post_delete(self, authenticated_grant_admin_client, factories, db_session):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant, name="Test Report")
+        db_form = factories.form.create(section=report.sections[0], title="Organisation information")
+        depends_on_question = factories.question.create(
+            form=db_form,
+            text="Do you like cheese?",
+            name="cheese question",
+            data_type=QuestionDataType.YES_NO,
+        )
+        target_question = factories.question.create(
+            form=db_form,
+            text="What is your email?",
+            name="email question",
+            data_type=QuestionDataType.EMAIL,
+        )
+        expression = IsYes(question_id=depends_on_question.id, referenced_question=depends_on_question)
+        interfaces.collections.add_component_condition(target_question, interfaces.user.get_current_user(), expression)
+        db_session.commit()
+
+        expression_id = target_question.expressions[0].id
+        assert len(target_question.expressions) == 1
+
+        form = GenericConfirmDeletionForm(data={"confirm_deletion": True})
+        response = authenticated_grant_admin_client.post(
+            url_for(
+                "deliver_grant_funding.edit_question_condition",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                expression_id=expression_id,
+                delete="",
+            ),
+            data=form.data,
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 302
+        assert response.location == AnyStringMatching(
+            rf"/grant/{authenticated_grant_admin_client.grant.id}/question/{target_question.id}"
+        )
+
+        assert len(target_question.expressions) == 0
+
+
+class TestAddQuestionValidation:
+    def test_404(self, authenticated_grant_admin_client):
+        response = authenticated_grant_admin_client.get(
+            url_for("deliver_grant_funding.add_question_validation", grant_id=uuid.uuid4(), question_id=uuid.uuid4())
+        )
+        assert response.status_code == 404
+
+    @pytest.mark.parametrize(
+        "client_fixture, can_access",
+        (
+            ("authenticated_grant_member_client", False),
+            ("authenticated_grant_admin_client", True),
+        ),
+    )
+    def test_get(self, request, client_fixture, can_access, factories, db_session):
+        client = request.getfixturevalue(client_fixture)
+        report = factories.collection.create(grant=client.grant, name="Test Report")
+        db_form = factories.form.create(section=report.sections[0], title="Organisation information")
+        question = factories.question.create(
+            form=db_form,
+            text="How many employees do you have?",
+            name="employee count",
+            data_type=QuestionDataType.INTEGER,
+        )
+
+        response = client.get(
+            url_for(
+                "deliver_grant_funding.add_question_validation",
+                grant_id=client.grant.id,
+                question_id=question.id,
+            )
+        )
+
+        if not can_access:
+            assert response.status_code == 403
+        else:
+            assert response.status_code == 200
+            soup = BeautifulSoup(response.data, "html.parser")
+
+            assert get_h1_text(soup) == "Add validation"
+
+            assert "Form" in soup.text
+            assert "Organisation information" in soup.text
+
+            assert "Question" in soup.text
+            assert "How many employees do you have?" in soup.text
+
+            assert "The answer to the question" in soup.text
+
+            greater_than_radio = soup.find("input", {"type": "radio", "value": "Greater than"})
+            less_than_radio = soup.find("input", {"type": "radio", "value": "Less than"})
+            between_radio = soup.find("input", {"type": "radio", "value": "Between"})
+            assert greater_than_radio is not None
+            assert less_than_radio is not None
+            assert between_radio is not None
+
+            assert page_has_button(soup, "Add validation")
+
+    def test_get_no_validation_available(self, authenticated_grant_admin_client, factories):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant, name="Test Report")
+        db_form = factories.form.create(section=report.sections[0], title="Organisation information")
+        question = factories.question.create(
+            form=db_form,
+            text="What is your name?",
+            name="applicant name",
+            data_type=QuestionDataType.TEXT_SINGLE_LINE,
+        )
+
+        response = authenticated_grant_admin_client.get(
+            url_for(
+                "deliver_grant_funding.add_question_validation",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                question_id=question.id,
+            )
+        )
+
+        assert response.status_code == 200
+        soup = BeautifulSoup(response.data, "html.parser")
+        assert "This question cannot be validated." in soup.text
+
+    def test_post(self, authenticated_grant_admin_client, factories, db_session):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant, name="Test Report")
+        db_form = factories.form.create(section=report.sections[0], title="Organisation information")
+        question = factories.question.create(
+            form=db_form,
+            text="How many employees do you have?",
+            name="employee count",
+            data_type=QuestionDataType.INTEGER,
+        )
+
+        assert len(question.expressions) == 0
+
+        ValidationForm = build_managed_expression_form(ExpressionType.VALIDATION, question)
+        form = ValidationForm(
+            data={"type": "Greater than", "greater_than_value": "10", "greater_than_inclusive": False}
+        )
+
+        response = authenticated_grant_admin_client.post(
+            url_for(
+                "deliver_grant_funding.add_question_validation",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                question_id=question.id,
+            ),
+            data=form.data,
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 302
+        assert response.location == AnyStringMatching(
+            rf"/grant/{authenticated_grant_admin_client.grant.id}/question/{question.id}"
+        )
+
+        assert len(question.expressions) == 1
+        expression = question.expressions[0]
+        assert expression.type == ExpressionType.VALIDATION
+        assert expression.managed_name == "Greater than"
+
+    def test_post_duplicate_validation(self, authenticated_grant_admin_client, factories, db_session):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant, name="Test Report")
+        db_form = factories.form.create(section=report.sections[0], title="Organisation information")
+        question = factories.question.create(
+            form=db_form,
+            text="How many employees do you have?",
+            name="employee count",
+            data_type=QuestionDataType.INTEGER,
+        )
+
+        ValidationForm = build_managed_expression_form(ExpressionType.VALIDATION, question)
+        first_validation = ValidationForm(
+            data={"type": "Greater than", "greater_than_value": "10", "greater_than_inclusive": False}
+        )
+        expression = first_validation.get_expression(question)
+        interfaces.collections.add_question_validation(question, interfaces.user.get_current_user(), expression)
+        db_session.commit()
+
+        duplicate_form = ValidationForm(
+            data={"type": "Greater than", "greater_than_value": "10", "greater_than_inclusive": False}
+        )
+        response = authenticated_grant_admin_client.post(
+            url_for(
+                "deliver_grant_funding.add_question_validation",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                question_id=question.id,
+            ),
+            data=duplicate_form.data,
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 200
+        soup = BeautifulSoup(response.data, "html.parser")
+        assert "validation already exists on the question" in soup.text
+
+
+class TestEditQuestionValidation:
+    def test_404(self, authenticated_grant_admin_client):
+        response = authenticated_grant_admin_client.get(
+            url_for("deliver_grant_funding.edit_question_validation", grant_id=uuid.uuid4(), expression_id=uuid.uuid4())
+        )
+        assert response.status_code == 404
+
+    @pytest.mark.parametrize(
+        "client_fixture, can_access",
+        (
+            ("authenticated_grant_member_client", False),
+            ("authenticated_grant_admin_client", True),
+        ),
+    )
+    def test_get(self, request, client_fixture, can_access, factories, db_session):
+        client = request.getfixturevalue(client_fixture)
+        report = factories.collection.create(grant=client.grant, name="Test Report")
+        db_form = factories.form.create(section=report.sections[0], title="Organisation information")
+        question = factories.question.create(
+            form=db_form,
+            text="How many employees do you have?",
+            name="employee count",
+            data_type=QuestionDataType.INTEGER,
+        )
+
+        ValidationForm = build_managed_expression_form(ExpressionType.VALIDATION, question)
+        form = ValidationForm(
+            data={"type": "Greater than", "greater_than_value": "10", "greater_than_inclusive": False}
+        )
+        expression = form.get_expression(question)
+        interfaces.collections.add_question_validation(question, interfaces.user.get_current_user(), expression)
+        db_session.commit()
+
+        db_session.refresh(question)
+        expression_id = question.expressions[0].id
+
+        response = client.get(
+            url_for(
+                "deliver_grant_funding.edit_question_validation",
+                grant_id=client.grant.id,
+                expression_id=expression_id,
+            )
+        )
+
+        if not can_access:
+            assert response.status_code == 403
+        else:
+            assert response.status_code == 200
+            soup = BeautifulSoup(response.data, "html.parser")
+
+            assert get_h1_text(soup) == "Edit validation"
+
+            assert "Form" in soup.text
+            assert "Organisation information" in soup.text
+
+            assert "Question" in soup.text
+            assert "How many employees do you have?" in soup.text
+
+            assert "The answer to the question" in soup.text
+            assert "must be" in soup.text
+
+            greater_than_radio = soup.find("input", {"type": "radio", "value": "Greater than"})
+            less_than_radio = soup.find("input", {"type": "radio", "value": "Less than"})
+            between_radio = soup.find("input", {"type": "radio", "value": "Between"})
+            assert greater_than_radio.get("checked") is not None
+            assert less_than_radio.get("checked") is None
+            assert between_radio.get("checked") is None
+
+            min_value_input = soup.find("input", {"name": "greater_than_value"})
+            assert min_value_input.get("value") == "10"
+
+            assert page_has_button(soup, "Edit validation")
+
+            delete_link = page_has_link(soup, "Delete validation")
+            assert delete_link is not None
+
+    def test_get_with_delete_parameter(self, authenticated_grant_admin_client, factories, db_session):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant, name="Test Report")
+        db_form = factories.form.create(section=report.sections[0], title="Organisation information")
+        question = factories.question.create(
+            form=db_form,
+            text="How many employees do you have?",
+            name="employee count",
+            data_type=QuestionDataType.INTEGER,
+        )
+
+        ValidationForm = build_managed_expression_form(ExpressionType.VALIDATION, question)
+        form = ValidationForm(
+            data={"type": "Greater than", "greater_than_value": "10", "greater_than_inclusive": False}
+        )
+        expression = form.get_expression(question)
+        interfaces.collections.add_question_validation(question, interfaces.user.get_current_user(), expression)
+        db_session.commit()
+
+        db_session.refresh(question)
+        expression_id = question.expressions[0].id
+
+        response = authenticated_grant_admin_client.get(
+            url_for(
+                "deliver_grant_funding.edit_question_validation",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                expression_id=expression_id,
+                delete="",
+            )
+        )
+
+        assert response.status_code == 200
+        soup = BeautifulSoup(response.data, "html.parser")
+        assert page_has_button(soup, "Yes, delete this validation")
+
+    def test_post_update_validation(self, authenticated_grant_admin_client, factories, db_session):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant, name="Test Report")
+        db_form = factories.form.create(section=report.sections[0], title="Organisation information")
+        question = factories.question.create(
+            form=db_form,
+            text="How many employees do you have?",
+            name="employee count",
+            data_type=QuestionDataType.INTEGER,
+        )
+
+        ValidationForm = build_managed_expression_form(ExpressionType.VALIDATION, question)
+        original_form = ValidationForm(
+            data={"type": "Greater than", "greater_than_value": "10", "greater_than_inclusive": False}
+        )
+        expression = original_form.get_expression(question)
+        interfaces.collections.add_question_validation(question, interfaces.user.get_current_user(), expression)
+        db_session.commit()
+
+        expression_id = question.expressions[0].id
+        assert question.expressions[0].managed_name == "Greater than"
+
+        UpdateForm = build_managed_expression_form(ExpressionType.VALIDATION, question, question.expressions[0])
+        form = UpdateForm(data={"type": "Less than", "less_than_value": "100", "less_than_inclusive": True})
+
+        response = authenticated_grant_admin_client.post(
+            url_for(
+                "deliver_grant_funding.edit_question_validation",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                expression_id=expression_id,
+            ),
+            data=form.data,
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 302
+        assert response.location == AnyStringMatching(
+            rf"/grant/{authenticated_grant_admin_client.grant.id}/question/{question.id}"
+        )
+
+        assert len(question.expressions) == 1
+        assert question.expressions[0].managed_name == "Less than"
+
+    def test_post_update_validation_duplicate(self, authenticated_grant_admin_client, factories, db_session):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant, name="Test Report")
+        db_form = factories.form.create(section=report.sections[0], title="Organisation information")
+        question = factories.question.create(
+            form=db_form,
+            text="How many employees do you have?",
+            name="employee count",
+            data_type=QuestionDataType.INTEGER,
+        )
+
+        ValidationForm = build_managed_expression_form(ExpressionType.VALIDATION, question)
+        greater_than_form = ValidationForm(
+            data={"type": "Greater than", "greater_than_value": "10", "greater_than_inclusive": False}
+        )
+        greater_than_expression = greater_than_form.get_expression(question)
+        interfaces.collections.add_question_validation(
+            question, interfaces.user.get_current_user(), greater_than_expression
+        )
+
+        less_than_form = ValidationForm(
+            data={"type": "Less than", "less_than_value": "100", "less_than_inclusive": True}
+        )
+        less_than_expression = less_than_form.get_expression(question)
+        interfaces.collections.add_question_validation(
+            question, interfaces.user.get_current_user(), less_than_expression
+        )
+        db_session.commit()
+
+        assert len(question.expressions) == 2
+        greater_than_expression_id = None
+        for expr in question.expressions:
+            if expr.managed_name == "Greater than":
+                greater_than_expression_id = expr.id
+                break
+
+        UpdateForm = build_managed_expression_form(ExpressionType.VALIDATION, question, question.expressions[0])
+        form = UpdateForm(data={"type": "Less than", "less_than_value": "100", "less_than_inclusive": True})
+
+        response = authenticated_grant_admin_client.post(
+            url_for(
+                "deliver_grant_funding.edit_question_validation",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                expression_id=greater_than_expression_id,
+            ),
+            data=form.data,
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 200
+        soup = BeautifulSoup(response.data, "html.parser")
+        assert "validation already exists on the question" in soup.text
+
+    def test_post_delete(self, authenticated_grant_admin_client, factories, db_session):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant, name="Test Report")
+        db_form = factories.form.create(section=report.sections[0], title="Organisation information")
+        question = factories.question.create(
+            form=db_form,
+            text="How many employees do you have?",
+            name="employee count",
+            data_type=QuestionDataType.INTEGER,
+        )
+
+        ValidationForm = build_managed_expression_form(ExpressionType.VALIDATION, question)
+        form = ValidationForm(
+            data={"type": "Greater than", "greater_than_value": "10", "greater_than_inclusive": False}
+        )
+        expression = form.get_expression(question)
+        interfaces.collections.add_question_validation(question, interfaces.user.get_current_user(), expression)
+        db_session.commit()
+
+        expression_id = question.expressions[0].id
+        assert len(question.expressions) == 1
+
+        delete_form = GenericConfirmDeletionForm(data={"confirm_deletion": True})
+        response = authenticated_grant_admin_client.post(
+            url_for(
+                "deliver_grant_funding.edit_question_validation",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                expression_id=expression_id,
+                delete="",
+            ),
+            data=delete_form.data,
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 302
+        assert response.location == AnyStringMatching(
+            rf"/grant/{authenticated_grant_admin_client.grant.id}/question/{question.id}"
+        )
+
+        assert len(question.expressions) == 0
 
 
 class TestListSubmissions:

--- a/tests/integration/developers/test_deliver_routes.py
+++ b/tests/integration/developers/test_deliver_routes.py
@@ -374,7 +374,7 @@ def test_create_question_choose_type_get(authenticated_platform_admin_client, fa
     assert result.status_code == 200
 
     soup = BeautifulSoup(result.data, "html.parser")
-    assert get_h1_text(soup) == "What is the type of the question?"
+    assert get_h1_text(soup) == "What is the type of question?"
 
 
 def test_create_question_choose_type_post(authenticated_platform_admin_client, factories):
@@ -418,8 +418,8 @@ def test_create_question_choose_type_post_error(authenticated_platform_admin_cli
     assert result.status_code == 200
     soup = BeautifulSoup(result.data, "html.parser")
     assert get_h2_text(soup) == "There is a problem"
-    assert len(soup.find_all("a", href="#question type")) == 1
-    assert soup.find_all("a", href="#question type")[0].text.strip() == "Select a question type"
+    assert len(soup.find_all("a", href="#question_data_type")) == 1
+    assert soup.find_all("a", href="#question_data_type")[0].text.strip() == "Select a question type"
 
 
 def test_add_text_question_get(authenticated_platform_admin_client, factories):

--- a/tests/unit/test_all_routes_access.py
+++ b/tests/unit/test_all_routes_access.py
@@ -70,6 +70,9 @@ routes_with_expected_grant_admin_only_access = [
     "deliver_grant_funding.change_form_name",
     "deliver_grant_funding.move_task",
     "deliver_grant_funding.move_question",
+    "deliver_grant_funding.choose_question_type",
+    "deliver_grant_funding.add_question",
+    "deliver_grant_funding.edit_question",
 ]
 routes_with_expected_member_only_access = [
     "deliver_grant_funding.list_users_for_grant",

--- a/tests/unit/test_all_routes_access.py
+++ b/tests/unit/test_all_routes_access.py
@@ -73,6 +73,11 @@ routes_with_expected_grant_admin_only_access = [
     "deliver_grant_funding.choose_question_type",
     "deliver_grant_funding.add_question",
     "deliver_grant_funding.edit_question",
+    "deliver_grant_funding.add_question_condition_select_question",
+    "deliver_grant_funding.add_question_condition",
+    "deliver_grant_funding.edit_question_condition",
+    "deliver_grant_funding.add_question_validation",
+    "deliver_grant_funding.edit_question_validation",
 ]
 routes_with_expected_member_only_access = [
     "deliver_grant_funding.list_users_for_grant",


### PR DESCRIPTION
## 🎫 Ticket
[FSPT-744](https://mhclgdigital.atlassian.net/browse/FSPT-744)

## 📝 Description
Get these implemented by copying the implementation from the developers tab. Next week we'll work with design to align+settle on the first pass of designs for these pages based on discussion around the prototypes.

## 📸 Show the thing (screenshots, gifs)
![2025-08-08 14 34 46](https://github.com/user-attachments/assets/e50e648a-9d83-4eb1-9a84-3f626fc10e9e)

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested

[FSPT-744]: https://mhclgdigital.atlassian.net/browse/FSPT-744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ