### PR TITLE
FSPT-747: Reports tab E2E tests

### DIFF
--- a/tests/e2e/pages.py
+++ b/tests/e2e/pages.py
@@ -5,6 +5,7 @@ from abc import ABC
 from playwright.sync_api import Locator, Page, expect
 
 from tests.e2e.developer_pages import GrantDevelopersPage
+from tests.e2e.reports_pages import GrantReportsPage
 
 
 class BasePage:
@@ -278,12 +279,14 @@ class GrantDashboardBasePage(TopNavMixin, BasePage):
     dashboard_nav: Locator
     settings_nav: Locator
     developers_nav: Locator
+    reports_nav: Locator
 
     def __init__(self, page: Page, domain: str) -> None:
         super().__init__(page, domain)
         self.dashboard_nav = self.page.get_by_role("link", name="Grant home")
         self.settings_nav = self.page.get_by_role("link", name="Grant details")
         self.developers_nav = self.page.get_by_role("link", name="Developers")
+        self.reports_nav = self.page.get_by_role("link", name="Reports")
 
     def click_dashboard(self) -> GrantDashboardPage:
         self.dashboard_nav.click()
@@ -303,6 +306,12 @@ class GrantDashboardBasePage(TopNavMixin, BasePage):
         grant_developers_page = GrantDevelopersPage(self.page, self.domain, grant_name=grant_name)
         expect(grant_developers_page.heading).to_be_visible()
         return grant_developers_page
+
+    def click_reports(self, grant_name: str) -> GrantReportsPage:
+        self.reports_nav.click()
+        grant_reports_page = GrantReportsPage(self.page, self.domain, grant_name=grant_name)
+        expect(grant_reports_page.heading).to_be_visible()
+        return grant_reports_page
 
 
 class GrantDashboardPage(GrantDashboardBasePage):

