### PR TITLE
FSPT-590: use accessible autocomplete for question conditions

### DIFF
--- a/app/deliver_grant_funding/forms.py
+++ b/app/deliver_grant_funding/forms.py
@@ -28,6 +28,7 @@ from app.common.data.interfaces.grants import grant_name_exists
 from app.common.data.interfaces.user import get_user_by_email
 from app.common.data.types import GroupDisplayOptions, MultilineTextInputRows, NumberInputWidths, QuestionDataType
 from app.common.expressions.registry import get_supported_form_questions
+from app.common.forms.fields import MHCLGAccessibleAutocomplete
 from app.common.forms.validators import CommunitiesEmail, WordRange
 
 if TYPE_CHECKING:
@@ -447,7 +448,7 @@ class ConditionSelectQuestionForm(FlaskForm):
         "Which answer should the condition check?",
         choices=[],
         validators=[DataRequired("Select a question")],
-        widget=GovSelect(),
+        widget=MHCLGAccessibleAutocomplete(),
     )
     submit = SubmitField("Continue", widget=GovSubmitInput())
 
@@ -456,9 +457,11 @@ class ConditionSelectQuestionForm(FlaskForm):
 
         self.target_question = question
 
-        self.question.choices = [
-            (question.id, f"{question.text} ({question.name})") for question in get_supported_form_questions(question)
-        ]
+        if len(get_supported_form_questions(question)) > 0:
+            self.question.choices = [("", "")] + [
+                (str(question.id), f"{question.text} ({question.name})")
+                for question in get_supported_form_questions(question)
+            ]  # type: ignore[assignment]
 
     def validate_question(self: "ConditionSelectQuestionForm", field: "Field") -> None:
         depends_on_question = get_question_by_id(self.question.data)

--- a/tests/e2e/reports_pages.py
+++ b/tests/e2e/reports_pages.py
@@ -687,11 +687,12 @@ class AddConditionPage(ReportsBasePage):
     def select_condition_question(self, condition_question: str) -> None:
         # We don't easily know randomly generated uuid apended to the previous question texts, so have to grab it to
         # select the correct option
-        question_select_locator = self.page.get_by_label(" What answer should the condition check? ")
-        full_question_text = (
-            question_select_locator.locator("option").filter(has_text=condition_question).first.get_attribute("value")
-        )
-        question_select_locator.select_option(full_question_text)
+        expect(self.page.locator("[class='autocomplete__wrapper']")).to_be_attached()
+        element = self.page.get_by_role("combobox")
+        element.click()
+        element.fill(condition_question)
+        element.press("Enter")
+
         self.continue_button.click()
 
     def click_add_condition(


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-590

## 📝 Description
Use the accessible autocomplete component instead of a standard select. This might be nicer when there are a lot of questions.

## 📸 Show the thing (screenshots, gifs)
<!-- Include screenshots for UI changes, new features, or visual modifications -->
<!-- Use "Before" and "After" sections if showing changes to existing functionality -->

### Before
![2025-09-12 16 49 18](https://github.com/user-attachments/assets/ec1b9a9d-4bf6-445d-9c8b-639ea9b76328)

### After
![2025-09-12 16 48 44](https://github.com/user-attachments/assets/049054b9-a2fb-4553-be60-18bbe9a9319e)