### PR TITLE
Renaming the python field for Expression.type -> Expression.type_

### DIFF
--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -802,7 +802,7 @@ def add_question_validation(question: Question, user: User, managed_expression: 
         statement=managed_expression.statement,
         context=managed_expression.model_dump(mode="json"),
         created_by=user,
-        type=ExpressionType.VALIDATION,
+        type_=ExpressionType.VALIDATION,
         managed_name=managed_expression._key,
     )
     question.expressions.append(expression)

--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -260,11 +260,11 @@ class Component(BaseModel):
 
     @property
     def conditions(self) -> list["Expression"]:
-        return [expression for expression in self.expressions if expression.type == ExpressionType.CONDITION]
+        return [expression for expression in self.expressions if expression.type_ == ExpressionType.CONDITION]
 
     @property
     def validations(self) -> list["Expression"]:
-        return [expression for expression in self.expressions if expression.type == ExpressionType.VALIDATION]
+        return [expression for expression in self.expressions if expression.type_ == ExpressionType.VALIDATION]
 
     def get_expression(self, id: uuid.UUID) -> "Expression":
         try:
@@ -421,8 +421,8 @@ class Expression(BaseModel):
 
     context: Mapped[json_flat_scalars] = mapped_column(mutable_json_type(dbtype=JSONB, nested=True))  # type: ignore[no-untyped-call]
 
-    type: Mapped[ExpressionType] = mapped_column(
-        SqlEnum(ExpressionType, name="expression_type_enum", validate_strings=True)
+    type_: Mapped[ExpressionType] = mapped_column(
+        "type", SqlEnum(ExpressionType, name="expression_type_enum", validate_strings=True)
     )
 
     managed_name: Mapped[Optional[ManagedExpressionsEnum]] = mapped_column(
@@ -473,7 +473,7 @@ class Expression(BaseModel):
             statement=managed_expression.statement,
             context=managed_expression.model_dump(mode="json"),
             created_by=created_by,
-            type=ExpressionType.CONDITION,
+            type_=ExpressionType.CONDITION,
             managed_name=managed_expression._key,
         )
 

--- a/tests/integration/common/data/db/test_constraints.py
+++ b/tests/integration/common/data/db/test_constraints.py
@@ -27,7 +27,7 @@ class TestExpressionConstraints:
         factories.expression.create(
             question=q,
             created_by=user,
-            type=ExpressionType.VALIDATION,
+            type_=ExpressionType.VALIDATION,
             statement="",
             managed_name=ManagedExpressionsEnum.GREATER_THAN,
         )
@@ -36,7 +36,7 @@ class TestExpressionConstraints:
             factories.expression.create(
                 question=q,
                 created_by=user,
-                type=ExpressionType.VALIDATION,
+                type_=ExpressionType.VALIDATION,
                 statement="",
                 managed_name=ManagedExpressionsEnum.GREATER_THAN,
             )

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -189,8 +189,8 @@ class TestGetFormById:
         form = factories.form.create()
         question_one = factories.question.create(form=form)
         question_two = factories.question.create(form=form)
-        factories.expression.create_batch(5, question=question_one, type=ExpressionType.CONDITION, statement="")
-        factories.expression.create_batch(5, question=question_two, type=ExpressionType.CONDITION, statement="")
+        factories.expression.create_batch(5, question=question_one, type_=ExpressionType.CONDITION, statement="")
+        factories.expression.create_batch(5, question=question_two, type_=ExpressionType.CONDITION, statement="")
 
         # fetching the form and eagerly loading all questions and their expressions
         from_db = get_form_by_id(form_id=form.id, with_all_questions=True)
@@ -1363,7 +1363,7 @@ class TestExpressions:
         from_db = get_question_by_id(question.id)
 
         assert len(from_db.expressions) == 1
-        assert from_db.expressions[0].type == ExpressionType.CONDITION
+        assert from_db.expressions[0].type_ == ExpressionType.CONDITION
         assert from_db.expressions[0].statement == f"{q0.safe_qid} > 3000"
 
         # check the serialised context lines up with the values in the managed expression
@@ -1405,7 +1405,7 @@ class TestExpressions:
         from_db = get_question_by_id(question.id)
 
         assert len(from_db.expressions) == 1
-        assert from_db.expressions[0].type == ExpressionType.CONDITION
+        assert from_db.expressions[0].type_ == ExpressionType.CONDITION
         assert from_db.expressions[0].managed_name == ManagedExpressionsEnum.ANY_OF
         assert q0.safe_qid and items[0].key and items[1].key in from_db.expressions[0].statement
 
@@ -1430,7 +1430,7 @@ class TestExpressions:
         from_db = get_question_by_id(question.id)
 
         assert len(from_db.expressions) == 1
-        assert from_db.expressions[0].type == ExpressionType.CONDITION
+        assert from_db.expressions[0].type_ == ExpressionType.CONDITION
         assert from_db.expressions[0].managed_name == ManagedExpressionsEnum.SPECIFICALLY
         assert q0.safe_qid and items[0].key in from_db.expressions[0].statement
 
@@ -1462,7 +1462,7 @@ class TestExpressions:
         from_db = get_question_by_id(question.id)
 
         assert len(from_db.expressions) == 1
-        assert from_db.expressions[0].type == ExpressionType.VALIDATION
+        assert from_db.expressions[0].type_ == ExpressionType.VALIDATION
         assert from_db.expressions[0].statement == f"{question.safe_qid} > 3000"
 
         # check the serialised context lines up with the values in the managed expression
@@ -1502,7 +1502,7 @@ class TestExpressions:
         from_db = get_question_by_id(question.id)
 
         assert len(from_db.expressions) == 1
-        assert from_db.expressions[0].type == ExpressionType.CONDITION
+        assert from_db.expressions[0].type_ == ExpressionType.CONDITION
         assert from_db.expressions[0].managed_name == ManagedExpressionsEnum.ANY_OF
         assert q0.safe_qid and items[2].key in from_db.expressions[0].statement
 
@@ -1529,7 +1529,7 @@ class TestExpressions:
         from_db = get_question_by_id(question.id)
 
         assert len(from_db.expressions) == 1
-        assert from_db.expressions[0].type == ExpressionType.CONDITION
+        assert from_db.expressions[0].type_ == ExpressionType.CONDITION
         assert from_db.expressions[0].managed_name == ManagedExpressionsEnum.SPECIFICALLY
         assert q0.safe_qid and items[1].key in from_db.expressions[0].statement
 
@@ -1574,13 +1574,13 @@ class TestExpressions:
             get_expression(expression_id)
 
     def test_get_expression(self, db_session, factories):
-        expression = factories.expression.create(statement="", type=ExpressionType.VALIDATION)
+        expression = factories.expression.create(statement="", type_=ExpressionType.VALIDATION)
 
         db_expr = get_expression(expression.id)
         assert db_expr is expression
 
     def test_get_expression_missing(self, db_session, factories):
-        factories.expression.create(statement="", type=ExpressionType.VALIDATION)
+        factories.expression.create(statement="", type_=ExpressionType.VALIDATION)
 
         with pytest.raises(NoResultFound):
             get_expression(uuid.uuid4())
@@ -1599,7 +1599,7 @@ class TestExpressions:
         assert len(queries) == 1
 
         assert retrieved_expression.id == expression_id
-        assert retrieved_expression.type == ExpressionType.VALIDATION
+        assert retrieved_expression.type_ == ExpressionType.VALIDATION
         assert retrieved_expression.managed_name == "Greater than"
 
         with track_sql_queries() as queries:

--- a/tests/integration/common/data/test_models.py
+++ b/tests/integration/common/data/test_models.py
@@ -19,22 +19,22 @@ class TestQuestionModel:
     def test_question_property_selects_expressions(self, factories):
         question = factories.question.create()
         condition_expression = factories.expression.create(
-            question=question, type=ExpressionType.CONDITION, statement=""
+            question=question, type_=ExpressionType.CONDITION, statement=""
         )
         validation_expression = factories.expression.create(
-            question=question, type=ExpressionType.VALIDATION, statement=""
+            question=question, type_=ExpressionType.VALIDATION, statement=""
         )
         assert question.conditions == [condition_expression]
         assert question.validations == [validation_expression]
 
     def test_question_gets_a_valid_expression_that_belongs_to_it(self, factories):
         question = factories.question.create()
-        expression = factories.expression.create(question=question, type=ExpressionType.CONDITION, statement="")
+        expression = factories.expression.create(question=question, type_=ExpressionType.CONDITION, statement="")
         assert question.get_expression(expression.id) == expression
 
     def test_question_does_not_get_a_valid_expression_that_does_not_belong_to_it(self, factories):
         question = factories.question.create()
-        expression_on_other_question = factories.expression.create(type=ExpressionType.CONDITION, statement="")
+        expression_on_other_question = factories.expression.create(type_=ExpressionType.CONDITION, statement="")
 
         with pytest.raises(ValueError) as e:
             question.get_expression(expression_on_other_question.id)

--- a/tests/integration/common/expressions/test_init.py
+++ b/tests/integration/common/expressions/test_init.py
@@ -120,7 +120,7 @@ class TestEvaluatingManagedExpressionsWithRequiredFunctions:
     def test_managed_expression_with_required_function_allowed_imported(
         self, factories, mocker, question_value, expected_result
     ):
-        expr = factories.expression.build(statement="q_123 < date(2024, 1, 1)", type=ExpressionType.VALIDATION)
+        expr = factories.expression.build(statement="q_123 < date(2024, 1, 1)", type_=ExpressionType.VALIDATION)
         mocker.patch(
             "app.common.data.models.Expression.required_functions",
             new_callable=PropertyMock,
@@ -138,7 +138,7 @@ class TestEvaluatingManagedExpressionsWithRequiredFunctions:
     def test_managed_expression_with_required_function_allowed_builtin(
         self, factories, mocker, question_value, expected_result
     ):
-        expr = factories.expression.build(statement="q_123 > min(1,2)", type=ExpressionType.VALIDATION)
+        expr = factories.expression.build(statement="q_123 > min(1,2)", type_=ExpressionType.VALIDATION)
         mocker.patch(
             "app.common.data.models.Expression.required_functions",
             new_callable=PropertyMock,
@@ -159,7 +159,7 @@ class TestEvaluatingManagedExpressionsWithRequiredFunctions:
         def _custom_test_function():
             return 42
 
-        expr = factories.expression.build(statement="q_123 > calculate_result()", type=ExpressionType.VALIDATION)
+        expr = factories.expression.build(statement="q_123 > calculate_result()", type_=ExpressionType.VALIDATION)
         mocker.patch(
             "app.common.data.models.Expression.required_functions",
             new_callable=PropertyMock,
@@ -169,7 +169,7 @@ class TestEvaluatingManagedExpressionsWithRequiredFunctions:
 
     def test_managed_expression_with_required_function_builtin_not_present_builtin(self, factories):
         # test with a builtin function that isn't on the allowed list
-        expr = factories.expression.build(statement="q_123 > max(1,2)", type=ExpressionType.VALIDATION)
+        expr = factories.expression.build(statement="q_123 > max(1,2)", type_=ExpressionType.VALIDATION)
         # Don't patch the required_functions property, so it returns an empty dict
         with pytest.raises(DisallowedExpression):
             evaluate(expr, ExpressionContext(from_submission={"q_123": 123}))
@@ -179,7 +179,7 @@ class TestEvaluatingManagedExpressionsWithRequiredFunctions:
             return 42
 
         # Test with a custom function that isn't on the allowed list
-        expr = factories.expression.build(statement="q_123 > _custom_test_function()", type=ExpressionType.VALIDATION)
+        expr = factories.expression.build(statement="q_123 > _custom_test_function()", type_=ExpressionType.VALIDATION)
         # Don't patch the required_functions property, so it returns an empty dict
         with pytest.raises(DisallowedExpression):
             evaluate(expr, ExpressionContext(from_submission={"q_123": 123}))

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -1874,7 +1874,7 @@ class TestAddQuestionCondition:
 
         assert len(target_question.expressions) == 1
         expression = target_question.expressions[0]
-        assert expression.type == ExpressionType.CONDITION
+        assert expression.type_ == ExpressionType.CONDITION
         assert expression.managed_name == "Yes"
         assert expression.managed.referenced_question.id == depends_on_question.id
 
@@ -1915,7 +1915,7 @@ class TestAddQuestionCondition:
 
         assert len(target_group.expressions) == 1
         expression = target_group.expressions[0]
-        assert expression.type == ExpressionType.CONDITION
+        assert expression.type_ == ExpressionType.CONDITION
         assert expression.managed_name == "Yes"
         assert expression.managed.referenced_question.id == depends_on_question.id
 
@@ -2357,7 +2357,7 @@ class TestAddQuestionValidation:
 
         assert len(question.expressions) == 1
         expression = question.expressions[0]
-        assert expression.type == ExpressionType.VALIDATION
+        assert expression.type_ == ExpressionType.VALIDATION
         assert expression.managed_name == "Greater than"
 
     def test_post_duplicate_validation(self, authenticated_grant_admin_client, factories, db_session):

--- a/tests/integration/deliver_grant_funding/routes/test_runner.py
+++ b/tests/integration/deliver_grant_funding/routes/test_runner.py
@@ -232,7 +232,7 @@ class TestAskAQuestion:
         assert response.status_code == 200
 
         # the question should no longer be accessible
-        factories.expression.create(question=question, type=ExpressionType.CONDITION, statement="False")
+        factories.expression.create(question=question, type_=ExpressionType.CONDITION, statement="False")
 
         response = authenticated_grant_admin_client.get(
             url_for(

--- a/tests/models.py
+++ b/tests/models.py
@@ -666,7 +666,7 @@ class _ExpressionFactory(SQLAlchemyModelFactory):
     # todo: we could actually set this based on the question sub factory to make sure the default expression
     #       makes some kind of sense for the question type
     statement = factory.LazyFunction(_required)
-    type = factory.LazyFunction(_required)
+    type_ = factory.LazyFunction(_required)
 
 
 class _InvitationFactory(SQLAlchemyModelFactory):

--- a/tests/unit/common/helpers/test_collections.py
+++ b/tests/unit/common/helpers/test_collections.py
@@ -40,7 +40,7 @@ class TestSubmissionHelper:
             visible_question = factories.question.build(form=form)
 
             invisible_question = factories.question.build(form=form)
-            factories.expression.build(question=invisible_question, type=ExpressionType.CONDITION, statement="False")
+            factories.expression.build(question=invisible_question, type_=ExpressionType.CONDITION, statement="False")
 
             helper = SubmissionHelper(submission)
             helper_questions = helper.cached_get_ordered_visible_questions(form)
@@ -56,7 +56,7 @@ class TestSubmissionHelper:
             factories.question.build(form_id=form.id, parent=invisible_group)
             factories.question.build(form_id=form.id, parent=invisible_group)
             factories.question.build(form_id=form.id, parent=invisible_group)
-            factories.expression.build(question=invisible_group, type=ExpressionType.CONDITION, statement="False")
+            factories.expression.build(question=invisible_group, type_=ExpressionType.CONDITION, statement="False")
 
             helper = SubmissionHelper(submission)
             helper_questions = helper.cached_get_ordered_visible_questions(form)
@@ -72,7 +72,7 @@ class TestSubmissionHelper:
             q2 = factories.question.build(form_id=form.id, parent=group)
             q3 = factories.question.build(form_id=form.id, parent=group)
 
-            factories.expression.build(question=q2, type=ExpressionType.CONDITION, statement="False")
+            factories.expression.build(question=q2, type_=ExpressionType.CONDITION, statement="False")
 
             helper = SubmissionHelper(submission)
             helper_questions = helper.cached_get_ordered_visible_questions(form)
@@ -240,7 +240,7 @@ class TestSubmissionHelper:
             question_two = factories.question.build(form=form, id=uuid.UUID(int=1), order=1)
             question_three = factories.question.build(form=form, id=uuid.UUID(int=2), order=2)
 
-            factories.expression.build(question=question_two, type=ExpressionType.CONDITION, statement="False")
+            factories.expression.build(question=question_two, type_=ExpressionType.CONDITION, statement="False")
 
             helper = SubmissionHelper(submission)
 
@@ -295,7 +295,7 @@ class TestSubmissionHelper:
             question_two = factories.question.build(form=form, id=uuid.UUID(int=1), order=1)
             question_three = factories.question.build(form=form, id=uuid.UUID(int=2), order=2)
 
-            factories.expression.build(question=question_two, type=ExpressionType.CONDITION, statement="False")
+            factories.expression.build(question=question_two, type_=ExpressionType.CONDITION, statement="False")
 
             helper = SubmissionHelper(submission)
 
@@ -357,7 +357,7 @@ class TestSubmissionHelper:
             question = factories.question.build()
             helper = SubmissionHelper(factories.submission.build(collection=question.form.collection))
 
-            factories.expression.build(question=question, type=ExpressionType.CONDITION, statement="False")
+            factories.expression.build(question=question, type_=ExpressionType.CONDITION, statement="False")
 
             assert helper.is_component_visible(question, helper.cached_expression_context) is False
 
@@ -365,7 +365,7 @@ class TestSubmissionHelper:
             question = factories.question.build()
             helper = SubmissionHelper(factories.submission.build(collection=question.form.collection))
 
-            factories.expression.build(question=question, type=ExpressionType.CONDITION, statement="True")
+            factories.expression.build(question=question, type_=ExpressionType.CONDITION, statement="True")
 
             assert helper.is_component_visible(question, helper.cached_expression_context) is True
 
@@ -375,7 +375,7 @@ class TestSubmissionHelper:
             question = factories.question.build(form=group.form)
             helper = SubmissionHelper(factories.submission.build(collection=question.form.collection))
 
-            expression = factories.expression.build(question=group, type=ExpressionType.CONDITION, statement="False")
+            expression = factories.expression.build(question=group, type_=ExpressionType.CONDITION, statement="False")
 
             assert helper.is_component_visible(question, helper.cached_expression_context) is True
             assert helper.is_component_visible(group, helper.cached_expression_context) is False


### PR DESCRIPTION
Rename of the python field for `Expression.type` -> `Expression.type_` to remove collision with the builtin `type` type.