### PR TITLE
FSPT-761 Performance improvements

### DIFF
--- a/app/common/collections/runner.py
+++ b/app/common/collections/runner.py
@@ -61,9 +61,9 @@ class FormRunner:
             self.form = self.component.form
             _QuestionForm = build_question_form(
                 self.questions,
-                self.submission.expression_context,
+                self.submission.cached_expression_context,
             )
-            self._question_form = _QuestionForm(data=self.submission.form_data)
+            self._question_form = _QuestionForm(data=self.submission.cached_form_data)
 
         if self.form:
             all_questions_answered, _ = self.submission.get_all_questions_are_answered_for_form(self.form)
@@ -195,7 +195,7 @@ class FormRunner:
         if not self.component:
             raise ValueError("Question context not set")
 
-        context = self.submission.expression_context
+        context = self.submission.cached_expression_context
 
         if not self.submission.is_component_visible(self.component, context):
             self._valid = False

--- a/app/common/collections/runner.py
+++ b/app/common/collections/runner.py
@@ -177,7 +177,7 @@ class FormRunner:
             # Regardless of where they're from (eg even check-your-answers), take them to the next unanswered question
             # this will let users stay in a data-submitting flow if they've changed a conditional answer which has
             # unlocked more questions.
-            while next_question and self.submission.get_answer_for_question(next_question.id) is not None:
+            while next_question and self.submission.cached_get_answer_for_question(next_question.id) is not None:
                 next_question = self.submission.get_next_question(next_question.id)
 
             return (

--- a/app/common/collections/runner.py
+++ b/app/common/collections/runner.py
@@ -46,7 +46,7 @@ class FormRunner:
         # pass the whole group into the form runner
         if question and question.parent and question.parent.same_page:
             self.component = question.parent
-            self.questions = self.submission.get_ordered_visible_questions(self.component)
+            self.questions = self.submission.cached_get_ordered_visible_questions(self.component)
         else:
             self.component = question
             self.questions = [self.component] if self.component else []
@@ -66,7 +66,7 @@ class FormRunner:
             self._question_form = _QuestionForm(data=self.submission.cached_form_data)
 
         if self.form:
-            all_questions_answered, _ = self.submission.get_all_questions_are_answered_for_form(self.form)
+            all_questions_answered, _ = self.submission.cached_get_all_questions_are_answered_for_form(self.form)
             self._check_your_answers_form = CheckYourAnswersForm(
                 section_completed=(
                     "yes" if self.submission.get_status_for_form(self.form) == SubmissionStatusEnum.COMPLETED else None

--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -537,9 +537,11 @@ def _check_component_order_dependency(component: Component, swap_component: Comp
 
     # we could be comparing to either an individual question or a group of multiple questions so collect those
     # as lists to compare against each other
-    child_components = [component] + ([c for c in component.all_components] if isinstance(component, Group) else [])
+    child_components = [component] + (
+        [c for c in component.cached_all_components] if isinstance(component, Group) else []
+    )
     child_swap_components = [swap_component] + (
-        [c for c in swap_component.all_components] if isinstance(swap_component, Group) else []
+        [c for c in swap_component.cached_all_components] if isinstance(swap_component, Group) else []
     )
 
     for c in child_components:
@@ -572,7 +574,7 @@ def is_component_dependency_order_valid(component: Component, depends_on_compone
     # fetching the entire schema means whatever is calling this doesn't have to worry about
     # guaranteeing lazy loading performance behaviour
     form = get_form_by_id(component.form_id, with_all_questions=True)
-    return form.all_components.index(component) > form.all_components.index(depends_on_component)
+    return form.cached_all_components.index(component) > form.cached_all_components.index(depends_on_component)
 
 
 def raise_if_question_has_any_dependencies(question: Question | Group) -> Never | None:
@@ -581,10 +583,12 @@ def raise_if_question_has_any_dependencies(question: Question | Group) -> Never 
     form = get_form_by_id(question.form_id, with_all_questions=True)
 
     # all of the child components that might be removed or impacted with a change to this components
-    child_components_ids = [c.id for c in [question] + (question.all_components if isinstance(question, Group) else [])]
+    child_components_ids = [
+        c.id for c in [question] + (question.cached_all_components if isinstance(question, Group) else [])
+    ]
 
     # go through all components in this schema and compare against any related child components
-    for target_question in form.all_components:
+    for target_question in form.cached_all_components:
         for condition in target_question.conditions:
             if condition.managed and condition.managed.question_id in child_components_ids:
                 raise DependencyOrderException(
@@ -598,9 +602,9 @@ def raise_if_group_questions_depend_on_each_other(group: Group) -> Never | None:
     # guaranteeing lazy loading performance behaviour - should investigate fetching the group with all
     # questions and expressions standalone, consider shared join options for components
     _ = get_form_by_id(group.form_id, with_all_questions=True)
-    for question in group.questions:
+    for question in group.cached_questions:
         for condition in question.conditions:
-            if condition.managed and condition.managed.question_id in [q.id for q in group.questions]:
+            if condition.managed and condition.managed.question_id in [q.id for q in group.cached_questions]:
                 raise DependencyOrderException(
                     "You cannot set a group to be same page if it contains questions that depend on each other",
                     question,

--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -162,15 +162,22 @@ def get_submission(submission_id: UUID, with_full_schema: bool = False) -> Submi
             [
                 # get all flat components to drive single batches of selectin
                 # joinedload lets us avoid an exponentially increasing number of queries
-                joinedload(Submission.collection).joinedload(Collection.forms).selectinload(Form._all_components),
+                joinedload(Submission.collection)
+                .joinedload(Collection.forms)
+                .selectinload(Form._all_components)
+                .joinedload(Component.expressions),
                 # get any nested components in one go
                 joinedload(Submission.collection)
                 .joinedload(Collection.forms)
                 .selectinload(Form._all_components)
-                .selectinload(Component.components),
+                .selectinload(Component.components)
+                .joinedload(Component.expressions),
                 # eagerly populate the forms top level components - this is a redundant query but
                 # leaves as much as possible with the ORM
-                joinedload(Submission.collection).joinedload(Collection.forms).selectinload(Form.components),
+                joinedload(Submission.collection)
+                .joinedload(Collection.forms)
+                .selectinload(Form.components)
+                .joinedload(Component.expressions),
                 joinedload(Submission.events),
             ]
         )

--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -1,4 +1,5 @@
 import uuid
+from functools import cached_property
 from typing import TYPE_CHECKING, Optional, Union
 
 from sqlalchemy import CheckConstraint, ForeignKey, ForeignKeyConstraint, Index, UniqueConstraint, text
@@ -189,13 +190,13 @@ class Form(BaseModel):
         cascade="all, save-update, merge",
     )
 
-    @property
-    def questions(self) -> list["Question"]:
+    @cached_property
+    def cached_questions(self) -> list["Question"]:
         """Consistently returns all questions in the form, respecting order and any level of nesting."""
         return [q for q in get_ordered_nested_components(self.components) if isinstance(q, Question)]
 
-    @property
-    def all_components(self) -> list["Component"]:
+    @cached_property
+    def cached_all_components(self) -> list["Component"]:
         return get_ordered_nested_components(self.components)
 
 
@@ -383,12 +384,12 @@ class Group(Component):
         data_type: None
 
     # todo: rename to something that makes it clear this is processed, something like all_nested_questions
-    @property
-    def questions(self) -> list["Question"]:
+    @cached_property
+    def cached_questions(self) -> list["Question"]:
         return [q for q in get_ordered_nested_components(self.components) if isinstance(q, Question)]
 
-    @property
-    def all_components(self) -> list["Component"]:
+    @cached_property
+    def cached_all_components(self) -> list["Component"]:
         return get_ordered_nested_components(self.components)
 
     @property

--- a/app/common/expressions/registry.py
+++ b/app/common/expressions/registry.py
@@ -57,5 +57,5 @@ def register_managed_expression(cls: type["ManagedExpression"]) -> type["Managed
 
 
 def get_supported_form_questions(question: "Component") -> list["Question"]:
-    questions = question.form.questions
+    questions = question.form.cached_questions
     return [q for q in questions if q.data_type in get_registered_data_types() and q.id != question.id]

--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -2,6 +2,7 @@ import csv
 import json
 import uuid
 from datetime import datetime
+from functools import cached_property
 from io import StringIO
 from itertools import chain
 from typing import TYPE_CHECKING, Any, List, Optional, Union
@@ -93,8 +94,8 @@ class SubmissionHelper:
     def reference(self) -> str:
         return self.submission.reference
 
-    @property
-    def form_data(self) -> dict[str, Any]:
+    @cached_property
+    def cached_form_data(self) -> dict[str, Any]:
         form_data = {
             question.safe_qid: answer.get_value_for_form()
             for form in self.submission.collection.forms
@@ -103,8 +104,8 @@ class SubmissionHelper:
         }
         return form_data
 
-    @property
-    def expression_context(self) -> ExpressionContext:
+    @cached_property
+    def cached_expression_context(self) -> ExpressionContext:
         submission_data = {
             question.safe_qid: answer.get_value_for_expression()
             for form in self.collection.forms
@@ -199,7 +200,7 @@ class SubmissionHelper:
         answers = [answer for q in visible_questions if (answer := self.get_answer_for_question(q.id)) is not None]
         return len(visible_questions) == len(answers), answers
 
-    @property
+    @cached_property
     def all_forms_are_completed(self) -> bool:
         form_statuses = set([self.get_status_for_form(form) for form in self.collection.forms])
         return {SubmissionStatusEnum.COMPLETED} == form_statuses
@@ -252,7 +253,7 @@ class SubmissionHelper:
         return [
             question
             for question in parent.cached_questions
-            if self.is_component_visible(question, self.expression_context)
+            if self.is_component_visible(question, self.cached_expression_context)
         ]
 
     def get_first_question_for_form(self, form: "Form") -> Optional["Question"]:

--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -201,7 +201,7 @@ class SubmissionHelper:
                 f"Could not find a question with id={question_id} in collection={self.collection.id}"
             ) from e
 
-    def get_all_questions_are_answered_for_form(self, form: "Form") -> tuple[bool, list[AllAnswerTypes]]:
+    def _get_all_questions_are_answered_for_form(self, form: "Form") -> tuple[bool, list[AllAnswerTypes]]:
         visible_questions = self.cached_get_ordered_visible_questions(form)
         answers = [
             answer for q in visible_questions if (answer := self.cached_get_answer_for_question(q.id)) is not None

--- a/app/common/templates/common/macros/collections.html
+++ b/app/common/templates/common/macros/collections.html
@@ -126,7 +126,7 @@
   <h1 class="govuk-heading-l">{{ "Your submitted answers" if submission.is_completed else "Check your answers" }}</h1>
 
   {% set rows = [] %}
-  {% for question in submission.get_ordered_visible_questions(form) %}
+  {% for question in submission.cached_get_ordered_visible_questions(form) %}
     {% set answer = submission.cached_get_answer_for_question(question.id) %}
     {% if answer is not none %}
       {% set value_html %}
@@ -182,7 +182,7 @@
     {% set check_your_answers_form = runner.check_your_answers_form %}
     <form method="post" novalidate>
       {{ check_your_answers_form.csrf_token }}
-      {% set all_questions_answered, _ = submission.get_all_questions_are_answered_for_form(form) %}
+      {% set all_questions_answered, _ = submission.cached_get_all_questions_are_answered_for_form(form) %}
       {% if all_questions_answered %}
         {{
           check_your_answers_form.section_completed(params={

--- a/app/common/templates/common/macros/collections.html
+++ b/app/common/templates/common/macros/collections.html
@@ -127,7 +127,7 @@
 
   {% set rows = [] %}
   {% for question in submission.get_ordered_visible_questions(form) %}
-    {% set answer = submission.get_answer_for_question(question.id) %}
+    {% set answer = submission.cached_get_answer_for_question(question.id) %}
     {% if answer is not none %}
       {% set value_html %}
         {% include answer._render_answer_template %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_group_questions.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_group_questions.html
@@ -97,7 +97,7 @@
 
         {% if grant_admin %}
           <a class="govuk-button govuk-button--secondary" href="{{ url_for('deliver_grant_funding.choose_question_type', grant_id=grant.id, form_id=db_form.id, parent_id=group.id) }}"
-            >{{ "Add another question" if group.questions else "Add a question" }}</a
+            >{{ "Add another question" if group.cached_questions else "Add a question" }}</a
           >
         {% endif %}
       </div>

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_report_tasks.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_report_tasks.html
@@ -70,7 +70,7 @@
             <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.list_task_questions', grant_id=grant.id, form_id=form.id) }}">{{ form.title }}</a>
           {% endset %}
           {% set questionsHtml %}
-            {{ form.questions | length }}
+            {{ form.cached_questions | length }}
             questions<span class="govuk-visually-hidden"> in {{ form.title }}</span>
           {% endset %}
           {% set actions = [] %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_task_questions.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_task_questions.html
@@ -55,14 +55,14 @@
     <div class="govuk-grid-column-one-third govuk-!-text-align-right">
       <form method="post" novalidate>
         {{ form.csrf_token }}
-        {{ form.submit(params={"text": "Preview task", "classes": "govuk-button--secondary", "disabled": true if db_form.questions | length == 0 else false}) }}
+        {{ form.submit(params={"text": "Preview task", "classes": "govuk-button--secondary", "disabled": true if db_form.cached_questions | length == 0 else false}) }}
       </form>
     </div>
   </div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h2 class="govuk-heading-m govuk-!-margin-top-5">Questions</h2>
-      {% if not db_form.questions %}
+      {% if not db_form.cached_questions %}
         <p class="govuk-body">This task has no questions.</p>
       {% else %}
         {{ question_table(db_form, role_can_edit=grant_admin) }}
@@ -70,7 +70,9 @@
 
       {% if grant_admin %}
         <div class="govuk-button-group">
-          <a class="govuk-button govuk-button--secondary" href="{{ url_for('deliver_grant_funding.choose_question_type', grant_id=grant.id, form_id=db_form.id) }}">{{ "Add another question" if db_form.questions else "Add a question" }}</a>
+          <a class="govuk-button govuk-button--secondary" href="{{ url_for('deliver_grant_funding.choose_question_type', grant_id=grant.id, form_id=db_form.id) }}"
+            >{{ "Add another question" if db_form.cached_questions else "Add a question" }}</a
+          >
           <a class="govuk-button govuk-button--secondary" href="{{ url_for('deliver_grant_funding.add_question_group_name', grant_id=grant.id, form_id=db_form.id) }}">{{ "Add a question group" }}</a>
         </div>
       {% endif %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/view_submission.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/view_submission.html
@@ -36,7 +36,7 @@
     {% set rows = [] %}
     {% for question in helper.get_ordered_visible_questions(form) %}
 
-      {% set answer = helper.get_answer_for_question(question.id) %}
+      {% set answer = helper.cached_get_answer_for_question(question.id) %}
       {% set value_html %}
         {% if answer %}
           {% include answer._render_answer_template %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/view_submission.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/view_submission.html
@@ -34,7 +34,7 @@
   {% for form in helper.get_ordered_visible_forms() %}
     <h2 class="govuk-heading-m govuk-!-margin-top-4">{{ form.title }}</h2>
     {% set rows = [] %}
-    {% for question in helper.get_ordered_visible_questions(form) %}
+    {% for question in helper.cached_get_ordered_visible_questions(form) %}
 
       {% set answer = helper.cached_get_answer_for_question(question.id) %}
       {% set value_html %}

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -170,8 +170,9 @@ def test_get_submission_with_full_schema(db_session, factories, track_sql_querie
     count = 0
     with track_sql_queries() as queries:
         for f in from_db.collection.forms:
-            for _q in f.cached_questions:
-                count += 1
+            for q in f._all_components:
+                for _e in q.expressions:
+                    count += 1
 
     assert queries == []
 

--- a/tests/integration/common/data/test_models.py
+++ b/tests/integration/common/data/test_models.py
@@ -82,7 +82,7 @@ class TestFormModel:
         sub_group = factories.group.create(form_id=form.id, parent=group, order=1)
         question4 = factories.question.create(form_id=form.id, parent=sub_group, order=0)
 
-        assert form.questions == [question1, question2, question3, question4]
+        assert form.cached_questions == [question1, question2, question3, question4]
 
 
 class TestGroupModel:
@@ -95,8 +95,8 @@ class TestGroupModel:
         sub_group = factories.group.create(form_id=group.form_id, parent=group, order=2)
         question4 = factories.question.create(form_id=group.form_id, parent=sub_group, order=0)
 
-        assert group.questions == [question2, question3, question4]
-        assert sub_group.questions == [question4]
+        assert group.cached_questions == [question2, question3, question4]
+        assert sub_group.cached_questions == [question4]
 
     @pytest.mark.parametrize("show_questions_on_the_same_page", [True, False])
     def test_same_page_property(self, factories, show_questions_on_the_same_page):

--- a/tests/integration/common/expressions/test_registry.py
+++ b/tests/integration/common/expressions/test_registry.py
@@ -33,6 +33,7 @@ class TestManagedExpressions:
         assert get_supported_form_questions(valid_question) == []
 
         second_question = factories.question.build(data_type=QuestionDataType.INTEGER, form=form)
+        del form.cached_questions
 
         # make sure the original question under test does show up in the correct circumstances
         assert get_supported_form_questions(second_question) == [valid_question]

--- a/tests/integration/common/helpers/test_collections.py
+++ b/tests/integration/common/helpers/test_collections.py
@@ -547,8 +547,9 @@ class TestCollectionHelper:
     def test_generate_csv_content_skipped_questions_previously_answered(self, factories):
         collection = factories.collection.create(create_completed_submissions_conditional_question__test=True)
         c_helper = CollectionHelper(collection=collection, submission_mode=SubmissionModeEnum.TEST)
-        dependant_question_id = collection.forms[0].questions[0].id
-        conditional_question_id = collection.forms[0].questions[1].id
+        dependant_question_id = collection.forms[0].cached_questions[0].id
+        conditional_question_id = collection.forms[0].cached_questions[1].id
+        
         # Find the submission where question 2 is not expected to be answered it and store some data as though it has
         # previously been answered
         submission = next(

--- a/tests/integration/common/helpers/test_collections.py
+++ b/tests/integration/common/helpers/test_collections.py
@@ -39,14 +39,14 @@ class TestSubmissionHelper:
             submission = factories.submission.build(collection=question.form.collection)
             helper = SubmissionHelper(submission)
 
-            assert helper.get_answer_for_question(question.id) is None
+            assert helper.cached_get_answer_for_question(question.id) is None
 
             form = build_question_form([question], expression_context=EC())(
                 q_d696aebc49d24170a92fb6ef42994294="User submitted data"
             )
             helper.submit_answer_for_question(question.id, form)
 
-            assert helper.get_answer_for_question(question.id) == TextSingleLineAnswer("User submitted data")
+            assert helper.cached_get_answer_for_question(question.id) == TextSingleLineAnswer("User submitted data")
 
         def test_get_data_maps_type(self, db_session, factories):
             question = factories.question.build(
@@ -58,7 +58,7 @@ class TestSubmissionHelper:
             form = build_question_form([question], expression_context=EC())(q_d696aebc49d24170a92fb6ef42994294=5)
             helper.submit_answer_for_question(question.id, form)
 
-            assert helper.get_answer_for_question(question.id) == IntegerAnswer(value=5)
+            assert helper.cached_get_answer_for_question(question.id) == IntegerAnswer(value=5)
 
         def test_can_get_falsey_answers(self, db_session, factories):
             question = factories.question.build(
@@ -70,7 +70,7 @@ class TestSubmissionHelper:
             form = build_question_form([question], expression_context=EC())(q_d696aebc49d24170a92fb6ef42994294=0)
             helper.submit_answer_for_question(question.id, form)
 
-            assert helper.get_answer_for_question(question.id) == IntegerAnswer(value=0)
+            assert helper.cached_get_answer_for_question(question.id) == IntegerAnswer(value=0)
 
         def test_cannot_submit_answer_on_submitted_submission(self, db_session, factories):
             question = factories.question.build(id=uuid.UUID("d696aebc-49d2-4170-a92f-b6ef42994294"))
@@ -555,7 +555,7 @@ class TestCollectionHelper:
         submission = next(
             helper.submission
             for _, helper in c_helper.submission_helpers.items()
-            if helper.get_answer_for_question(dependant_question_id).get_value_for_text_export() == "20"
+            if helper.cached_get_answer_for_question(dependant_question_id).get_value_for_text_export() == "20"
         )
         submission.data[str(conditional_question_id)] = IntegerAnswer(value=120).get_value_for_submission()
         csv_content = c_helper.generate_csv_content_for_all_submissions()

--- a/tests/integration/common/helpers/test_collections.py
+++ b/tests/integration/common/helpers/test_collections.py
@@ -549,7 +549,7 @@ class TestCollectionHelper:
         c_helper = CollectionHelper(collection=collection, submission_mode=SubmissionModeEnum.TEST)
         dependant_question_id = collection.forms[0].cached_questions[0].id
         conditional_question_id = collection.forms[0].cached_questions[1].id
-        
+
         # Find the submission where question 2 is not expected to be answered it and store some data as though it has
         # previously been answered
         submission = next(

--- a/tests/integration/common/helpers/test_collections.py
+++ b/tests/integration/common/helpers/test_collections.py
@@ -103,7 +103,7 @@ class TestSubmissionHelper:
             submission = factories.submission.build(collection=form.collection)
             helper = SubmissionHelper(submission)
 
-            assert helper.form_data == {}
+            assert helper.cached_form_data == {}
 
         def test_with_submission_data(self, factories):
             assert len(QuestionDataType) == 8, "Update this test if adding new questions"
@@ -170,7 +170,7 @@ class TestSubmissionHelper:
             )
             helper = SubmissionHelper(submission)
 
-            assert helper.form_data == {
+            assert helper.cached_form_data == {
                 "q_d696aebc49d24170a92fb6ef42994294": "answer",
                 "q_d696aebc49d24170a92fb6ef42994295": "answer\nthis",
                 "q_d696aebc49d24170a92fb6ef42994296": 50,
@@ -192,7 +192,7 @@ class TestSubmissionHelper:
             submission = factories.submission.build(collection=form.collection)
             helper = SubmissionHelper(submission)
 
-            assert helper.expression_context == ExpressionContext()
+            assert helper.cached_expression_context == ExpressionContext()
 
         def test_with_submission_data(self, factories):
             assert len(QuestionDataType) == 8, "Update this test if adding new questions"
@@ -261,7 +261,7 @@ class TestSubmissionHelper:
             )
             helper = SubmissionHelper(submission)
 
-            assert helper.expression_context == ExpressionContext(
+            assert helper.cached_expression_context == ExpressionContext(
                 from_submission=immutabledict(
                     {
                         "q_d696aebc49d24170a92fb6ef42994294": "answer",

--- a/tests/integration/test_fixtures.py
+++ b/tests/integration/test_fixtures.py
@@ -131,7 +131,7 @@ def test_collection_factory_completed_submissions(db_session, factories):
 
     for submission in collection_from_db.test_submissions:
         helper = SubmissionHelper(submission)
-        all_questions = collection.forms[0].questions
+        all_questions = collection.forms[0].cached_questions
         for question in all_questions:
             assert helper.get_question(question.id).text == question.text
             answer = helper.get_answer_for_question(question.id)

--- a/tests/integration/test_fixtures.py
+++ b/tests/integration/test_fixtures.py
@@ -134,6 +134,6 @@ def test_collection_factory_completed_submissions(db_session, factories):
         all_questions = collection.forms[0].cached_questions
         for question in all_questions:
             assert helper.get_question(question.id).text == question.text
-            answer = helper.get_answer_for_question(question.id)
+            answer = helper.cached_get_answer_for_question(question.id)
             assert answer
             assert answer.get_value_for_submission() == submission.data[str(question.id)]

--- a/tests/unit/common/data/test_models.py
+++ b/tests/unit/common/data/test_models.py
@@ -37,8 +37,8 @@ class TestNestedComponents:
         nested_questions2 = factories.question.build_batch(3, parent=g2)
         q2 = factories.question.build(form=form)
 
-        assert form.questions == [q1, *nested_questions, *nested_questions2, q2]
-        assert group.questions == [*nested_questions, *nested_questions2]
+        assert form.cached_questions == [q1, *nested_questions, *nested_questions2, q2]
+        assert group.cached_questions == [*nested_questions, *nested_questions2]
 
     def test_get_components_nested_orders(self, factories):
         form = factories.form.build()
@@ -48,7 +48,7 @@ class TestNestedComponents:
         q2 = factories.question.build(form=form, order=1)
 
         assert get_ordered_nested_components(form.components) == [group, nested_q, q2, q1]
-        assert form.questions == [nested_q, q2, q1]
+        assert form.cached_questions == [nested_q, q2, q1]
 
     def test_get_components_nested_depth_5(self, factories):
         form = factories.form.build()
@@ -71,4 +71,4 @@ class TestNestedComponents:
             nested_q,
             q2,
         ]
-        assert form.questions == [q1, nested_q, q2]
+        assert form.cached_questions == [q1, nested_q, q2]

--- a/tests/unit/common/helpers/test_collections.py
+++ b/tests/unit/common/helpers/test_collections.py
@@ -317,6 +317,7 @@ class TestSubmissionHelper:
             assert helper.all_forms_are_completed is False
 
             submission.data[str(question_one.id)] = "User submitted data"
+            helper.cached_get_answer_for_question.cache_clear()
             submission.events = [
                 factories.submission_event.build(
                     submission=submission, form=form_one, key=SubmissionEventKey.FORM_RUNNER_FORM_COMPLETED
@@ -327,6 +328,7 @@ class TestSubmissionHelper:
             assert helper.all_forms_are_completed is False
 
             submission.data[str(question_two.id)] = "User submitted data"
+            helper.cached_get_answer_for_question.cache_clear()
             del helper.all_forms_are_completed
 
             # all questions complete but a form not marked as completed is still not completed

--- a/tests/unit/common/helpers/test_collections.py
+++ b/tests/unit/common/helpers/test_collections.py
@@ -30,7 +30,7 @@ class TestSubmissionHelper:
             _question_1 = factories.question.build(order=1, form=form)
 
             helper = SubmissionHelper(submission)
-            helper_questions = helper.get_ordered_visible_questions(form)
+            helper_questions = helper.cached_get_ordered_visible_questions(form)
             assert len(helper_questions) == 3
             assert [s.order for s in helper_questions] == [0, 1, 2]
 
@@ -43,7 +43,7 @@ class TestSubmissionHelper:
             factories.expression.build(question=invisible_question, type=ExpressionType.CONDITION, statement="False")
 
             helper = SubmissionHelper(submission)
-            helper_questions = helper.get_ordered_visible_questions(form)
+            helper_questions = helper.cached_get_ordered_visible_questions(form)
             assert len(helper_questions) == 1
             assert helper_questions[0].id == visible_question.id
 
@@ -59,7 +59,7 @@ class TestSubmissionHelper:
             factories.expression.build(question=invisible_group, type=ExpressionType.CONDITION, statement="False")
 
             helper = SubmissionHelper(submission)
-            helper_questions = helper.get_ordered_visible_questions(form)
+            helper_questions = helper.cached_get_ordered_visible_questions(form)
             assert len(helper_questions) == 1
             assert helper_questions[0].id == visible_question.id
 
@@ -75,10 +75,10 @@ class TestSubmissionHelper:
             factories.expression.build(question=q2, type=ExpressionType.CONDITION, statement="False")
 
             helper = SubmissionHelper(submission)
-            helper_questions = helper.get_ordered_visible_questions(form)
+            helper_questions = helper.cached_get_ordered_visible_questions(form)
             assert helper_questions == [q0, q1, q3]
 
-            group_questions = helper.get_ordered_visible_questions(group)
+            group_questions = helper.cached_get_ordered_visible_questions(group)
             assert group_questions == [q1, q3]
 
     class TestGetForm:
@@ -318,6 +318,7 @@ class TestSubmissionHelper:
 
             submission.data[str(question_one.id)] = "User submitted data"
             helper.cached_get_answer_for_question.cache_clear()
+            helper.cached_get_all_questions_are_answered_for_form.cache_clear()
             submission.events = [
                 factories.submission_event.build(
                     submission=submission, form=form_one, key=SubmissionEventKey.FORM_RUNNER_FORM_COMPLETED
@@ -329,6 +330,7 @@ class TestSubmissionHelper:
 
             submission.data[str(question_two.id)] = "User submitted data"
             helper.cached_get_answer_for_question.cache_clear()
+            helper.cached_get_all_questions_are_answered_for_form.cache_clear()
             del helper.all_forms_are_completed
 
             # all questions complete but a form not marked as completed is still not completed

--- a/tests/unit/common/helpers/test_collections.py
+++ b/tests/unit/common/helpers/test_collections.py
@@ -175,7 +175,7 @@ class TestSubmissionHelper:
 
             helper = SubmissionHelper(submission)
 
-            for question in form.questions:
+            for question in form.cached_questions:
                 assert helper.get_form_for_question(question.id) == form
 
         def test_question_does_not_exist_in_collection_forms(self, db_session, factories):

--- a/tests/unit/common/helpers/test_collections.py
+++ b/tests/unit/common/helpers/test_collections.py
@@ -327,9 +327,11 @@ class TestSubmissionHelper:
             assert helper.all_forms_are_completed is False
 
             submission.data[str(question_two.id)] = "User submitted data"
+            del helper.all_forms_are_completed
 
             # all questions complete but a form not marked as completed is still not completed
             assert helper.all_forms_are_completed is False
+            del helper.all_forms_are_completed
 
             submission.events.append(
                 factories.submission_event.build(
@@ -345,7 +347,7 @@ class TestSubmissionHelper:
             question = factories.question.build()
             helper = SubmissionHelper(factories.submission.build(collection=question.form.collection))
 
-            assert helper.is_component_visible(question, helper.expression_context) is True
+            assert helper.is_component_visible(question, helper.cached_expression_context) is True
 
         def test_is_component_visible_not_visible_with_failing_condition(self, factories):
             question = factories.question.build()
@@ -353,7 +355,7 @@ class TestSubmissionHelper:
 
             factories.expression.build(question=question, type=ExpressionType.CONDITION, statement="False")
 
-            assert helper.is_component_visible(question, helper.expression_context) is False
+            assert helper.is_component_visible(question, helper.cached_expression_context) is False
 
         def test_is_component_visible_visible_with_passing_condition(self, factories):
             question = factories.question.build()
@@ -361,7 +363,7 @@ class TestSubmissionHelper:
 
             factories.expression.build(question=question, type=ExpressionType.CONDITION, statement="True")
 
-            assert helper.is_component_visible(question, helper.expression_context) is True
+            assert helper.is_component_visible(question, helper.cached_expression_context) is True
 
         def test_is_component_visible_not_visible_with_nested_conditions(self, factories):
             group = factories.group.build()
@@ -371,17 +373,17 @@ class TestSubmissionHelper:
 
             expression = factories.expression.build(question=group, type=ExpressionType.CONDITION, statement="False")
 
-            assert helper.is_component_visible(question, helper.expression_context) is True
-            assert helper.is_component_visible(group, helper.expression_context) is False
+            assert helper.is_component_visible(question, helper.cached_expression_context) is True
+            assert helper.is_component_visible(group, helper.cached_expression_context) is False
 
             # when nested sub-components inherit the property of their parents
             question.parent = group
-            assert helper.is_component_visible(question, helper.expression_context) is False
+            assert helper.is_component_visible(question, helper.cached_expression_context) is False
 
             # when further nested this still applies
             question.parent = sub_group
-            assert helper.is_component_visible(question, helper.expression_context) is False
+            assert helper.is_component_visible(question, helper.cached_expression_context) is False
 
             # if the parents condition changes this is reflected
             expression.statement = "True"
-            assert helper.is_component_visible(question, helper.expression_context) is True
+            assert helper.is_component_visible(question, helper.cached_expression_context) is True


### PR DESCRIPTION
We're assuming that form/ question changes happen at the end of HTTP requests and that its OK to have the same calculated property returned throughout the lifecycle of one request.

This is an assumption we'll need to validate and make clear - we've started by prefixing any properties that are cached with `cached_` to make it clear to devs that if they change something they'll probably still get the old result within that request (although this could also be documented in the method descriptions).

Update the tests to clear cache after accessing those properties.

We've observed just these changes move us from the tasklist loading at ~650ms to ~30ms which indicates a lot of time was being spent recursively calculated components in the CPU.
