### PR TITLE
FSPT-760 Fix sync to dev pipeline

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -53,8 +53,26 @@ jobs:
       - name: Login to Amazon ECR
         uses: aws-actions/amazon-ecr-login@d63b14614fe5d7fc5e5e52c523dea4e876816cc4
 
+      - name: Check if image exists in ECR
+        id: check_image_exists_in_ecr
+        run: |
+          AWS_REGION="eu-west-2"
+          REPO_NAME="funding-service-ci-shared-app"
+          IMAGE_TAG=${{ github.sha }}
+
+          # the script should only fail for network or config failures, a missing image tag will successfully return nothing
+          REMOTE_IMAGE_TAG="$(aws ecr batch-get-image --repository-name=$REPO_NAME --image-ids=imageTag=$IMAGE_TAG --query 'images[].imageId.imageTag' --output=text --region $AWS_REGION)"
+
+          if [[ $IMAGE_TAG == $REMOTE_IMAGE_TAG ]]; then
+            # CI image tags are immutable and cannot be overridden
+            echo "image_exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "image_exists=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Build and publish to ECR
         id: build_and_publish
+        if: steps.check_image_exists_in_ecr.outputs.image_exists == 'false'
         run: |
           AWS_ACCOUNT_ID=${{ secrets.CI_AWS_ACCOUNT}}
           AWS_REGION="eu-west-2"
@@ -69,6 +87,7 @@ jobs:
           pack build "$ECR_IMAGE_URI" \
             --builder paketobuildpacks/builder-jammy-full \
             --publish
+
 
   notify_slack:
       needs:


### PR DESCRIPTION
We have a scheduled job that deploys the main branch to the dev enivoronment to keep it up to date for developers to throw things at the environment but keep ti separate from the core deployment path.

When we moved our primary image build to a shared ECR we also made the image tags immutable which seems to cause paketo to fail on publish. There may be build pack specific ways of instructing publishing that this is the case (as it already seems to check the manifest for the image at the start) but for now just ignore the package and build step if its already been run.

We'd only expect to run package for the same git SHA if its a scheduled job thats running sepearately and later for the dev environment and its already been run for the deployment pipeline - this shouldn't be a common occurence.

Example failure mode:

```
PUT
TAG_INVALID: The image tag '0f1d07c932342d2766a9ca9565244f80820d20d9'
already exists in the 'funding-service-ci-shared-app' repository and
cannot be overwritten because the tag is immutable.
```

This PR has checked that the logic contained here works by verifying it against two example runs: 
- first run - the SHA hasn't been built in ECR https://github.com/communitiesuk/funding-service/actions/runs/17496923760
- second run - the SHA has now been built as is present in ECR https://github.com/communitiesuk/funding-service/actions/runs/17497122516

However we've not validated here that this actually addressed the scheduled job deploying to dev - strangely running the workflow manually multiple times doesn't seem to run into the immutable tag issue even without any changes.

My guess is that pushing to the same image tag with the exact same image (hash) will be managed by packeto but if the repositories dependencies have changed since the original build it will now have a different hash and will fail with an immutable tag warning (`uv export --no-dev --format requirements-txt --no-hashes > requirements.txt` is run before building which I guess would use the latest main which may differ from when the image was originally built as part of the deployment pipeline)
