### PR TITLE
WIP Submission helper doesn't recalculate visible questions

### DIFF
--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -67,6 +67,14 @@ class SubmissionHelper:
         self.submission = submission
         self.collection = self.submission.collection
 
+        ordered_visible_questions = {}
+        for form in chain.from_iterable(section.forms for section in self.collection.sections):
+            ordered_visible_questions[form.id] = [
+                question for question in form.questions if self.is_component_visible(question, self.expression_context)
+            ]
+
+        self.ordered_visible_questions = ordered_visible_questions
+
     @classmethod
     def load(cls, submission_id: uuid.UUID) -> "SubmissionHelper":
         return cls(get_submission(submission_id, with_full_schema=True))
@@ -259,9 +267,7 @@ class SubmissionHelper:
 
     def get_ordered_visible_questions_for_form(self, form: "Form") -> list["Question"]:
         """Returns the visible, ordered questions for a given form based upon the current state of this collection."""
-        # todo: this probably no longer works without an additional property to factor in depth for global order
-        # calculating that on the fly might get expensive
-        return [question for question in form.questions if self.is_component_visible(question, self.expression_context)]
+        return self.ordered_visible_questions.get(form.id, [])
 
     def get_first_question_for_form(self, form: "Form") -> Optional["Question"]:
         questions = self.get_ordered_visible_questions_for_form(form)


### PR DESCRIPTION
We've set everything up to work around the currently available "visible" questions for a given form. This method now recursively steps through all components and nested components for a form and checks all of the conditions (including checking current answers) every time this property is called which is becoming a very expensive operation especially across all forms.

Almost all of these issues should go away if we only calculate these things at instantiation and then re-use those properties. We should go through and make sure no time is being taken up outside or round trips to databases.

This changes the tasklist loading from ~550ms to ~100ms but there are more simple changes to make.

Methods that are still called thousands of times:
- get question
- get answer for question
- the forms "all_components" and "questions" properties