### PR TITLE
Refactor ExpressionContext

### DIFF
--- a/app/common/data/types.py
+++ b/app/common/data/types.py
@@ -5,7 +5,6 @@ import typing
 from enum import IntEnum
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
 
-from immutabledict import immutabledict
 from pydantic import BaseModel
 from sqlalchemy import TypeDecorator
 from sqlalchemy.dialects.postgresql import JSONB
@@ -18,7 +17,6 @@ if TYPE_CHECKING:
 scalars = str | int | float | bool | None
 json_scalars = Dict[str, Any]
 json_flat_scalars = Dict[str, scalars]
-immutable_json_flat_scalars = immutabledict[str, scalars]
 
 TRunnerUrlMap = dict[
     "FormRunnerState",

--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -8,7 +8,6 @@ from itertools import chain
 from typing import TYPE_CHECKING, Any, List, Optional, Union
 from uuid import UUID
 
-from immutabledict import immutabledict
 from pydantic import BaseModel as PydanticBaseModel
 from pydantic import TypeAdapter
 
@@ -43,6 +42,7 @@ from app.common.data.types import (
 )
 from app.common.expressions import (
     ExpressionContext,
+    SubmissionContext,
     UndefinedVariableInExpression,
     evaluate,
 )
@@ -119,7 +119,7 @@ class SubmissionHelper:
             for question in form.cached_questions
             if (answer := self.cached_get_answer_for_question(question.id)) is not None
         }
-        return ExpressionContext(from_submission=immutabledict(submission_data))
+        return ExpressionContext(submission_context=SubmissionContext(submission_data=submission_data))
 
     @property
     def all_visible_questions(self) -> dict[UUID, "Question"]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
     "sqlalchemy-json==0.7.0",
     "simpleeval==1.0.3",
     "num2words==0.5.14",
-    "immutabledict==4.2.1",
     "mistune==3.1.4",
     "faker==37.6.0",
 ]

--- a/tests/integration/common/helpers/test_collections.py
+++ b/tests/integration/common/helpers/test_collections.py
@@ -6,7 +6,6 @@ from io import StringIO
 from unittest import mock
 
 import pytest
-from immutabledict import immutabledict
 
 from app.common.collections.forms import build_question_form
 from app.common.collections.types import (
@@ -21,7 +20,7 @@ from app.common.collections.types import (
 )
 from app.common.data import interfaces
 from app.common.data.types import QuestionDataType, SubmissionModeEnum, SubmissionStatusEnum, TasklistTaskStatusEnum
-from app.common.expressions import ExpressionContext
+from app.common.expressions import ExpressionContext, SubmissionContext
 from app.common.filters import format_datetime
 from app.common.helpers.collections import (
     CollectionHelper,
@@ -275,8 +274,8 @@ class TestSubmissionHelper:
             helper = SubmissionHelper(submission)
 
             assert helper.cached_expression_context == ExpressionContext(
-                from_submission=immutabledict(
-                    {
+                submission_context=SubmissionContext(
+                    submission_data={
                         "q_d696aebc49d24170a92fb6ef42994294": "answer",
                         "q_d696aebc49d24170a92fb6ef42994295": "answer\nthis",
                         "q_d696aebc49d24170a92fb6ef42994296": 50,

--- a/tests/unit/common/expressions/test_expressions.py
+++ b/tests/unit/common/expressions/test_expressions.py
@@ -1,13 +1,13 @@
 from unittest.mock import Mock
 
 import pytest
-from immutabledict import immutabledict
 
 from app.common.data.models import Expression
 from app.common.expressions import (
     DisallowedExpression,
     ExpressionContext,
     InvalidEvaluationResult,
+    SubmissionContext,
     UndefinedVariableInExpression,
     _evaluate_expression_with_context,
     evaluate,
@@ -95,7 +95,10 @@ class TestEvaluate:
 
     def test_additional_context(self):
         assert (
-            evaluate(Expression(statement="answer == 1"), context=ExpressionContext(immutabledict({"answer": 1})))
+            evaluate(
+                Expression(statement="answer == 1"),
+                context=ExpressionContext(SubmissionContext(submission_data={"answer": 1})),
+            )
             is True
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -532,7 +532,6 @@ dependencies = [
     { name = "govuk-frontend-jinja" },
     { name = "govuk-frontend-wtf" },
     { name = "gunicorn", extra = ["gevent"] },
-    { name = "immutabledict" },
     { name = "mistune" },
     { name = "msal" },
     { name = "notifications-python-client" },
@@ -595,7 +594,6 @@ requires-dist = [
     { name = "govuk-frontend-jinja", specifier = "==3.7.0" },
     { name = "govuk-frontend-wtf", specifier = "==3.2.0" },
     { name = "gunicorn", extras = ["gevent"], specifier = "==23.0.0" },
-    { name = "immutabledict", specifier = "==4.2.1" },
     { name = "mistune", specifier = "==3.1.4" },
     { name = "msal", specifier = "==1.33.0" },
     { name = "notifications-python-client", specifier = "==10.0.1" },
@@ -797,15 +795,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
-]
-
-[[package]]
-name = "immutabledict"
-version = "4.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e0/c5/4240186fbabc58fba41bbe17c5f0cd37ffd4c0b85a5029ab104f946df175/immutabledict-4.2.1.tar.gz", hash = "sha256:d91017248981c72eb66c8ff9834e99c2f53562346f23e7f51e7a5ebcf66a3bcc", size = 6228, upload-time = "2024-11-17T13:25:21.555Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/56/25ca7b848164b7d93dbd5fc97dd7751700c93e324fe854afbeb562ee2f98/immutabledict-4.2.1-py3-none-any.whl", hash = "sha256:c56a26ced38c236f79e74af3ccce53772827cef5c3bce7cab33ff2060f756373", size = 4700, upload-time = "2024-11-17T13:25:19.52Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-780

## 📝 Description
This was effectively a custom implementation of python's native ChainMap, which takes a set of dictionaries and essentially layers them on top of each other.

To reduce the amount of custom code we have, this strips it down to prefer using ChainMap.

When passing data to an expression, there are currently two things we care about:

- the latest view of data for the submission (answers that a user has provided to the questions in a report)
- the data attached to an expression itself

The latest view of data for a submission has two layers:

- the data submitted by a user in the current POST request 
- all of the data we have on the Submission model in the DB

Any data submitted in the current post request (generally just one question) should override an older answer on the Submission in the DB, so we check form data and then submission data.

The expression data is entirely separate, but because we're using ChainMap it needs to be considered either 'more important' or 'less important' than submission data. I've fairly arbitrarily chosen that the current order/preference is:

- submission data (answers to questions)
- expression data

These are not currently namespaced. We might want to namespace these in the future so that there is no chance of overlap at all.

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [x] Edge cases and error conditions are tested

## 📚 Additional Notes
Are tests running a bit slower with this change? Maybe 🫠 