--- a/tests/e2e/reports_pages.py
+++ b/tests/e2e/reports_pages.py
@@ -1,0 +1,609 @@
+from __future__ import annotations
+
+import re
+from typing import cast
+
+from playwright.sync_api import Locator, Page, expect
+
+from app.common.data.types import ManagedExpressionsEnum, QuestionDataType
+from app.common.expressions.managed import GreaterThan, LessThan, ManagedExpression
+
+
+class ReportsBasePage:
+    domain: str
+    page: Page
+
+    heading: Locator
+    grant_name: str
+
+    def __init__(self, page: Page, domain: str, heading: Locator, grant_name: str) -> None:
+        self.page = page
+        self.domain = domain
+        self.heading = heading
+        self.grant_name = grant_name
+
+
+class GrantReportsPage(ReportsBasePage):
+    add_report_button: Locator
+    summary_row_submissions: Locator
+
+    def __init__(self, page: Page, domain: str, grant_name: str) -> None:
+        super().__init__(
+            page, domain, grant_name=grant_name, heading=page.get_by_role("heading", name=f"{grant_name} Reports")
+        )
+        self.add_report_button = self.page.get_by_role("button", name="Add a monitoring report").or_(
+            self.page.get_by_role("button", name="Add another monitoring report")
+        )
+        self.summary_row_submissions = page.locator("div.govuk-summary-list__row").filter(
+            has=page.get_by_text("Submissions")
+        )
+
+    def click_add_report(self) -> AddReportPage:
+        self.add_report_button.click()
+        add_report_page = AddReportPage(self.page, self.domain, grant_name=self.grant_name)
+        expect(add_report_page.heading).to_be_visible()
+        return add_report_page
+
+    def check_report_exists(self, report_name: str) -> None:
+        expect(self.page.get_by_role("heading", name=report_name)).to_be_visible()
+
+    def click_add_task(self, report_name: str, grant_name: str) -> AddTaskPage:
+        self.page.get_by_role("link", name=f"Add tasks to {report_name}").click()
+        add_task_page = AddTaskPage(
+            self.page,
+            self.domain,
+            grant_name=grant_name,
+            report_name=report_name,
+        )
+        expect(add_task_page.heading).to_be_visible()
+        return add_task_page
+
+    def click_manage_tasks(self, report_name: str, grant_name: str) -> ReportTasksPage:
+        self.page.get_by_role("link", name=re.compile(r"\d+ tasks")).click()
+        report_tasks_page = ReportTasksPage(self.page, self.domain, grant_name=grant_name, report_name=report_name)
+        expect(report_tasks_page.heading).to_be_visible()
+        return report_tasks_page
+
+    def click_view_submissions(self, report_name: str) -> SubmissionsListPage:
+        self.summary_row_submissions.get_by_role("link", name="1 test submission").click()
+        submissions_list_page = SubmissionsListPage(self.page, self.domain, self.grant_name, report_name)
+        expect(submissions_list_page.heading).to_be_visible()
+        return submissions_list_page
+
+    def click_change_name(self, report_name: str, grant_name: str) -> ChangeReportNamePage:
+        self.page.get_by_role("link", name="Change name").click()
+        change_report_name_page = ChangeReportNamePage(self.page, self.domain, self.grant_name)
+        expect(change_report_name_page.heading).to_be_visible()
+        return change_report_name_page
+
+    def delete_report(self, report_name: str, grant_name: str) -> GrantReportsPage:
+        self.page.get_by_role("link", name="Delete").click()
+        self.page.get_by_role("button", name="Yes, delete this report").click()
+        reports_page = GrantReportsPage(self.page, self.domain, grant_name=grant_name)
+        expect(reports_page.heading).to_be_visible()
+        return reports_page
+
+
+class AddReportPage(ReportsBasePage):
+    def __init__(self, page: Page, domain: str, grant_name: str) -> None:
+        super().__init__(
+            page,
+            domain,
+            grant_name=grant_name,
+            heading=page.get_by_role("heading", name="What is the name of the monitoring report?"),
+        )
+
+    def fill_in_report_name(self, name: str) -> None:
+        self.page.get_by_role("textbox", name="What is the name of the monitoring report?").fill(name)
+
+    def click_submit(self, grant_name: str) -> GrantReportsPage:
+        self.page.get_by_role("button", name="Set up report").click()
+        reports_page = GrantReportsPage(self.page, self.domain, grant_name=grant_name)
+        expect(reports_page.heading).to_be_visible()
+        return reports_page
+
+
+class ChangeReportNamePage(ReportsBasePage):
+    def __init__(self, page: Page, domain: str, grant_name: str) -> None:
+        super().__init__(
+            page,
+            domain,
+            grant_name=grant_name,
+            heading=page.get_by_role("heading", name="Change the name for this monitoring report"),
+        )
+
+    def fill_in_report_name(self, name: str) -> None:
+        self.page.get_by_role("textbox", name="Change the name for this monitoring report").fill(name)
+
+    def click_submit(self, grant_name: str) -> GrantReportsPage:
+        self.page.get_by_role("button", name="Update report name").click()
+        reports_page = GrantReportsPage(self.page, self.domain, grant_name=grant_name)
+        expect(reports_page.heading).to_be_visible()
+        return reports_page
+
+    def click_cancel(self, grant_name: str) -> GrantReportsPage:
+        self.page.get_by_role("link", name="Cancel").click()
+        reports_page = GrantReportsPage(self.page, self.domain, grant_name=grant_name)
+        expect(reports_page.heading).to_be_visible()
+        return reports_page
+
+    def click_back(self, grant_name: str) -> GrantReportsPage:
+        self.page.get_by_role("link", name="Back").click()
+        reports_page = GrantReportsPage(self.page, self.domain, grant_name=grant_name)
+        expect(reports_page.heading).to_be_visible()
+        return reports_page
+
+
+class ReportTasksPage(ReportsBasePage):
+    report_name: str
+    preview_report_button: Locator
+    reports_breadcrumb: Locator
+
+    def __init__(self, page: Page, domain: str, grant_name: str, report_name: str) -> None:
+        super().__init__(
+            page,
+            domain,
+            grant_name=grant_name,
+            heading=page.get_by_role("heading", name="Tasks"),
+        )
+        self.report_name = report_name
+        self.preview_report_button = self.page.get_by_role("button", name="Preview report")
+        self.reports_breadcrumb = self.page.locator("a.govuk-breadcrumbs__link").filter(has=page.get_by_text("Reports"))
+
+    def click_reports_breadcrumb(self) -> "GrantReportsPage":
+        self.reports_breadcrumb.click()
+        grant_reports_page = GrantReportsPage(self.page, self.domain, grant_name=self.grant_name)
+        return grant_reports_page
+
+    def check_task_exists(self, task_title: str) -> None:
+        expect(self.page.get_by_role("link", name=task_title, exact=True)).to_be_visible()
+
+    def click_preview_report(self) -> RunnerTasklistPage:
+        self.preview_report_button.click()
+        tasklist_page = RunnerTasklistPage(
+            self.page, self.domain, grant_name=self.grant_name, report_name=self.report_name
+        )
+        expect(tasklist_page.heading).to_be_visible()
+        return tasklist_page
+
+    def click_manage_task(self, task_name: str) -> ManageTaskPage:
+        self.page.get_by_role("link", name=task_name, exact=True).click()
+        manage_task_page = ManageTaskPage(
+            self.page,
+            self.domain,
+            grant_name=self.grant_name,
+            report_name=self.report_name,
+            task_name=task_name,
+        )
+        expect(manage_task_page.heading).to_be_visible()
+        return manage_task_page
+
+    def click_add_task(self) -> AddTaskPage:
+        self.page.get_by_role("link", name="Add a task").or_(
+            self.page.get_by_role("link", name="Add another task")
+        ).click()
+        task_type_page = AddTaskPage(
+            self.page,
+            self.domain,
+            grant_name=self.grant_name,
+            report_name=self.report_name,
+        )
+        expect(task_type_page.heading).to_be_visible()
+        return task_type_page
+
+
+class ManageTaskPage(ReportsBasePage):
+    report_name: str
+    task_name: str
+    preview_task_button: Locator
+    add_question_button: Locator
+    change_task_name_link: Locator
+    delete_task_link: Locator
+
+    def __init__(self, page: Page, domain: str, grant_name: str, report_name: str, task_name: str) -> None:
+        super().__init__(
+            page,
+            domain,
+            grant_name=grant_name,
+            heading=page.get_by_role("heading", name=f"{task_name}"),
+        )
+        self.report_name = report_name
+        self.task_name = task_name
+        self.preview_task_button = self.page.get_by_role("button", name="Preview task")
+        self.add_question_button = self.page.get_by_role("link", name="Add a question").or_(
+            self.page.get_by_role("link", name="Add another question")
+        )
+        self.change_task_name_link = self.page.get_by_role("link", name="Change task name")
+        self.delete_task_link = self.page.get_by_role("button", name="Delete task")
+
+    def click_add_question(self) -> SelectQuestionTypePage:
+        self.add_question_button.click()
+
+        select_question_type_page = SelectQuestionTypePage(
+            self.page,
+            self.domain,
+            grant_name=self.grant_name,
+            report_name=self.report_name,
+            task_name=self.task_name,
+        )
+        expect(select_question_type_page.heading).to_be_visible()
+        return select_question_type_page
+
+    def check_question_exists(self, question_name: str) -> None:
+        expect(self.page.get_by_role("term").filter(has_text=question_name)).to_be_visible()
+
+    def click_edit_question(self, question_name: str) -> "EditQuestionPage":
+        self.page.get_by_role("link", name=question_name).click()
+        edit_question_page = EditQuestionPage(
+            self.page,
+            self.domain,
+            grant_name=self.grant_name,
+            report_name=self.report_name,
+            task_name=self.task_name,
+        )
+        expect(edit_question_page.heading).to_be_visible()
+        return edit_question_page
+
+
+class EditQuestionPage(ReportsBasePage):
+    add_validation_button: Locator
+    task_breadcrumb: Locator
+
+    def __init__(self, page: Page, domain: str, grant_name: str, report_name: str, task_name: str) -> None:
+        super().__init__(
+            page,
+            domain,
+            grant_name=grant_name,
+            heading=page.get_by_role("heading", name="Edit question"),
+        )
+        self.report_name = report_name
+        self.task_name = task_name
+        self.add_validation_button = self.page.get_by_role("button", name="Add validation").or_(
+            self.page.get_by_role("button", name="Add more validation")
+        )
+        self.task_breadcrumb = self.page.locator("a.govuk-breadcrumbs__link").filter(
+            has=page.get_by_text(f"{task_name}")
+        )
+
+    def click_add_validation(self) -> "AddValidationPage":
+        self.add_validation_button.click()
+        add_validation_page = AddValidationPage(
+            self.page,
+            self.domain,
+            grant_name=self.grant_name,
+            report_name=self.report_name,
+            task_name=self.task_name,
+        )
+        expect(add_validation_page.heading).to_be_visible()
+        return add_validation_page
+
+    def click_task_breadcrumb(self) -> "ManageTaskPage":
+        self.task_breadcrumb.click()
+        manage_task_page = ManageTaskPage(
+            self.page,
+            self.domain,
+            grant_name=self.grant_name,
+            report_name=self.report_name,
+            task_name=self.task_name,
+        )
+        expect(manage_task_page.heading).to_be_visible()
+        return manage_task_page
+
+
+class AddValidationPage(ReportsBasePage):
+    add_validation_button: Locator
+
+    def __init__(self, page: Page, domain: str, grant_name: str, report_name: str, task_name: str) -> None:
+        super().__init__(
+            page,
+            domain,
+            grant_name=grant_name,
+            heading=page.get_by_role("heading", name="Add validation"),
+        )
+        self.report_name = report_name
+        self.task_name = task_name
+        self.add_validation_button = self.page.get_by_role("button", name="Add validation")
+
+    def configure_managed_validation(self, managed_validation: ManagedExpression) -> None:
+        self.click_managed_validation_type(managed_validation)
+
+        match managed_validation._key:
+            case ManagedExpressionsEnum.GREATER_THAN:
+                managed_validation = cast(GreaterThan, managed_validation)
+                self.page.get_by_role("textbox", name="Minimum value").fill(str(managed_validation.minimum_value))
+
+                if managed_validation.inclusive:
+                    self.page.get_by_role("checkbox", name="An answer of exactly the minimum value is allowed").check()
+
+            case ManagedExpressionsEnum.LESS_THAN:
+                managed_validation = cast(LessThan, managed_validation)
+                self.page.get_by_role("textbox", name="Maximum value").fill(str(managed_validation.maximum_value))
+
+                if managed_validation.inclusive:
+                    self.page.get_by_role("checkbox", name="An answer of exactly the maximum value is allowed").check()
+
+    def click_managed_validation_type(self, managed_validation: ManagedExpression) -> None:
+        self.page.get_by_role("radio", name=managed_validation._key.value).click()
+
+    def click_add_validation(self) -> "EditQuestionPage":
+        self.add_validation_button.click()
+        edit_question_page = EditQuestionPage(
+            self.page,
+            self.domain,
+            grant_name=self.grant_name,
+            report_name=self.report_name,
+            task_name=self.task_name,
+        )
+        expect(edit_question_page.heading).to_be_visible()
+        return edit_question_page
+
+
+class SelectQuestionTypePage(ReportsBasePage):
+    report_name: str
+    task_name: str
+
+    def __init__(self, page: Page, domain: str, grant_name: str, report_name: str, task_name: str) -> None:
+        super().__init__(
+            page,
+            domain,
+            grant_name=grant_name,
+            heading=page.get_by_role("heading", name="What type of question do you need?"),
+        )
+        self.report_name = report_name
+        self.task_name = task_name
+
+    def click_question_type(self, question_type: str) -> None:
+        self.page.get_by_role("radio", name=question_type).click()
+
+    def click_continue(self) -> AddQuestionDetailsPage:
+        self.page.get_by_role("button", name="Continue").click()
+        question_details_page = AddQuestionDetailsPage(
+            self.page,
+            self.domain,
+            grant_name=self.grant_name,
+            report_name=self.report_name,
+            task_name=self.task_name,
+        )
+        expect(question_details_page.heading).to_be_visible()
+        return question_details_page
+
+
+class AddQuestionDetailsPage(ReportsBasePage):
+    report_name: str
+    task_name: str
+
+    def __init__(self, page: Page, domain: str, grant_name: str, report_name: str, task_name: str) -> None:
+        super().__init__(
+            page,
+            domain,
+            grant_name=grant_name,
+            heading=page.get_by_role("heading", name="Add question"),
+        )
+        self.report_name = report_name
+        self.task_name = task_name
+
+    def fill_question_text(self, question_text: str) -> None:
+        self.page.get_by_role("textbox", name="Question text").fill(question_text)
+
+    def fill_question_name(self, question_name: str) -> None:
+        self.page.get_by_role("textbox", name="Question name").fill(question_name)
+
+    def fill_question_hint(self, question_hint: str) -> None:
+        self.page.get_by_role("textbox", name="Question hint").fill(question_hint)
+
+    def fill_data_source_items(self, items: list[str]) -> None:
+        self.page.get_by_role("textbox", name="List of options").fill("\n".join(items))
+
+    def click_other_option_checkbox(self) -> None:
+        self.page.get_by_role("checkbox", name="Include an ‘other’ option").click()
+
+    def enter_other_option_text(self, text: str = "Other") -> None:
+        self.page.get_by_role("textbox", name="‘Other’ option text").fill(text)
+
+    def click_submit(self) -> "EditQuestionPage":
+        self.page.get_by_role("button", name="Add question").click()
+        edit_question_page = EditQuestionPage(
+            self.page,
+            self.domain,
+            grant_name=self.grant_name,
+            report_name=self.report_name,
+            task_name=self.task_name,
+        )
+        expect(edit_question_page.heading).to_be_visible()
+        return edit_question_page
+
+    def click_return_to_task(self) -> ManageTaskPage:
+        self.page.get_by_role("link", name="Return to the task").click()
+        manage_task_page = ManageTaskPage(
+            self.page,
+            self.domain,
+            grant_name=self.grant_name,
+            report_name=self.report_name,
+            task_name=self.task_name,
+        )
+        expect(manage_task_page.heading).to_be_visible()
+        return manage_task_page
+
+
+class AddTaskPage(ReportsBasePage):
+    report_name: str
+
+    def __init__(self, page: Page, domain: str, grant_name: str, report_name: str) -> None:
+        super().__init__(
+            page,
+            domain,
+            grant_name=grant_name,
+            heading=page.get_by_role("heading", name="What is the name of the task?"),
+        )
+        self.report_name = report_name
+
+    def fill_in_task_name(self, task_name: str) -> None:
+        self.page.get_by_role("textbox", name="Task name").fill(task_name)
+
+    def click_add_task(self) -> ReportTasksPage:
+        self.page.get_by_role("button", name="Add task").click()
+        report_tasks_page = ReportTasksPage(
+            self.page, self.domain, grant_name=self.grant_name, report_name=self.report_name
+        )
+        expect(report_tasks_page.heading).to_be_visible()
+        return report_tasks_page
+
+
+class RunnerTasklistPage(ReportsBasePage):
+    report_name: str
+    submission_status_box: Locator
+    submit_button: Locator
+    back_link: Locator
+
+    def __init__(
+        self,
+        page: Page,
+        domain: str,
+        grant_name: str,
+        report_name: str,
+    ) -> None:
+        super().__init__(
+            page,
+            domain,
+            grant_name=grant_name,
+            heading=page.get_by_role("heading", name=report_name),
+        )
+        self.report_name = report_name
+        self.submission_status_box = page.get_by_test_id("submission-status")
+        self.submit_button = page.get_by_role("button", name="Submit")
+        self.back_link = self.page.get_by_role("link", name="Back")
+
+    def click_on_task(self, task_name: str) -> None:
+        self.page.get_by_role("link", name=task_name).click()
+
+    def click_submit(self) -> ReportTasksPage:
+        self.submit_button.click()
+        report_tasks_page = ReportTasksPage(self.page, self.domain, self.grant_name, self.report_name)
+        expect(report_tasks_page.heading).to_be_visible()
+        return report_tasks_page
+
+    def click_back(self) -> ReportTasksPage:
+        self.back_link.click()
+        report_tasks_page = ReportTasksPage(
+            self.page, self.domain, grant_name=self.grant_name, report_name=self.report_name
+        )
+        expect(report_tasks_page.heading).to_be_visible()
+        return report_tasks_page
+
+
+class RunnerQuestionPage(ReportsBasePage):
+    continue_button: Locator
+    question_name: str
+
+    def __init__(
+        self,
+        page: Page,
+        domain: str,
+        grant_name: str,
+        question_name: str,
+    ) -> None:
+        super().__init__(
+            page,
+            domain,
+            grant_name=grant_name,
+            heading=page.get_by_role("heading", name=question_name),
+        )
+        self.question_name = question_name
+        self.continue_button = page.get_by_role("button", name="Continue")
+
+    def respond_to_question(self, question_type: QuestionDataType, answer: str) -> None:
+        if question_type == QuestionDataType.CHECKBOXES:
+            for choice in answer:
+                self.page.get_by_role("checkbox", name=choice).click()
+        elif question_type == QuestionDataType.YES_NO or question_type == QuestionDataType.RADIOS:
+            # once we start having multiple of these on a page - enjoy the refactor =]
+            accessible_autocomplete = self.page.query_selector("[data-accessible-autocomplete]")
+            if accessible_autocomplete:
+                # there is a few ms of delay during the call to "enhanceSelectElement" which allows the select
+                # being progressively enhanced to be selected before its complete as playwright will act immediately
+                # on the role being available - this causes the test to fail particularly when there is network latency.
+                # Wait for the full input + options to be loaded before using it
+                expect(self.page.locator("[class='autocomplete__wrapper']")).to_be_attached()
+                element = self.page.get_by_role("combobox")
+                element.click()
+                element.fill(answer)
+                element.press("Enter")
+            else:
+                self.page.get_by_role("radio", name=answer).click()
+        else:
+            self.page.get_by_role("textbox", name=self.question_name).fill(answer)
+
+    def click_continue(
+        self,
+    ) -> None:
+        self.continue_button.click()
+
+
+class RunnerCheckYourAnswersPage(ReportsBasePage):
+    save_and_continue_button: Locator
+    mark_as_complete_yes: Locator
+
+    def __init__(
+        self,
+        page: Page,
+        domain: str,
+        grant_name: str,
+    ) -> None:
+        super().__init__(
+            page,
+            domain,
+            grant_name=grant_name,
+            heading=page.get_by_role("heading", name="Check your answers"),
+        )
+        self.save_and_continue_button = page.get_by_role("button", name="Save and continue")
+        self.mark_as_complete_yes = page.get_by_role("radio", name="Yes, I’ve completed this task")
+
+    def click_mark_as_complete_yes(self) -> None:
+        self.mark_as_complete_yes.click()
+
+    def click_save_and_continue(self, report_name: str) -> RunnerTasklistPage:
+        self.save_and_continue_button.click()
+        task_list_page = RunnerTasklistPage(self.page, self.domain, self.grant_name, report_name=report_name)
+        expect(task_list_page.heading).to_be_visible()
+        return task_list_page
+
+
+class SubmissionsListPage(ReportsBasePage):
+    report_name: str
+
+    def __init__(self, page: Page, domain: str, grant_name: str, report_name: str) -> None:
+        super().__init__(
+            page,
+            domain,
+            grant_name=grant_name,
+            heading=page.get_by_role("heading", name=f"{report_name} Monitoring Reports"),
+        )
+        self.report_name = report_name
+
+    def click_on_first_submission(self) -> ViewSubmissionPage:
+        first_submission_reference = self.page.locator("[data-submission-link]").first.inner_text()
+        return self.click_on_submission(first_submission_reference)
+
+    def click_on_submission(self, report_reference: str) -> ViewSubmissionPage:
+        self.page.get_by_role("link", name=report_reference).click()
+        view_submission_page = ViewSubmissionPage(
+            self.page, self.domain, self.grant_name, report_reference=report_reference
+        )
+        expect(view_submission_page.heading).to_be_visible()
+        return view_submission_page
+
+
+class ViewSubmissionPage(ReportsBasePage):
+    report_reference: str
+
+    def __init__(self, page: Page, domain: str, grant_name: str, report_reference: str) -> None:
+        super().__init__(
+            page,
+            domain,
+            grant_name=grant_name,
+            heading=page.get_by_role("heading", name="Submission"),
+        )
+        self.report_reference = report_reference
+
+    def get_questions_list_for_task(self, task_name: str) -> Locator:
+        return self.page.get_by_test_id(task_name)

