### PR TITLE
Remove param from `build_expression_context`

### DIFF
--- a/app/common/expressions/__init__.py
+++ b/app/common/expressions/__init__.py
@@ -98,11 +98,11 @@ class ExpressionContext(ChainMap[str, Any]):
     @staticmethod
     def build_expression_context(
         collection: "Collection",
-        fallback_question_names: bool,
         mode: Literal["evaluation", "interpolation"],
         submission_helper: Optional["SubmissionHelper"] = None,
     ) -> "ExpressionContext":
         """Pulls together all of the context that we want to be able to expose to an expression when evaluating it."""
+        fallback_question_names = mode == "interpolation"
 
         assert len(ExpressionContext.ContextSources) == 1, (
             "When defining a new source of context for expressions, "

--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -87,13 +87,11 @@ class SubmissionHelper:
         self.cached_evaluation_context = ExpressionContext.build_expression_context(
             collection=self.submission.collection,
             submission_helper=self,
-            fallback_question_names=False,
             mode="evaluation",
         )
         self.cached_interpolation_context = ExpressionContext.build_expression_context(
             collection=self.submission.collection,
             submission_helper=self,
-            fallback_question_names=True,
             mode="interpolation",
         )
 
@@ -103,13 +101,12 @@ class SubmissionHelper:
 
     @staticmethod
     def get_interpolator(
-        collection: "Collection", fallback_question_names: bool, submission_helper: Optional["SubmissionHelper"] = None
+        collection: "Collection", submission_helper: Optional["SubmissionHelper"] = None
     ) -> Callable[[str], str]:
         return partial(
             interpolate,
             context=ExpressionContext.build_expression_context(
                 collection=collection,
-                fallback_question_names=fallback_question_names,
                 mode="interpolation",
                 submission_helper=submission_helper,
             ),

--- a/app/deliver_grant_funding/routes/api.py
+++ b/app/deliver_grant_funding/routes/api.py
@@ -29,7 +29,7 @@ def preview_guidance(collection_id: UUID) -> ResponseReturnValue:
 
     form = PreviewGuidanceForm()
     if form.validate_on_submit():
-        interpolate = SubmissionHelper.get_interpolator(collection, fallback_question_names=True)
+        interpolate = SubmissionHelper.get_interpolator(collection)
         return jsonify(
             PreviewGuidanceSuccessResponse(
                 guidance_html=interpolate(current_app.extensions["govuk_markdown"].convert(form.guidance.data))

--- a/app/deliver_grant_funding/routes/reports.py
+++ b/app/deliver_grant_funding/routes/reports.py
@@ -304,7 +304,7 @@ def change_group_name(grant_id: UUID, group_id: UUID) -> ResponseReturnValue:
             update_group(
                 db_group,
                 expression_context=ExpressionContext.build_expression_context(
-                    collection=db_group.form.collection, fallback_question_names=True, mode="interpolation"
+                    collection=db_group.form.collection, mode="interpolation"
                 ),
                 name=form.name.data,
             )
@@ -349,7 +349,7 @@ def change_group_display_options(grant_id: UUID, group_id: UUID) -> ResponseRetu
             update_group(
                 db_group,
                 expression_context=ExpressionContext.build_expression_context(
-                    collection=db_group.form.collection, fallback_question_names=True, mode="interpolation"
+                    collection=db_group.form.collection, mode="interpolation"
                 ),
                 presentation_options=QuestionPresentationOptions.from_group_form(form),
             )
@@ -422,7 +422,7 @@ def list_task_questions(grant_id: UUID, form_id: UUID) -> ResponseReturnValue:
         db_form=db_form,
         delete_form=delete_wtform,
         form=preview_form,
-        interpolate=SubmissionHelper.get_interpolator(collection=db_form.collection, fallback_question_names=True),
+        interpolate=SubmissionHelper.get_interpolator(collection=db_form.collection),
     )
 
 
@@ -464,7 +464,7 @@ def list_group_questions(grant_id: UUID, group_id: UUID) -> ResponseReturnValue:
         db_form=group.form,
         delete_form=delete_wtform,
         group=group,
-        interpolate=SubmissionHelper.get_interpolator(collection=group.form.collection, fallback_question_names=True),
+        interpolate=SubmissionHelper.get_interpolator(collection=group.form.collection),
     )
 
 
@@ -576,7 +576,7 @@ def add_question_group_display_options(grant_id: UUID, form_id: UUID) -> Respons
         group_name=add_question_group.group_name,
         form=wt_form,
         parent=parent,
-        interpolate=SubmissionHelper.get_interpolator(collection=form.collection, fallback_question_names=True),
+        interpolate=SubmissionHelper.get_interpolator(collection=form.collection),
     )
 
 
@@ -735,7 +735,7 @@ def add_question(grant_id: UUID, form_id: UUID) -> ResponseReturnValue:
                 items=wt_form.normalised_data_source_items,
                 presentation_options=QuestionPresentationOptions.from_question_form(wt_form),
                 expression_context=ExpressionContext.build_expression_context(
-                    collection=form.collection, fallback_question_names=True, mode="interpolation"
+                    collection=form.collection, mode="interpolation"
                 ),
                 parent=parent,
             )
