### PR TITLE
Prevent breaking referential integrity between components

### DIFF
--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -531,25 +531,21 @@ def _check_component_order_dependency(component: Component, swap_component: Comp
     )
 
     for c in child_components:
-        for condition in c.conditions:
-            # check against each of the possible options we're comparing against
-            if condition.managed and condition.managed.question_id in [c.id for c in child_swap_components]:
+        component_name = "question_groups" if c.is_group else "questions"
+        for cr in c.owned_component_references:
+            if cr.depends_on_component in child_swap_components:
                 raise DependencyOrderException(
-                    "You cannot move "
-                    + ("question groups" if c.is_group else "questions")
-                    + " above answers they depend on",
+                    f"You cannot move {component_name} above answers they depend on",
                     component,
                     swap_component,
                 )
 
     for c in child_swap_components:
-        for condition in c.conditions:
-            # check against each of the possible options we're comparing against
-            if condition.managed and condition.managed.question_id in [c.id for c in child_components]:
+        component_name = "question_groups" if c.is_group else "questions"
+        for cr in c.owned_component_references:
+            if cr.depends_on_component in child_components:
                 raise DependencyOrderException(
-                    "You cannot move answers below "
-                    + ("question groups" if c.is_group else "questions")
-                    + " that depend on them",
+                    f"You cannot move answers below {component_name} that depend on them",
                     swap_component,
                     component,
                 )


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-780

## 📝 Description
Now that components (questions and groups) can include answers from other questions in their text, we need to make it impossible to invalidate that reference after it's been set up. One of the ways this is possible is by setting up a reference from q2 to q1, and then making q2 be shown to a user before q1.

This logic already exists in the function `_check_component_order_dependency`, which is called when moving components up and down.

By changing the logic for this function to scan our new ComponentReference table instead of checking just the conditions on each component, we can achieve this check in a more reliable way. ComponentReferences are created whenever a question refers to another one, either in its text or through its expressions (conditions and validation).

## 📸 Show the thing (screenshots, gifs)
![2025-09-24 09 42 40](https://github.com/user-attachments/assets/ceb650c9-859b-4c72-8115-82cdf81f1f06)


## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- [x] No N+1 query problems introduced
- [x] Any new DB queries include appropriate where clauses based on the user's permissions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested