### PR TITLE
Allowing managed expressions to specify functions that can be called in their statement

### DIFF
--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -1,6 +1,6 @@
 import uuid
 from functools import cached_property
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 from sqlalchemy import CheckConstraint, ForeignKey, ForeignKeyConstraint, Index, UniqueConstraint, text
 from sqlalchemy import Enum as SqlEnum
@@ -476,6 +476,14 @@ class Expression(BaseModel):
             type=ExpressionType.CONDITION,
             managed_name=managed_expression._key,
         )
+
+    @property
+    def required_functions(self) -> dict[str, Callable[[Any], Any]]:
+        if self.managed_name:
+            return self.managed.required_functions
+
+        # In future, make this return a default list of functions for non-managed expressions
+        return {}
 
 
 class DataSource(BaseModel):

--- a/app/common/expressions/__init__.py
+++ b/app/common/expressions/__init__.py
@@ -169,7 +169,9 @@ def _evaluate_expression_with_context(expression: "Expression", context: Express
         context = ExpressionContext()
     context.expression_context = immutabledict(expression.context or {})
 
-    evaluator = simpleeval.EvalWithCompoundTypes(names=context)  # type: ignore[no-untyped-call]
+    evaluator = simpleeval.EvalWithCompoundTypes(
+        names=context, functions=expression.managed.required_functions if expression.managed_name else None
+    )  # type: ignore[no-untyped-call]
 
     # Remove all nodes except those we explicitly allowlist
     evaluator.nodes = {

--- a/app/common/expressions/__init__.py
+++ b/app/common/expressions/__init__.py
@@ -169,9 +169,7 @@ def _evaluate_expression_with_context(expression: "Expression", context: Express
         context = ExpressionContext()
     context.expression_context = immutabledict(expression.context or {})
 
-    evaluator = simpleeval.EvalWithCompoundTypes(
-        names=context, functions=expression.managed.required_functions if expression.managed_name else None
-    )  # type: ignore[no-untyped-call]
+    evaluator = simpleeval.EvalWithCompoundTypes(names=context, functions=expression.required_functions)  # type: ignore[no-untyped-call]
 
     # Remove all nodes except those we explicitly allowlist
     evaluator.nodes = {

--- a/app/common/expressions/managed.py
+++ b/app/common/expressions/managed.py
@@ -48,28 +48,25 @@ class ManagedExpression(BaseModel, SafeQidMixin):
     def message(self) -> str: ...
 
     @property
-    @abc.abstractmethod
-    def required_functions(self) -> dict[str, Callable[[Any], Any]] | None:
+    def required_functions(self) -> dict[str, Callable[[Any], Any]]:
         """
         Used when we evaluate an expression to add specific functions to the list of what simpleeval will accept
         and parse.
-        For a default implementation (if your ManagedExpression statement can be evaluated as a straight python
-        string, eg. q_123 < 56) use:
-
-            @property
-            def required_functions(self) -> dict[str, Callable[[Any], Any]] | None:
-                return super().required_functions
+        Provides a default implementation that returns an empty dict (no additional functions).
 
         If your ManagedExpression needs a specific function to evaluate the statement,
         eg. q_543 < calculate_something_complex(),
         override this function as follows:
 
             @property
-            def required_functions(self) -> dict[str, Callable[[Any], Any]] | None:
+            def required_functions(self) -> dict[str, Callable[[Any], Any]]:
                 return dict(calculate_something_complex=app.stuff.calculate_something_complex)
 
+        Where the keys of the dict are the function names as they will appear in the expression statement, and the
+        values are the function definitions.
+
         """
-        return None
+        return dict()
 
     @property
     def referenced_question(self) -> "Question":
@@ -233,10 +230,6 @@ class GreaterThan(ManagedExpression):
             inclusive=form.greater_than_inclusive.data,  # ty: ignore[unresolved-attribute]
         )
 
-    @property
-    def required_functions(self) -> dict[str, Callable[[Any], Any]] | None:
-        return super().required_functions
-
 
 @register_managed_expression
 class LessThan(ManagedExpression):
@@ -292,10 +285,6 @@ class LessThan(ManagedExpression):
             maximum_value=form.less_than_value.data,  # ty: ignore[unresolved-attribute]
             inclusive=form.less_than_inclusive.data,  # ty: ignore[unresolved-attribute]
         )
-
-    @property
-    def required_functions(self) -> dict[str, Callable[[Any], Any]] | None:
-        return super().required_functions
 
 
 @register_managed_expression
@@ -392,20 +381,12 @@ class Between(ManagedExpression):
             maximum_inclusive=form.between_top_inclusive.data,  # ty: ignore[unresolved-attribute]
         )
 
-    @property
-    def required_functions(self) -> dict[str, Callable[[Any], Any]] | None:
-        return super().required_functions
-
 
 class BaseDataSourceManagedExpression(ManagedExpression):
     @property
     @abc.abstractmethod  # todo: decorator does nothing here because ABCMeta cant be used
     def referenced_data_source_items(self) -> list["TRadioItem"]:
         raise NotImplementedError
-
-    @property
-    def required_functions(self) -> dict[str, Callable[[Any], Any]] | None:
-        return super().required_functions
 
 
 @register_managed_expression
@@ -510,10 +491,6 @@ class IsYes(ManagedExpression):
     def build_from_form(form: "_ManagedExpressionForm", question: "Question") -> "IsYes":
         return IsYes(question_id=question.id)
 
-    @property
-    def required_functions(self) -> dict[str, Callable[[Any], Any]] | None:
-        return super().required_functions
-
 
 @register_managed_expression
 class IsNo(ManagedExpression):
@@ -550,10 +527,6 @@ class IsNo(ManagedExpression):
     @staticmethod
     def build_from_form(form: "_ManagedExpressionForm", question: "Question") -> "IsNo":
         return IsNo(question_id=question.id)
-
-    @property
-    def required_functions(self) -> dict[str, Callable[[Any], Any]] | None:
-        return super().required_functions
 
 
 @register_managed_expression

--- a/tests/integration/common/expressions/test_init.py
+++ b/tests/integration/common/expressions/test_init.py
@@ -1,17 +1,13 @@
-import uuid
-from typing import Callable, ClassVar
-from typing import Optional as TOptional
+import datetime
+from unittest.mock import PropertyMock
 
 import pytest
 from immutabledict import immutabledict
-from wtforms.fields.core import Field
 
-from app import QuestionDataType
-from app.common.data.models import Expression, Question
+from app.common.data.models import Expression
+from app.common.data.types import ExpressionType
 from app.common.expressions import DisallowedExpression, ExpressionContext, evaluate
-from app.common.expressions.forms import _ManagedExpressionForm
-from app.common.expressions.managed import GreaterThan, ManagedExpression
-from app.common.expressions.registry import register_managed_expression
+from app.common.expressions.managed import GreaterThan
 
 
 class TestExpressionContext:
@@ -113,158 +109,77 @@ class TestEvaluatingManagedExpressions:
         assert evaluate(expr, ExpressionContext(immutabledict({q0.safe_qid: 3001}))) is True
 
 
-def _custom_test_function():
-    return 42
-
-
-# @register_managed_expression
-class CustomManagedExpression(ManagedExpression):
-    name = "CustomManagedExpression"
-    supported_condition_data_types: ClassVar[set[QuestionDataType]] = {QuestionDataType.INTEGER}
-    supported_validator_data_types: ClassVar[set[QuestionDataType]] = {}  # type: ignore[assignment]
-    _key = "CustomManagedExpression"
-
-    @property
-    def statement(self) -> str:
-        return f"{self.safe_qid} >= custom_test_function()"
-
-    @property
-    def description(self) -> str:
-        return ""
-
-    @property
-    def message(self) -> str:
-        return ""
-
-    @property
-    def required_functions(self) -> dict[str, Callable]:
-        return dict(custom_test_function=_custom_test_function)
-
-    @staticmethod
-    def get_form_fields(
-        expression: TOptional[Expression] = None, referenced_question: TOptional[Question] = None
-    ) -> dict[str, Field]:
-        return dict()
-
-    @staticmethod
-    def update_validators(form: _ManagedExpressionForm) -> None:
-        pass
-
-    @staticmethod
-    def build_from_form(form: _ManagedExpressionForm, question: Question) -> "ManagedExpression":
-        pass
-
-
-# @register_managed_expression
-class CustomBuiltInManagedExpression(CustomManagedExpression):
-    name = "CustomBuiltInManagedExpression"
-    _key = "CustomBuiltInManagedExpression"
-
-    @property
-    def statement(self) -> str:
-        return f"{self.safe_qid} >= min(1,2)"
-
-    @property
-    def required_functions(self) -> dict[str, Callable]:
-        return dict(min=min)
-
-
 class TestEvaluatingManagedExpressionsWithRequiredFunctions:
-    @pytest.fixture(autouse=True)
-    def _register_managed_expressions(self):
-        """
-        This fixture registers our custom managed expression classes above. Using the annotation on the classes directly
-        means they exist for all other tests in a test run, which causes failures when we are checking what types of
-        managed expressions are available.
-        """
-
-        def _deregister_managed_expression(managed_expression_cls: type[ManagedExpression]):
-            from app.common.expressions import registry
-
-            registry._registry_by_expression_enum.pop(managed_expression_cls.name, None)
-            for data_type in managed_expression_cls.supported_condition_data_types:
-                if data_type in registry._condition_registry_by_data_type:
-                    registry._condition_registry_by_data_type[data_type] = [
-                        cls
-                        for cls in registry._condition_registry_by_data_type[data_type]
-                        if cls != managed_expression_cls
-                    ]
-            for data_type in managed_expression_cls.supported_validator_data_types:
-                if data_type in registry._validator_registry_by_data_type:
-                    registry._validator_registry_by_data_type[data_type] = [
-                        cls
-                        for cls in registry._validator_registry_by_data_type[data_type]
-                        if cls != managed_expression_cls
-                    ]
-
-        register_managed_expression(CustomManagedExpression)
-        register_managed_expression(CustomBuiltInManagedExpression)
-        yield
-        # Cleanup the registry
-        _deregister_managed_expression(CustomManagedExpression)
-        _deregister_managed_expression(CustomBuiltInManagedExpression)
-
-    def test_managed_expression_with_custom_required_function_true(self, factories):
-        expr = CustomManagedExpression(question_id=uuid.uuid4(), _key="CustomManagedExpression")  # type:ignore
-        assert (
-            evaluate(
-                Expression(
-                    managed_name="CustomManagedExpression",  # type:ignore
-                    statement=expr.statement,
-                    context={"question_id": expr.question_id, expr.safe_qid: 500},
-                )
-            )
-            is True
+    @pytest.mark.parametrize(
+        "question_value, expected_result",
+        [
+            (datetime.date(2023, 12, 1), True),
+            (datetime.date(2026, 12, 1), False),
+        ],
+    )
+    def test_managed_expression_with_required_function_allowed_imported(
+        self, factories, mocker, question_value, expected_result
+    ):
+        expr = factories.expression.build(statement="q_123 < date(2024, 1, 1)", type=ExpressionType.VALIDATION)
+        mocker.patch(
+            "app.common.data.models.Expression.required_functions",
+            new_callable=PropertyMock,
+            return_value={"date": datetime.date},
         )
+        assert evaluate(expr, ExpressionContext(from_submission={"q_123": question_value})) is expected_result
 
-    def test_managed_expression_with_custom_required_function_false(self, factories):
-        expr = CustomManagedExpression(question_id=uuid.uuid4(), _key="CustomManagedExpression")  # type:ignore
-        assert (
-            evaluate(
-                Expression(
-                    managed_name="CustomManagedExpression",  # type:ignore
-                    statement=expr.statement,
-                    context={"question_id": expr.question_id, expr.safe_qid: 3},
-                )
-            )
-            is False
+    @pytest.mark.parametrize(
+        "question_value, expected_result",
+        [
+            (309, True),
+            (0, False),
+        ],
+    )
+    def test_managed_expression_with_required_function_allowed_builtin(
+        self, factories, mocker, question_value, expected_result
+    ):
+        expr = factories.expression.build(statement="q_123 > min(1,2)", type=ExpressionType.VALIDATION)
+        mocker.patch(
+            "app.common.data.models.Expression.required_functions",
+            new_callable=PropertyMock,
+            return_value={"min": min},
         )
+        assert evaluate(expr, ExpressionContext(from_submission={"q_123": question_value})) is expected_result
 
-    def test_managed_expression_with_builtin_required_function(self, factories):
-        expr = CustomBuiltInManagedExpression(question_id=uuid.uuid4(), _key="CustomBuiltInManagedExpression")  # type:ignore
-        assert (
-            evaluate(
-                Expression(
-                    managed_name="CustomBuiltInManagedExpression",  # type:ignore
-                    statement=expr.statement,
-                    context={"question_id": expr.question_id, expr.safe_qid: 100},
-                )
-            )
-            is True
+    @pytest.mark.parametrize(
+        "question_value, expected_result",
+        [
+            (100, True),
+            (5, False),
+        ],
+    )
+    def test_managed_expression_with_required_function_allowed_custom(
+        self, factories, mocker, question_value, expected_result
+    ):
+        def _custom_test_function():
+            return 42
+
+        expr = factories.expression.build(statement="q_123 > calculate_result()", type=ExpressionType.VALIDATION)
+        mocker.patch(
+            "app.common.data.models.Expression.required_functions",
+            new_callable=PropertyMock,
+            return_value={"calculate_result": _custom_test_function},
         )
+        assert evaluate(expr, ExpressionContext(from_submission={"q_123": question_value})) is expected_result
 
-    def test_managed_expression_with_required_function_not_present(self, factories):
-        expr = CustomManagedExpression(question_id=uuid.uuid4(), _key="CustomManagedExpression")  # type:ignore
-
-        def _temp_test_function():
-            return 0
-
-        # Test with a custom function we haven't added to required_functions
+    def test_managed_expression_with_required_function_builtin_not_present_builtin(self, factories):
+        # test with a builtin function that isn't on the allowed list
+        expr = factories.expression.build(statement="q_123 > max(1,2)", type=ExpressionType.VALIDATION)
+        # Don't patch the required_functions property, so it returns an empty dict
         with pytest.raises(DisallowedExpression):
-            evaluate(
-                Expression(
-                    managed_name="CustomManagedExpression",  # type:ignore
-                    statement=f"{expr.safe_qid} >= _temp_test_function()",
-                    context={"question_id": expr.question_id, expr.safe_qid: 500},
-                )
-            )
+            evaluate(expr, ExpressionContext(from_submission={"q_123": 123}))
 
-        # Test with a builtin function that isn't on the allowed list
+    def test_managed_expression_with_required_function_not_present_custom(self, factories):
+        def _custom_test_function():
+            return 42
+
+        # Test with a custom function that isn't on the allowed list
+        expr = factories.expression.build(statement="q_123 > _custom_test_function()", type=ExpressionType.VALIDATION)
+        # Don't patch the required_functions property, so it returns an empty dict
         with pytest.raises(DisallowedExpression):
-            evaluate(
-                Expression(
-                    managed_name="CustomManagedExpression",  # type:ignore
-                    statement=f"{expr.safe_qid} >= max(1,2)",
-                    context={"question_id": expr.question_id, expr.safe_qid: 500},
-                )
-            )
+            evaluate(expr, ExpressionContext(from_submission={"q_123": 123}))

--- a/tests/integration/common/expressions/test_init.py
+++ b/tests/integration/common/expressions/test_init.py
@@ -1,9 +1,17 @@
+import uuid
+from typing import Callable, ClassVar
+from typing import Optional as TOptional
+
 import pytest
 from immutabledict import immutabledict
+from wtforms.fields.core import Field
 
-from app.common.data.models import Expression
-from app.common.expressions import ExpressionContext, evaluate
-from app.common.expressions.managed import GreaterThan
+from app import QuestionDataType
+from app.common.data.models import Expression, Question
+from app.common.expressions import DisallowedExpression, ExpressionContext, evaluate
+from app.common.expressions.forms import _ManagedExpressionForm
+from app.common.expressions.managed import GreaterThan, ManagedExpression
+from app.common.expressions.registry import register_managed_expression
 
 
 class TestExpressionContext:
@@ -103,3 +111,160 @@ class TestEvaluatingManagedExpressions:
         assert evaluate(expr, ExpressionContext(immutabledict({q0.safe_qid: 500}))) is False
         assert evaluate(expr, ExpressionContext(immutabledict({q0.safe_qid: 3000}))) is False
         assert evaluate(expr, ExpressionContext(immutabledict({q0.safe_qid: 3001}))) is True
+
+
+def _custom_test_function():
+    return 42
+
+
+# @register_managed_expression
+class CustomManagedExpression(ManagedExpression):
+    name = "CustomManagedExpression"
+    supported_condition_data_types: ClassVar[set[QuestionDataType]] = {QuestionDataType.INTEGER}
+    supported_validator_data_types: ClassVar[set[QuestionDataType]] = {}  # type: ignore[assignment]
+    _key = "CustomManagedExpression"
+
+    @property
+    def statement(self) -> str:
+        return f"{self.safe_qid} >= custom_test_function()"
+
+    @property
+    def description(self) -> str:
+        return ""
+
+    @property
+    def message(self) -> str:
+        return ""
+
+    @property
+    def required_functions(self) -> dict[str, Callable]:
+        return dict(custom_test_function=_custom_test_function)
+
+    @staticmethod
+    def get_form_fields(
+        expression: TOptional[Expression] = None, referenced_question: TOptional[Question] = None
+    ) -> dict[str, Field]:
+        return dict()
+
+    @staticmethod
+    def update_validators(form: _ManagedExpressionForm) -> None:
+        pass
+
+    @staticmethod
+    def build_from_form(form: _ManagedExpressionForm, question: Question) -> "ManagedExpression":
+        pass
+
+
+# @register_managed_expression
+class CustomBuiltInManagedExpression(CustomManagedExpression):
+    name = "CustomBuiltInManagedExpression"
+    _key = "CustomBuiltInManagedExpression"
+
+    @property
+    def statement(self) -> str:
+        return f"{self.safe_qid} >= min(1,2)"
+
+    @property
+    def required_functions(self) -> dict[str, Callable]:
+        return dict(min=min)
+
+
+class TestEvaluatingManagedExpressionsWithRequiredFunctions:
+    @pytest.fixture(autouse=True)
+    def _register_managed_expressions(self):
+        """
+        This fixture registers our custom managed expression classes above. Using the annotation on the classes directly
+        means they exist for all other tests in a test run, which causes failures when we are checking what types of
+        managed expressions are available.
+        """
+
+        def _deregister_managed_expression(managed_expression_cls: type[ManagedExpression]):
+            from app.common.expressions import registry
+
+            registry._registry_by_expression_enum.pop(managed_expression_cls.name, None)
+            for data_type in managed_expression_cls.supported_condition_data_types:
+                if data_type in registry._condition_registry_by_data_type:
+                    registry._condition_registry_by_data_type[data_type] = [
+                        cls
+                        for cls in registry._condition_registry_by_data_type[data_type]
+                        if cls != managed_expression_cls
+                    ]
+            for data_type in managed_expression_cls.supported_validator_data_types:
+                if data_type in registry._validator_registry_by_data_type:
+                    registry._validator_registry_by_data_type[data_type] = [
+                        cls
+                        for cls in registry._validator_registry_by_data_type[data_type]
+                        if cls != managed_expression_cls
+                    ]
+
+        register_managed_expression(CustomManagedExpression)
+        register_managed_expression(CustomBuiltInManagedExpression)
+        yield
+        # Cleanup the registry
+        _deregister_managed_expression(CustomManagedExpression)
+        _deregister_managed_expression(CustomBuiltInManagedExpression)
+
+    def test_managed_expression_with_custom_required_function_true(self, factories):
+        expr = CustomManagedExpression(question_id=uuid.uuid4(), _key="CustomManagedExpression")  # type:ignore
+        assert (
+            evaluate(
+                Expression(
+                    managed_name="CustomManagedExpression",  # type:ignore
+                    statement=expr.statement,
+                    context={"question_id": expr.question_id, expr.safe_qid: 500},
+                )
+            )
+            is True
+        )
+
+    def test_managed_expression_with_custom_required_function_false(self, factories):
+        expr = CustomManagedExpression(question_id=uuid.uuid4(), _key="CustomManagedExpression")  # type:ignore
+        assert (
+            evaluate(
+                Expression(
+                    managed_name="CustomManagedExpression",  # type:ignore
+                    statement=expr.statement,
+                    context={"question_id": expr.question_id, expr.safe_qid: 3},
+                )
+            )
+            is False
+        )
+
+    def test_managed_expression_with_builtin_required_function(self, factories):
+        expr = CustomBuiltInManagedExpression(question_id=uuid.uuid4(), _key="CustomBuiltInManagedExpression")  # type:ignore
+        assert (
+            evaluate(
+                Expression(
+                    managed_name="CustomBuiltInManagedExpression",  # type:ignore
+                    statement=expr.statement,
+                    context={"question_id": expr.question_id, expr.safe_qid: 100},
+                )
+            )
+            is True
+        )
+
+    def test_managed_expression_with_required_function_not_present(self, factories):
+        expr = CustomManagedExpression(question_id=uuid.uuid4(), _key="CustomManagedExpression")  # type:ignore
+
+        def _temp_test_function():
+            return 0
+
+        # Test with a custom function we haven't added to required_functions
+        with pytest.raises(DisallowedExpression):
+            evaluate(
+                Expression(
+                    managed_name="CustomManagedExpression",  # type:ignore
+                    statement=f"{expr.safe_qid} >= _temp_test_function()",
+                    context={"question_id": expr.question_id, expr.safe_qid: 500},
+                )
+            )
+
+        # Test with a builtin function that isn't on the allowed list
+        with pytest.raises(DisallowedExpression):
+            evaluate(
+                Expression(
+                    managed_name="CustomManagedExpression",  # type:ignore
+                    statement=f"{expr.safe_qid} >= max(1,2)",
+                    context={"question_id": expr.question_id, expr.safe_qid: 500},
+                )
+            )


### PR DESCRIPTION
This allows a managed expression to use additional functions in the statement to be evaluated without falling foul of the locking down of simple eval. For example, if you need to use a custom function to determine something that is used in your statement, you can register this function as being allowed for that type of managed expression. See `TestEvaluatingManagedExpressionsWithRequiredFunctions` for examples. This will be used when we support a Date question type

## 📝 Description
When discussing how to implement https://mhclgdigital.atlassian.net/browse/FSPT-770 with @samuelhwilliams, we agreed we needed to extend the interface of `ManagedExpression` to allow expressions to specify any additional functions they need in their statements.

I've split that extension out into a separate PR for clarity.

In this PR, this new functionality is not used anywhere, but there are test managed expressions setup to prove this works and check we still can't use any old function that we haven't registered.

No changes visible to users, this is just an extension of what's possible from the code, not used anywhere yet.

## 🧪 Testing
Unit tests added to tests/integration/common/expressions/test_init.py

## 📋 Developer Checklist

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- [ ] No N+1 query problems introduced
- [ ] Any new DB queries include appropriate where clauses based on the user's permissions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [ ] I need the reviewer(s) to pull and run this change locally
- [ ] New (non-developer) functionality has appropriate unit and integration tests
- [ ] End-to-end tests have been updated (if applicable)
- [x] Edge cases and error conditions are tested

## 📚 Additional Notes
<!-- Any additional context, concerns, or considerations for reviewers -->
