### PR TITLE
FSPT-606 Add end to end steps for adding a group

### DIFF
--- a/app/common/templates/common/macros/move-up-down-table.html
+++ b/app/common/templates/common/macros/move-up-down-table.html
@@ -45,7 +45,10 @@
       {% set collection = section.collection %}
       {% set grant = collection.grant %}
       {% set link %}
-        <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('developers.deliver.choose_question_type', grant_id=grant.id, collection_id=collection.id, section_id=section.id, form_id=form.id, parent=component.id) }}">
+        <a
+          class="govuk-link govuk-link--no-visited-state"
+          href="{{ url_for('developers.deliver.choose_question_type', grant_id=grant.id, collection_id=collection.id, section_id=section.id, form_id=form.id, parent=component.id) }}"
+          data-testid="add-question-{{ component.name }}">
           Add question
         </a>
       {% endset %}


### PR DESCRIPTION
This uses the existing questions to test methodology but allows those questions to be included in groups to cover both the form runner routing to group questions and the form builder being able to add groups.

When we need to check more complex things like group conditions we may need to revise this interface but this should do for now (those things are likely covered lower down anyway).