### PR TITLE
Fix import-linter for CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,7 @@ repos:
     rev: v2.4
     hooks:
       - id: import-linter
+        language: python
 
   - repo: local
     hooks:


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
This has stopped working in CI since https://github.com/communitiesuk/funding-service/pull/763