@@ -821,7 +821,7 @@ def select_context_source_question(grant_id: UUID, form_id: UUID) -> ResponseRet
 
     wtform = SelectDataSourceQuestionForm(
         form=db_form,
-        interpolate=SubmissionHelper.get_interpolator(collection=db_form.collection, fallback_question_names=True),
+        interpolate=SubmissionHelper.get_interpolator(collection=db_form.collection),
         current_question=get_question_by_id(add_context_data.question_id) if add_context_data.question_id else None,
     )
 
@@ -935,7 +935,7 @@ def edit_question(grant_id: UUID, question_id: UUID) -> ResponseReturnValue:  # 
             update_question(
                 question=question,
                 expression_context=ExpressionContext.build_expression_context(
-                    collection=question.form.collection, fallback_question_names=True, mode="interpolation"
+                    collection=question.form.collection, mode="interpolation"
                 ),
                 text=wt_form.text.data,
                 hint=wt_form.hint.data,
@@ -991,9 +991,7 @@ def edit_question(grant_id: UUID, question_id: UUID) -> ResponseReturnValue:  # 
         form=wt_form,
         confirm_deletion_form=confirm_deletion_form if "delete" in request.args else None,
         managed_validation_available=get_managed_validators_by_data_type(question.data_type),
-        interpolate=SubmissionHelper.get_interpolator(
-            collection=question.form.collection, fallback_question_names=True
-        ),
+        interpolate=SubmissionHelper.get_interpolator(collection=question.form.collection),
     )
 
 
@@ -1028,7 +1026,7 @@ def manage_guidance(grant_id: UUID, question_id: UUID) -> ResponseReturnValue:
                 update_group(
                     cast("Group", question),
                     expression_context=ExpressionContext.build_expression_context(
-                        collection=question.form.collection, fallback_question_names=True, mode="interpolation"
+                        collection=question.form.collection, mode="interpolation"
                     ),
                     guidance_heading=form.guidance_heading.data,
                     guidance_body=form.guidance_body.data,
@@ -1037,7 +1035,7 @@ def manage_guidance(grant_id: UUID, question_id: UUID) -> ResponseReturnValue:
                 update_question(
                     cast("Question", question),
                     expression_context=ExpressionContext.build_expression_context(
-                        collection=question.form.collection, fallback_question_names=True, mode="interpolation"
+                        collection=question.form.collection, mode="interpolation"
                     ),
                     guidance_heading=form.guidance_heading.data,
                     guidance_body=form.guidance_body.data,
@@ -1074,9 +1072,7 @@ def manage_guidance(grant_id: UUID, question_id: UUID) -> ResponseReturnValue:
         grant=question.form.collection.grant,
         question=question,
         form=form,
-        interpolate=SubmissionHelper.get_interpolator(
-            collection=question.form.collection, fallback_question_names=True
-        ),
+        interpolate=SubmissionHelper.get_interpolator(collection=question.form.collection),
     )
 
 
@@ -1089,9 +1085,7 @@ def add_question_condition_select_question(grant_id: UUID, component_id: UUID) -
     component = get_component_by_id(component_id)
     form = ConditionSelectQuestionForm(
         question=component,
-        interpolate=SubmissionHelper.get_interpolator(
-            collection=component.form.collection, fallback_question_names=True
-        ),
+        interpolate=SubmissionHelper.get_interpolator(collection=component.form.collection),
     )
 
     if form.validate_on_submit():
@@ -1110,7 +1104,7 @@ def add_question_condition_select_question(grant_id: UUID, component_id: UUID) -
         component=component,
         grant=component.form.collection.grant,
         form=form,
-        interpolate=SubmissionHelper.get_interpolator(component.form.collection, fallback_question_names=True),
+        interpolate=SubmissionHelper.get_interpolator(component.form.collection),
     )
 
 
@@ -1157,7 +1151,7 @@ def add_question_condition(grant_id: UUID, component_id: UUID, depends_on_questi
         grant=component.form.collection.grant,
         form=form,
         QuestionDataType=QuestionDataType,
-        interpolate=SubmissionHelper.get_interpolator(component.form.collection, fallback_question_names=True),
+        interpolate=SubmissionHelper.get_interpolator(component.form.collection),
     )
 
 
