### PR TITLE
FSPT-751 Show question groups on same page

### DIFF
--- a/app/common/collections/runner.py
+++ b/app/common/collections/runner.py
@@ -59,7 +59,6 @@ class FormRunner:
 
         if self.component:
             self.form = self.component.form
-            # todo: resolve type hinting issues w/ circular dependencies and bringing in class for instance check
             _QuestionForm = build_question_form(
                 self.questions,
                 self.submission.expression_context,
@@ -161,7 +160,8 @@ class FormRunner:
         form: Optional["Form"] = None,
         source: Optional[FormRunnerState] = None,
     ) -> str:
-        return self.url_map[state](self, question or self.component, form or self.form, source)  # type: ignore
+        # todo: resolve type hinting issues w/ circular dependencies and bringing in class for instance check
+        return self.url_map[state](self, question or self.component, form or self.form, source)  # type: ignore[arg-type]
 
     @property
     def next_url(self) -> str:

--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -796,6 +796,9 @@ def add_component_condition(component: Component, user: User, managed_expression
     expression = Expression.from_managed(managed_expression, user)
     component.expressions.append(expression)
 
+    if component.parent and component.parent.same_page:
+        raise_if_group_questions_depend_on_each_other(component.parent)
+
     try:
         if (
             isinstance(managed_expression, BaseDataSourceManagedExpression)

--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -708,6 +708,15 @@ def update_group(
         group.slug = slugify(name)  # ty: ignore[invalid-argument-type]
 
     if presentation_options is not NOT_PROVIDED:
+        if (
+            not group.presentation_options.show_questions_on_the_same_page
+            and presentation_options.show_questions_on_the_same_page  # ty:ignore [possibly-unbound-attribute]
+        ):
+            try:
+                raise_if_group_questions_depend_on_each_other(group)
+            except DependencyOrderException as e:
+                db.session.rollback()
+                raise e
         group.presentation_options = presentation_options or QuestionPresentationOptions()  # ty: ignore[invalid-assignment]
 
     try:

--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -796,10 +796,10 @@ def add_component_condition(component: Component, user: User, managed_expression
     expression = Expression.from_managed(managed_expression, user)
     component.expressions.append(expression)
 
-    if component.parent and component.parent.same_page:
-        raise_if_group_questions_depend_on_each_other(component.parent)
-
     try:
+        if component.parent and component.parent.same_page:
+            raise_if_group_questions_depend_on_each_other(component.parent)
+
         if (
             isinstance(managed_expression, BaseDataSourceManagedExpression)
             and managed_expression.referenced_question.data_source
@@ -809,6 +809,9 @@ def add_component_condition(component: Component, user: User, managed_expression
     except IntegrityError as e:
         db.session.rollback()
         raise DuplicateValueError(e) from e
+    except DependencyOrderException as e:
+        db.session.rollback()
+        raise e
     return component
 
 

--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -442,6 +442,10 @@ class Group(Component):
     def all_components(self) -> list["Component"]:
         return get_ordered_nested_components(self.components)
 
+    @property
+    def same_page(self) -> bool:
+        return bool(self.presentation_options.show_questions_on_the_same_page) if self.presentation_options else False
+
 
 class SubmissionEvent(BaseModel):
     __tablename__ = "submission_event"

--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -434,6 +434,7 @@ class Group(Component):
         # reflect that groups will never have a data type but don't hook in a competing migration
         data_type: None
 
+    # todo: rename to something that makes it clear this is processed, something like all_nested_questions
     @property
     def questions(self) -> list["Question"]:
         return [q for q in get_ordered_nested_components(self.components) if isinstance(q, Question)]

--- a/app/common/templates/common/macros/collections.html
+++ b/app/common/templates/common/macros/collections.html
@@ -12,93 +12,73 @@
 {% endmacro %}
 
 {% macro collection_question(runner) %}
-  {% set question = runner.question %}
+  {% set is_group = runner.component.is_group %}
+  {% set questions = runner.component.questions if is_group else [runner.component] %}
   {% set form = runner.question_form %}
-  {% set questionAsPageHeading = not runner.question.guidance_heading %}
+  {% set questionAsPageHeading = not runner.component.guidance_heading and not is_group %}
 
   <form method="post" novalidate>
     {{ form.csrf_token }}
 
-    <span class="govuk-caption-l">{{ question.form.title }}</span>
-    {% if runner.question.guidance_heading %}
-      <h1 class="govuk-heading-l">{{ runner.question.guidance_heading }}</h1>
-      {{ runner.question.guidance_body | govuk_markdown }}
+    <span class="govuk-caption-l">{{ runner.component.form.title }}</span>
+    {% if runner.component.guidance_heading %}
+      <h1 class="govuk-heading-l">{{ runner.component.guidance_heading }}</h1>
+      {{ runner.component.guidance_body | govuk_markdown }}
+    {% elif is_group %}
+      <h1 class="govuk-heading-l">{{ runner.component.name }}</h1>
     {% endif %}
 
     {# https://github.com/alphagov/govuk-frontend/issues/1841 #}
     {# GOV.UK Frontend macros don't let you add captions to label/legend-headings that are outside of the <h> element #}
     {# We want the caption outside of the <h> element to keep things more concise and understandable to screenreader users #}
     {# So we just manually add the caption here. #}
-    {% if question.data_type == enum.question_type.TEXT_MULTI_LINE %}
-      {{
-        form.render_question(
-          question,
-          params={
-            "label": {"classes": "govuk-label--l" if questionAsPageHeading else "govuk-!-font-weight-bold", "isPageHeading": questionAsPageHeading},
-            "maxwords": question.presentation_options.word_limit,
-            "rows": question.presentation_options.rows,
-            "attributes": {"data-module": "paste-html-bullets-as-markdown"},
-          }
-        )
-      }}
-    {% elif question.data_type == enum.question_type.TEXT_SINGLE_LINE or question.data_type == enum.question_type.EMAIL or question.data_type == enum.question_type.URL %}
-      {{
-        form.render_question(
-          question,
-          params={
-            "label": {"classes": "govuk-label--l" if questionAsPageHeading else "govuk-!-font-weight-bold", "isPageHeading": questionAsPageHeading}
-          }
-        )
-      }}
-    {% elif question.data_type == enum.question_type.INTEGER %}
-      {{
-        form.render_question(
-          question,
-          params={
-            "label": {"classes": "govuk-label--l" if questionAsPageHeading else "govuk-!-font-weight-bold" ,"isPageHeading": questionAsPageHeading},
-            "inputmode": "numeric",
-            "spellcheck": false,
-            "classes": question.presentation_options.width or '',
-            "prefix": {"text": question.presentation_options.prefix or ''},
-            "suffix": {"text": question.presentation_options.suffix or ''}
-          }
-        )
-      }}
-    {% elif question.data_type == enum.question_type.YES_NO %}
-      {{
-        form.render_question(
-          question,
-          params={
-            "fieldset": {"legend": {"text": question.text, "classes": "govuk-fieldset__legend--l" if questionAsPageHeading else "govuk-!-font-weight-bold", "isPageHeading": questionAsPageHeading} },
-            "classes": "govuk-radios--inline"
-          }
-        )
-      }}
-    {% elif question.data_type == enum.question_type.CHECKBOXES %}
-      {{
-        form.render_question(
-          question,
-          params={
-            "fieldset": {"legend": {"text": question.text, "classes": "govuk-fieldset__legend--l" if questionAsPageHeading else "govuk-!-font-weight-bold", "isPageHeading": questionAsPageHeading} },
-          }
-        )
-      }}
-    {% elif question.data_type == enum.question_type.RADIOS %}
-      {% if form.get_question_field(question).widget.is_accessible_autocomplete %}
-        {#
-          `govuk-!-width-full` override here to line up with the default width of the accessible autocomplete component. We could potentially do something smarter, like copy the class
-          from here to the enhanced autocomplete, but leaving that for a future increment.
-        #}
+    {% for question in questions %}
+      {% if question.data_type == enum.question_type.TEXT_MULTI_LINE %}
         {{
           form.render_question(
             question,
             params={
-              "label": {"text": question.text, "classes": "govuk-fieldset__legend--l" if questionAsPageHeading else "govuk-!-font-weight-bold", "isPageHeading": questionAsPageHeading},
-              "classes": "govuk-!-width-full"
+              "label": {"classes": "govuk-label--l" if questionAsPageHeading else "govuk-!-font-weight-bold", "isPageHeading": questionAsPageHeading},
+              "maxwords": question.presentation_options.word_limit,
+              "rows": question.presentation_options.rows,
+              "attributes": {"data-module": "paste-html-bullets-as-markdown"},
             }
           )
         }}
-      {% else %}
+      {% elif question.data_type == enum.question_type.TEXT_SINGLE_LINE or question.data_type == enum.question_type.EMAIL or question.data_type == enum.question_type.URL %}
+        {{
+          form.render_question(
+            question,
+            params={
+              "label": {"classes": "govuk-label--l" if questionAsPageHeading else "govuk-!-font-weight-bold", "isPageHeading": questionAsPageHeading}
+            }
+          )
+        }}
+      {% elif question.data_type == enum.question_type.INTEGER %}
+        {{
+          form.render_question(
+            question,
+            params={
+              "label": {"classes": "govuk-label--l" if questionAsPageHeading else "govuk-!-font-weight-bold" ,"isPageHeading": questionAsPageHeading},
+              "inputmode": "numeric",
+              "spellcheck": false,
+              "classes": question.presentation_options.width or '',
+              "prefix": {"text": question.presentation_options.prefix or ''},
+              "suffix": {"text": question.presentation_options.suffix or ''}
+            }
+          )
+        }}
+      {% elif question.data_type == enum.question_type.YES_NO %}
+        {{
+          form.render_question(
+            question,
+            params={
+              "fieldset": {"legend": {"text": question.text, "classes": "govuk-fieldset__legend--l" if questionAsPageHeading else "govuk-!-font-weight-bold", "isPageHeading": questionAsPageHeading} },
+              "classes": "govuk-radios--inline"
+            }
+          )
+        }}
+      {% elif question.data_type == enum.question_type.CHECKBOXES %}
         {{
           form.render_question(
             question,
@@ -107,9 +87,33 @@
             }
           )
         }}
+      {% elif question.data_type == enum.question_type.RADIOS %}
+        {% if form.get_question_field(question).widget.is_accessible_autocomplete %}
+          {#
+            `govuk-!-width-full` override here to line up with the default width of the accessible autocomplete component. We could potentially do something smarter, like copy the class
+            from here to the enhanced autocomplete, but leaving that for a future increment.
+          #}
+          {{
+            form.render_question(
+              question,
+              params={
+                "label": {"text": question.text, "classes": "govuk-fieldset__legend--l" if questionAsPageHeading else "govuk-!-font-weight-bold", "isPageHeading": questionAsPageHeading},
+                "classes": "govuk-!-width-full"
+              }
+            )
+          }}
+        {% else %}
+          {{
+            form.render_question(
+              question,
+              params={
+                "fieldset": {"legend": {"text": question.text, "classes": "govuk-fieldset__legend--l" if questionAsPageHeading else "govuk-!-font-weight-bold", "isPageHeading": questionAsPageHeading} },
+              }
+            )
+          }}
+        {% endif %}
       {% endif %}
-    {% endif %}
-
+    {% endfor %}
     {{ form.submit }}
   </form>
 {% endmacro %}

--- a/app/common/templates/common/macros/collections.html
+++ b/app/common/templates/common/macros/collections.html
@@ -13,7 +13,7 @@
 
 {% macro collection_question(runner) %}
   {% set is_group = runner.component.is_group %}
-  {% set questions = runner.component.questions if is_group else [runner.component] %}
+  {% set questions = runner.questions if is_group else [runner.component] %}
   {% set form = runner.question_form %}
   {% set questionAsPageHeading = not runner.component.guidance_heading and not is_group %}
 
@@ -126,7 +126,7 @@
   <h1 class="govuk-heading-l">{{ "Your submitted answers" if submission.is_completed else "Check your answers" }}</h1>
 
   {% set rows = [] %}
-  {% for question in submission.get_ordered_visible_questions_for_form(form) %}
+  {% for question in submission.get_ordered_visible_questions(form) %}
     {% set answer = submission.get_answer_for_question(question.id) %}
     {% if answer is not none %}
       {% set value_html %}

--- a/app/common/templates/common/macros/collections.html
+++ b/app/common/templates/common/macros/collections.html
@@ -132,6 +132,8 @@
       {% set value_html %}
         {% include answer._render_answer_template %}
       {% endset %}
+
+      {# todo: can we "anchor" or link to the specific question if we're going to be changing a question on a same page group #}
       {%
         set actions = (
         []

--- a/app/deliver_grant_funding/forms.py
+++ b/app/deliver_grant_funding/forms.py
@@ -505,6 +505,13 @@ class ConditionSelectQuestionForm(FlaskForm):
         if not is_component_dependency_order_valid(self.target_question, depends_on_question):
             raise ValidationError("Select an answer that comes before this question in the form")
 
+        if (
+            self.target_question.parent
+            and self.target_question.parent.same_page
+            and (depends_on_question.parent == self.target_question.parent)
+        ):
+            raise ValidationError("Select an answer that is not on the same page as this question")
+
 
 class AddGuidanceForm(FlaskForm):
     guidance_heading = StringField(

--- a/app/deliver_grant_funding/routes/reports.py
+++ b/app/deliver_grant_funding/routes/reports.py
@@ -31,7 +31,6 @@ from app.common.data.interfaces.collections import (
     move_component_up,
     move_form_down,
     move_form_up,
-    raise_if_group_questions_depend_on_each_other,
     raise_if_question_has_any_dependencies,
     remove_question_expression,
     update_collection,
@@ -328,10 +327,10 @@ def change_group_display_options(grant_id: UUID, group_id: UUID) -> ResponseRetu
     )
     if form.validate_on_submit():
         try:
-            # todo: pass this as a value into the template so that we can grey out the option before reaching this point
-            #       will need to decide how thats displayed:
-            #       p text before the radio might work - grey hint on grey hint bad
-            raise_if_group_questions_depend_on_each_other(db_group)
+            # todo: pass the result of checking if questions depend on each other
+            #       into the template so that we can grey out the option before reaching this point
+            #       will need to decide how thats displayed: p text before the radio might work - grey hint
+            #       on grey hint bad
             update_group(db_group, presentation_options=QuestionPresentationOptions.from_group_form(form))
             return redirect(
                 url_for(

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/view_submission.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/view_submission.html
@@ -35,7 +35,7 @@
   {% for form in helper.get_ordered_visible_forms_for_section(section) %}
     <h2 class="govuk-heading-m govuk-!-margin-top-4">{{ form.title }}</h2>
     {% set rows = [] %}
-    {% for question in helper.get_ordered_visible_questions_for_form(form) %}
+    {% for question in helper.get_ordered_visible_questions(form) %}
 
       {% set answer = helper.get_answer_for_question(question.id) %}
       {% set value_html %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/runner/ask_a_question.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/runner/ask_a_question.html
@@ -2,7 +2,7 @@
 {% from "common/macros/collections.html" import collection_before with context %}
 {% extends "developers/deliver/access_grant_funding_base.html" %}
 
-{% set page_title = runner.question.text ~ " - " ~ runner.form.title %}
+{% set page_title = runner.component.text ~ " - " ~ runner.form.title %}
 
 {# configure the page for the base error summary #}
 {# todo: probably worth just aliasing this in the render call #}

--- a/app/developers/templates/developers/access/ask_a_question.html
+++ b/app/developers/templates/developers/access/ask_a_question.html
@@ -2,7 +2,7 @@
 {% from "common/macros/collections.html" import collection_before with context %}
 {% extends "developers/access/base.html" %}
 
-{% set page_title = runner.question.text ~ " - " ~ runner.form.title %}
+{% set page_title = runner.component.text ~ " - " ~ runner.form.title %}
 
 {% set form = runner.question_form %}
 

--- a/app/developers/templates/developers/deliver/ask_a_question.html
+++ b/app/developers/templates/developers/deliver/ask_a_question.html
@@ -2,7 +2,7 @@
 {% from "common/macros/collections.html" import collection_before with context %}
 {% extends "developers/deliver/access_grant_funding_base.html" %}
 
-{% set page_title = runner.question.text ~ " - " ~ runner.form.title %}
+{% set page_title = runner.component.text ~ " - " ~ runner.form.title %}
 
 {# configure the page for the base error summary #}
 {# todo: probably worth just aliasing this in the render call #}

--- a/app/developers/templates/developers/deliver/manage_submission.html
+++ b/app/developers/templates/developers/deliver/manage_submission.html
@@ -34,7 +34,7 @@
     {% for form in submission_helper.get_ordered_visible_forms_for_section(section) %}
       <h3 class="govuk-heading-s govuk-!-margin-top-4">{{ form.title }}</h3>
       {% set rows = [] %}
-      {% for question in submission_helper.get_ordered_visible_questions_for_form(form) %}
+      {% for question in submission_helper.get_ordered_visible_questions(form) %}
 
         {% set answer = submission_helper.get_answer_for_question(question.id) %}
         {% set value_html %}

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -1284,6 +1284,19 @@ class TestExpressions:
         with pytest.raises(DuplicateValueError):
             add_component_condition(question, user, managed_expression)
 
+    def test_add_condition_raises_if_same_page(self, db_session, factories):
+        group = factories.group.create(
+            presentation_options=QuestionPresentationOptions(show_questions_on_the_same_page=True)
+        )
+        q0 = factories.question.create(form=group.form, parent=group, data_type=QuestionDataType.INTEGER)
+        q1 = factories.question.create(form=group.form, parent=group)
+        user = factories.user.create()
+
+        managed_expression = GreaterThan(minimum_value=3000, question_id=q0.id)
+
+        with pytest.raises(DependencyOrderException):
+            add_component_condition(q1, user, managed_expression)
+
     def test_add_radios_question_condition(self, db_session, factories):
         q0 = factories.question.create(data_type=QuestionDataType.RADIOS)
         question = factories.question.create(form=q0.form)

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -1297,6 +1297,9 @@ class TestExpressions:
         with pytest.raises(DependencyOrderException):
             add_component_condition(q1, user, managed_expression)
 
+        # check that the ORM has been rolled back and invalidated any changes from the interface
+        assert q1.expressions == []
+
     def test_add_radios_question_condition(self, db_session, factories):
         q0 = factories.question.create(data_type=QuestionDataType.RADIOS)
         question = factories.question.create(form=q0.form)

--- a/tests/integration/common/data/test_models.py
+++ b/tests/integration/common/data/test_models.py
@@ -97,3 +97,15 @@ class TestGroupModel:
 
         assert group.questions == [question2, question3, question4]
         assert sub_group.questions == [question4]
+
+    @pytest.mark.parametrize("show_questions_on_the_same_page", [True, False])
+    def test_same_page_property(self, factories, show_questions_on_the_same_page):
+        form = factories.form.create()
+        group = factories.group.create(
+            form_id=form.id,
+            presentation_options=QuestionPresentationOptions(
+                show_questions_on_the_same_page=show_questions_on_the_same_page
+            ),
+        )
+
+        assert group.same_page is show_questions_on_the_same_page

--- a/tests/integration/common/helpers/test_collections.py
+++ b/tests/integration/common/helpers/test_collections.py
@@ -39,7 +39,7 @@ class TestSubmissionHelper:
 
             assert helper.get_answer_for_question(question.id) is None
 
-            form = build_question_form(question, expression_context=EC())(
+            form = build_question_form([question], expression_context=EC())(
                 q_d696aebc49d24170a92fb6ef42994294="User submitted data"
             )
             helper.submit_answer_for_question(question.id, form)
@@ -53,7 +53,7 @@ class TestSubmissionHelper:
             submission = factories.submission.build(collection=question.form.section.collection)
             helper = SubmissionHelper(submission)
 
-            form = build_question_form(question, expression_context=EC())(q_d696aebc49d24170a92fb6ef42994294=5)
+            form = build_question_form([question], expression_context=EC())(q_d696aebc49d24170a92fb6ef42994294=5)
             helper.submit_answer_for_question(question.id, form)
 
             assert helper.get_answer_for_question(question.id) == IntegerAnswer(value=5)
@@ -65,7 +65,7 @@ class TestSubmissionHelper:
             submission = factories.submission.build(collection=question.form.section.collection)
             helper = SubmissionHelper(submission)
 
-            form = build_question_form(question, expression_context=EC())(q_d696aebc49d24170a92fb6ef42994294=0)
+            form = build_question_form([question], expression_context=EC())(q_d696aebc49d24170a92fb6ef42994294=0)
             helper.submit_answer_for_question(question.id, form)
 
             assert helper.get_answer_for_question(question.id) == IntegerAnswer(value=0)
@@ -75,7 +75,7 @@ class TestSubmissionHelper:
             submission = factories.submission.build(collection=question.form.section.collection)
             helper = SubmissionHelper(submission)
 
-            form = build_question_form(question, expression_context=EC())(
+            form = build_question_form([question], expression_context=EC())(
                 q_d696aebc49d24170a92fb6ef42994294="User submitted data"
             )
             helper.submit_answer_for_question(question.id, form)
@@ -292,7 +292,7 @@ class TestSubmissionHelper:
 
             helper.submit_answer_for_question(
                 question_one.id,
-                build_question_form(question_one, expression_context=EC())(
+                build_question_form([question_one], expression_context=EC())(
                     q_d696aebc49d24170a92fb6ef42994294="User submitted data"
                 ),
             )
@@ -302,7 +302,7 @@ class TestSubmissionHelper:
 
             helper.submit_answer_for_question(
                 question_two.id,
-                build_question_form(question_two, expression_context=EC())(
+                build_question_form([question_two], expression_context=EC())(
                     q_d696aebc49d24170a92fb6ef42994295="User submitted data"
                 ),
             )
@@ -318,7 +318,7 @@ class TestSubmissionHelper:
             # make sure the second form is unaffected by the first forms status
             helper.submit_answer_for_question(
                 question_three.id,
-                build_question_form(question_three, expression_context=EC())(
+                build_question_form([question_three], expression_context=EC())(
                     q_d696aebc49d24170a92fb6ef42994296="User submitted data"
                 ),
             )
@@ -344,7 +344,7 @@ class TestSubmissionHelper:
 
             helper.submit_answer_for_question(
                 question.id,
-                build_question_form(question, expression_context=EC())(
+                build_question_form([question], expression_context=EC())(
                     q_d696aebc49d24170a92fb6ef42994294="User submitted data"
                 ),
             )
@@ -356,7 +356,7 @@ class TestSubmissionHelper:
 
             helper.submit_answer_for_question(
                 question_two.id,
-                build_question_form(question_two, expression_context=EC())(
+                build_question_form([question_two], expression_context=EC())(
                     q_d696aebc49d24170a92fb6ef42994295="User submitted data"
                 ),
             )
@@ -386,7 +386,7 @@ class TestSubmissionHelper:
 
             helper.submit_answer_for_question(
                 question.id,
-                build_question_form(question, expression_context=EC())(
+                build_question_form([question], expression_context=EC())(
                     q_d696aebc49d24170a92fb6ef42994294="User submitted data"
                 ),
             )
@@ -410,7 +410,7 @@ class TestSubmissionHelper:
 
             helper.submit_answer_for_question(
                 question.id,
-                build_question_form(question, expression_context=EC())(
+                build_question_form([question], expression_context=EC())(
                     q_d696aebc49d24170a92fb6ef42994294="User submitted data"
                 ),
             )
@@ -431,7 +431,7 @@ class TestSubmissionHelper:
 
             helper.submit_answer_for_question(
                 question.id,
-                build_question_form(question, expression_context=EC())(
+                build_question_form([question], expression_context=EC())(
                     q_d696aebc49d24170a92fb6ef42994294="User submitted data"
                 ),
             )

--- a/tests/models.py
+++ b/tests/models.py
@@ -612,11 +612,10 @@ class _QuestionFactory(SQLAlchemyModelFactory):
                     DataSourceItemReference(expression_id=expression.id, data_source_item_id=item.id)
                     for item in referenced_items
                 ]
-
-            db.session.add(expression)
             self.expressions.append(expression)
 
         if create:
+            db.session.add(expression)
             db.session.commit()
 
 

--- a/tests/unit/common/collections/test_runner.py
+++ b/tests/unit/common/collections/test_runner.py
@@ -4,7 +4,7 @@ import pytest
 
 from app.common.collections.runner import FormRunner
 from app.common.collections.types import TextSingleLineAnswer
-from app.common.data.types import FormRunnerState, QuestionDataType
+from app.common.data.types import FormRunnerState, QuestionDataType, QuestionPresentationOptions
 from app.common.helpers.collections import SubmissionHelper
 
 
@@ -15,19 +15,34 @@ class TestFormRunner:
         helper = SubmissionHelper(submission)
 
         question_state_context = FormRunner(submission=helper, question=question, source=None)
-        assert question_state_context.question == question
+        assert question_state_context.component == question
         assert question_state_context.form == question.form
         assert question_state_context.question_form is not None
 
         check_your_answers_context = FormRunner(submission=helper, form=question.form, source=None)
-        assert check_your_answers_context.question is None
+        assert check_your_answers_context.component is None
         assert check_your_answers_context.form == question.form
         assert check_your_answers_context.check_your_answers_form is not None
 
         tasklist_context = FormRunner(submission=helper, source=None)
-        assert tasklist_context.question is None
+        assert tasklist_context.component is None
         assert tasklist_context.form is None
         assert tasklist_context.tasklist_form is not None
+
+    def test_form_runner_loads_and_sets_context_for_same_page_group(self, factories):
+        group = factories.group.build(
+            presentation_options=QuestionPresentationOptions(show_questions_on_the_same_page=True)
+        )
+        q1 = factories.question.build(parent=group, form=group.form)
+        q2 = factories.question.build(parent=group, form=group.form)
+        submission = factories.submission.build(collection=group.form.section.collection)
+        helper = SubmissionHelper(submission)
+
+        runner = FormRunner(submission=helper, question=q1, source=None)
+
+        assert runner.component == group
+        assert runner.component.questions == [q1, q2]
+        assert runner.question_form is not None
 
     def test_form_runner_correctly_configures_dynamic_question_form(self, factories):
         question = factories.question.build(data_type=QuestionDataType.TEXT_SINGLE_LINE)
@@ -40,6 +55,27 @@ class TestFormRunner:
         runner = FormRunner(submission=helper, question=question, source=None)
         assert runner.question_form.get_question_field(question) is not None
         assert runner.question_form.get_answer_to_question(question) == "An answer"
+
+    def test_form_runner_correctly_configured_dynamic_question_form_for_same_page(self, factories):
+        group = factories.group.build(
+            presentation_options=QuestionPresentationOptions(show_questions_on_the_same_page=True)
+        )
+        q1 = factories.question.build(parent=group, form=group.form)
+        q2 = factories.question.build(parent=group, form=group.form)
+        submission = factories.submission.build(
+            collection=group.form.section.collection,
+            data={
+                str(q1.id): TextSingleLineAnswer("An answer for q1").get_value_for_submission(),
+                str(q2.id): TextSingleLineAnswer("An answer for q2").get_value_for_submission(),
+            },
+        )
+        helper = SubmissionHelper(submission)
+
+        runner = FormRunner(submission=helper, question=q1, source=None)
+        assert runner.question_form.get_question_field(q1) is not None
+        assert runner.question_form.get_answer_to_question(q1) == "An answer for q1"
+        assert runner.question_form.get_answer_to_question(q2) == "An answer for q2"
+        assert runner.question_form.get_question_field(q2) is not None
 
     def test_calls_mapped_urls_with_the_right_information(self, factories):
         question = factories.question.build()
@@ -159,6 +195,38 @@ class TestFormRunner:
 
         start_of_form = MappedFormRunner(submission=helper, question=question, source=None)
         assert start_of_form.back_url == "mock_tasklist_url"
+
+    def test_next_back_url_for_group(self, factories):
+        q1 = factories.question.build(order=0)
+        group = factories.group.build(
+            form=q1.form,
+            presentation_options=QuestionPresentationOptions(show_questions_on_the_same_page=True),
+            order=1,
+        )
+        factories.question.build(parent=group, order=0)
+        nested_q3 = factories.question.build(parent=group, order=1)
+        factories.question.build(parent=group, order=2)
+        q5 = factories.question.build(form=group.form, order=2)
+        submission = factories.submission.build(collection=group.form.section.collection)
+        helper = SubmissionHelper(submission)
+
+        question_mock = Mock(side_effect=lambda r, q, f, s: f"mock_question_url_{str(q.id)}")
+        check_your_answers_mock = Mock(return_value="mock_check_answers_url")
+
+        class MappedFormRunner(FormRunner):
+            url_map = {
+                FormRunnerState.QUESTION: question_mock,
+                FormRunnerState.CHECK_YOUR_ANSWERS: check_your_answers_mock,
+            }
+
+        runner = MappedFormRunner(submission=helper, question=nested_q3, source=None)
+
+        # even though we're in the middle of a group of questions, the next question should come after the
+        # group as they're all shown on the same page
+        assert runner.validate_can_show_question_page() and runner.next_url == f"mock_question_url_{str(q5.id)}"
+
+        # similarly the back question should be the question before the group of same page
+        assert runner.validate_can_show_question_page() and runner.back_url == f"mock_question_url_{str(q1.id)}"
 
     class TestUrlConfig:
         @pytest.mark.parametrize("runner_class", FormRunner.__subclasses__())


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-751

## 📝 Description
This tweaks the form runner to accept a list of questions and then iterate through those questions when validating/ submitting/ presenting questions and answers.

Cover the form runner and dynamic form building validation libraries.

## 📸 Show the thing (screenshots, gifs)

Questions showing on the same page and being validated together (some standard, some custom validations)

<img width="1145" height="1357" alt="funding communities gov localhost_8080_developers_deliver_submissions_69ff0f3d-3fac-4a2c-beff-fe0a904ee5e3_0025d8d4-bc36-4466-8081-a94cf4e066c0" src="https://github.com/user-attachments/assets/e1d51610-afd8-4f17-b312-c640a7a523cd" />

Blocking a group from being same page if existing questions have inter dependencies

<img width="1000" height="835" alt="Screenshot 2025-08-22 at 13 15 30" src="https://github.com/user-attachments/assets/8b0d64f9-fd70-49ec-a5ad-f0e4f3aa30b3" />

Blocking a condition from being added if its parent is a same page group

<img width="1001" height="926" alt="Screenshot 2025-08-22 at 13 15 51" src="https://github.com/user-attachments/assets/69ce0481-2e69-467c-89b5-c2d192e65242" />
