### PR TITLE
Update content for question guidance

### DIFF
--- a/app/assets/js/markdown-editor-toolbar/index.js
+++ b/app/assets/js/markdown-editor-toolbar/index.js
@@ -74,7 +74,7 @@ const createToolbarForTextArea = textArea => {
 
 const getButtonText = (identifier, i18n) => {
   const snakeCaseIdentifier = identifier.replaceAll('-', '_')
-  return i18n[snakeCaseIdentifier]
+  return {h2: "Add a second-level heading", link: "Add a link", bullet_list: "Add a bulleted list", numbered_list: "Add a numbered list"}[snakeCaseIdentifier];
 }
 
 const createButtonGroup = (

--- a/app/deliver_grant_funding/forms.py
+++ b/app/deliver_grant_funding/forms.py
@@ -478,12 +478,18 @@ class ConditionSelectQuestionForm(FlaskForm):
 
 class AddGuidanceForm(FlaskForm):
     guidance_heading = StringField(
-        "Page heading",
+        "Give your page a heading",
+        description=(
+            "When you add guidance your question text will no longer be the main page heading, "
+            "so you need to use a different one. "
+            "Use a heading that’s a statement rather than a question - for example, ‘Interview needs’."
+        ),
         widget=GovTextInput(),
         filters=[strip_string_if_not_empty],
     )
     guidance_body = StringField(
-        "Guidance",
+        "Add guidance text",
+        description="Use Markdown if you need to format your guidance content. Formatting help can be found below.",
         widget=GovTextArea(),
         filters=[strip_string_if_not_empty],
     )

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/edit_question.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/edit_question.html
@@ -91,12 +91,20 @@
 
         {{ advancedFormattingOptions(form, question.data_type, enum) }}
 
-        <h2 class="govuk-heading-m">Guidance (optional)</h2>
-        {% if not question.guidance_body %}
-          <p class="govuk-body">Only add guidance if you need to give a longer explanation of how to answer the question, or to format your content with paragraphs, headings, lists or links.</p>
-          <a class="govuk-button govuk-button--secondary" href="{{ url_for('deliver_grant_funding.manage_guidance', grant_id=grant.id, question_id=question.id) }}">Add guidance</a>
+        <h2 class="govuk-heading-m">Guidance</h2>
+        <p class="govuk-body">Only add guidance if you need to give a longer explanation of how to answer the question, or to format your content with paragraphs, headings, lists or links.</p>
+
+        {% if question.guidance_body %}
+          {{
+            govukSummaryList({
+              "rows": [
+                {"key": {"text": "Page heading"}, "value": {"text": question.guidance_heading}, "actions": {"items": [{"href": url_for('deliver_grant_funding.manage_guidance', grant_id=grant.id, question_id=question.id), "text": "Change", "visuallyHiddenText": "page heading"}] } },
+                {"key": {"text": "Guidance text"}, "value": {"html": question.guidance_body.replace('\n', '<br>')}, "actions": {"items": [{"href": url_for('deliver_grant_funding.manage_guidance', grant_id=grant.id, question_id=question.id), "text": "Change", "visuallyHiddenText": "guidance text"}] } },
+              ]
+            })
+          }}
         {% else %}
-          <a class="govuk-button govuk-button--secondary" href="{{ url_for('deliver_grant_funding.manage_guidance', grant_id=grant.id, question_id=question.id) }}">Edit guidance</a>
+          <a class="govuk-button govuk-button--secondary" href="{{ url_for('deliver_grant_funding.manage_guidance', grant_id=grant.id, question_id=question.id) }}"> Add guidance </a>
         {% endif %}
 
         <div class="govuk-form-group">

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/manage_guidance.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/manage_guidance.html
@@ -1,5 +1,6 @@
 {% extends "deliver_grant_funding/grant_base.html" %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/details/macro.html" import govukDetails %}
 
 {% set page_title = "Add guidance" if not question.guidance_body else "Edit guidance" %}
 {% set submit_label = "Add guidance" if not question.guidance_body else "Update guidance" %}
@@ -13,9 +14,45 @@
   }}
 {% endblock beforeContent %}
 
+
+{% set guidance_help %}
+  <h3 class="govuk-heading-m">Links and URLs</h3>
+  <p>To add a link, use square brackets [ ] around the link text, and round brackets ( ) around the full URL. Make sure there are no spaces between the two sets of brackets. For example:</p>
+  <div class="govuk-inset-text">
+    <pre class="app-markdown-editor__markdown-example-block"><code class="app-markdown-editor__markdown-example-block-code">[Link text](https://www.gov.uk/link-text-url)</code></pre>
+  </div>
+
+  <h3 class="govuk-heading-m">Headings</h3>
+  <p>Do not use headings to style your text in bold. This can cause issues for people using assistive technology.</p>
+  <h4 class="govuk-heading-s">Second-level headings</h4>
+  <p>To add a second-level heading (H2), use 2 hashtags followed by a space. For example:</p>
+  <div class="govuk-inset-text">
+    <pre class="app-markdown-editor__markdown-example-block"><code class="app-markdown-editor__markdown-example-block-code">## This is a second-level heading</code></pre>
+  </div>
+
+  <h3 class="govuk-heading-m">Bulleted lists</h3>
+  <p>To add bullet points, start each item with * (asterisk) or - (dash). Make sure there is one space after the asterisk or dash.</p>
+  <p>Leave one empty line before adding the first bullet point and another after the last bullet point. For example:</p>
+  <div class="govuk-inset-text">
+    <pre class="app-markdown-editor__markdown-example-block"><code class="app-markdown-editor__markdown-example-block-code">* First bullet point
+* Second bullet point
+* Third bullet point</code></pre>
+  </div>
+
+  <h3 class="govuk-heading-m">Numbered lists</h3>
+  <p>Use numbers for each list item, followed by a full stop. Make sure there is one space after the full stop.</p>
+  <p>Leave one empty line before adding the first list item and another after the last list item. For example:</p>
+  <div class="govuk-inset-text">
+    <pre class="app-markdown-editor__markdown-example-block"><code class="app-markdown-editor__markdown-example-block-code">1. First item
+2. Second item
+3. Third item</code></pre>
+  </div>
+{% endset %}
+
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l">{{ question.text }}</span>
       <h2 class="govuk-heading-l">{{ page_title }}</h2>
       <p class="govuk-body">Use guidance if you need to:</p>
       <ul class="govuk-list govuk-list--bullet">
@@ -25,8 +62,11 @@
       <p class="govuk-body">Guidance will be displayed at the top of the page, above your question.</p>
       <form method="post" novalidate>
         {{ form.csrf_token }}
-        {{ form.guidance_heading(params={"label": {"classes": "govuk-!-font-weight-bold"} }) }}
-        {{ form.guidance_body(params={"label": {"classes": "govuk-!-font-weight-bold"}, "attributes": {"data-module": "markdown-editor-toolbar", "data-allow-headings": "true", "data-i18n": "{}"} }) }}
+        {{ form.guidance_heading(params={"label": {"classes": "govuk-label--m"} }) }}
+        {{ form.guidance_body(params={"label": {"classes": "govuk-label--m"}, "rows": 15, "attributes": {"data-module": "markdown-editor-toolbar", "data-allow-headings": "true", "data-i18n": "{}"} }) }}
+
+        {{ govukDetails(params={"summaryText": "Formatting help", "html": guidance_help}) }}
+
         {{ form.submit(params={"text": submit_label }) }}
       </form>
     </div>


### PR DESCRIPTION
## 🎫 Ticket
[<!-- Link to Jira ticket, GitHub issue, or other tracking system -->](https://mhclgdigital.atlassian.net/browse/FSPT-750)

## 📝 Description
Lift the formatting, layout and content from GOV.UK Forms for our own implementation of question guidance.

## 📸 Show the thing (screenshots, gifs)

### Question page (no guidance)
<img width="704" height="388" alt="image" src="https://github.com/user-attachments/assets/101415db-3643-4c6f-8d63-6ac2bbf71fd4" />

### Question page (with guidance)
<img width="729" height="822" alt="image" src="https://github.com/user-attachments/assets/8e313653-055d-42f1-8caf-6a309ab68df7" />

### Add/edit guidance page
<img width="1902" height="1655" alt="image" src="https://github.com/user-attachments/assets/cbd3cded-c25c-442c-ad80-f596c20f9865" />

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [-] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested

## 📚 Additional Notes
<!-- Any additional context, concerns, or considerations for reviewers -->
