### PR TITLE
Fspt 770 approx date

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -21,6 +21,7 @@ from app.common.data.types import (
 )
 from app.common.filters import (
     format_date,
+    format_date_approximate,
     format_date_range,
     format_date_short,
     format_datetime,
@@ -167,6 +168,7 @@ def create_app() -> Flask:
         return dict(
             format_date=format_date,
             format_date_short=format_date_short,
+            format_date_approximate=format_date_approximate,
             format_datetime=format_datetime,
             format_date_range=format_date_range,
             format_datetime_range=format_datetime_range,

--- a/app/common/collections/forms.py
+++ b/app/common/collections/forms.py
@@ -21,7 +21,12 @@ from wtforms.validators import DataRequired, Email, InputRequired, Optional, Val
 from app.common.data.models import Expression, Question
 from app.common.data.types import QuestionDataType
 from app.common.expressions import ExpressionContext, evaluate
-from app.common.forms.fields import MHCLGAccessibleAutocomplete, MHCLGCheckboxesInput, MHCLGRadioInput
+from app.common.forms.fields import (
+    GovApproxDateInput,
+    MHCLGAccessibleAutocomplete,
+    MHCLGCheckboxesInput,
+    MHCLGRadioInput,
+)
 from app.common.forms.validators import FinalOptionExclusive, URLWithoutProtocol, WordRange
 
 _accepted_fields = EmailField | StringField | IntegerField | RadioField | SelectField | SelectMultipleField | DateField
@@ -229,9 +234,11 @@ def build_question_form(questions: list[Question], expression_context: Expressio
                 field = DateField(
                     label=question.text,
                     description=question.hint or "",
-                    widget=GovDateInput(),
+                    widget=GovDateInput() if not question.approximate_date else GovApproxDateInput(),
                     validators=[DataRequired(f"Enter the {question.name}")],
-                    format=["%d %m %Y", "%d %b %Y", "%d %B %Y"],  # multiple formats to help user input
+                    format=["%d %m %Y", "%d %b %Y", "%d %B %Y"]
+                    if not question.approximate_date
+                    else ["%m %Y", "%b %Y", "%B %Y"],  # multiple formats to help user input
                 )
 
             case _:

--- a/app/common/collections/forms.py
+++ b/app/common/collections/forms.py
@@ -22,8 +22,8 @@ from app.common.data.models import Expression, Question
 from app.common.data.types import QuestionDataType
 from app.common.expressions import ExpressionContext, evaluate
 from app.common.forms.fields import (
-    GovApproxDateInput,
     MHCLGAccessibleAutocomplete,
+    MHCLGApproximateDateInput,
     MHCLGCheckboxesInput,
     MHCLGRadioInput,
 )
@@ -234,7 +234,7 @@ def build_question_form(questions: list[Question], expression_context: Expressio
                 field = DateField(
                     label=question.text,
                     description=question.hint or "",
-                    widget=GovDateInput() if not question.approximate_date else GovApproxDateInput(),
+                    widget=GovDateInput() if not question.approximate_date else MHCLGApproximateDateInput(),
                     validators=[DataRequired(f"Enter the {question.name}")],
                     format=["%d %m %Y", "%d %b %Y", "%d %B %Y"]
                     if not question.approximate_date

--- a/app/common/collections/types.py
+++ b/app/common/collections/types.py
@@ -179,6 +179,7 @@ class MultipleChoiceFromListAnswer(SubmissionAnswerBaseModel):
 
 class DateAnswer(SubmissionAnswerBaseModel):
     answer: date
+    approximate_date: bool = False
 
     @property
     def _render_answer_template(self) -> str:

--- a/app/common/collections/types.py
+++ b/app/common/collections/types.py
@@ -195,10 +195,10 @@ class DateAnswer(SubmissionAnswerBaseModel):
         return self.answer
 
     def get_value_for_text_export(self) -> str:
-        return self.answer.isoformat()
+        return self.answer.isoformat() if not self.approximate_date else self.answer.strftime("%B %-Y")
 
     def get_value_for_json_export(self) -> str:
-        return self.answer.isoformat()
+        return self.answer.isoformat() if not self.approximate_date else self.answer.strftime("%B %-Y")
 
 
 AllAnswerTypes = Union[

--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -373,6 +373,10 @@ class Question(Component, SafeQidMixin):
             else None
         )
 
+    @property
+    def approximate_date(self) -> bool | None:
+        return self.presentation_options.approximate_date if self.data_type == QuestionDataType.DATE else None
+
     # END: Helper properties for populating `QuestionForm` instances
 
 

--- a/app/common/data/types.py
+++ b/app/common/data/types.py
@@ -159,6 +159,9 @@ class QuestionPresentationOptions(BaseModel):
     # Groups
     show_questions_on_the_same_page: bool | None = None
 
+    # Dates
+    approximate_date: bool | None = None
+
     @staticmethod
     def from_question_form(form: "QuestionForm") -> QuestionPresentationOptions:
         match form._question_type:
@@ -177,6 +180,8 @@ class QuestionPresentationOptions(BaseModel):
                     suffix=form.suffix.data,
                     width=form.width.data,
                 )
+            case QuestionDataType.DATE:
+                return QuestionPresentationOptions(approximate_date=form.approximate_date.data)
             case _:
                 return QuestionPresentationOptions()
 

--- a/app/common/expressions/managed.py
+++ b/app/common/expressions/managed.py
@@ -92,7 +92,7 @@ class ManagedExpression(BaseModel, SafeQidMixin):
     @staticmethod
     @abc.abstractmethod
     def get_form_fields(
-        expression: TOptional["Expression"] = None, referenced_question: TOptional["Question"] = None
+        referenced_question: "Question", expression: TOptional["Expression"] = None
     ) -> dict[str, "Field"]:
         """
         A hook used by `build_managed_expression_form`. It should return the set of form fields which need to be
@@ -143,9 +143,7 @@ class ManagedExpression(BaseModel, SafeQidMixin):
         ...
 
     @classmethod
-    def concatenate_all_wtf_fields_html(
-        cls, form: "_ManagedExpressionForm", referenced_question: TOptional["Question"] = None
-    ) -> Markup:
+    def concatenate_all_wtf_fields_html(cls, form: "_ManagedExpressionForm", referenced_question: "Question") -> Markup:
         """
         A hook used by `build_managed_expression_form` to support conditionally-revealed the fields that a user needs
         to complete when they select this managed expression type from the radio list of available managed expressions.
@@ -219,7 +217,7 @@ class GreaterThan(ManagedExpression):
 
     @staticmethod
     def get_form_fields(
-        expression: TOptional["Expression"] = None, referenced_question: TOptional["Question"] = None
+        referenced_question: "Question", expression: TOptional["Expression"] = None
     ) -> dict[str, "Field"]:
         return {
             "greater_than_value": IntegerField(
@@ -275,7 +273,7 @@ class LessThan(ManagedExpression):
 
     @staticmethod
     def get_form_fields(
-        expression: TOptional["Expression"] = None, referenced_question: TOptional["Question"] = None
+        referenced_question: "Question", expression: TOptional["Expression"] = None
     ) -> dict[str, "Field"]:
         return {
             "less_than_value": IntegerField(
@@ -349,7 +347,7 @@ class Between(ManagedExpression):
 
     @staticmethod
     def get_form_fields(
-        expression: TOptional["Expression"] = None, referenced_question: TOptional["Question"] = None
+        referenced_question: "Question", expression: TOptional["Expression"] = None
     ) -> dict[str, "Field"]:
         return {
             "between_bottom_of_range": IntegerField(
@@ -436,7 +434,7 @@ class AnyOf(BaseDataSourceManagedExpression):
 
     @staticmethod
     def get_form_fields(
-        expression: TOptional["Expression"] = None, referenced_question: TOptional["Question"] = None
+        referenced_question: "Question", expression: TOptional["Expression"] = None
     ) -> dict[str, "Field"]:
         if referenced_question is None or referenced_question.data_source is None:
             raise ValueError("The question for the AnyOf expression must have a data source")
@@ -497,7 +495,7 @@ class IsYes(ManagedExpression):
 
     @staticmethod
     def get_form_fields(
-        expression: TOptional["Expression"] = None, referenced_question: TOptional["Question"] = None
+        referenced_question: "Question", expression: TOptional["Expression"] = None
     ) -> dict[str, "Field"]:
         return {}
 
@@ -534,7 +532,7 @@ class IsNo(ManagedExpression):
 
     @staticmethod
     def get_form_fields(
-        expression: TOptional["Expression"] = None, referenced_question: TOptional["Question"] = None
+        referenced_question: "Question", expression: TOptional["Expression"] = None
     ) -> dict[str, "Field"]:
         return {}
 
@@ -573,7 +571,7 @@ class Specifically(BaseDataSourceManagedExpression):
 
     @staticmethod
     def get_form_fields(
-        expression: TOptional["Expression"] = None, referenced_question: TOptional["Question"] = None
+        referenced_question: "Question", expression: TOptional["Expression"] = None
     ) -> dict[str, "Field"]:
         if referenced_question is None or referenced_question.data_source is None:
             raise ValueError("The question for the Specifically expression must have a data source")
@@ -625,8 +623,8 @@ class IsBefore(ManagedExpression):
     def message(self) -> str:
         return (
             f"The answer must be {'on or ' if self.inclusive else ''}before "
-            + f"{format_date_short(self.latest_value) if not self.referenced_question.approximate_date else self.latest_value.strftime('%B %Y')}"
-        )  # noqa: E501
+            + f"{format_date_short(self.latest_value) if not self.referenced_question.approximate_date else self.latest_value.strftime('%B %Y')}"  # noqa: E501
+        )
 
     @property
     def statement(self) -> str:
@@ -637,7 +635,7 @@ class IsBefore(ManagedExpression):
 
     @staticmethod
     def get_form_fields(
-        expression: TOptional["Expression"] = None, referenced_question: TOptional["Question"] = None
+        referenced_question: "Question", expression: TOptional["Expression"] = None
     ) -> dict[str, "Field"]:
         return {
             "latest_value": DateField(
@@ -707,7 +705,7 @@ class IsAfter(ManagedExpression):
 
     @staticmethod
     def get_form_fields(
-        expression: TOptional["Expression"] = None, referenced_question: TOptional["Question"] = None
+        referenced_question: "Question", expression: TOptional["Expression"] = None
     ) -> dict[str, "Field"]:
         return {
             "earliest_value": DateField(
@@ -791,7 +789,7 @@ class BetweenDates(ManagedExpression):
 
     @staticmethod
     def get_form_fields(
-        expression: TOptional["Expression"] = None, referenced_question: TOptional["Question"] = None
+        referenced_question: "Question", expression: TOptional["Expression"] = None
     ) -> dict[str, "Field"]:
         return {
             "between_bottom_of_range": DateField(

--- a/app/common/expressions/managed.py
+++ b/app/common/expressions/managed.py
@@ -772,7 +772,7 @@ class BetweenDates(ManagedExpression):
             "The answer must be between "
             f"{format_date_short(self.earliest_value) if not self.referenced_question.approximate_date else self.earliest_value.strftime('%B %Y')}"  # noqa: E501
             f"{' (inclusive)' if self.earliest_inclusive else ' (exclusive)'}"
-            f" and {format_date_short(self.latest_value) if not self.referenced_question.approximate_date else self.latest_value.strftime('%B %Y')}("  # noqa: E501
+            f" and {format_date_short(self.latest_value) if not self.referenced_question.approximate_date else self.latest_value.strftime('%B %Y')}"  # noqa: E501
             f"{' (inclusive)' if self.latest_inclusive else ' (exclusive)'}"
         )
 

--- a/app/common/expressions/managed.py
+++ b/app/common/expressions/managed.py
@@ -24,7 +24,7 @@ from wtforms.validators import DataRequired, InputRequired, Optional, Validation
 
 from app.common.data.types import ManagedExpressionsEnum, QuestionDataType
 from app.common.expressions.registry import lookup_managed_expression, register_managed_expression
-from app.common.filters import format_date_short
+from app.common.filters import format_date_approximate, format_date_short
 from app.common.forms.fields import MHCLGApproximateDateInput
 from app.common.qid import SafeQidMixin
 from app.types import TRadioItem
@@ -623,7 +623,7 @@ class IsBefore(ManagedExpression):
     def message(self) -> str:
         return (
             f"The answer must be {'on or ' if self.inclusive else ''}before "
-            + f"{format_date_short(self.latest_value) if not self.referenced_question.approximate_date else self.latest_value.strftime('%B %Y')}"  # noqa: E501
+            + f"{format_date_short(self.latest_value) if not self.referenced_question.approximate_date else format_date_approximate(self.latest_value)}"  # noqa: E501
         )
 
     @property
@@ -693,7 +693,7 @@ class IsAfter(ManagedExpression):
     def message(self) -> str:
         return (
             f"The answer must be {'on or ' if self.inclusive else ''}after "
-            + f"{format_date_short(self.earliest_value) if not self.referenced_question.approximate_date else self.earliest_value.strftime('%B %Y')}"  # noqa: E501
+            + f"{format_date_short(self.earliest_value) if not self.referenced_question.approximate_date else format_date_approximate(self.earliest_value)}"  # noqa: E501
         )
 
     @property
@@ -770,9 +770,9 @@ class BetweenDates(ManagedExpression):
         # todo: make this use expression evaluation/interpolation rather than f-strings
         return (
             "The answer must be between "
-            f"{format_date_short(self.earliest_value) if not self.referenced_question.approximate_date else self.earliest_value.strftime('%B %Y')}"  # noqa: E501
+            f"{format_date_short(self.earliest_value) if not self.referenced_question.approximate_date else format_date_approximate(self.earliest_value)}"  # noqa: E501
             f"{' (inclusive)' if self.earliest_inclusive else ' (exclusive)'}"
-            f" and {format_date_short(self.latest_value) if not self.referenced_question.approximate_date else self.latest_value.strftime('%B %Y')}"  # noqa: E501
+            f" and {format_date_short(self.latest_value) if not self.referenced_question.approximate_date else format_date_approximate(self.latest_value)}"  # noqa: E501
             f"{' (inclusive)' if self.latest_inclusive else ' (exclusive)'}"
         )
 

--- a/app/common/filters.py
+++ b/app/common/filters.py
@@ -20,6 +20,14 @@ def format_date_short(value: date | datetime) -> str:
     return value.strftime("%-d %B %-Y")
 
 
+def format_date_approximate(value: date | datetime) -> str:
+    """Format a date or datetime as follows:
+
+    > May 2025
+    """
+    return value.strftime("%B %-Y")
+
+
 def format_datetime(value: datetime) -> str:
     """Format a datetime as follows:
 

--- a/app/common/forms/fields.py
+++ b/app/common/forms/fields.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from govuk_frontend_wtf.gov_form_base import GovIterableBase
+from govuk_frontend_wtf.gov_form_base import GovFormBase, GovIterableBase
 from govuk_frontend_wtf.wtforms_widgets import GovSelect
 from wtforms import Field
 
@@ -112,5 +112,70 @@ class MHCLGCheckboxesInput(MHCLGDividableIterableBase):
                     "text": field.label.text,
                 },
             },
+        )
+        return params
+
+
+class GovApproxDateInput(GovFormBase):
+    """Renders two input fields representing Month and Year.
+
+    To be used as a widget for WTForms' DateField or DateTimeField.
+    The input field labels are hardcoded to "Month" and "Year".
+    The provided label is set as a legend above the input fields.
+    The field names MUST all be the same for this widget to work.
+    """
+
+    template = "govuk_frontend_wtf/date.html"
+
+    def __call__(self, field, **kwargs):  # type: ignore
+        kwargs.setdefault("id", field.id)
+        if "value" not in kwargs:
+            kwargs["value"] = field._value()
+        if "required" not in kwargs and "required" in getattr(field, "flags", []):
+            kwargs["required"] = True
+        return super().__call__(field, **kwargs)
+
+    def map_gov_params(self, field, **kwargs):  # type: ignore
+        params = super().map_gov_params(field, **kwargs)
+        month, year = [None] * 2
+        if field.raw_data is not None:
+            month, year = field.raw_data
+        elif field.data:
+            month, year = field.data.strftime("%m %Y").split(" ")
+
+        params.setdefault(
+            "fieldset",
+            {
+                "legend": {"text": field.label.text},
+            },
+        )
+        params.setdefault(
+            "items",
+            [
+                {
+                    "label": "Month",
+                    "id": "{}-month".format(field.name),
+                    "name": field.name,
+                    "classes": " ".join(
+                        [
+                            "govuk-input--width-2",
+                            "govuk-input--error" if field.errors else "",
+                        ]
+                    ).strip(),
+                    "value": month,
+                },
+                {
+                    "label": "Year",
+                    "id": "{}-year".format(field.name),
+                    "name": field.name,
+                    "classes": " ".join(
+                        [
+                            "govuk-input--width-4",
+                            "govuk-input--error" if field.errors else "",
+                        ]
+                    ).strip(),
+                    "value": year,
+                },
+            ],
         )
         return params

--- a/app/common/forms/fields.py
+++ b/app/common/forms/fields.py
@@ -116,7 +116,7 @@ class MHCLGCheckboxesInput(MHCLGDividableIterableBase):
         return params
 
 
-class GovApproxDateInput(GovFormBase):
+class MHCLGApproximateDateInput(GovFormBase):
     """Renders two input fields representing Month and Year.
 
     To be used as a widget for WTForms' DateField or DateTimeField.

--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -491,7 +491,7 @@ def _form_data_to_question_type(question: "Question", form: DynamicQuestionForm)
             ]
             return MultipleChoiceFromListAnswer(choices=choices)
         case QuestionDataType.DATE:
-            return DateAnswer(answer=answer)
+            return DateAnswer(answer=answer, approximate_date=question.approximate_date or False)  # ty: ignore[missing-argument]
 
     raise ValueError(f"Could not parse data for question type={question.data_type}")
 

--- a/app/common/templates/common/partials/answers/date.html
+++ b/app/common/templates/common/partials/answers/date.html
@@ -1,1 +1,1 @@
-<span data-testid="answer-{{ question.text }}">{{ format_date_short(answer.answer) }}</span>
+<span data-testid="answer-{{ question.text }}">{{ format_date_approximate(answer.answer) if answer.approximate_date else format_date_short(answer.answer) }}</span>

--- a/app/deliver_grant_funding/forms.py
+++ b/app/deliver_grant_funding/forms.py
@@ -306,6 +306,13 @@ class QuestionForm(FlaskForm):
         default=NumberInputWidths.BILLIONS.value,
     )
 
+    # Date field presentation options
+    approximate_date = BooleanField(
+        "Ask for an approximate date (month and year only)",
+        validators=[Optional()],
+        widget=GovCheckboxInput(),
+    )
+
     submit = SubmitField(widget=GovSubmitInput())
 
     def __init__(

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/partials/_advanced_formatting_options.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/partials/_advanced_formatting_options.html
@@ -9,6 +9,8 @@
       {{ form.prefix(params={"classes": "govuk-input--width-10", "label": {"classes": "govuk-!-font-weight-bold"} }) }}
       {{ form.suffix(params={"classes": "govuk-input--width-10", "label": {"classes": "govuk-!-font-weight-bold"} }) }}
       {{ form.width(params={"label": {"classes": "govuk-!-font-weight-bold"} }) }}
+    {% elif data_type == enum.question_type.DATE %}
+      {{ form.approximate_date(params={"label": {"classes": "govuk-!-font-weight-bold"} }) }}
     {% endif %}
   {% endset %}
 

--- a/tests/unit/common/collections/test_types.py
+++ b/tests/unit/common/collections/test_types.py
@@ -60,7 +60,16 @@ class TestSubmissionAnswerBaseModels:
             (IntegerAnswer, {"value": 50, "prefix": "£"}, {"value": 50, "prefix": "£"}),
             (IntegerAnswer, {"value": 50, "suffix": "lbs"}, {"value": 50, "suffix": "lbs"}),
             (SingleChoiceFromListAnswer, {"key": "key", "label": "label"}, {"key": "key", "label": "label"}),
-            (DateAnswer, {"answer": datetime.date(2023, 10, 5)}, {"answer": "2023-10-05"}),
+            (
+                DateAnswer,
+                {"answer": datetime.date(2023, 10, 5), "approximate_date": False},
+                {"answer": "2023-10-05", "approximate_date": False},
+            ),
+            (
+                DateAnswer,
+                {"answer": datetime.date(2023, 10, 1), "approximate_date": True},
+                {"answer": "2023-10-01", "approximate_date": True},
+            ),
         ),
     )
     def test_get_value_for_submission(self, model, data, submission_data):
@@ -93,8 +102,23 @@ class TestSubmissionAnswerBaseModels:
             (IntegerAnswer, {"value": 1_000_000, "prefix": "£"}, "£1,000,000"),
             (IntegerAnswer, {"value": 1_000_000, "suffix": "lbs"}, "1,000,000lbs"),
             (SingleChoiceFromListAnswer, {"key": "key", "label": "label"}, "label"),
-            (DateAnswer, {"answer": datetime.date(2023, 10, 5)}, "2023-10-05"),
+            (DateAnswer, {"answer": datetime.date(2023, 10, 5), "approximate_date": False}, "2023-10-05"),
+            (DateAnswer, {"answer": datetime.date(2023, 10, 1), "approximate_date": True}, "October 2023"),
         ),
     )
     def test_get_value_for_text_export(self, model, data, text_export_value):
         assert model(**data).get_value_for_text_export() == text_export_value
+
+    @pytest.mark.parametrize(
+        "model, data, json_export_value",
+        (
+            (IntegerAnswer, {"value": 50}, {"value": 50}),
+            (IntegerAnswer, {"value": 1_000_000, "prefix": "£"}, {"value": 1_000_000, "prefix": "£"}),
+            (IntegerAnswer, {"value": 1_000_000, "suffix": "lbs"}, {"value": 1_000_000, "suffix": "lbs"}),
+            (SingleChoiceFromListAnswer, {"key": "key1", "label": "label1"}, {"key": "key1", "label": "label1"}),
+            (DateAnswer, {"answer": datetime.date(2023, 10, 5), "approximate_date": False}, "2023-10-05"),
+            (DateAnswer, {"answer": datetime.date(2023, 10, 1), "approximate_date": True}, "October 2023"),
+        ),
+    )
+    def test_get_value_for_json_export(self, model, data, json_export_value):
+        assert model(**data).get_value_for_json_export() == json_export_value

--- a/tests/unit/common/forms/test_fields.py
+++ b/tests/unit/common/forms/test_fields.py
@@ -1,9 +1,11 @@
+import datetime
+
 from bs4 import BeautifulSoup
 from flask_wtf import FlaskForm
-from wtforms import RadioField, SelectMultipleField
+from wtforms import DateField, RadioField, SelectMultipleField
 from wtforms.validators import DataRequired
 
-from app.common.forms.fields import MHCLGCheckboxesInput, MHCLGRadioInput
+from app.common.forms.fields import MHCLGApproximateDateInput, MHCLGCheckboxesInput, MHCLGRadioInput
 
 
 class TestMHCLGRadioInput:
@@ -68,3 +70,24 @@ class TestMHCLGCheckboxesInput:
 
         last_checkbox = soup.select("input[type=checkbox]")[-1]
         assert last_checkbox["data-behaviour"] == "exclusive"
+
+
+class TestDateInput:
+    def test_approximate_date_input_renders(self):
+        class TestForm(FlaskForm):
+            field = DateField(
+                "test date",
+                default=datetime.date(2023, 5, 4),
+                widget=MHCLGApproximateDateInput(),
+                format=["%m %Y", "%b %Y", "%B %Y"],
+            )
+
+        form = TestForm()
+
+        soup = BeautifulSoup(str(form.field), "html.parser")
+        all_inputs = soup.find_all("input")
+        assert len(all_inputs) == 2
+        assert all_inputs[0].get("id") == "field-month"
+        assert all_inputs[0].get("value") == "05"
+        assert all_inputs[1].get("id") == "field-year"
+        assert all_inputs[1].get("value") == "2023"


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-770

## 📝 Description
Enhances the date question time to support an advanced presentation option of 'Approximate Date'. This allows users to enter just a month and year (eg. 'Roughly when did you lose your passport').

It updates the managed condition expressions for date to work with an approx date as well.

Underneath, it stores these approximate dates as the 1st of the month, which means we can treat the data as a `date` for comparison/maths etc.

## 📸 Show the thing (screenshots, gifs)

https://github.com/user-attachments/assets/3d91f9fd-f8d0-49fd-bdb7-a2decd41a1ae



## 🧪 Testing
Unit, integration and E2E tests updated to include approx date

## 📋 Developer Checklist


### Review Readiness
- [x ] PR title and description provide sufficient context for reviewers
- [x ] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- [ x] No N+1 query problems introduced
- [ ] Any new DB queries include appropriate where clauses based on the user's permissions

### Testing
- [x ] I have tested this change and it meets the acceptance criteria for the ticket
- [ ] I need the reviewer(s) to pull and run this change locally
- [x ] New (non-developer) functionality has appropriate unit and integration tests
- [ x] End-to-end tests have been updated (if applicable)
- [x ] Edge cases and error conditions are tested


