### PR TITLE
Make notification banners blue again

### DIFF
--- a/app/assets/main.scss
+++ b/app/assets/main.scss
@@ -221,3 +221,17 @@ $inset-nested-rows: 15px;
   white-space: pre-line;
   margin-top: 0px;
 }
+
+
+// Temporary: return notification banners to their correct colours. We have set `govuk-brand-colour`, and currently
+// the notification banner uses that as its border colour. This has been confirmed as unintended by the GDS Design System
+// team. See: https://github.com/alphagov/govuk-design-system/issues/4877
+.govuk-notification-banner {
+  border-color: govuk-colour("blue");
+  background-color: govuk-colour("blue");
+}
+
+.govuk-notification-banner--success {
+  border-color: $govuk-success-colour;
+  background-color: $govuk-success-colour;
+}


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
When we set `govuk-brand-colour` to MHCLG teal, we did it with the intention of changing only the header and footer bars. However, the current Design System implementation for notification banners also uses the `govuk-brand-colour`, so our notification banners now have teal borders as well. 

We don't like the look of this, and prefer them to stay blue for the standard case. So here we add some overrides back on those classes to restore them to GOV.UK Blue.

When the Design System roll out a fix for this issue, we can remove this workaround.

## 📸 Show the thing (screenshots, gifs)
<!-- Include screenshots for UI changes, new features, or visual modifications -->
<!-- Use "Before" and "After" sections if showing changes to existing functionality -->

### Before
<img width="1022" height="797" alt="image" src="https://github.com/user-attachments/assets/2790cbeb-6c07-4536-854f-d803ff41919b" />


### After
<img width="1022" height="782" alt="image" src="https://github.com/user-attachments/assets/9f8877aa-ddef-4c79-b137-54e4187a0d2f" />