### PR TITLE
BAU: Strip empty space from single/multi line text inputs

### DIFF
--- a/app/common/collections/forms.py
+++ b/app/common/collections/forms.py
@@ -149,6 +149,7 @@ def build_question_form(  # noqa: C901
                     description=interpolate(text=question.hint or "", context=interpolation_context),
                     widget=GovTextInput(),
                     validators=[DataRequired(f"Enter the {question.name}")],
+                    filters=[lambda x: x.strip() if x else x],
                 )
             case QuestionDataType.TEXT_MULTI_LINE:
                 field = StringField(
@@ -165,6 +166,7 @@ def build_question_form(  # noqa: C901
                         if question.presentation_options.word_limit
                         else []
                     ),
+                    filters=[lambda x: x.strip() if x else x],
                 )
             case QuestionDataType.INTEGER:
                 field = IntegerField(


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
During a demo we spotted that single line text inputs weren't being stripped of empty space at the start/end of the strings, which looked odd when that answer was used in interpolated context.

This strips empty spaces from the answers given to these question types.

## 🧪 Testing
Pull the branch and try inputting some text with spaces at the start/end and see the empty spaces get stripped.

## 📋 Developer Checklist

### Review Readiness
- [X] PR title and description provide sufficient context for reviewers
- [X] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- ~[ ] No N+1 query problems introduced~
- ~[ ] Any new DB queries include appropriate where clauses based on the user's permissions~

### Testing
- ~[ ] I have tested this change and it meets the acceptance criteria for the ticket~
- ~[ ] I need the reviewer(s) to pull and run this change locally~
- ~[ ] New (non-developer) functionality has appropriate unit and integration tests~
- ~[ ] End-to-end tests have been updated (if applicable)~
- ~[ ] Edge cases and error conditions are tested~
