### PR TITLE
BAU: Remove pending invitations for platform admins

### DIFF
--- a/app/common/data/interfaces/user.py
+++ b/app/common/data/interfaces/user.py
@@ -248,6 +248,11 @@ def upsert_user_and_set_platform_admin_role(azure_ad_subject_id: str, email_addr
         email_address=email_address,
         name=name,
     )
+    # Claiming invitations here is an edge case but avoids pre-invited grant team members who might sign in for the
+    # first time as a platform admin from having pending invitations in the database and Grant Team views
+    invitations = get_usable_invitations_by_email(email=email_address)
+    for invite in invitations:
+        claim_invitation(invitation=invite, user=user)
     set_platform_admin_role_for_user(user)
     return user
 


### PR DESCRIPTION
During user testing we added a user as a grant team member but subsequently had to add them to the FSD_ADMIN group and get them to sign in as Funding Service Admins. This left the pending Grant Team member invitation unclaimed and made the Grant Team view look odd (with them appearing in both tables).

This is a small edge case but when a funding service admin logs in, as well as removing any existing roles they might have, we should also claim any pending invitations.

## 🧪 Testing
- On your local set-up, invite an email as a grant team member and observe that email shows up as a grant team member who has not yet signed in
- Sign out and sign back in with that email but set yourself to be a platform admin
- That user should no longer show as 'not yet signed in' on grant team views

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [X] PR title and description provide sufficient context for reviewers
- [X] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- [X] No N+1 query problems introduced
- [X] Any new DB queries include appropriate where clauses based on the user's permissions

### Testing
- [X] I have tested this change and it meets the acceptance criteria for the ticket
- ~[ ] I need the reviewer(s) to pull and run this change locally~
- [X] New (non-developer) functionality has appropriate unit and integration tests
- ~[ ] End-to-end tests have been updated (if applicable)~
- [X] Edge cases and error conditions are tested

## 📚 Additional Notes
<!-- Any additional context, concerns, or considerations for reviewers -->