@@ -1210,7 +1204,7 @@ def edit_question_condition(grant_id: UUID, expression_id: UUID) -> ResponseRetu
         expression=expression,
         QuestionDataType=QuestionDataType,
         depends_on_question=depends_on_question,
-        interpolate=SubmissionHelper.get_interpolator(component.form.collection, fallback_question_names=True),
+        interpolate=SubmissionHelper.get_interpolator(component.form.collection),
     )
 
 
@@ -1249,7 +1243,7 @@ def add_question_validation(grant_id: UUID, question_id: UUID) -> ResponseReturn
         grant=question.form.collection.grant,
         form=form,
         QuestionDataType=QuestionDataType,
-        interpolate=SubmissionHelper.get_interpolator(question.form.collection, fallback_question_names=True),
+        interpolate=SubmissionHelper.get_interpolator(question.form.collection),
     )
 
 
@@ -1310,7 +1304,7 @@ def edit_question_validation(grant_id: UUID, expression_id: UUID) -> ResponseRet
         confirm_deletion_form=confirm_deletion_form if "delete" in request.args else None,
         expression=expression,
         QuestionDataType=QuestionDataType,
-        interpolate=SubmissionHelper.get_interpolator(question.form.collection, fallback_question_names=True),
+        interpolate=SubmissionHelper.get_interpolator(question.form.collection),
     )
 
 
@@ -1377,7 +1371,5 @@ def view_submission(grant_id: UUID, submission_id: UUID) -> ResponseReturnValue:
         "deliver_grant_funding/reports/view_submission.html",
         grant=helper.grant,
         helper=helper,
-        interpolate=SubmissionHelper.get_interpolator(
-            collection=helper.collection, fallback_question_names=True, submission_helper=helper
-        ),
+        interpolate=SubmissionHelper.get_interpolator(collection=helper.collection, submission_helper=helper),
     )

--- a/app/developers/access_routes.py
+++ b/app/developers/access_routes.py
@@ -102,7 +102,7 @@ def ask_a_question(submission_id: uuid.UUID, question_id: uuid.UUID) -> Response
         "developers/access/ask_a_question.html",
         runner=runner,
         interpolate=SubmissionHelper.get_interpolator(
-            runner.submission.collection, fallback_question_names=True, submission_helper=runner.submission
+            runner.submission.collection, submission_helper=runner.submission
         ),
     )
 

--- a/app/developers/commands.py
+++ b/app/developers/commands.py
@@ -307,9 +307,7 @@ def sync_component_references() -> None:
     for component in db.session.query(Component).all():
         _validate_and_sync_component_references(
             component,
-            ExpressionContext.build_expression_context(
-                collection=component.form.collection, fallback_question_names=True, mode="interpolation"
-            ),
+            ExpressionContext.build_expression_context(collection=component.form.collection, mode="interpolation"),
         )
 
     count = db.session.query(Component).count()

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -2191,7 +2191,7 @@ class TestValidateAndSyncComponentReferences:
         _validate_and_sync_component_references(
             dependent_question,
             ExpressionContext.build_expression_context(
-                collection=dependent_question.form.collection, fallback_question_names=True, mode="interpolation"
+                collection=dependent_question.form.collection, mode="interpolation"
             ),
         )
 
@@ -2208,7 +2208,7 @@ class TestValidateAndSyncComponentReferences:
         _validate_and_sync_component_references(
             dependent_question,
             ExpressionContext.build_expression_context(
-                collection=dependent_question.form.collection, fallback_question_names=True, mode="interpolation"
+                collection=dependent_question.form.collection, mode="interpolation"
             ),
         )
         db_session.flush()
@@ -2230,7 +2230,7 @@ class TestValidateAndSyncComponentReferences:
         _validate_and_sync_component_references(
             dependent_question,
             ExpressionContext.build_expression_context(
-                collection=dependent_question.form.collection, fallback_question_names=True, mode="interpolation"
+                collection=dependent_question.form.collection, mode="interpolation"
             ),
         )
         db_session.flush()
@@ -2251,7 +2251,7 @@ class TestValidateAndSyncComponentReferences:
             _validate_and_sync_component_references(
                 dependent_question,
                 ExpressionContext.build_expression_context(
-                    collection=dependent_question.form.collection, fallback_question_names=True, mode="interpolation"
+                    collection=dependent_question.form.collection, mode="interpolation"
                 ),
             )
 
@@ -2262,9 +2262,7 @@ class TestValidateAndSyncComponentReferences:
         with pytest.raises(InvalidReferenceInExpression):
             _validate_and_sync_component_references(
                 question,
-                ExpressionContext.build_expression_context(
-                    collection=question.form.collection, fallback_question_names=True, mode="interpolation"
-                ),
+                ExpressionContext.build_expression_context(collection=question.form.collection, mode="interpolation"),
             )
 
     def test_throws_error_on_unknown_references(self, db_session, factories):