--- a/tests/e2e/test_create_preview_collection.py
+++ b/tests/e2e/test_create_preview_collection.py
@@ -1,0 +1,290 @@
+import dataclasses
+import uuid
+from typing import NotRequired, TypedDict
+
+import pytest
+from playwright.sync_api import Page, expect
+
+from app.common.data.types import QuestionDataType, QuestionPresentationOptions
+from app.common.expressions.managed import GreaterThan, LessThan, ManagedExpression
+from tests.e2e.config import EndToEndTestSecrets
+from tests.e2e.dataclasses import E2ETestUser
+from tests.e2e.pages import AllGrantsPage
+from tests.e2e.reports_pages import (
+    ManageTaskPage,
+    ReportTasksPage,
+    RunnerCheckYourAnswersPage,
+    RunnerQuestionPage,
+)
+
+
+@dataclasses.dataclass
+class _QuestionResponse:
+    answer: str | list[str]
+    error_message: str | None = None
+
+
+TQuestionToTest = TypedDict(
+    "TQuestionToTest",
+    {
+        "type": QuestionDataType,
+        "text": str,  # this is mutated by the test runner to store the unique (uuid'd) question name
+        "answers": list[_QuestionResponse],
+        "choices": NotRequired[list[str]],
+        "options": NotRequired[QuestionPresentationOptions],
+    },
+)
+
+
+questions_to_test: dict[str, TQuestionToTest] = {
+    "email": {
+        "type": QuestionDataType.EMAIL,
+        "text": "Enter an email address",
+        "answers": [
+            _QuestionResponse("not-an-email", "Enter an email address in the correct format, like name@example.com"),
+            _QuestionResponse("name@example.com"),
+        ],
+    },
+    "text-single-line": {
+        "type": QuestionDataType.TEXT_SINGLE_LINE,
+        "text": "Enter a single line of text",
+        "answers": [_QuestionResponse("E2E question text single line")],
+    },
+    "text-multi-line": {
+        "type": QuestionDataType.TEXT_MULTI_LINE,
+        "text": "Enter a few lines of text",
+        "answers": [_QuestionResponse("E2E question text multi line\nwith a second line")],
+    },
+    "integer": {
+        "type": QuestionDataType.INTEGER,
+        "text": "Enter a number",
+        "answers": [
+            _QuestionResponse("0", "The answer must be greater than 1"),
+            _QuestionResponse("101", "The answer must be less than or equal to 100"),
+            _QuestionResponse("100"),
+        ],
+    },
+    "yes-no": {
+        "type": QuestionDataType.YES_NO,
+        "text": "Yes or no",
+        "answers": [
+            _QuestionResponse("Yes"),
+        ],
+    },
+    "radio": {
+        "type": QuestionDataType.RADIOS,
+        "text": "Select an option",
+        "choices": ["option 1", "option 2", "option 3"],
+        "answers": [
+            _QuestionResponse("option 2"),
+        ],
+    },
+    "autocomplete": {
+        "type": QuestionDataType.RADIOS,
+        "text": "Select an option from the accessible autocomplete",
+        "choices": [f"option {x}" for x in range(1, 30)],
+        "answers": [
+            _QuestionResponse("Other"),
+        ],
+        "options": QuestionPresentationOptions(last_data_source_item_is_distinct_from_others=True),
+    },
+    "url": {
+        "type": QuestionDataType.URL,
+        "text": "Enter a website address",
+        "answers": [
+            _QuestionResponse("not-a-url", "Enter a website address in the correct format, like www.gov.uk"),
+            _QuestionResponse("https://gov.uk"),
+        ],
+    },
+    "checkboxes": {
+        "type": QuestionDataType.CHECKBOXES,
+        "text": "Select one or more options",
+        "choices": ["option 1", "option 2", "option 3", "option 4"],
+        "answers": [
+            _QuestionResponse(["option 2", "option 3"]),
+        ],
+        "options": QuestionPresentationOptions(last_data_source_item_is_distinct_from_others=True),
+    },
+}
+
+
+def create_question(question_definition: TQuestionToTest, manage_task_page: ManageTaskPage) -> None:
+    question_type_page = manage_task_page.click_add_question()
+    question_type_page.click_question_type(question_definition["type"])
+    question_details_page = question_type_page.click_continue()
+
+    expect(question_details_page.page.get_by_text(question_definition["type"].value, exact=True)).to_be_visible()
+    question_uuid = uuid.uuid4()
+    question_text = f"{question_definition['text']} - {question_uuid}"
+    question_definition["text"] = question_text
+    question_details_page.fill_question_text(question_text)
+    question_details_page.fill_question_name(f"e2e_question_{question_uuid}")
+    question_details_page.fill_question_hint(f"e2e_hint_{question_uuid}")
+
+    if question_definition["type"] in [QuestionDataType.RADIOS, QuestionDataType.CHECKBOXES]:
+        question_details_page.fill_data_source_items(question_definition["choices"])
+
+        options = question_definition.get("options")
+        if options is not None and options.last_data_source_item_is_distinct_from_others is not None:
+            question_details_page.click_other_option_checkbox()
+            question_details_page.enter_other_option_text()
+
+    question_details_page.click_submit()
+    question_details_page.click_return_to_task()
+
+
+def add_validation(manage_task_page: ManageTaskPage, question_text: str, validation: ManagedExpression) -> None:
+    edit_question_page = manage_task_page.click_edit_question(question_text)
+    add_validation_page = edit_question_page.click_add_validation()
+    add_validation_page.configure_managed_validation(validation)
+    edit_question_page = add_validation_page.click_add_validation()
+    edit_question_page.click_task_breadcrumb()
+
+
+def navigate_to_report_tasks_page(page: Page, domain: str, grant_name: str, report_name: str) -> ReportTasksPage:
+    all_grants_page = AllGrantsPage(page, domain)
+    all_grants_page.navigate()
+    grant_dashboard_page = all_grants_page.click_grant(grant_name)
+    grant_reports_page = grant_dashboard_page.click_reports(grant_name)
+    report_tasks_page = grant_reports_page.click_manage_tasks(grant_name=grant_name, report_name=report_name)
+    return report_tasks_page
+
+
+@pytest.mark.skip_in_environments(["prod"])
+def test_create_and_preview_report(
+    page: Page, domain: str, e2e_test_secrets: EndToEndTestSecrets, authenticated_browser_sso: E2ETestUser
+):
+    try:
+        new_grant_name = f"E2E developer_grant {uuid.uuid4()}"
+        all_grants_page = AllGrantsPage(page, domain)
+        all_grants_page.navigate()
+
+        # Set up new grant
+        grant_intro_page = all_grants_page.click_set_up_a_grant()
+        grant_ggis_page = grant_intro_page.click_continue()
+        grant_ggis_page.select_yes()
+        grant_ggis_page.fill_ggis_number()
+        grant_name_page = grant_ggis_page.click_save_and_continue()
+        grant_name_page.fill_name(new_grant_name)
+        grant_description_page = grant_name_page.click_save_and_continue()
+        grant_description_page.fill_description()
+        grant_contact_page = grant_description_page.click_save_and_continue()
+        grant_contact_page.fill_contact_name()
+        grant_contact_page.fill_contact_email()
+        grant_check_your_answers_page = grant_contact_page.click_save_and_continue()
+        grant_dashboard_page = grant_check_your_answers_page.click_add_grant()
+
+        # Go to Reports tab
+        grant_reports_page = grant_dashboard_page.click_reports(new_grant_name)
+
+        # Add a new report
+        add_report_page = grant_reports_page.click_add_report()
+        new_report_name = f"E2E report {uuid.uuid4()}"
+        add_report_page.fill_in_report_name(new_report_name)
+        grant_reports_page = add_report_page.click_submit(new_grant_name)
+        grant_reports_page.check_report_exists(new_report_name)
+
+        # Add a new task
+        add_task_page = grant_reports_page.click_add_task(report_name=new_report_name, grant_name=new_grant_name)
+        task_name = f"E2E task {uuid.uuid4()}"
+        add_task_page.fill_in_task_name(task_name)
+        report_tasks_page = add_task_page.click_add_task()
+        report_tasks_page.check_task_exists(task_name)
+
+        manage_task_page = report_tasks_page.click_manage_task(task_name=task_name)
+
+        # Add a question of each type
+        for question_to_test in questions_to_test.values():
+            create_question(question_to_test, manage_task_page)
+
+        # TODO: move this into `question_to_test` definition as well
+        add_validation(
+            manage_task_page,
+            questions_to_test["integer"]["text"],
+            GreaterThan(question_id=uuid.uuid4(), minimum_value=1, inclusive=False),  # question_id does not matter here
+        )
+
+        add_validation(
+            manage_task_page,
+            questions_to_test["integer"]["text"],
+            LessThan(question_id=uuid.uuid4(), maximum_value=100, inclusive=True),  # question_id does not matter here
+        )
+
+        # Preview the report
+        report_tasks_page = navigate_to_report_tasks_page(page, domain, new_grant_name, new_report_name)
+        tasklist_page = report_tasks_page.click_preview_report()
+
+        # Check the tasklist has loaded
+        expect(
+            tasklist_page.submission_status_box.filter(has=tasklist_page.page.get_by_text("Not started"))
+        ).to_be_visible()
+        expect(tasklist_page.submit_button).to_be_disabled()
+        expect(tasklist_page.page.get_by_role("link", name=task_name)).to_be_visible()
+
+        # Complete the first task
+        tasklist_page.click_on_task(task_name=task_name)
+        for question_to_test in questions_to_test.values():
+            question_page = RunnerQuestionPage(page, domain, new_grant_name, question_to_test["text"])
+            expect(question_page.heading).to_be_visible()
+
+            for question_response in question_to_test["answers"]:
+                question_page.respond_to_question(
+                    question_type=question_to_test["type"], answer=question_response.answer
+                )
+                question_page.click_continue()
+
+                if question_response.error_message:
+                    expect(question_page.page.get_by_role("link", name=question_response.error_message)).to_be_visible()
+
+        # Check the answers page
+        check_your_answers = RunnerCheckYourAnswersPage(page, domain, new_grant_name)
+
+        for question in questions_to_test.values():
+            question_heading = check_your_answers.page.get_by_text(question["text"], exact=True)
+            expect(question_heading).to_be_visible()
+            if question["type"] == QuestionDataType.CHECKBOXES:
+                checkbox_answers_list = check_your_answers.page.get_by_test_id(f"answer-{question['text']}").locator(
+                    "li"
+                )
+                expect(checkbox_answers_list).to_have_text(question["answers"][-1].answer)
+            else:
+                expect(check_your_answers.page.get_by_test_id(f"answer-{question['text']}")).to_have_text(
+                    question["answers"][-1].answer
+                )
+
+        expect(check_your_answers.page.get_by_text("Have you completed this task?", exact=True)).to_be_visible()
+
+        check_your_answers.click_mark_as_complete_yes()
+        tasklist_page = check_your_answers.click_save_and_continue(report_name=new_report_name)
+
+        # Submit the report
+        expect(
+            tasklist_page.submission_status_box.filter(has=tasklist_page.page.get_by_text("In progress"))
+        ).to_be_visible()
+        expect(tasklist_page.submit_button).to_be_enabled()
+
+        report_tasks_page = tasklist_page.click_submit()
+
+        # View the submitted report
+        grant_reports_page = report_tasks_page.click_reports_breadcrumb()
+        expect(grant_reports_page.summary_row_submissions.get_by_text("1 test submission")).to_be_visible()
+        submissions_list_page = grant_reports_page.click_view_submissions(new_report_name)
+
+        view_report_page = submissions_list_page.click_on_first_submission()
+
+        answers_list = view_report_page.get_questions_list_for_task(task_name)
+        expect(answers_list).to_be_visible()
+        for question in questions_to_test.values():
+            if question["type"] == QuestionDataType.CHECKBOXES:
+                expect(
+                    answers_list.get_by_text(f"{question['text']} {' '.join(question['answers'][-1].answer)}")
+                ).to_be_visible()
+            else:
+                expect(answers_list.get_by_text(f"{question['text']} {question['answers'][-1].answer}")).to_be_visible()
+
+    finally:
+        # Tidy up by deleting the grant, which will cascade to all related entities
+        all_grants_page.navigate()
+        grant_dashboard_page = all_grants_page.click_grant(new_grant_name)
+        developers_page = grant_dashboard_page.click_developers(new_grant_name)
+        developers_page.delete_grant()


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-747

