### PR TITLE
FSPT-747: Include advanced formatting options in Reports tab e2e tests

### DIFF
--- a/tests/e2e/reports_pages.py
+++ b/tests/e2e/reports_pages.py
@@ -5,7 +5,7 @@ from typing import cast
 
 from playwright.sync_api import Locator, Page, expect
 
-from app.common.data.types import ManagedExpressionsEnum, QuestionDataType
+from app.common.data.types import ManagedExpressionsEnum, MultilineTextInputRows, NumberInputWidths, QuestionDataType
 from app.common.expressions.managed import GreaterThan, LessThan, ManagedExpression
 
 
@@ -399,6 +399,24 @@ class AddQuestionDetailsPage(ReportsBasePage):
 
     def enter_other_option_text(self, text: str = "Other") -> None:
         self.page.get_by_role("textbox", name="‘Other’ option text").fill(text)
+
+    def click_advanced_formatting_options(self) -> None:
+        self.page.get_by_text("Advanced formatting options").click()
+
+    def fill_word_limit(self, word_limit: int) -> None:
+        self.page.get_by_role("textbox", name="Word limit").fill(str(word_limit))
+
+    def fill_prefix(self, text: str) -> None:
+        self.page.get_by_role("textbox", name="Prefix").fill(text)
+
+    def fill_suffix(self, text: str) -> None:
+        self.page.get_by_role("textbox", name="Suffix").fill(text)
+
+    def select_input_width(self, width: NumberInputWidths) -> None:
+        self.page.get_by_label("width").select_option(width.name.title())
+
+    def select_multiline_input_rows(self, rows: MultilineTextInputRows) -> None:
+        self.page.get_by_label("Text area size").select_option(f"{rows.name.title()} ({rows.value} rows)")
 
     def click_submit(self) -> "EditQuestionPage":
         self.page.get_by_role("button", name="Add question").click()

