### PR TITLE
Address new warnings and deprecations

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -21,10 +21,10 @@ export default defineConfig({
     preprocessorOptions: {
       scss: {
         silenceDeprecations: [
-          "mixed-decls",
           "global-builtin",
           "slash-div",
           "import",
+          "color-functions",
         ],
       },
     },


### PR DESCRIPTION
```

funding-service-1  | Warning: mixed-decls deprecation is obsolete. If you were previously silencing it, your code may now behave in unexpected ways.
funding-service-1  |
funding-service-1  | Deprecation Warning [color-functions]: red() is deprecated. Suggestion:
funding-service-1  |
funding-service-1  | color.channel($color, "red", $space: rgb)
funding-service-1  |
funding-service-1  | More info: https://sass-lang.com/d/color-functions
funding-service-1  |
funding-service-1  |     ╷
funding-service-1  | 158 │     "red": red($colour),
funding-service-1  |     │            ^^^^^^^^^^^^
funding-service-1  |     ╵
funding-service-1  |     node_modules/govuk-frontend/dist/govuk/helpers/_colour.scss 158:12            -as-hexadecimal()
funding-service-1  |     node_modules/govuk-frontend/dist/govuk/helpers/_colour.scss 139:11            govuk-tint()
funding-service-1  |     node_modules/govuk-frontend/dist/govuk/settings/_colours-applied.scss 187:45  @import
funding-service-1  |     node_modules/govuk-frontend/dist/govuk/settings/_index.scss 13:9              @import
funding-service-1  |     node_modules/govuk-frontend/dist/govuk/_base.scss 1:9                         @import
funding-service-1  |     node_modules/govuk-frontend/dist/govuk/index.scss 1:9                         @import
funding-service-1  |     app/assets/main.scss 7:9                                                      root stylesheet
funding-service-1  |
funding-service-1  | Deprecation Warning [color-functions]: green() is deprecated. Suggestion:
funding-service-1  |
funding-service-1  | color.channel($color, "green", $space: rgb)
funding-service-1  |
funding-service-1  | More info: https://sass-lang.com/d/color-functions
funding-service-1  |
funding-service-1  |     ╷
funding-service-1  | 159 │     "green": green($colour),
funding-service-1  |     │              ^^^^^^^^^^^^^^
funding-service-1  |     ╵
funding-service-1  |     node_modules/govuk-frontend/dist/govuk/helpers/_colour.scss 159:14            -as-hexadecimal()
funding-service-1  |     node_modules/govuk-frontend/dist/govuk/helpers/_colour.scss 139:11            govuk-tint()
funding-service-1  |     node_modules/govuk-frontend/dist/govuk/settings/_colours-applied.scss 187:45  @import
funding-service-1  |     node_modules/govuk-frontend/dist/govuk/settings/_index.scss 13:9              @import
funding-service-1  |     node_modules/govuk-frontend/dist/govuk/_base.scss 1:9                         @import
funding-service-1  |     node_modules/govuk-frontend/dist/govuk/index.scss 1:9                         @import
funding-service-1  |     app/assets/main.scss 7:9                                                      root stylesheet
funding-service-1  |
funding-service-1  | Deprecation Warning [color-functions]: blue() is deprecated. Suggestion:
funding-service-1  |
funding-service-1  | color.channel($color, "blue", $space: rgb)
funding-service-1  |
funding-service-1  | More info: https://sass-lang.com/d/color-functions
funding-service-1  |
funding-service-1  |     ╷
funding-service-1  | 160 │     "blue": blue($colour),
funding-service-1  |     │             ^^^^^^^^^^^^^
funding-service-1  |     ╵
funding-service-1  |     node_modules/govuk-frontend/dist/govuk/helpers/_colour.scss 160:13            -as-hexadecimal()
funding-service-1  |     node_modules/govuk-frontend/dist/govuk/helpers/_colour.scss 139:11            govuk-tint()
funding-service-1  |     node_modules/govuk-frontend/dist/govuk/settings/_colours-applied.scss 187:45  @import
funding-service-1  |     node_modules/govuk-frontend/dist/govuk/settings/_index.scss 13:9              @import
funding-service-1  |     node_modules/govuk-frontend/dist/govuk/_base.scss 1:9                         @import
funding-service-1  |     node_modules/govuk-frontend/dist/govuk/index.scss 1:9                         @import
funding-service-1  |     app/assets/main.scss 7:9                                                      root stylesheet

```