### PR TITLE
FSPT-604 Manage group display options page

### DIFF
--- a/app/common/collections/runner.py
+++ b/app/common/collections/runner.py
@@ -61,7 +61,7 @@ class FormRunner:
                 #        importing the class, there's probably a nicer way
                 self._questions = [self.component]  # type: ignore[list-item]
             elif self.component.is_group and self.component.display_same_page:  # type: ignore[union-attr]
-                self._questions = self.component.questions  # type: ignore[union-attr]
+                self._questions = self.submission.get_ordered_visible_questions_for_group(self.component)  # type: ignore[arg-type]
             else:
                 raise ValueError("Runner component must be a question or same page group")
 

--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -441,6 +441,10 @@ class Group(Component):
         data_type: None
 
     @property
+    def display_same_page(self) -> bool:
+        return bool(self.presentation_options.show_questions_on_the_same_page)
+
+    @property
     def questions(self) -> list["Question"]:
         return cast(list["Question"], get_ordered_nested_questions_for_components(self.components))
 

--- a/app/common/data/types.py
+++ b/app/common/data/types.py
@@ -13,7 +13,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 if TYPE_CHECKING:
     from app.common.collections.runner import FormRunner
     from app.common.data.models import Form, Question
-    from app.deliver_grant_funding.forms import QuestionForm
+    from app.deliver_grant_funding.forms import GroupDisplayForm, QuestionForm
 
 scalars = str | int | float | bool | None
 json_scalars = Dict[str, Any]
@@ -147,8 +147,11 @@ class QuestionPresentationOptions(BaseModel):
     # https://design-system.service.gov.uk/components/text-input/#fixed-width-inputs
     width: NumberInputWidths | None = None
 
+    # Groups
+    show_questions_on_the_same_page: bool | None = None
+
     @staticmethod
-    def from_form(form: "QuestionForm") -> QuestionPresentationOptions:
+    def from_question_form(form: "QuestionForm") -> QuestionPresentationOptions:
         match form._question_type:
             case QuestionDataType.RADIOS | QuestionDataType.CHECKBOXES:
                 return QuestionPresentationOptions(
@@ -167,6 +170,10 @@ class QuestionPresentationOptions(BaseModel):
                 )
             case _:
                 return QuestionPresentationOptions()
+
+    @staticmethod
+    def from_group_form(form: "GroupDisplayForm") -> QuestionPresentationOptions:
+        return QuestionPresentationOptions(show_questions_on_the_same_page=form.show_questions_on_the_same_page.data)
 
 
 class QuestionOptionsPostgresType(TypeDecorator):  # type: ignore[type-arg]

--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -52,6 +52,7 @@ if TYPE_CHECKING:
         Expression,
         Form,
         Grant,
+        Group,
         Question,
         Section,
         Submission,
@@ -280,6 +281,12 @@ class SubmissionHelper:
             # todo: check dependency chain for conditions when undefined variables are encountered to avoid
             #       always suppressing errors and not surfacing issues on misconfigured forms
             return False
+
+    # todo: make this uniform and cover appropriately
+    def get_ordered_visible_questions_for_group(self, group: "Group") -> list["Question"]:
+        return [
+            question for question in group.questions if self.is_component_visible(question, self.expression_context)
+        ]
 
     def get_ordered_visible_questions_for_form(self, form: "Form") -> list["Question"]:
         """Returns the visible, ordered questions for a given form based upon the current state of this collection."""

