### PR TITLE
Prevent using questions from later in the task

### DIFF
--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -196,6 +196,9 @@ class Form(BaseModel):
         """Consistently returns all questions in the form, respecting order and any level of nesting."""
         return [q for q in get_ordered_nested_components(self.components) if isinstance(q, Question)]
 
+    def global_question_index(self, question: "Question") -> int:
+        return self.cached_questions.index(question)
+
     @cached_property
     def cached_all_components(self) -> list["Component"]:
         return get_ordered_nested_components(self.components)

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -1696,6 +1696,7 @@ class TestSelectContextSource:
 
         report = factories.collection.create(grant=authenticated_grant_admin_client.grant)
         form = factories.form.create(collection=report)
+        factories.question.create(form=form)
 
         with authenticated_grant_admin_client.session_transaction() as sess:
             sess["question"] = AddContextToQuestionSessionModel(


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-780

## 📝 Description
When inserting a reference to some contextual data, we currently let you add a reference to a question that is displayed after the one being edited.

Referentially this doesn't make sense, so let's not list those questions in the select dropdown.

Once the reference is set up, other integrity checks will prevent it from being broken (eg by re-ordering questions)


### Edge case

If you are trying to insert a reference into the first question in the task, the dropdown list is just empty. This is a broken case. Open for thoughts on how to address this, we could:

1. Instead of showing the dropdown, show some text saying something like "There are no earlier questions in this task to reference."
2. Have the radio option on the "select data source" page greyed out? Or throw an error on submission saying there are no questions available?

## 📸 Show the thing (screenshots, gifs)
![2025-09-24 12 46 27](https://github.com/user-attachments/assets/eefba9b9-1ba6-40d3-bc83-2ae420abbadc)

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- [x] No N+1 query problems introduced
- [x] Any new DB queries include appropriate where clauses based on the user's permissions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested