### PR TITLE
BAU: Don't allow questions to reference themselves

### DIFF
--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -893,7 +893,7 @@ def _validate_and_sync_component_references(component: Component, expression_con
                     )
 
                 # Prevent manually injecting a reference to a question that appears later in the same form
-                if question.form.global_component_index(question) > question.form.global_component_index(component):
+                if question.form.global_component_index(question) >= question.form.global_component_index(component):
                     raise InvalidReferenceInExpression(
                         f"Reference is not valid: {wrapped_ref}", field_name=field_name, bad_reference=wrapped_ref
                     )

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -2255,6 +2255,18 @@ class TestValidateAndSyncComponentReferences:
                 ),
             )
 
+    def test_throws_error_on_referencing_same_question_in_form(self, db_session, factories):
+        question = factories.question.create()
+        question.text = f"Reference to (({question.safe_qid}))"
+
+        with pytest.raises(InvalidReferenceInExpression):
+            _validate_and_sync_component_references(
+                question,
+                ExpressionContext.build_expression_context(
+                    collection=question.form.collection, fallback_question_names=True, mode="interpolation"
+                ),
+            )
+
     def test_throws_error_on_unknown_references(self, db_session, factories):
         dependent_question = factories.question.create()
 


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
When inserting data from other questions into a question's text, hint or guidance we don't surface the current question in the flow, but a user could manually add a reference to itself we weren't catching it.

This change just raises an error if a user tries to manually reference the current question, as this wouldn't make sense in the context of the form and would look broken for grant recipients.

## 🧪 Testing
On main when editing a question, manually reference the same question as context in the question text/hint/guidance and save the question. It should let you save.

Pull the branch and try to do the same again; it should now raise an error, stopping you from referencing the question in itself.

## 📋 Developer Checklist

### Review Readiness
- [X] PR title and description provide sufficient context for reviewers
- [X] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- ~[ ] No N+1 query problems introduced~
- ~[ ] Any new DB queries include appropriate where clauses based on the user's permissions~

### Testing
- [X] I have tested this change and it meets the acceptance criteria for the ticket
- ~[ ] I need the reviewer(s) to pull and run this change locally~
- [X] New (non-developer) functionality has appropriate unit and integration tests
- ~[ ] End-to-end tests have been updated (if applicable)~
- [X] Edge cases and error conditions are tested