--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -46,7 +46,16 @@ from app.common.expressions import (
 from app.common.filters import format_datetime
 
 if TYPE_CHECKING:
-    from app.common.data.models import Collection, Component, Expression, Form, Grant, Question, Section, Submission
+    from app.common.data.models import (
+        Collection,
+        Component,
+        Expression,
+        Form,
+        Grant,
+        Question,
+        Section,
+        Submission,
+    )
 
 
 class SubmissionHelper:
@@ -193,6 +202,21 @@ class SubmissionHelper:
         except StopIteration as e:
             raise ValueError(
                 f"Could not find a question with id={question_id} in collection={self.collection.id}"
+            ) from e
+
+    def get_component(self, component_id: uuid.UUID) -> "Component":
+        try:
+            return next(
+                filter(
+                    lambda c: c.id == component_id,
+                    chain.from_iterable(
+                        form.all_components for section in self.collection.sections for form in section.forms
+                    ),
+                )
+            )
+        except StopIteration as e:
+            raise ValueError(
+                f"Could not find a component with id={component_id} in collection={self.collection.id}"
             ) from e
 
     def get_ordered_visible_sections(self) -> list["Section"]:

--- a/app/common/templates/common/macros/collections.html
+++ b/app/common/templates/common/macros/collections.html
@@ -12,92 +12,72 @@
 {% endmacro %}
 
 {% macro collection_question(runner) %}
-  {% set question = runner.question %}
+  {% set is_group = runner.component.is_group %}
+  {% set questions = runner.component.questions if is_group else [runner.component] %}
   {% set form = runner.question_form %}
-  {% set questionAsPageHeading = not runner.question.guidance_heading %}
+  {% set questionAsPageHeading = not runner.component.guidance_heading and not is_group %}
 
   <form method="post" novalidate>
     {{ form.csrf_token }}
 
-    <span class="govuk-caption-l">{{ question.form.title }}</span>
-    {% if runner.question.guidance_heading %}
-      <h1 class="govuk-heading-l">{{ runner.question.guidance_heading }}</h1>
-      {{ runner.question.guidance_body | govuk_markdown }}
+    <span class="govuk-caption-l">{{ runner.component.form.title }}</span>
+    {% if is_group %}
+      <h1 class="govuk-heading-l">{{ runner.component.name }}</h1>
+    {% elif runner.component.guidance_heading %}
+      <h1 class="govuk-heading-l">{{ runner.component.guidance_heading }}</h1>
+      {{ runner.component.guidance_body | govuk_markdown }}
     {% endif %}
 
     {# https://github.com/alphagov/govuk-frontend/issues/1841 #}
     {# GOV.UK Frontend macros don't let you add captions to label/legend-headings that are outside of the <h> element #}
     {# We want the caption outside of the <h> element to keep things more concise and understandable to screenreader users #}
     {# So we just manually add the caption here. #}
-    {% if question.data_type == enum.question_type.TEXT_MULTI_LINE %}
-      {{
-        form.render_question(
-          question,
-          params={
-            "label": {"classes": "govuk-label--l" if questionAsPageHeading else "govuk-!-font-weight-bold", "isPageHeading": questionAsPageHeading},
-            "maxwords": question.presentation_options.word_limit,
-            "rows": question.presentation_options.rows
-          }
-        )
-      }}
-    {% elif question.data_type == enum.question_type.TEXT_SINGLE_LINE or question.data_type == enum.question_type.EMAIL or question.data_type == enum.question_type.URL %}
-      {{
-        form.render_question(
-          question,
-          params={
-            "label": {"classes": "govuk-label--l" if questionAsPageHeading else "govuk-!-font-weight-bold", "isPageHeading": questionAsPageHeading}
-          }
-        )
-      }}
-    {% elif question.data_type == enum.question_type.INTEGER %}
-      {{
-        form.render_question(
-          question,
-          params={
-            "label": {"classes": "govuk-label--l" if questionAsPageHeading else "govuk-!-font-weight-bold" ,"isPageHeading": questionAsPageHeading},
-            "inputmode": "numeric",
-            "spellcheck": false,
-            "classes": question.presentation_options.width or '',
-            "prefix": {"text": question.presentation_options.prefix or ''},
-            "suffix": {"text": question.presentation_options.suffix or ''}
-          }
-        )
-      }}
-    {% elif question.data_type == enum.question_type.YES_NO %}
-      {{
-        form.render_question(
-          question,
-          params={
-            "fieldset": {"legend": {"text": question.text, "classes": "govuk-fieldset__legend--l" if questionAsPageHeading else "govuk-!-font-weight-bold", "isPageHeading": questionAsPageHeading} },
-            "classes": "govuk-radios--inline"
-          }
-        )
-      }}
-    {% elif question.data_type == enum.question_type.CHECKBOXES %}
-      {{
-        form.render_question(
-          question,
-          params={
-            "fieldset": {"legend": {"text": question.text, "classes": "govuk-fieldset__legend--l" if questionAsPageHeading else "govuk-!-font-weight-bold", "isPageHeading": questionAsPageHeading} },
-          }
-        )
-      }}
-    {% elif question.data_type == enum.question_type.RADIOS %}
-      {% if form.get_question_field(question).widget.is_accessible_autocomplete %}
-        {#
-          `govuk-!-width-full` override here to line up with the default width of the accessible autocomplete component. We could potentially do something smarter, like copy the class
-          from here to the enhanced autocomplete, but leaving that for a future increment.
-        #}
+    {% for question in questions %}
+      {% if question.data_type == enum.question_type.TEXT_MULTI_LINE %}
         {{
           form.render_question(
             question,
             params={
-              "label": {"text": question.text, "classes": "govuk-fieldset__legend--l" if questionAsPageHeading else "govuk-!-font-weight-bold", "isPageHeading": questionAsPageHeading},
-              "classes": "govuk-!-width-full"
+              "label": {"classes": "govuk-label--l" if questionAsPageHeading else "govuk-!-font-weight-bold", "isPageHeading": questionAsPageHeading},
+              "maxwords": question.presentation_options.word_limit,
+              "rows": question.presentation_options.rows
             }
           )
         }}
-      {% else %}
+      {% elif question.data_type == enum.question_type.TEXT_SINGLE_LINE or question.data_type == enum.question_type.EMAIL or question.data_type == enum.question_type.URL %}
+        {{
+          form.render_question(
+            question,
+            params={
+              "label": {"classes": "govuk-label--l" if questionAsPageHeading else "govuk-!-font-weight-bold", "isPageHeading": questionAsPageHeading}
+            }
+          )
+        }}
+      {% elif question.data_type == enum.question_type.INTEGER %}
+        {{
+          form.render_question(
+            question,
+            params={
+              "label": {"classes": "govuk-label--l" if questionAsPageHeading else "govuk-!-font-weight-bold" ,"isPageHeading": questionAsPageHeading},
+              "inputmode": "numeric",
+              "spellcheck": false,
+              "classes": question.presentation_options.width or '',
+              "prefix": {"text": question.presentation_options.prefix or ''},
+              "suffix": {"text": question.presentation_options.suffix or ''}
+            }
+          )
+        }}
+      {% elif question.data_type == enum.question_type.YES_NO %}
+        {{
+          form.render_question(
+            question,
+            params={
+              "fieldset": {"legend": {"text": question.text, "classes": "govuk-fieldset__legend--l" if questionAsPageHeading else "govuk-!-font-weight-bold", "isPageHeading": questionAsPageHeading} },
+              "classes": "govuk-radios--inline"
+            }
+          )
+        }}
+      {% elif question.data_type == enum.question_type.CHECKBOXES %}
         {{
           form.render_question(
             question,
@@ -106,8 +86,33 @@
             }
           )
         }}
+      {% elif question.data_type == enum.question_type.RADIOS %}
+        {% if form.get_question_field(question).widget.is_accessible_autocomplete %}
+          {#
+            `govuk-!-width-full` override here to line up with the default width of the accessible autocomplete component. We could potentially do something smarter, like copy the class
+            from here to the enhanced autocomplete, but leaving that for a future increment.
+          #}
+          {{
+            form.render_question(
+              question,
+              params={
+                "label": {"text": question.text, "classes": "govuk-fieldset__legend--l" if questionAsPageHeading else "govuk-!-font-weight-bold", "isPageHeading": questionAsPageHeading},
+                "classes": "govuk-!-width-full"
+              }
+            )
+          }}
+        {% else %}
+          {{
+            form.render_question(
+              question,
+              params={
+                "fieldset": {"legend": {"text": question.text, "classes": "govuk-fieldset__legend--l" if questionAsPageHeading else "govuk-!-font-weight-bold", "isPageHeading": questionAsPageHeading} },
+              }
+            )
+          }}
+        {% endif %}
       {% endif %}
-    {% endif %}
+    {% endfor %}
 
     {{ form.submit }}
   </form>

--- a/app/common/templates/common/macros/collections.html
+++ b/app/common/templates/common/macros/collections.html
@@ -32,7 +32,8 @@
     {# GOV.UK Frontend macros don't let you add captions to label/legend-headings that are outside of the <h> element #}
     {# We want the caption outside of the <h> element to keep things more concise and understandable to screenreader users #}
     {# So we just manually add the caption here. #}
-    {% for question in questions %}
+    {# fixme: if you need to access it name it appropriately #}
+    {% for question in runner._questions %}
       {% if question.data_type == enum.question_type.TEXT_MULTI_LINE %}
         {{
           form.render_question(

--- a/app/deliver_grant_funding/forms.py
+++ b/app/deliver_grant_funding/forms.py
@@ -488,3 +488,17 @@ class AddGuidanceForm(FlaskForm):
         filters=[strip_string_if_not_empty],
     )
     submit = SubmitField("Add guidance", widget=GovSubmitInput())
+
+
+class GroupDisplayForm(FlaskForm):
+    show_questions_on_the_same_page = RadioField(
+        "How do you want this question group to be displayed?",
+        choices=[
+            (False, "One question per page"),
+            (True, "Multiple questions on the same page"),
+        ],
+        default=False,
+        validators=[DataRequired("Select how you want this question group to be displayed")],
+        widget=GovRadioInput(),
+    )
+    submit = SubmitField(widget=GovSubmitInput())

--- a/app/deliver_grant_funding/forms.py
+++ b/app/deliver_grant_funding/forms.py
@@ -19,7 +19,11 @@ from wtforms.fields.simple import BooleanField, StringField, SubmitField, TextAr
 from wtforms.validators import DataRequired, Email, Optional, ValidationError
 
 from app.common.auth.authorisation_helper import AuthorisationHelper
-from app.common.data.interfaces.collections import get_question_by_id, is_component_dependency_order_valid
+from app.common.data.interfaces.collections import (
+    get_question_by_id,
+    is_component_dependency_in_same_page_valid,
+    is_component_dependency_order_valid,
+)
 from app.common.data.interfaces.grants import grant_name_exists
 from app.common.data.interfaces.user import get_user_by_email
 from app.common.data.types import MultilineTextInputRows, NumberInputWidths, QuestionDataType
@@ -474,6 +478,9 @@ class ConditionSelectQuestionForm(FlaskForm):
         depends_on_question = get_question_by_id(self.question.data)
         if not is_component_dependency_order_valid(self.target_question, depends_on_question):
             raise ValidationError("Select an answer that comes before this question in the form")
+
+        if not is_component_dependency_in_same_page_valid(self.target_question, depends_on_question):
+            raise ValidationError("Select an answer that is not on the same page as this question")
 
 
 class AddGuidanceForm(FlaskForm):

--- a/app/deliver_grant_funding/routes/reports.py
+++ b/app/deliver_grant_funding/routes/reports.py
@@ -393,7 +393,7 @@ def add_question(grant_id: UUID, form_id: UUID) -> ResponseReturnValue:
                 name=wt_form.name.data,
                 data_type=question_data_type_enum,
                 items=wt_form.normalised_data_source_items,
-                presentation_options=QuestionPresentationOptions.from_form(wt_form),
+                presentation_options=QuestionPresentationOptions.from_question_form(wt_form),
             )
             flash("Question created", FlashMessageType.QUESTION_CREATED)
             return redirect(
@@ -466,7 +466,7 @@ def edit_question(grant_id: UUID, question_id: UUID) -> ResponseReturnValue:
                 hint=wt_form.hint.data,
                 name=wt_form.name.data,
                 items=wt_form.normalised_data_source_items,
-                presentation_options=QuestionPresentationOptions.from_form(wt_form),
+                presentation_options=QuestionPresentationOptions.from_question_form(wt_form),
             )
             return redirect(
                 url_for(

--- a/app/deliver_grant_funding/routes/runner.py
+++ b/app/deliver_grant_funding/routes/runner.py
@@ -53,7 +53,7 @@ def submission_tasklist(grant_id: UUID, submission_id: UUID) -> ResponseReturnVa
 def ask_a_question(grant_id: UUID, submission_id: UUID, question_id: UUID) -> ResponseReturnValue:
     source = request.args.get("source")
     runner = DGFFormRunner.load(
-        submission_id=submission_id, question_id=question_id, source=FormRunnerState(source) if source else None
+        submission_id=submission_id, component_id=question_id, source=FormRunnerState(source) if source else None
     )
 
     if not runner.validate_can_show_question_page():

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/runner/ask_a_question.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/runner/ask_a_question.html
@@ -2,7 +2,7 @@
 {% from "common/macros/collections.html" import collection_before with context %}
 {% extends "developers/deliver/access_grant_funding_base.html" %}
 
-{% set page_title = runner.question.text ~ " - " ~ runner.form.title %}
+{% set page_title = runner.component.text ~ " - " ~ runner.form.title %}
 
 {# configure the page for the base error summary #}
 {# todo: probably worth just aliasing this in the render call #}

--- a/app/developers/access_routes.py
+++ b/app/developers/access_routes.py
@@ -88,7 +88,7 @@ def submission_tasklist(submission_id: uuid.UUID) -> ResponseReturnValue:
 def ask_a_question(submission_id: uuid.UUID, question_id: uuid.UUID) -> ResponseReturnValue:
     source = request.args.get("source")
     runner = AGFFormRunner.load(
-        submission_id=submission_id, question_id=question_id, source=FormRunnerState(source) if source else None
+        submission_id=submission_id, component_id=question_id, source=FormRunnerState(source) if source else None
     )
 
     if not runner.validate_can_show_question_page():

--- a/app/developers/deliver_routes.py
+++ b/app/developers/deliver_routes.py
@@ -1179,8 +1179,9 @@ def submission_tasklist(submission_id: UUID) -> ResponseReturnValue:
 @auto_commit_after_request
 def ask_a_question(submission_id: UUID, question_id: UUID) -> ResponseReturnValue:
     source = request.args.get("source")
+
     runner = DevelopersFormRunner.load(
-        submission_id=submission_id, question_id=question_id, source=FormRunnerState(source) if source else None
+        submission_id=submission_id, component_id=question_id, source=FormRunnerState(source) if source else None
     )
 
     if not runner.validate_can_show_question_page():

--- a/app/developers/templates/developers/access/ask_a_question.html
+++ b/app/developers/templates/developers/access/ask_a_question.html
@@ -2,7 +2,7 @@
 {% from "common/macros/collections.html" import collection_before with context %}
 {% extends "developers/access/base.html" %}
 
-{% set page_title = runner.question.text ~ " - " ~ runner.form.title %}
+{% set page_title = runner.component.text ~ " - " ~ runner.form.title %}
 
 {% set form = runner.question_form %}
 

--- a/app/developers/templates/developers/deliver/ask_a_question.html
+++ b/app/developers/templates/developers/deliver/ask_a_question.html
@@ -2,7 +2,7 @@
 {% from "common/macros/collections.html" import collection_before with context %}
 {% extends "developers/deliver/access_grant_funding_base.html" %}
 
-{% set page_title = runner.question.text ~ " - " ~ runner.form.title %}
+{% set page_title = runner.component.text ~ " - " ~ runner.form.title %}
 
 {# configure the page for the base error summary #}
 {# todo: probably worth just aliasing this in the render call #}

--- a/app/developers/templates/developers/deliver/edit_group.html
+++ b/app/developers/templates/developers/deliver/edit_group.html
@@ -51,6 +51,22 @@
       </h1>
 
       {# todo: group settings as a h2 which shows same page or not #}
+      <h2 class="govuk-heading-m">Group settings</h2>
+
+      {{
+        govukSummaryList({
+          "rows": [{
+            "key": { "text": "Display" },
+            "value": { "text": "Multiple questions on the same page" if group.presentation_options.show_questions_on_the_same_page else "One question per page" },
+            "actions": {
+              "items": [{
+                "text": "Change",
+                "href": url_for("developers.deliver.manage_group_display_options", grant_id=grant.id, collection_id=collection.id, section_id=section.id, form_id=db_form.id, group_id=group.id)
+              }]
+            }
+          }]
+        })
+      }}
 
       <form method="post" novalidate>
         <div class="govuk-form-group">

--- a/app/developers/templates/developers/deliver/edit_group.html
+++ b/app/developers/templates/developers/deliver/edit_group.html
@@ -141,6 +141,9 @@
       }}
       <h2 class="govuk-heading-m govuk-!-margin-top-5">Manage group</h2>
       <p class="govuk-body">
+        <a class="govuk-link" href="{{ url_for('developers.deliver.manage_group', grant_id=grant.id, collection_id=collection.id, section_id=section.id, group_id=group.id) }}"> Change group name </a>
+      </p>
+      <p class="govuk-body">
         <a class="govuk-link app-link--destructive" href="{{ url_for('developers.deliver.edit_group', grant_id=grant.id, collection_id=collection.id, section_id=section.id, form_id=db_form.id, group_id=group.id, delete='') }}">
           Delete this group
         </a>

--- a/app/developers/templates/developers/deliver/manage_group.html
+++ b/app/developers/templates/developers/deliver/manage_group.html
@@ -1,0 +1,28 @@
+{% extends "deliver_grant_funding/grant_base.html" %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+
+{% set page_title = "Edit group - " ~ section.title %}
+{% set active_item_identifier = "developers" %}
+
+{% block beforeContent %}
+  {{
+    govukBackLink({
+        "text": "Back",
+        "href": url_for("developers.deliver.edit_group", grant_id=grant.id, collection_id=collection.id, section_id=section.id, form_id=db_group.form.id, group_id=db_group.id)
+    })
+  }}
+{% endblock beforeContent %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">Manage group</h1>
+
+      <form method="post" novalidate>
+        {{ form.csrf_token }}
+        {{ form.name }}
+        {{ form.submit(params={"text": "Update group"}) }}
+      </form>
+    </div>
+  </div>
+{% endblock content %}

--- a/app/developers/templates/developers/deliver/manage_group_display_options.html
+++ b/app/developers/templates/developers/deliver/manage_group_display_options.html
@@ -1,0 +1,51 @@
+{% extends "deliver_grant_funding/grant_base.html" %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+
+{% set page_title = "Group display options - " ~ group.name %}
+{% set active_item_identifier = "developers" %}
+
+{% block beforeContent %}
+  {{
+    govukBackLink({
+        "text": "Back",
+        "href": url_for("developers.deliver.edit_group", grant_id = grant.id, collection_id=collection.id, section_id=section.id, form_id=db_form.id, group_id=group.id)
+    })
+  }}
+{% endblock beforeContent %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l">{{ group.text }}</span>
+      <h1 class="govuk-heading-l">How do you want this question group to be displayed?</h1>
+      <form method="post" novalidate>
+        {{ form.csrf_token }}
+        {{
+          form.show_questions_on_the_same_page(params={
+            "fieldset": {
+              "legend": {
+                "classes": "govuk-visually-hidden"
+              }
+            },
+            "items": [
+              {},
+              {
+                "hint": {
+                  "text": "The question group name will be the page title",
+                }
+              }
+            ]
+          })
+        }}
+        <div class="govuk-button-group">
+          {{
+            form.submit(params={
+                "text": "Update display"
+            })
+          }}
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('developers.deliver.edit_group', grant_id=grant.id, collection_id=collection.id, section_id=section.id, form_id=db_form.id, group_id=group.id) }}">Cancel</a>
+        </div>
+      </form>
+    </div>
+  </div>
+{% endblock content %}

--- a/tests/integration/common/collections/test_forms.py
+++ b/tests/integration/common/collections/test_forms.py
@@ -33,7 +33,7 @@ def test_validation_attached_to_field_and_runs__text(factories, value, error_mes
         name="test_text",
     )
 
-    _FormClass = build_question_form(question, expression_context=ExpressionContext())
+    _FormClass = build_question_form([question], expression_context=ExpressionContext())
     form = _FormClass(formdata=MultiDict({"q_e4bd98ab41ef4d23b1e59c0404891e7b": str(value)}))
 
     valid = form.validate()
@@ -70,7 +70,7 @@ def test_validation_attached_to_field_and_runs__integer(factories, value, error_
         question, user, LessThan(question_id=question.id, maximum_value=100, inclusive=False)
     )
 
-    _FormClass = build_question_form(question, expression_context=ExpressionContext())
+    _FormClass = build_question_form([question], expression_context=ExpressionContext())
     form = _FormClass(formdata=MultiDict({"q_e4bd98ab41ef4d23b1e59c0404891e7a": str(value)}))
 
     valid = form.validate()
@@ -91,7 +91,7 @@ def test_special_radio_field_enhancement_to_autocomplete(factories, app, db_sess
         data_type=QuestionDataType.RADIOS,
         items=[str(i) for i in range(25)],
     )
-    form = build_question_form(q, expression_context=EC())()
+    form = build_question_form([q], expression_context=EC())()
 
     question_field = form.get_question_field(q)
     assert isinstance(question_field, SelectField)

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -37,6 +37,7 @@ from app.common.data.interfaces.collections import (
     raise_if_data_source_item_reference_dependency,
     raise_if_question_has_any_dependencies,
     remove_question_expression,
+    update_group,
     update_question,
     update_question_expression,
     update_submission_data,
@@ -945,6 +946,30 @@ def test_move_question_up_down(db_session, factories):
     assert q1.order == 2
     assert q2.order == 0
     assert q3.order == 1
+
+
+class TestUpdateGroup:
+    def test_update_group(self, db_session, factories):
+        group = factories.group.create()
+        updated_group = update_group(
+            group,
+            name="Changed name",
+        )
+
+        assert updated_group.name == "Changed name"
+        assert updated_group.text == "Changed name"
+        assert updated_group.slug == "changed-name"
+        assert updated_group.presentation_options == QuestionPresentationOptions()
+
+    def test_update_group_presentation_options(self, db_session, factories):
+        group = factories.group.create()
+        updated_group = update_group(
+            group,
+            name=group.name,
+            presentation_options=QuestionPresentationOptions(show_questions_on_the_same_page=True),
+        )
+
+        assert updated_group.presentation_options.show_questions_on_the_same_page is True
 
 
 def test_move_question_with_dependencies(db_session, factories):

--- a/tests/integration/common/helpers/test_collections.py
+++ b/tests/integration/common/helpers/test_collections.py
@@ -39,7 +39,7 @@ class TestSubmissionHelper:
 
             assert helper.get_answer_for_question(question.id) is None
 
-            form = build_question_form(question, expression_context=EC())(
+            form = build_question_form([question], expression_context=EC())(
                 q_d696aebc49d24170a92fb6ef42994294="User submitted data"
             )
             helper.submit_answer_for_question(question.id, form)
@@ -53,7 +53,7 @@ class TestSubmissionHelper:
             submission = factories.submission.build(collection=question.form.section.collection)
             helper = SubmissionHelper(submission)
 
-            form = build_question_form(question, expression_context=EC())(q_d696aebc49d24170a92fb6ef42994294=5)
+            form = build_question_form([question], expression_context=EC())(q_d696aebc49d24170a92fb6ef42994294=5)
             helper.submit_answer_for_question(question.id, form)
 
             assert helper.get_answer_for_question(question.id) == IntegerAnswer(value=5)
@@ -65,7 +65,7 @@ class TestSubmissionHelper:
             submission = factories.submission.build(collection=question.form.section.collection)
             helper = SubmissionHelper(submission)
 
-            form = build_question_form(question, expression_context=EC())(q_d696aebc49d24170a92fb6ef42994294=0)
+            form = build_question_form([question], expression_context=EC())(q_d696aebc49d24170a92fb6ef42994294=0)
             helper.submit_answer_for_question(question.id, form)
 
             assert helper.get_answer_for_question(question.id) == IntegerAnswer(value=0)
@@ -75,7 +75,7 @@ class TestSubmissionHelper:
             submission = factories.submission.build(collection=question.form.section.collection)
             helper = SubmissionHelper(submission)
 
-            form = build_question_form(question, expression_context=EC())(
+            form = build_question_form([question], expression_context=EC())(
                 q_d696aebc49d24170a92fb6ef42994294="User submitted data"
             )
             helper.submit_answer_for_question(question.id, form)
@@ -292,7 +292,7 @@ class TestSubmissionHelper:
 
             helper.submit_answer_for_question(
                 question_one.id,
-                build_question_form(question_one, expression_context=EC())(
+                build_question_form([question_one], expression_context=EC())(
                     q_d696aebc49d24170a92fb6ef42994294="User submitted data"
                 ),
             )
@@ -302,7 +302,7 @@ class TestSubmissionHelper:
 
             helper.submit_answer_for_question(
                 question_two.id,
-                build_question_form(question_two, expression_context=EC())(
+                build_question_form([question_two], expression_context=EC())(
                     q_d696aebc49d24170a92fb6ef42994295="User submitted data"
                 ),
             )
@@ -318,7 +318,7 @@ class TestSubmissionHelper:
             # make sure the second form is unaffected by the first forms status
             helper.submit_answer_for_question(
                 question_three.id,
-                build_question_form(question_three, expression_context=EC())(
+                build_question_form([question_three], expression_context=EC())(
                     q_d696aebc49d24170a92fb6ef42994296="User submitted data"
                 ),
             )
@@ -344,7 +344,7 @@ class TestSubmissionHelper:
 
             helper.submit_answer_for_question(
                 question.id,
-                build_question_form(question, expression_context=EC())(
+                build_question_form([question], expression_context=EC())(
                     q_d696aebc49d24170a92fb6ef42994294="User submitted data"
                 ),
             )
@@ -356,7 +356,7 @@ class TestSubmissionHelper:
 
             helper.submit_answer_for_question(
                 question_two.id,
-                build_question_form(question_two, expression_context=EC())(
+                build_question_form([question_two], expression_context=EC())(
                     q_d696aebc49d24170a92fb6ef42994295="User submitted data"
                 ),
             )
@@ -386,7 +386,7 @@ class TestSubmissionHelper:
 
             helper.submit_answer_for_question(
                 question.id,
-                build_question_form(question, expression_context=EC())(
+                build_question_form([question], expression_context=EC())(
                     q_d696aebc49d24170a92fb6ef42994294="User submitted data"
                 ),
             )
@@ -410,7 +410,7 @@ class TestSubmissionHelper:
 
             helper.submit_answer_for_question(
                 question.id,
-                build_question_form(question, expression_context=EC())(
+                build_question_form([question], expression_context=EC())(
                     q_d696aebc49d24170a92fb6ef42994294="User submitted data"
                 ),
             )
@@ -431,7 +431,7 @@ class TestSubmissionHelper:
 
             helper.submit_answer_for_question(
                 question.id,
-                build_question_form(question, expression_context=EC())(
+                build_question_form([question], expression_context=EC())(
                     q_d696aebc49d24170a92fb6ef42994294="User submitted data"
                 ),
             )

--- a/tests/models.py
+++ b/tests/models.py
@@ -635,6 +635,8 @@ class _GroupFactory(SQLAlchemyModelFactory):
     form = factory.SubFactory(_FormFactory)
     form_id = factory.LazyAttribute(lambda o: o.form.id)
 
+    presentation_options = factory.LazyFunction(lambda: QuestionPresentationOptions())
+
     @factory.post_generation  # type: ignore[misc]
     def expressions(self, create: bool, extracted: list[Any], **kwargs: Any) -> None:
         if not extracted:

--- a/tests/unit/common/collections/test_forms.py
+++ b/tests/unit/common/collections/test_forms.py
@@ -31,7 +31,7 @@ class TestBuildQuestionForm:
             id=uuid.UUID("e4bd98ab-41ef-4d23-b1e5-9c0404891e7a"), data_type=QuestionDataType.INTEGER
         )
 
-        _FormClass = build_question_form(question, expression_context=ExpressionContext())
+        _FormClass = build_question_form([question], expression_context=ExpressionContext())
         form = _FormClass()
 
         assert not hasattr(form, "csrf_token")
@@ -57,7 +57,7 @@ class TestBuildQuestionForm:
                 id=uuid.UUID("e4bd98ab-41ef-4d23-b1e5-9c0404891e7a"), data_type=QuestionDataType.INTEGER
             )
 
-            _FormClass = build_question_form(question, expression_context=ExpressionContext())
+            _FormClass = build_question_form([question], expression_context=ExpressionContext())
             form = _FormClass(formdata=MultiDict({"q_e4bd98ab41ef4d23b1e59c0404891e7a": "500"}))
             assert hasattr(form, "csrf_token")
             assert hasattr(form, "submit")
@@ -69,7 +69,7 @@ class TestBuildQuestionForm:
             text="Question text",
             data_type=QuestionDataType.TEXT_SINGLE_LINE,
         )
-        form = build_question_form(q, expression_context=EC())
+        form = build_question_form([q], expression_context=EC())
         assert hasattr(form, "q_31673d5195b04589b25433b866dfd94f")
         assert hasattr(form, "submit")
 
@@ -101,7 +101,7 @@ class TestBuildQuestionForm:
         q = factories.question.build(
             text="Question text", hint="Question hint", data_type=data_type, presentation_options=presentation_options
         )
-        form = build_question_form(q, expression_context=EC())()
+        form = build_question_form([q], expression_context=EC())()
 
         question_field = form.get_question_field(q)
         assert isinstance(question_field, expected_field_type)

--- a/tests/unit/common/collections/test_runner.py
+++ b/tests/unit/common/collections/test_runner.py
@@ -4,7 +4,7 @@ import pytest
 
 from app.common.collections.runner import FormRunner
 from app.common.collections.types import TextSingleLineAnswer
-from app.common.data.types import FormRunnerState, QuestionDataType
+from app.common.data.types import FormRunnerState, QuestionDataType, QuestionPresentationOptions
 from app.common.helpers.collections import SubmissionHelper
 
 
@@ -14,20 +14,45 @@ class TestFormRunner:
         submission = factories.submission.build(collection=question.form.section.collection)
         helper = SubmissionHelper(submission)
 
-        question_state_context = FormRunner(submission=helper, question=question, source=None)
-        assert question_state_context.question == question
+        question_state_context = FormRunner(submission=helper, component=question, source=None)
+        assert question_state_context.component == question
         assert question_state_context.form == question.form
         assert question_state_context.question_form is not None
 
         check_your_answers_context = FormRunner(submission=helper, form=question.form, source=None)
-        assert check_your_answers_context.question is None
+        assert check_your_answers_context.component is None
         assert check_your_answers_context.form == question.form
         assert check_your_answers_context.check_your_answers_form is not None
 
         tasklist_context = FormRunner(submission=helper, source=None)
-        assert tasklist_context.question is None
+        assert tasklist_context.component is None
         assert tasklist_context.form is None
         assert tasklist_context.tasklist_form is not None
+
+    def test_form_runner_loads_and_sets_context_for_same_page_group(self, factories):
+        group = factories.group.build(
+            presentation_options=QuestionPresentationOptions(show_questions_on_the_same_page=True)
+        )
+        q1 = factories.question.build(parent=group, form=group.form)
+        q2 = factories.question.build(parent=group, form=group.form)
+        submission = factories.submission.build(collection=group.form.section.collection)
+        helper = SubmissionHelper(submission)
+
+        runner = FormRunner(submission=helper, component=q1, source=None)
+
+        assert runner.component == group
+        assert runner._questions == [q1, q2]
+        assert runner.question_form is not None
+
+    def test_form_runner_rejects_invalid_component(self, factories):
+        group = factories.group.build(
+            presentation_options=QuestionPresentationOptions(show_questions_on_the_same_page=False)
+        )
+        submission = factories.submission.build(collection=group.form.section.collection)
+        helper = SubmissionHelper(submission)
+
+        with pytest.raises(ValueError, match="Runner component must be a question or same page group"):
+            FormRunner(submission=helper, component=group, source=None)
 
     def test_form_runner_correctly_configures_dynamic_question_form(self, factories):
         question = factories.question.build(data_type=QuestionDataType.TEXT_SINGLE_LINE)
@@ -37,9 +62,30 @@ class TestFormRunner:
         )
         helper = SubmissionHelper(submission)
 
-        runner = FormRunner(submission=helper, question=question, source=None)
+        runner = FormRunner(submission=helper, component=question, source=None)
         assert runner.question_form.get_question_field(question) is not None
         assert runner.question_form.get_answer_to_question(question) == "An answer"
+
+    def test_form_runner_correctly_configured_dynamic_question_form_for_same_page(self, factories):
+        group = factories.group.build(
+            presentation_options=QuestionPresentationOptions(show_questions_on_the_same_page=True)
+        )
+        q1 = factories.question.build(parent=group, form=group.form)
+        q2 = factories.question.build(parent=group, form=group.form)
+        submission = factories.submission.build(
+            collection=group.form.section.collection,
+            data={
+                str(q1.id): TextSingleLineAnswer("An answer for q1").get_value_for_submission(),
+                str(q2.id): TextSingleLineAnswer("An answer for q2").get_value_for_submission(),
+            },
+        )
+        helper = SubmissionHelper(submission)
+
+        runner = FormRunner(submission=helper, component=q1, source=None)
+        assert runner.question_form.get_question_field(q1) is not None
+        assert runner.question_form.get_answer_to_question(q1) == "An answer for q1"
+        assert runner.question_form.get_answer_to_question(q2) == "An answer for q2"
+        assert runner.question_form.get_question_field(q2) is not None
 
     def test_calls_mapped_urls_with_the_right_information(self, factories):
         question = factories.question.build()
@@ -59,7 +105,7 @@ class TestFormRunner:
                 FormRunnerState.CHECK_YOUR_ANSWERS: check_answers_mock,
             }
 
-        runner = MappedFormRunner(submission=helper, question=question, source=None)
+        runner = MappedFormRunner(submission=helper, component=question, source=None)
         url = runner.to_url(FormRunnerState.QUESTION, source=FormRunnerState.TASKLIST)
         assert url == "mock_question_url"
         question_mock.assert_called_once_with(runner, question, question.form, FormRunnerState.TASKLIST)
@@ -95,14 +141,46 @@ class TestFormRunner:
                 FormRunnerState.CHECK_YOUR_ANSWERS: check_your_answers_mock,
             }
 
-        runner = MappedFormRunner(submission=helper, question=question, source=None)
+        runner = MappedFormRunner(submission=helper, component=question, source=None)
         assert (
             runner.validate_can_show_question_page()
             and runner.next_url == f"mock_question_url_{str(second_question.id)}"
         )
 
-        end_of_form = MappedFormRunner(submission=helper, question=second_question, source=None)
+        end_of_form = MappedFormRunner(submission=helper, component=second_question, source=None)
         assert end_of_form.validate_can_show_question_page() and end_of_form.next_url == "mock_check_answers_url"
+
+    def test_next_back_url_for_group(self, factories):
+        q1 = factories.question.build(order=0)
+        group = factories.group.build(
+            form=q1.form,
+            presentation_options=QuestionPresentationOptions(show_questions_on_the_same_page=True),
+            order=1,
+        )
+        factories.question.build(parent=group, order=0)
+        nested_q3 = factories.question.build(parent=group, order=1)
+        factories.question.build(parent=group, order=2)
+        q5 = factories.question.build(form=group.form, order=2)
+        submission = factories.submission.build(collection=group.form.section.collection)
+        helper = SubmissionHelper(submission)
+
+        question_mock = Mock(side_effect=lambda r, q, f, s: f"mock_question_url_{str(q.id)}")
+        check_your_answers_mock = Mock(return_value="mock_check_answers_url")
+
+        class MappedFormRunner(FormRunner):
+            url_map = {
+                FormRunnerState.QUESTION: question_mock,
+                FormRunnerState.CHECK_YOUR_ANSWERS: check_your_answers_mock,
+            }
+
+        runner = MappedFormRunner(submission=helper, component=nested_q3, source=None)
+
+        # even though we're in the middle of a group of questions, the next question should come after the
+        # group as they're all shown on the same page
+        assert runner.validate_can_show_question_page() and runner.next_url == f"mock_question_url_{str(q5.id)}"
+
+        # similarly the back question should be the question before the group of same page
+        assert runner.validate_can_show_question_page() and runner.back_url == f"mock_question_url_{str(q1.id)}"
 
     @pytest.mark.parametrize("source", [FormRunnerState.QUESTION, FormRunnerState.CHECK_YOUR_ANSWERS])
     def test_next_url_skips_answered_questions_and_always_goes_to_next_unanswered_question(
@@ -128,17 +206,17 @@ class TestFormRunner:
                 FormRunnerState.CHECK_YOUR_ANSWERS: check_your_answers_mock,
             }
 
-        runner = MappedFormRunner(submission=helper, question=question, source=source)
+        runner = MappedFormRunner(submission=helper, component=question, source=source)
         runner.validate_can_show_question_page()
         assert runner.next_url == f"mock_question_url_{str(third_question.id)}", (
             "should skip over 2nd question as it has an answer"
         )
 
-        runner = MappedFormRunner(submission=helper, question=second_question, source=source)
+        runner = MappedFormRunner(submission=helper, component=second_question, source=source)
         runner.validate_can_show_question_page()
         assert runner.next_url == f"mock_question_url_{str(third_question.id)}"
 
-        runner = MappedFormRunner(submission=helper, question=third_question, source=source)
+        runner = MappedFormRunner(submission=helper, component=third_question, source=source)
         runner.validate_can_show_question_page()
         assert runner.next_url == "mock_check_answers_url"
 
@@ -154,10 +232,10 @@ class TestFormRunner:
         class MappedFormRunner(FormRunner):
             url_map = {FormRunnerState.QUESTION: question_mock, FormRunnerState.TASKLIST: tasklist_mock}
 
-        runner = MappedFormRunner(submission=helper, question=second_question, source=None)
+        runner = MappedFormRunner(submission=helper, component=second_question, source=None)
         assert runner.back_url == f"mock_question_url_{str(question.id)}"
 
-        start_of_form = MappedFormRunner(submission=helper, question=question, source=None)
+        start_of_form = MappedFormRunner(submission=helper, component=question, source=None)
         assert start_of_form.back_url == "mock_tasklist_url"
 
     class TestUrlConfig:
@@ -165,6 +243,6 @@ class TestFormRunner:
         def test_runners_url_map_resolves(self, factories, runner_class):
             question = factories.question.build()
             submission = factories.submission.build(collection=question.form.section.collection)
-            runner = runner_class(submission=SubmissionHelper(submission), question=question)
+            runner = runner_class(submission=SubmissionHelper(submission), component=question)
             for state in FormRunnerState:
                 assert runner.to_url(state) is not None

--- a/tests/unit/test_all_routes_access.py
+++ b/tests/unit/test_all_routes_access.py
@@ -38,6 +38,7 @@ routes_with_expected_platform_admin_only_access = [
     "developers.deliver.add_question",
     "developers.deliver.add_group",
     "developers.deliver.edit_group",
+    "developers.deliver.manage_group",
     "developers.deliver.manage_group_display_options",
     "developers.deliver.move_question",
     "developers.deliver.edit_question",

--- a/tests/unit/test_all_routes_access.py
+++ b/tests/unit/test_all_routes_access.py
@@ -38,6 +38,7 @@ routes_with_expected_platform_admin_only_access = [
     "developers.deliver.add_question",
     "developers.deliver.add_group",
     "developers.deliver.edit_group",
+    "developers.deliver.manage_group_display_options",
     "developers.deliver.move_question",
     "developers.deliver.edit_question",
     "developers.deliver.add_question_condition_select_question",


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-604

## 📝 Description
Adds a page to allow form designers to configure the presentation
options on a group. This uses the same interface as the existing
presentation options for questions but for the time being only has one
option.

## 📸 Show the thing (screenshots, gifs)
Note these are just developer pages and any notes from dev/ design mobbing sessions will be applied at (i.e consistently calling these "question groups" rather than "groups")

<img width="699" height="468" alt="Screenshot 2025-08-15 at 13 51 45" src="https://github.com/user-attachments/assets/1417bf37-5ea4-40df-b5f7-6cccfec07fb0" />

<img width="682" height="505" alt="Screenshot 2025-08-15 at 13 51 39" src="https://github.com/user-attachments/assets/717ba52e-38dc-4021-9908-eea602ab7788" />

<img width="2834" height="4474" alt="funding communities gov localhost_8080_developers_deliver_submissions_290ba025-8a61-4861-8a8b-93f673e1e231_811e3a9c-80be-4233-adc2-3ef80bc571e9" src="https://github.com/user-attachments/assets/d6e93bb1-2250-4f6b-9681-f0eac0080f6f" />

---

<img width="1154" height="4020" alt="funding communities gov localhost_8080_developers_deliver_submissions_290ba025-8a61-4861-8a8b-93f673e1e231_811e3a9c-80be-4233-adc2-3ef80bc571e9 (1)" src="https://github.com/user-attachments/assets/0cd968f5-40cb-47b1-a0e4-03d2359d0132" />

---

<img width="1154" height="5070" alt="funding communities gov localhost_8080_developers_deliver_submissions_290ba025-8a61-4861-8a8b-93f673e1e231_811e3a9c-80be-4233-adc2-3ef80bc571e9 (2)" src="https://github.com/user-attachments/assets/ca185126-e6d5-49dc-99fc-2522d3891978" />
