### PR TITLE
BAU: Interpolate contextual info in more places

### DIFF
--- a/app/deliver_grant_funding/forms.py
+++ b/app/deliver_grant_funding/forms.py
@@ -531,14 +531,14 @@ class ConditionSelectQuestionForm(FlaskForm):
     )
     submit = SubmitField("Continue", widget=GovSubmitInput())
 
-    def __init__(self, *args, question: "Component", **kwargs):  # type: ignore[no-untyped-def]
+    def __init__(self, *args, question: "Component", interpolate: Callable[[str], str], **kwargs):  # type: ignore[no-untyped-def]
         super().__init__(*args, **kwargs)
 
         self.target_question = question
 
         if len(get_supported_form_questions(question)) > 0:
             self.question.choices = [("", "")] + [
-                (str(question.id), f"{question.text} ({question.name})")
+                (str(question.id), f"{interpolate(question.text)} ({question.name})")
                 for question in get_supported_form_questions(question)
             ]  # type: ignore[assignment]
 

--- a/app/deliver_grant_funding/routes/reports.py
+++ b/app/deliver_grant_funding/routes/reports.py
@@ -1078,7 +1078,12 @@ def manage_guidance(grant_id: UUID, question_id: UUID) -> ResponseReturnValue:
 @has_grant_role(RoleEnum.ADMIN)
 def add_question_condition_select_question(grant_id: UUID, component_id: UUID) -> ResponseReturnValue:
     component = get_component_by_id(component_id)
-    form = ConditionSelectQuestionForm(question=component)
+    form = ConditionSelectQuestionForm(
+        question=component,
+        interpolate=SubmissionHelper.get_interpolator(
+            collection=component.form.collection, fallback_question_names=True
+        ),
+    )
 
     if form.validate_on_submit():
         depends_on_question = get_question_by_id(form.question.data)
@@ -1096,6 +1101,7 @@ def add_question_condition_select_question(grant_id: UUID, component_id: UUID) -
         component=component,
         grant=component.form.collection.grant,
         form=form,
+        interpolate=SubmissionHelper.get_interpolator(component.form.collection, fallback_question_names=True),
     )
 
 
@@ -1142,6 +1148,7 @@ def add_question_condition(grant_id: UUID, component_id: UUID, depends_on_questi
         grant=component.form.collection.grant,
         form=form,
         QuestionDataType=QuestionDataType,
+        interpolate=SubmissionHelper.get_interpolator(component.form.collection, fallback_question_names=True),
     )
 
 
@@ -1194,6 +1201,7 @@ def edit_question_condition(grant_id: UUID, expression_id: UUID) -> ResponseRetu
         expression=expression,
         QuestionDataType=QuestionDataType,
         depends_on_question=depends_on_question,
+        interpolate=SubmissionHelper.get_interpolator(component.form.collection, fallback_question_names=True),
     )
 
 
@@ -1232,6 +1240,7 @@ def add_question_validation(grant_id: UUID, question_id: UUID) -> ResponseReturn
         grant=question.form.collection.grant,
         form=form,
         QuestionDataType=QuestionDataType,
+        interpolate=SubmissionHelper.get_interpolator(question.form.collection, fallback_question_names=True),
     )
 
 
@@ -1292,6 +1301,7 @@ def edit_question_validation(grant_id: UUID, expression_id: UUID) -> ResponseRet
         confirm_deletion_form=confirm_deletion_form if "delete" in request.args else None,
         expression=expression,
         QuestionDataType=QuestionDataType,
+        interpolate=SubmissionHelper.get_interpolator(question.form.collection, fallback_question_names=True),
     )
 
 
@@ -1358,4 +1368,7 @@ def view_submission(grant_id: UUID, submission_id: UUID) -> ResponseReturnValue:
         "deliver_grant_funding/reports/view_submission.html",
         grant=helper.grant,
         helper=helper,
+        interpolate=SubmissionHelper.get_interpolator(
+            collection=helper.collection, fallback_question_names=True, submission_helper=helper
+        ),
     )

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/macros/question_table.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/macros/question_table.html
@@ -42,7 +42,7 @@
     {% set actions = [] %}
     {% set parent_has_multiple_questions_to_move = (question.parent.components if nested else parent.components)|length > 1 %}
     {% if role_can_edit and parent_has_multiple_questions_to_move %}
-      {% set visually_hidden_text = ("group of questions: " ~ question.text) if question.is_group else question.text %}
+      {% set visually_hidden_text = interpolate(("group of questions: " ~ question.text) if question.is_group else question.text) %}
       {%
         do actions.append({
           "text": "Move up",

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/_add_question_condition_context.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/_add_question_condition_context.html
@@ -4,10 +4,10 @@
   govukSummaryList({
     "rows": [{
       "key": { "text": "The question" if not component.is_group else "The question group" },
-      "value": { "text": component.text },
+      "value": { "text": interpolate(component.text) },
     }, {
       "key": { "text": "Depends on the answer to" },
-      "value": { "text": "(Not selected)" if not depends_on_question else depends_on_question.text },
+      "value": { "text": "(Not selected)" if not depends_on_question else interpolate(depends_on_question.text) },
     }],
     "classes": "app-!-border-top-line govuk-!-margin-bottom-8"
   })

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/edit_question.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/edit_question.html
@@ -159,7 +159,7 @@
 
             {% set key_html %}
               {# todo: would users find it useful to be able to link to the question being depended on from here? #}
-              <span>{{ depends_on.text }}</span>
+              <span>{{ interpolate(depends_on.text) }}</span>
             {% endset %}
 
 

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/manage_question_condition_select_condition_type.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/manage_question_condition_select_condition_type.html
@@ -47,7 +47,7 @@
 
       {% if form is not none %}
         {% set label_html %}
-          What does the answer <span class="govuk-visually-hidden">to {{ depends_on_question.text }}</span> need to be?
+          What does the answer <span class="govuk-visually-hidden">to {{ interpolate(depends_on_question.text) }}</span> need to be?
         {% endset %}
         {{ render_managed_expression_form(form, label_html=label_html, submit_label=submit_label) }}
       {% else %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/manage_question_validation.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/manage_question_validation.html
@@ -42,7 +42,7 @@
         govukSummaryList({
           "rows": [
             {"key": {"text": "Task"}, "value": {"text": question.form.title} },
-            {"key": {"text": "Question"}, "value": {"text": question.text} },
+            {"key": {"text": "Question"}, "value": {"text": interpolate(question.text)} },
           ],
           "classes": "app-!-border-top-line"
         })
@@ -50,7 +50,7 @@
 
       {% if form is not none %}
         {% set label_html %}
-          What does the answer <span class="govuk-visually-hidden">to {{ question.text }}</span> need to be?
+          What does the answer <span class="govuk-visually-hidden">to {{ interpolate(question.text) }}</span> need to be?
         {% endset %}
 
         {{ render_managed_expression_form(form, label_html=label_html, submit_label=submit_label) }}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/view_submission.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/view_submission.html
@@ -47,7 +47,7 @@
       {%
         do rows.append({
           "key": {
-            "text": question.text,
+            "text": interpolate(question.text),
             "classes": "govuk-!-font-weight-regular",
           },
           "value": {

--- a/app/developers/access_routes.py
+++ b/app/developers/access_routes.py
@@ -98,7 +98,13 @@ def ask_a_question(submission_id: uuid.UUID, question_id: uuid.UUID) -> Response
         runner.save_question_answer()
         return redirect(runner.next_url)
 
-    return render_template("developers/access/ask_a_question.html", runner=runner)
+    return render_template(
+        "developers/access/ask_a_question.html",
+        runner=runner,
+        interpolate=SubmissionHelper.get_interpolator(
+            runner.submission.collection, fallback_question_names=True, submission_helper=runner.submission
+        ),
+    )
 
 
 @developers_access_blueprint.route(

--- a/app/developers/templates/developers/access/ask_a_question.html
+++ b/app/developers/templates/developers/access/ask_a_question.html
@@ -2,7 +2,7 @@
 {% from "common/macros/collections.html" import collection_before with context %}
 {% extends "developers/access/base.html" %}
 
-{% set page_title = runner.component.text ~ " - " ~ runner.form.title %}
+{% set page_title = interpolate(runner.component.text) ~ " - " ~ runner.form.title %}
 
 {% set form = runner.question_form %}
 


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
We missed a couple of places where contextual information should be interpolated or use the fallback option of the question name. Let's interpolate in all those places and make sure we're not showing the safe question id, including on Access Grant Funding's form runner.

## 🧪 Testing
Pull the branch and check interpolation is happening in all these places that are updated

## 📋 Developer Checklist

### Review Readiness
- [X] PR title and description provide sufficient context for reviewers
- [X] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- ~[ ] No N+1 query problems introduced~
- ~[ ] Any new DB queries include appropriate where clauses based on the user's permissions~

### Testing
- ~[ ] I have tested this change and it meets the acceptance criteria for the ticket~
- ~[ ] I need the reviewer(s) to pull and run this change locally~
- ~[ ] New (non-developer) functionality has appropriate unit and integration tests~
- ~[ ] End-to-end tests have been updated (if applicable)~
- ~[ ] Edge cases and error conditions are tested~
