### PR TITLE
Render integer prefixes and suffixes

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -25,6 +25,7 @@ from app.common.filters import (
     format_date_short,
     format_datetime,
     format_datetime_range,
+    format_thousands,
     to_ordinal,
 )
 from app.config import get_settings
@@ -167,6 +168,7 @@ def create_app() -> Flask:
             format_datetime=format_datetime,
             format_date_range=format_date_range,
             format_datetime_range=format_datetime_range,
+            format_thousands=format_thousands,
             to_ordinal=to_ordinal,
             enum=dict(
                 submission_mode=SubmissionModeEnum,

--- a/app/common/collections/types.py
+++ b/app/common/collections/types.py
@@ -65,10 +65,6 @@ class TextMultiLineAnswer(SubmissionAnswerRootModel[str]):
     pass
 
 
-class IntegerAnswer(SubmissionAnswerRootModel[int]):
-    pass
-
-
 class EmailAnswer(SubmissionAnswerRootModel[str]):
     @property
     def _render_answer_template(self) -> str:
@@ -91,6 +87,28 @@ class YesNoAnswer(SubmissionAnswerRootModel[bool]):
 
     def get_value_for_text_export(self) -> str:
         return "Yes" if self.root else "No"
+
+
+class IntegerAnswer(SubmissionAnswerBaseModel):
+    value: int
+    prefix: str | None = None
+    suffix: str | None = None
+
+    @property
+    def _render_answer_template(self) -> str:
+        return "common/partials/answers/integer.html"
+
+    def get_value_for_submission(self) -> dict[str, Any]:
+        return self.model_dump(mode="json", exclude_none=True)
+
+    def get_value_for_form(self) -> int:
+        return self.value
+
+    def get_value_for_expression(self) -> int:
+        return self.value
+
+    def get_value_for_text_export(self) -> str:
+        return f"{self.prefix or ''}{self.value:,d}{self.suffix or ''}"
 
 
 class SingleChoiceFromListAnswer(SubmissionAnswerBaseModel):

--- a/app/common/filters.py
+++ b/app/common/filters.py
@@ -64,3 +64,7 @@ def format_datetime_range(start: datetime, end: datetime) -> str:
 
 def to_ordinal(number: int) -> str:
     return cast(str, num2words(number, to="ordinal"))
+
+
+def format_thousands(number: int) -> str:
+    return f"{number:,}"

--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -439,7 +439,7 @@ def _form_data_to_question_type(question: "Question", form: DynamicQuestionForm)
         case QuestionDataType.TEXT_MULTI_LINE:
             return TextMultiLineAnswer(answer)  # ty: ignore[missing-argument]
         case QuestionDataType.INTEGER:
-            return IntegerAnswer(answer)  # ty: ignore[missing-argument]
+            return IntegerAnswer(value=answer, prefix=question.prefix, suffix=question.suffix)  # ty: ignore[missing-argument]
         case QuestionDataType.YES_NO:
             return YesNoAnswer(answer)  # ty: ignore[missing-argument]
         case QuestionDataType.RADIOS:

--- a/app/common/templates/common/partials/answers/integer.html
+++ b/app/common/templates/common/partials/answers/integer.html
@@ -1,0 +1,1 @@
+<span data-testid="answer-{{ question.text }}">{{ answer.prefix or '' }}{{ format_thousands(answer.value) }}{{ answer.suffix or '' }}</span>

--- a/app/deliver_grant_funding/forms.py
+++ b/app/deliver_grant_funding/forms.py
@@ -34,6 +34,10 @@ def strip_string_if_not_empty(value: str) -> str | None:
     return value.strip() if value else value
 
 
+def empty_string_to_none(value: str) -> str | None:
+    return value if value else None
+
+
 def _validate_no_blank_lines(form: FlaskForm, field: Field) -> None:
     choices = field.data.split("\n")
     if any(choice.strip() == "" for choice in choices):
@@ -302,11 +306,13 @@ class QuestionForm(FlaskForm):
         "Prefix (optional)",
         widget=GovTextInput(),
         validators=[Optional()],
+        filters=[strip_string_if_not_empty, empty_string_to_none],
     )
     suffix = StringField(
         "Suffix (optional)",
         widget=GovTextInput(),
         validators=[Optional()],
+        filters=[strip_string_if_not_empty, empty_string_to_none],
     )
     width = SelectField(
         "Input width",
@@ -377,6 +383,14 @@ class QuestionForm(FlaskForm):
                 data_source_items.append(cast(str, self.none_of_the_above_item_text.data))
 
         return data_source_items
+
+    def validate_prefix(self, field: Field) -> None:
+        if self.prefix.data and self.suffix.data:
+            raise ValidationError("Remove the suffix if you need a prefix")
+
+    def validate_suffix(self, field: Field) -> None:
+        if self.prefix.data and self.suffix.data:
+            raise ValidationError("Remove the prefix if you need a suffix")
 
 
 class GrantAddUserForm(FlaskForm):

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/partials/_advanced_formatting_options.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/partials/_advanced_formatting_options.html
@@ -17,6 +17,7 @@
       govukDetails({
       	"summaryText": "Advanced formatting options",
       	"html": advancedFormattingOptionsHtml,
+      	"open": form.errors,
       })
     }}
   {% endif %}

--- a/tests/integration/common/helpers/test_collections.py
+++ b/tests/integration/common/helpers/test_collections.py
@@ -56,7 +56,7 @@ class TestSubmissionHelper:
             form = build_question_form(question, expression_context=EC())(q_d696aebc49d24170a92fb6ef42994294=5)
             helper.submit_answer_for_question(question.id, form)
 
-            assert helper.get_answer_for_question(question.id) == IntegerAnswer(5)
+            assert helper.get_answer_for_question(question.id) == IntegerAnswer(value=5)
 
         def test_can_get_falsey_answers(self, db_session, factories):
             question = factories.question.build(
@@ -68,7 +68,7 @@ class TestSubmissionHelper:
             form = build_question_form(question, expression_context=EC())(q_d696aebc49d24170a92fb6ef42994294=0)
             helper.submit_answer_for_question(question.id, form)
 
-            assert helper.get_answer_for_question(question.id) == IntegerAnswer(0)
+            assert helper.get_answer_for_question(question.id) == IntegerAnswer(value=0)
 
         def test_cannot_submit_answer_on_submitted_submission(self, db_session, factories):
             question = factories.question.build(id=uuid.UUID("d696aebc-49d2-4170-a92f-b6ef42994294"))
@@ -156,7 +156,7 @@ class TestSubmissionHelper:
                 data={
                     str(q1.id): TextSingleLineAnswer("answer").get_value_for_submission(),
                     str(q2.id): TextMultiLineAnswer("answer\nthis").get_value_for_submission(),
-                    str(q3.id): IntegerAnswer(50).get_value_for_submission(),
+                    str(q3.id): IntegerAnswer(value=50).get_value_for_submission(),
                     str(q4.id): YesNoAnswer(True).get_value_for_submission(),  # ty: ignore[missing-argument]
                     str(q5.id): SingleChoiceFromListAnswer(key="my-key", label="My label").get_value_for_submission(),
                     str(q6.id): TextSingleLineAnswer("name@example.com").get_value_for_submission(),
@@ -247,7 +247,7 @@ class TestSubmissionHelper:
                 data={
                     str(q1.id): TextSingleLineAnswer("answer").get_value_for_submission(),
                     str(q2.id): TextMultiLineAnswer("answer\nthis").get_value_for_submission(),
-                    str(q3.id): IntegerAnswer(50).get_value_for_submission(),
+                    str(q3.id): IntegerAnswer(value=50).get_value_for_submission(),
                     str(q4.id): YesNoAnswer(True).get_value_for_submission(),  # ty: ignore[missing-argument]
                     str(q5.id): SingleChoiceFromListAnswer(key="my-key", label="My label").get_value_for_submission(),
                     str(q6.id): TextSingleLineAnswer("name@example.com").get_value_for_submission(),
@@ -550,7 +550,7 @@ class TestCollectionHelper:
             for _, helper in c_helper.submission_helpers.items()
             if helper.get_answer_for_question(dependant_question_id).get_value_for_text_export() == "20"
         )
-        submission.data[str(conditional_question_id)] = 120
+        submission.data[str(conditional_question_id)] = IntegerAnswer(value=120).get_value_for_submission()
         csv_content = c_helper.generate_csv_content_for_all_submissions()
         reader = csv.DictReader(StringIO(csv_content))
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -208,10 +208,10 @@ class _CollectionFactory(SQLAlchemyModelFactory):
 
         def _create_submission(mode: SubmissionModeEnum, complete_question_2: bool = False) -> None:
             response_data: dict[str, Any] = {
-                str(q1.id): IntegerAnswer(40 if complete_question_2 else 20).get_value_for_submission()  # ty: ignore[missing-argument]
+                str(q1.id): IntegerAnswer(value=(40 if complete_question_2 else 20)).get_value_for_submission()  # ty: ignore[missing-argument]
             }
             if complete_question_2:
-                response_data[str(q2.id)] = IntegerAnswer(80).get_value_for_submission()  # ty: ignore[missing-argument]
+                response_data[str(q2.id)] = IntegerAnswer(value=80).get_value_for_submission()  # ty: ignore[missing-argument]
 
             response_data[str(q3.id)] = TextSingleLineAnswer("digestive").get_value_for_submission()  # ty: ignore[missing-argument]
 
@@ -317,7 +317,7 @@ class _CollectionFactory(SQLAlchemyModelFactory):
         def _create_submission(mode: SubmissionModeEnum, count: int = 0) -> None:
             for _ in range(count):
                 response_data: dict[str, Any] = {
-                    str(q1.id): IntegerAnswer(faker.Faker().random_int(min=0, max=60)).get_value_for_submission()  # ty: ignore[missing-argument]
+                    str(q1.id): IntegerAnswer(value=faker.Faker().random_int(min=0, max=60)).get_value_for_submission()  # ty: ignore[missing-argument]
                 }
                 response_data[str(q2.id)] = YesNoAnswer(random.choice([True, False])).get_value_for_submission()  # ty: ignore[missing-argument]
 
@@ -420,7 +420,7 @@ class _CollectionFactory(SQLAlchemyModelFactory):
                             else "Line 1\r\nline2\r\nline 3"
                         ).get_value_for_submission(),
                         str(q3.id): IntegerAnswer(  # ty: ignore[missing-argument]
-                            faker.Faker().random_number(2) if use_random_data else 123
+                            value=(faker.Faker().random_number(2) if use_random_data else 123)
                         ).get_value_for_submission(),
                         str(q4.id): SingleChoiceFromListAnswer(  # ty: ignore[missing-argument]
                             key=q4.data_source.items[item_choice].key, label=q4.data_source.items[item_choice].label

--- a/tests/unit/common/collections/test_types.py
+++ b/tests/unit/common/collections/test_types.py
@@ -31,7 +31,6 @@ def test_all_answer_types_tested():
     (
         (TextSingleLineAnswer, "hello", "hello"),
         (TextMultiLineAnswer, "hello\nthere", "hello\nthere"),
-        (IntegerAnswer, 5, "5"),
         (EmailAnswer, "name@example.com", "name@example.com"),
         (UrlAnswer, "https://www.gov.uk", "https://www.gov.uk"),
         (YesNoAnswer, True, "Yes"),
@@ -54,28 +53,44 @@ class TestSubmissionAnswerRootModels:
 class TestSubmissionAnswerBaseModels:
     @pytest.mark.parametrize(
         "model, data, submission_data",
-        ((SingleChoiceFromListAnswer, {"key": "key", "label": "label"}, {"key": "key", "label": "label"}),),
+        (
+            (IntegerAnswer, {"value": 50}, {"value": 50}),
+            (IntegerAnswer, {"value": 50, "prefix": "£"}, {"value": 50, "prefix": "£"}),
+            (IntegerAnswer, {"value": 50, "suffix": "lbs"}, {"value": 50, "suffix": "lbs"}),
+            (SingleChoiceFromListAnswer, {"key": "key", "label": "label"}, {"key": "key", "label": "label"}),
+        ),
     )
     def test_get_value_for_submission(self, model, data, submission_data):
         assert model(**data).get_value_for_submission() == submission_data
 
     @pytest.mark.parametrize(
         "model, data, form_value",
-        ((SingleChoiceFromListAnswer, {"key": "key", "label": "label"}, "key"),),
+        (
+            (IntegerAnswer, {"value": 50}, 50),
+            (SingleChoiceFromListAnswer, {"key": "key", "label": "label"}, "key"),
+        ),
     )
     def test_get_value_for_form(self, model, data, form_value):
         assert model(**data).get_value_for_form() == form_value
 
     @pytest.mark.parametrize(
         "model, data, expression_value",
-        ((SingleChoiceFromListAnswer, {"key": "key", "label": "label"}, "key"),),
+        (
+            (IntegerAnswer, {"value": 50}, 50),
+            (SingleChoiceFromListAnswer, {"key": "key", "label": "label"}, "key"),
+        ),
     )
     def test_get_value_for_expression(self, model, data, expression_value):
         assert model(**data).get_value_for_expression() == expression_value
 
     @pytest.mark.parametrize(
         "model, data, text_export_value",
-        ((SingleChoiceFromListAnswer, {"key": "key", "label": "label"}, "label"),),
+        (
+            (IntegerAnswer, {"value": 50}, "50"),
+            (IntegerAnswer, {"value": 1_000_000, "prefix": "£"}, "£1,000,000"),
+            (IntegerAnswer, {"value": 1_000_000, "suffix": "lbs"}, "1,000,000lbs"),
+            (SingleChoiceFromListAnswer, {"key": "key", "label": "label"}, "label"),
+        ),
     )
     def test_get_value_for_text_export(self, model, data, text_export_value):
         assert model(**data).get_value_for_text_export() == text_export_value

--- a/tests/unit/deliver_grant_funding/test_forms.py
+++ b/tests/unit/deliver_grant_funding/test_forms.py
@@ -184,3 +184,43 @@ class TestQuestionForm:
         assert form.errors == {
             "data_source_items": [f"You have entered too many options. The maximum is {max_data_source_items}"]
         }
+
+    def test_prefixes_and_suffixes_blank_coerced_to_none(self, app):
+        form = QuestionForm(question_type=QuestionDataType.INTEGER)
+
+        formdata = MultiDict(
+            [
+                ("text", "question"),
+                ("hint", ""),
+                ("name", "name"),
+                ("prefix", ""),
+                ("suffix", "   "),
+            ]
+        )
+
+        form.process(formdata)
+
+        assert form.validate() is True
+        assert form.prefix.data is None
+        assert form.suffix.data is None
+
+    def test_prefixes_and_suffixes_mutually_exclusive(self, app):
+        form = QuestionForm(question_type=QuestionDataType.INTEGER)
+
+        formdata = MultiDict(
+            [
+                ("text", "question"),
+                ("hint", ""),
+                ("name", "name"),
+                ("prefix", "£"),
+                ("suffix", "lbs"),
+            ]
+        )
+
+        form.process(formdata)
+
+        assert form.validate() is False
+        assert form.errors == {
+            "prefix": ["Remove the suffix if you need a prefix"],
+            "suffix": ["Remove the prefix if you need a suffix"],
+        }


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-749

## 📝 Description
We recently added support for prefixes and suffixes in form building for integer
fields, so you can for example prepend the input with a '£' for currency inputs.

I forgot to cascade this through to places where those values are rendered out,
for example the check your answers page and the CSV export. This patch addresses
  that missing functionality.

It also formats numbers with commas to separate thousands/millions/etc.

If we had real data we'd have to consider how to manage doing migrations for
existing submissions, but right now we can still just empty everything out -
fortunately.

There's an outstanding question around how we should render this for CSV export - maybe the prefix/suffix should be part of the header and the value should remain a pure integer. But we can address this based on user feedback.


## 📸 Show the thing (screenshots, gifs)
<img width="906" height="1444" alt="image" src="https://github.com/user-attachments/assets/3bd938f3-996e-4f90-bd69-27b3d483dcf9" />

<img width="699" height="351" alt="image" src="https://github.com/user-attachments/assets/61d8ea51-5ea6-4f7b-a717-42d3404da02d" />

<img width="730" height="758" alt="image" src="https://github.com/user-attachments/assets/f21d7b09-6fbe-4554-9096-f0d26639a3b8" />

<img width="1068" height="624" alt="image" src="https://github.com/user-attachments/assets/9691ede4-48e6-49f4-9376-ec6a1de864eb" />

<img width="693" height="222" alt="image" src="https://github.com/user-attachments/assets/5613a4d1-58ce-4515-a8df-ff6d7a4fee66" />


## 🧪 Testing
<!-- Describe how you've tested this change, and how a reviewer can test it -->

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- [x] No N+1 query problems introduced
- [x] Any new DB queries include appropriate where clauses based on the user's permissions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [ ] End-to-end tests have been updated (if applicable)
- [ ] Edge cases and error conditions are tested

## 📚 Additional Notes
<!-- Any additional context, concerns, or considerations for reviewers -->
