### PR TITLE
Redirect to group when editing a question in a group

### DIFF
--- a/app/deliver_grant_funding/routes/reports.py
+++ b/app/deliver_grant_funding/routes/reports.py
@@ -946,6 +946,14 @@ def edit_question(grant_id: UUID, question_id: UUID) -> ResponseReturnValue:  # 
             if "question" in session:
                 del session["question"]
 
+            if question.parent and question.parent.is_group:
+                return redirect(
+                    url_for(
+                        "deliver_grant_funding.list_group_questions",
+                        grant_id=grant_id,
+                        group_id=question.parent.id,
+                    )
+                )
             return redirect(
                 url_for(
                     "deliver_grant_funding.list_task_questions",


### PR DESCRIPTION
At the moment if you save edits to a question which is inside a group, you get redirect to the top of the task/form list of questions. This navigation feels wrong.