### PR TITLE
Revert "Update pre-commit hook seddonym/import-linter to v2.4"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
         exclude: tests/pre_award/keys/rsa256
 
   - repo: https://github.com/seddonym/import-linter
-    rev: v2.4
+    rev: v2.3
     hooks:
       - id: import-linter
 


### PR DESCRIPTION
Reverts communitiesuk/funding-service#661

It's failing 🙃 