## 📝 Description
Now the reports tab is more or less fully built out and replicates all the Developers tab functionality (plus a little more) in line with our designs, we need to cover the full grant admin and grant team member journeys in e2e tests.

This PR lifts the existing 'Developer journey' test and replicates it for the Reports tab, along with adding the Reports tab page locators and helpers and small updates to test behaviour (eg. using breadcrumbs where back buttons no longer exist etc), and drops things that are no longer needed for the e2e tests to run (eg. default section names, task type page etc.) which might still be present in the Developer pages.

Subsequent PRs will cover:
- Change the name of/deleting reports and tasks
- Add additional formatting for number and multiline text questions
- Add examples of all validation options and possible conditions
- Add question guidance
- Add question groups (inc. question group guidance text, question group format options and group conditionals)
- Switch 'preview and submit report' steps to be done by a Grant team member (using the 'Become grant team member' button in the Developers tab)
- Add Export CSV step


## 📸 Show the thing (screenshots, gifs)
n/a

## 🧪 Testing
You can pull the branch and run the new test in headed mode to see it take all the steps.

## 📋 Developer Checklist

### Review Readiness
- [X] PR title and description provide sufficient context for reviewers
- [X] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- ~[ ] No N+1 query problems introduced~
- ~[ ] Any new DB queries include appropriate where clauses based on the user's permissions~

### Testing
- [X] I have tested this change and it meets the acceptance criteria for the ticket
- ~[ ] I need the reviewer(s) to pull and run this change locally~
- ~[ ] New (non-developer) functionality has appropriate unit and integration tests~
- [X] End-to-end tests have been updated (if applicable)
- [X] Edge cases and error conditions are tested

## 📚 Additional Notes