--- a/tests/e2e/test_create_preview_collection.py
+++ b/tests/e2e/test_create_preview_collection.py
@@ -193,6 +193,16 @@ def test_create_and_preview_report(
 
         manage_task_page = report_tasks_page.click_manage_task(task_name=task_name)
 
+        # Sense check that the test includes all question types
+        new_question_type_error = None
+        try:
+            assert len(QuestionDataType) == 8 and len(questions_to_test) == 9, (
+                "If you have added a new question type, please update this test to include the new type in "
+                "`questions_to_test`."
+            )
+        except AssertionError as e:
+            new_question_type_error = e
+
         # Add a question of each type
         for question_to_test in questions_to_test.values():
             create_question(question_to_test, manage_task_page)
@@ -288,3 +298,5 @@ def test_create_and_preview_report(
         grant_dashboard_page = all_grants_page.click_grant(new_grant_name)
         developers_page = grant_dashboard_page.click_developers(new_grant_name)
         developers_page.delete_grant()
+        if new_question_type_error:
+            raise new_question_type_error

--- a/tests/e2e/test_create_preview_collection.py
+++ b/tests/e2e/test_create_preview_collection.py
@@ -3,10 +3,16 @@ import uuid
 from typing import NotRequired, TypedDict
 
 import pytest
-from playwright.sync_api import Page, expect
+from playwright.sync_api import Locator, Page, expect
 
-from app.common.data.types import QuestionDataType, QuestionPresentationOptions
+from app.common.data.types import (
+    MultilineTextInputRows,
+    NumberInputWidths,
+    QuestionDataType,
+    QuestionPresentationOptions,
+)
 from app.common.expressions.managed import GreaterThan, LessThan, ManagedExpression
+from app.common.filters import format_thousands
 from tests.e2e.config import EndToEndTestSecrets
 from tests.e2e.dataclasses import E2ETestUser
 from tests.e2e.pages import AllGrantsPage
@@ -53,16 +59,29 @@ questions_to_test: dict[str, TQuestionToTest] = {
     "text-multi-line": {
         "type": QuestionDataType.TEXT_MULTI_LINE,
         "text": "Enter a few lines of text",
-        "answers": [_QuestionResponse("E2E question text multi line\nwith a second line")],
+        "answers": [
+            _QuestionResponse("E2E question text multi line\nwith a second line that's over the word limit"),
+            _QuestionResponse("E2E question text multi line\nwith a second line"),
+        ],
+        "options": QuestionPresentationOptions(word_limit=10, rows=MultilineTextInputRows.LARGE),
     },
-    "integer": {
+    "prefix-integer": {
         "type": QuestionDataType.INTEGER,
-        "text": "Enter a number",
+        "text": "Enter the total cost as a number",
         "answers": [
             _QuestionResponse("0", "The answer must be greater than 1"),
+            _QuestionResponse("10000"),
+        ],
+        "options": QuestionPresentationOptions(prefix="£", width=NumberInputWidths.BILLIONS),
+    },
+    "suffix-integer": {
+        "type": QuestionDataType.INTEGER,
+        "text": "Enter the total weight as a number",
+        "answers": [
             _QuestionResponse("101", "The answer must be less than or equal to 100"),
             _QuestionResponse("100"),
         ],
+        "options": QuestionPresentationOptions(suffix="kg", width=NumberInputWidths.HUNDREDS),
     },
     "yes-no": {
         "type": QuestionDataType.YES_NO,
@@ -129,6 +148,26 @@ def create_question(question_definition: TQuestionToTest, manage_task_page: Mana
             question_details_page.click_other_option_checkbox()
             question_details_page.enter_other_option_text()
 
+    if question_definition["type"] == QuestionDataType.INTEGER:
+        question_details_page.click_advanced_formatting_options()
+        options = question_definition.get("options")
+        if options is not None:
+            if options.prefix is not None:
+                question_details_page.fill_prefix(options.prefix)
+            if options.suffix is not None:
+                question_details_page.fill_suffix(options.suffix)
+            if options.width is not None:
+                question_details_page.select_input_width(options.width)
+
+    if question_definition["type"] == QuestionDataType.TEXT_MULTI_LINE:
+        question_details_page.click_advanced_formatting_options()
+        options = question_definition.get("options")
+        if options is not None:
+            if options.rows is not None:
+                question_details_page.select_multiline_input_rows(options.rows)
+            if options.word_limit is not None:
+                question_details_page.fill_word_limit(options.word_limit)
+
     question_details_page.click_submit()
     question_details_page.click_return_to_task()
 
@@ -148,6 +187,38 @@ def navigate_to_report_tasks_page(page: Page, domain: str, grant_name: str, repo
     grant_reports_page = grant_dashboard_page.click_reports(grant_name)
     report_tasks_page = grant_reports_page.click_manage_tasks(grant_name=grant_name, report_name=report_name)
     return report_tasks_page
+
+
+def assert_check_your_answers(check_your_answers_page: RunnerCheckYourAnswersPage, question: TQuestionToTest) -> None:
+    if question["type"] == QuestionDataType.CHECKBOXES:
+        checkbox_answers_list = check_your_answers_page.page.get_by_test_id(f"answer-{question['text']}").locator("li")
+        expect(checkbox_answers_list).to_have_text(question["answers"][-1].answer)
+    elif question["type"] == QuestionDataType.INTEGER:
+        expect(check_your_answers_page.page.get_by_test_id(f"answer-{question['text']}")).to_have_text(
+            f"{question['options'].prefix or ''}"
+            f"{format_thousands(int(question['answers'][-1].answer))}"
+            f"{question['options'].suffix or ''}"
+        )
+    else:
+        expect(check_your_answers_page.page.get_by_test_id(f"answer-{question['text']}")).to_have_text(
+            question["answers"][-1].answer
+        )
+
+
+def assert_view_report_answers(answers_list: Locator, question: TQuestionToTest) -> None:
+    if question["type"] == QuestionDataType.CHECKBOXES:
+        expect(
+            answers_list.get_by_text(f"{question['text']} {' '.join(question['answers'][-1].answer)}")
+        ).to_be_visible()
+    elif question["type"] == QuestionDataType.INTEGER:
+        expect(
+            answers_list.get_by_text(
+                f"{question['text']} {question['options'].prefix or ''}"
+                f"{format_thousands(int(question['answers'][-1].answer))}{question['options'].suffix or ''}"
+            )
+        ).to_be_visible()
+    else:
+        expect(answers_list.get_by_text(f"{question['text']} {question['answers'][-1].answer}")).to_be_visible()
 
 
 @pytest.mark.skip_in_environments(["prod"])
@@ -196,7 +267,7 @@ def test_create_and_preview_report(
         # Sense check that the test includes all question types
         new_question_type_error = None
         try:
-            assert len(QuestionDataType) == 8 and len(questions_to_test) == 9, (
+            assert len(QuestionDataType) == 8 and len(questions_to_test) == 10, (
                 "If you have added a new question type, please update this test to include the new type in "
                 "`questions_to_test`."
             )
@@ -210,13 +281,13 @@ def test_create_and_preview_report(
         # TODO: move this into `question_to_test` definition as well
         add_validation(
             manage_task_page,
-            questions_to_test["integer"]["text"],
+            questions_to_test["prefix-integer"]["text"],
             GreaterThan(question_id=uuid.uuid4(), minimum_value=1, inclusive=False),  # question_id does not matter here
         )
 
         add_validation(
             manage_task_page,
-            questions_to_test["integer"]["text"],
+            questions_to_test["suffix-integer"]["text"],
             LessThan(question_id=uuid.uuid4(), maximum_value=100, inclusive=True),  # question_id does not matter here
         )
 
@@ -247,25 +318,17 @@ def test_create_and_preview_report(
                     expect(question_page.page.get_by_role("link", name=question_response.error_message)).to_be_visible()
 
         # Check the answers page
-        check_your_answers = RunnerCheckYourAnswersPage(page, domain, new_grant_name)
+        check_your_answers_page = RunnerCheckYourAnswersPage(page, domain, new_grant_name)
 
         for question in questions_to_test.values():
-            question_heading = check_your_answers.page.get_by_text(question["text"], exact=True)
+            question_heading = check_your_answers_page.page.get_by_text(question["text"], exact=True)
             expect(question_heading).to_be_visible()
-            if question["type"] == QuestionDataType.CHECKBOXES:
-                checkbox_answers_list = check_your_answers.page.get_by_test_id(f"answer-{question['text']}").locator(
-                    "li"
-                )
-                expect(checkbox_answers_list).to_have_text(question["answers"][-1].answer)
-            else:
-                expect(check_your_answers.page.get_by_test_id(f"answer-{question['text']}")).to_have_text(
-                    question["answers"][-1].answer
-                )
+            assert_check_your_answers(check_your_answers_page, question)
 
-        expect(check_your_answers.page.get_by_text("Have you completed this task?", exact=True)).to_be_visible()
+        expect(check_your_answers_page.page.get_by_text("Have you completed this task?", exact=True)).to_be_visible()
 
-        check_your_answers.click_mark_as_complete_yes()
-        tasklist_page = check_your_answers.click_save_and_continue(report_name=new_report_name)
+        check_your_answers_page.click_mark_as_complete_yes()
+        tasklist_page = check_your_answers_page.click_save_and_continue(report_name=new_report_name)
 
         # Submit the report
         expect(
@@ -285,12 +348,7 @@ def test_create_and_preview_report(
         answers_list = view_report_page.get_questions_list_for_task(task_name)
         expect(answers_list).to_be_visible()
         for question in questions_to_test.values():
-            if question["type"] == QuestionDataType.CHECKBOXES:
-                expect(
-                    answers_list.get_by_text(f"{question['text']} {' '.join(question['answers'][-1].answer)}")
-                ).to_be_visible()
-            else:
-                expect(answers_list.get_by_text(f"{question['text']} {question['answers'][-1].answer}")).to_be_visible()
+            assert_view_report_answers(answers_list, question)
 
     finally:
         # Tidy up by deleting the grant, which will cascade to all related entities


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-747

## 📝 Description
We recently added advanced formatting options for Integer and Multiline Text question types. This adds them to our e2e tests for the Reports tab, splitting integers out into two question types so we can test prefix and suffix options and also check that they render correctly in the check your answers and view submissions views (ie. with prefix/suffix included and numbers properly formatted for thousands with comma separators).

First commit also adds an assertion in the test that will fail if future devs add a new question type but forget to include it in the e2e tests here, so that we're forced to update the e2e tests with each new question type.

## 🧪 Testing
Pull the branch and run the tests in headed mode to see the options being correctly selected/filled and in the form runner/check your answers.

## 📋 Developer Checklist

### Review Readiness
- [X] PR title and description provide sufficient context for reviewers
- [X] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- ~[ ] No N+1 query problems introduced~
- ~[ ] Any new DB queries include appropriate where clauses based on the user's permissions~

### Testing
- [X] I have tested this change and it meets the acceptance criteria for the ticket
- ~[ ] I need the reviewer(s) to pull and run this change locally~
- ~[ ] New (non-developer) functionality has appropriate unit and integration tests~
- [X] End-to-end tests have been updated (if applicable)
- [X] Edge cases and error conditions are tested

## 📚 Additional Notes
<!-- Any additional context, concerns, or considerations for reviewers -->
