### PR TITLE
Change check-your-answers page to full width

### DIFF
--- a/app/deliver_grant_funding/templates/deliver_grant_funding/runner/check_your_answers.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/runner/check_your_answers.html
@@ -12,6 +12,6 @@
 
 {% block content %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">{{ collection_check_your_answers(runner) }}</div>
+    <div class="govuk-grid-column-full">{{ collection_check_your_answers(runner) }}</div>
   </div>
 {% endblock content %}

--- a/app/developers/templates/developers/access/check_your_answers.html
+++ b/app/developers/templates/developers/access/check_your_answers.html
@@ -12,6 +12,6 @@
 
 {% block content %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">{{ collection_check_your_answers(runner) }}</div>
+    <div class="govuk-grid-column-full">{{ collection_check_your_answers(runner) }}</div>
   </div>
 {% endblock content %}


### PR DESCRIPTION
## 🎫 Ticket
N/A

## 📝 Description
The check your answers summary list looks overly cramped and dense when in a two-thirds column. Given that it it limits the width of each column to less than a standard two-thirds, we should be able to increase the width of this component to full so that the question and answers have a little bit more room to spread out, which should generally increase readability.


## 📸 Show the thing (screenshots, gifs)
<!-- Include screenshots for UI changes, new features, or visual modifications -->
<!-- Use "Before" and "After" sections if showing changes to existing functionality -->

### Before
<img width="1000" height="1364" alt="image" src="https://github.com/user-attachments/assets/693e789e-b33b-4600-a775-61b3ecd62c5d" />


### After
<img width="1018" height="1180" alt="image" src="https://github.com/user-attachments/assets/19c9b2aa-f9e4-4631-b460-9d828e09d983" />