### PR TITLE
Updating env var to fix seg fault

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,7 +200,8 @@ follow_untyped_imports = true
 [tool.pytest.ini_options]
 env = [
     "FLASK_ENV=unit_test",
-    "DATABASE_URL=postgresql+psycopg://overridden-by-fixture"
+    "DATABASE_URL=postgresql+psycopg://overridden-by-fixture",
+    "PGGSSENCMODE=disable" #https://github.com/ged/ruby-pg/issues/538#issuecomment-1591629049
 ]
 markers = [
     "e2e: Run E2E (browser) tests using playwright",


### PR DESCRIPTION
Setting PGGSSENCMODE to disable when running pytest as it fixes a segmentation fault we saw after upgrading to MacOS Tahoe. The fix in this post seems to help: https://github.com/ged/ruby-pg/issues/538#issuecomment-1591629049

See also: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-GSSENCMODE