@@ -2277,7 +2275,7 @@ class TestValidateAndSyncComponentReferences:
             _validate_and_sync_component_references(
                 dependent_question,
                 ExpressionContext.build_expression_context(
-                    collection=dependent_question.form.collection, fallback_question_names=True, mode="interpolation"
+                    collection=dependent_question.form.collection, mode="interpolation"
                 ),
             )
 
@@ -2294,7 +2292,7 @@ class TestValidateAndSyncComponentReferences:
             _validate_and_sync_component_references(
                 dependent_question,
                 ExpressionContext.build_expression_context(
-                    collection=dependent_question.form.collection, fallback_question_names=True, mode="interpolation"
+                    collection=dependent_question.form.collection, mode="interpolation"
                 ),
             )
 
@@ -2312,7 +2310,7 @@ class TestValidateAndSyncComponentReferences:
             _validate_and_sync_component_references(
                 dependent_question,
                 ExpressionContext.build_expression_context(
-                    collection=dependent_question.form.collection, fallback_question_names=True, mode="interpolation"
+                    collection=dependent_question.form.collection, mode="interpolation"
                 ),
             )
 
@@ -2337,7 +2335,7 @@ class TestValidateAndSyncComponentReferences:
         _validate_and_sync_component_references(
             dependent_question,
             ExpressionContext.build_expression_context(
-                collection=dependent_question.form.collection, fallback_question_names=True, mode="interpolation"
+                collection=dependent_question.form.collection, mode="interpolation"
             ),
         )
         db_session.flush()
@@ -2359,7 +2357,7 @@ class TestValidateAndSyncComponentReferences:
         _validate_and_sync_component_references(
             group,
             ExpressionContext.build_expression_context(
-                collection=referenced_question.form.collection, fallback_question_names=True, mode="interpolation"
+                collection=referenced_question.form.collection, mode="interpolation"
             ),
         )
         db_session.flush()

--- a/tests/models.py
+++ b/tests/models.py
@@ -605,9 +605,7 @@ class _QuestionFactory(SQLAlchemyModelFactory):
 
         _validate_and_sync_component_references(
             self,
-            ExpressionContext.build_expression_context(
-                collection=self.form.collection, fallback_question_names=True, mode="interpolation"
-            ),
+            ExpressionContext.build_expression_context(collection=self.form.collection, mode="interpolation"),
         )
 
         # Wipe the cache of questions on a form - because we're likely to be creating more forms/questions
@@ -677,9 +675,7 @@ class _GroupFactory(SQLAlchemyModelFactory):
 
         _validate_and_sync_component_references(
             self,
-            ExpressionContext.build_expression_context(
-                collection=self.form.collection, fallback_question_names=True, mode="interpolation"
-            ),
+            ExpressionContext.build_expression_context(collection=self.form.collection, mode="interpolation"),
         )
 
         # Wipe the cache of questions on a form - because we're likely to be creating more forms/questions

--- a/tests/unit/deliver_grant_funding/test_forms.py
+++ b/tests/unit/deliver_grant_funding/test_forms.py
@@ -237,9 +237,7 @@ class TestSelectDataSourceQuestionForm:
 
         form = SelectDataSourceQuestionForm(
             form=questions[2].form,
-            interpolate=SubmissionHelper.get_interpolator(
-                collection=questions[2].form.collection, fallback_question_names=True
-            ),
+            interpolate=SubmissionHelper.get_interpolator(collection=questions[2].form.collection),
             current_question=questions[2],
         )
 
@@ -258,9 +256,7 @@ class TestSelectDataSourceQuestionForm:
 
         form = SelectDataSourceQuestionForm(
             form=questions[2].form,
-            interpolate=SubmissionHelper.get_interpolator(
-                collection=questions[2].form.collection, fallback_question_names=True
-            ),
+            interpolate=SubmissionHelper.get_interpolator(collection=questions[2].form.collection),
             current_question=questions[2],
         )
 
@@ -271,9 +267,7 @@ class TestSelectDataSourceQuestionForm:
         group.presentation_options.show_questions_on_the_same_page = True
         form = SelectDataSourceQuestionForm(
             form=questions[2].form,
-            interpolate=SubmissionHelper.get_interpolator(
-                collection=questions[2].form.collection, fallback_question_names=True
-            ),
+            interpolate=SubmissionHelper.get_interpolator(collection=questions[2].form.collection),
             current_question=questions[2],
         )
 


### PR DESCRIPTION
We always want to fall back on question names when interpolating expressions, and we can't fallback when evaluating them. So let's remove this redundant parameter to clean up the calls a little bit.