### PR TITLE
Prepare to squash all migrations

### DIFF
--- a/app/common/data/migrations/versions/001_reset_migrations.py
+++ b/app/common/data/migrations/versions/001_reset_migrations.py
@@ -1,0 +1,20 @@
+"""reset migrations
+
+Revision ID: 001_reset_migrations
+Revises: 035_remove_sections
+Create Date: 2025-09-02 12:57:53.427819
+
+"""
+
+revision = "001_reset_migrations"
+down_revision = "035_remove_sections"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-576

## 📝 Description
We’ve had a lot of churn in our DB migrations. Now that we’re in prod and live, let’s squash our migrations down to our current feeling-good DB model.

This adds a no-op migration to get alembic onto a 001 ID. The next PR can then populate this migration file with all of the squashed instructions.

Process:
- Merge and deploy this
- All environments will run this no-op migration and set the `alembic_version` to `001_reset_migrations`.
- New PR with all of the squashed migration alembic instructions added to the 001_reset_migrations file.
- Merge and deploy this; migrations won't run because they're on the same ID.
  - We'll just need to make sure through good local testing that the instructions in the squashed file are indeed a correct representation of the current world, especially around things like a snapshot in time of enums.
- Continue as normal