### PR TITLE
Prepare to remove data source item reference table

### DIFF
--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-003_db_component_refs
+004_migrate_data_source_refs

--- a/app/common/data/migrations/versions/004_migrate_data_source_refs.py
+++ b/app/common/data/migrations/versions/004_migrate_data_source_refs.py
@@ -1,0 +1,34 @@
+"""empty message
+
+Revision ID: 004_migrate_data_source_refs
+Revises: 003_db_component_refs
+Create Date: 2025-09-25 12:05:32.549245
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "004_migrate_data_source_refs"
+down_revision = "003_db_component_refs"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("component_reference", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("depends_on_data_source_item_id", sa.Uuid(), nullable=True))
+        batch_op.create_foreign_key(
+            batch_op.f("fk_component_reference_depends_on_data_source_item_id_data_source_item"),
+            "data_source_item",
+            ["depends_on_data_source_item_id"],
+            ["id"],
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("component_reference", schema=None) as batch_op:
+        batch_op.drop_constraint(
+            batch_op.f("fk_component_reference_depends_on_data_source_item_id_data_source_item"), type_="foreignkey"
+        )
+        batch_op.drop_column("depends_on_data_source_item_id")

--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -579,6 +579,12 @@ class DataSourceItem(BaseModel):
     references: Mapped[list["DataSourceItemReference"]] = relationship(
         "DataSourceItemReference", back_populates="data_source_item"
     )
+    component_references: Mapped[list["ComponentReference"]] = relationship(
+        "ComponentReference",
+        back_populates="depends_on_data_source_item",
+        # explicitly disable cascading deletes so that ComponentReference can protect the DataSourceItems
+        passive_deletes="all",
+    )
 
     __table_args__ = (
         UniqueConstraint("data_source_id", "order", name="uq_data_source_id_order", deferrable=True),
@@ -622,6 +628,9 @@ class ComponentReference(BaseModel):
     depends_on_component: Mapped[Component] = relationship(
         "Component", foreign_keys=[depends_on_component_id], back_populates="depended_on_by"
     )
+
+    depends_on_data_source_item_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("data_source_item.id"))
+    depends_on_data_source_item: Mapped[DataSourceItem | None] = relationship("DataSourceItem")
 
     # Mirror columns from the referenced component for ordering the Component.component_references relationship
     _sort_form_id: Mapped[uuid.UUID] = column_property(

--- a/app/developers/commands.py
+++ b/app/developers/commands.py
@@ -285,8 +285,8 @@ def add_all_components_flat(component: Component, users: set[User], grant_export
             for reference in data_source_item.references:
                 grant_export["data_source_item_references"].append(to_dict(reference))
 
-        for component_reference in component.owned_component_references:
-            grant_export["component_references"].append(to_dict(component_reference))
+    for component_reference in component.owned_component_references:
+        grant_export["component_references"].append(to_dict(component_reference))
 
     if component.is_group:
         for sub_component in component.components:
@@ -299,7 +299,7 @@ def add_all_components_flat(component: Component, users: set[User], grant_export
 def sync_component_references() -> None:
     click.echo("Syncing all component references.")
 
-    count = db.session.query(Component).count()
+    count = db.session.query(ComponentReference).count()
     click.echo(f"Deleting {count} component references.")
 
     db.session.execute(delete(ComponentReference))
@@ -310,7 +310,7 @@ def sync_component_references() -> None:
             ExpressionContext.build_expression_context(collection=component.form.collection, mode="interpolation"),
         )
 
-    count = db.session.query(Component).count()
+    count = db.session.query(ComponentReference).count()
 
     db.session.commit()
 

--- a/app/developers/data/grants.json
+++ b/app/developers/data/grants.json
@@ -16,8 +16,99 @@
         {
           "component_id": "b9da63b3-2cff-4523-93ef-d282670ba61e",
           "depends_on_component_id": "65664e18-722d-484f-8488-c851c5c5de36",
+          "depends_on_data_source_item_id": "12a0b4a5-18e6-4a43-a72d-4a5cde866efd",
           "expression_id": "a314e646-7871-4d3c-b2f4-b7bd3ec54a57",
-          "id": "ba518076-96cd-464a-a566-52c2a6bbda8e"
+          "id": "4682b01a-054b-4939-bfbf-0367650f60d7"
+        },
+        {
+          "component_id": "4988b724-7b83-4b09-899b-3885fed52be1",
+          "depends_on_component_id": "65664e18-722d-484f-8488-c851c5c5de36",
+          "depends_on_data_source_item_id": "11dd117b-48b5-45a3-b838-a34d7e3fc405",
+          "expression_id": "6e5f0e5d-42b3-45ba-a363-0cf4023755de",
+          "id": "2f66be25-350e-4114-919c-67056e65b8f5"
+        },
+        {
+          "component_id": "0be64f3f-e841-48e2-aeeb-203dcc8f077d",
+          "depends_on_component_id": "058d7d3a-3e5e-4b94-9a81-57882961c59a",
+          "id": "10173b4a-7882-47dc-b1f3-259058a029ce"
+        },
+        {
+          "component_id": "db969e7d-01fc-42fa-9be6-cb5736dbfc57",
+          "depends_on_component_id": "058d7d3a-3e5e-4b94-9a81-57882961c59a",
+          "id": "14ec2fb9-d8a1-4c7d-9ce9-0cb714480cbf"
+        },
+        {
+          "component_id": "233960c6-2eac-4bef-bccd-0f0bee3a94e8",
+          "depends_on_component_id": "e5ef3248-6c32-4554-b4a7-4d286cdb3f6a",
+          "depends_on_data_source_item_id": "625963b4-06f8-44fe-bcc6-afde03b20040",
+          "expression_id": "28687a63-37b5-44f6-94a6-aa81d6310b7d",
+          "id": "115580d3-ce92-4e7c-a7d1-a9e3b92ba33a"
+        },
+        {
+          "component_id": "6e42d5ac-1475-4e3a-89f0-39c9ab1ac2d1",
+          "depends_on_component_id": "d99b94c3-66fa-4449-b4c4-ac5a2caeb8c9",
+          "expression_id": "fac76323-0d53-427f-ad85-2522a33c77e4",
+          "id": "a5df4911-602f-4f69-9d6d-11c5dc9baf74"
+        },
+        {
+          "component_id": "a4af0ddd-9d74-49d3-b4ff-3f2504f2a8d3",
+          "depends_on_component_id": "a4af0ddd-9d74-49d3-b4ff-3f2504f2a8d3",
+          "expression_id": "38eb1996-d8f8-44bd-8464-7c992a477123",
+          "id": "3ec2503e-d096-4a2f-82a3-c31119e64c75"
+        },
+        {
+          "component_id": "46068ea5-7e83-476e-91f4-71e87a1cc1a0",
+          "depends_on_component_id": "46068ea5-7e83-476e-91f4-71e87a1cc1a0",
+          "expression_id": "cf097d73-7286-4c35-aca4-d68eb14718d8",
+          "id": "9f6e2c24-a7ad-44b9-ac0e-4533d3529bf1"
+        },
+        {
+          "component_id": "e3858acb-ac9a-46e3-af20-553b48a9af10",
+          "depends_on_component_id": "46068ea5-7e83-476e-91f4-71e87a1cc1a0",
+          "expression_id": "4a97de8f-078d-4a63-ac4e-bb8025309929",
+          "id": "8ffc5f8f-342f-4ac7-b990-317ad1091a80"
+        },
+        {
+          "component_id": "0c48320f-0b45-4686-8bed-5a09509f7f8b",
+          "depends_on_component_id": "0c48320f-0b45-4686-8bed-5a09509f7f8b",
+          "expression_id": "319bfe99-75cb-45da-a45a-334024869bf2",
+          "id": "8b09406d-7782-4447-bf57-7a66a3f78fe2"
+        },
+        {
+          "component_id": "0e6df617-b770-4525-9c06-6fdbcca72a10",
+          "depends_on_component_id": "0e6df617-b770-4525-9c06-6fdbcca72a10",
+          "expression_id": "4ad122fe-ef03-44ae-a107-ca1d9f987e09",
+          "id": "11e462ad-6ffa-46e1-8470-e69d415bbf92"
+        },
+        {
+          "component_id": "22613139-724f-41d7-84a3-3549550c6a4b",
+          "depends_on_component_id": "0e6df617-b770-4525-9c06-6fdbcca72a10",
+          "expression_id": "cfa12ef8-bfd2-4077-96a4-cb3362ff45c4",
+          "id": "77a2bc9a-61d0-4478-b2ca-439513044d06"
+        },
+        {
+          "component_id": "677b317f-37cd-456c-905f-f3324f905e4a",
+          "depends_on_component_id": "897480b2-794d-416b-a827-2f4f2e8f5843",
+          "expression_id": "327ce841-a7ee-4ac3-b0be-f0d791b0f89e",
+          "id": "5eef7648-1ad2-494d-b3a0-c853a78ac43e"
+        },
+        {
+          "component_id": "b6e4dd70-7285-4595-9a1c-f1dfe7f68521",
+          "depends_on_component_id": "c1f6fdab-3e79-48ae-9c75-1210588afc1c",
+          "expression_id": "7930fb4c-84b8-40e3-9779-0ce9d7f7632a",
+          "id": "1b32aa76-520d-4385-b138-5519c0e77756"
+        },
+        {
+          "component_id": "19fc71ff-ec1b-414a-b8b9-52502c0d4617",
+          "depends_on_component_id": "c1f6fdab-3e79-48ae-9c75-1210588afc1c",
+          "expression_id": "b4c6550f-c0b9-4367-847a-f5852f53da9f",
+          "id": "82c8021d-cd5d-4d03-9f40-0bc42538d6e3"
+        },
+        {
+          "component_id": "ea608b3b-ff0c-4733-9ff4-29ac31868200",
+          "depends_on_component_id": "6452da2c-0154-4af1-8d96-f668edffa36a",
+          "expression_id": "0ee9c50f-dcd4-40d8-bcd4-cb04de7c54d0",
+          "id": "9a08fda4-6587-45a9-bfec-6b83a39c9c06"
         }
       ],
       "data_source_item_references": [
@@ -1577,370 +1668,1593 @@
       ],
       "component_references": [
         {
+          "component_id": "62a8bd04-08e0-4d92-8422-017aa16feafc",
+          "depends_on_component_id": "0faf4b7b-bed2-4c29-b4f9-90fe3a9d2768",
+          "expression_id": "be5a692c-874c-4bb1-a63b-f868ed39022a",
+          "id": "5c865ae6-291d-4a8d-8bef-99a3827065fe"
+        },
+        {
+          "component_id": "14f1872c-c092-4680-a3fa-60b09d9cced9",
+          "depends_on_component_id": "14f1872c-c092-4680-a3fa-60b09d9cced9",
+          "expression_id": "98e675cb-fe88-47ab-a18d-10dc584dfd28",
+          "id": "80f21d76-f46b-4223-b86e-6ce6fbe57fb1"
+        },
+        {
+          "component_id": "86209fa6-2192-4425-826c-3cfd9da964e7",
+          "depends_on_component_id": "0faf4b7b-bed2-4c29-b4f9-90fe3a9d2768",
+          "expression_id": "6e72d48c-b6fb-4a2a-a2f4-a3942ba29999",
+          "id": "5e93a8de-0ac2-495e-b2c3-d5acb3e2b539"
+        },
+        {
+          "component_id": "cce0b414-b5f1-44e9-b089-9356b6995567",
+          "depends_on_component_id": "14f1872c-c092-4680-a3fa-60b09d9cced9",
+          "expression_id": "0f76438a-6025-40b6-a4bd-42f16a585d89",
+          "id": "04e68bfb-cda4-4c32-9067-947fb28a4b69"
+        },
+        {
+          "component_id": "8ba008a1-a419-445f-a9bd-f3bb6cdcbfdc",
+          "depends_on_component_id": "14f1872c-c092-4680-a3fa-60b09d9cced9",
+          "expression_id": "0a9b7b7c-bb25-4cb9-ad90-5af4fdb6d32e",
+          "id": "121fde07-790e-4d3c-adc3-654f9e29b58d"
+        },
+        {
+          "component_id": "1c94b9c4-82a8-4719-8aaa-84eb6a0a7455",
+          "depends_on_component_id": "14f1872c-c092-4680-a3fa-60b09d9cced9",
+          "expression_id": "cb3d8380-5419-4e83-8670-7c1440463b66",
+          "id": "206a765e-eb4f-4f08-8e2d-753a58a3038e"
+        },
+        {
+          "component_id": "11403e70-d280-4978-9cc6-1fed2514704a",
+          "depends_on_component_id": "14f1872c-c092-4680-a3fa-60b09d9cced9",
+          "expression_id": "54af6006-e07b-4f26-8ec4-57ed4972e5ad",
+          "id": "c985b285-8c3d-441d-a624-3eb2394eab45"
+        },
+        {
+          "component_id": "e3cd1f14-2c65-4340-b8eb-ecc369cdc8b3",
+          "depends_on_component_id": "14f1872c-c092-4680-a3fa-60b09d9cced9",
+          "expression_id": "35864931-9e66-49ad-9e07-236ad9611ae4",
+          "id": "7a7dae45-b22c-4d28-90d2-a0c1a183c00f"
+        },
+        {
+          "component_id": "1a74455f-d4d0-48c7-8ee0-3660221c1a76",
+          "depends_on_component_id": "14f1872c-c092-4680-a3fa-60b09d9cced9",
+          "expression_id": "cb1a23e8-c5c4-4ce6-8110-46a0d966fe2b",
+          "id": "e2d0400f-ed56-48e3-89f0-6f81ebfd6366"
+        },
+        {
+          "component_id": "30e22749-ab20-46a2-912d-3d1e4d0e72f5",
+          "depends_on_component_id": "14f1872c-c092-4680-a3fa-60b09d9cced9",
+          "expression_id": "7ff22f10-d146-4280-9db0-f2ab546af388",
+          "id": "9317d4e6-8663-4166-a82a-ab0197f0a0d0"
+        },
+        {
+          "component_id": "ef994f67-eaab-4056-87bb-784995d5d742",
+          "depends_on_component_id": "14f1872c-c092-4680-a3fa-60b09d9cced9",
+          "expression_id": "3a526abf-c268-4c78-bcb5-537ba3245005",
+          "id": "5c739022-fc31-404b-9ee7-bb40c1c279cc"
+        },
+        {
+          "component_id": "54da3c53-c3be-4ef4-bda7-739d444e576f",
+          "depends_on_component_id": "14f1872c-c092-4680-a3fa-60b09d9cced9",
+          "expression_id": "1ae79999-37cb-43a9-a7c0-d1610e736c1e",
+          "id": "5b33a16d-a877-4781-b345-cf3450739ab3"
+        },
+        {
+          "component_id": "310c17af-1885-4760-89c6-9fb7b38a0075",
+          "depends_on_component_id": "0faf4b7b-bed2-4c29-b4f9-90fe3a9d2768",
+          "expression_id": "66faa030-63a7-4856-b7ff-312629c330bf",
+          "id": "f594dfac-1520-4496-8e7b-252cacc8df19"
+        },
+        {
           "component_id": "3ab8c5fd-d327-4101-a138-21640e4e99c6",
           "depends_on_component_id": "f0a87151-83ac-41fa-a57b-ab47b480d551",
+          "depends_on_data_source_item_id": "289d0349-a14a-40f7-987d-825a8ce61b59",
           "expression_id": "aec51b61-ed67-4b10-8288-4ad261270f8c",
-          "id": "1c360fc5-b28e-4dc6-8a4d-0bd8b3747343"
+          "id": "55033c9d-4b37-44e2-82e7-47b7c2b033c9"
+        },
+        {
+          "component_id": "fe24a087-ee0c-4c80-8428-338b83416841",
+          "depends_on_component_id": "3ab8c5fd-d327-4101-a138-21640e4e99c6",
+          "depends_on_data_source_item_id": "aacd8075-8c5b-435b-b80b-eb45f2c731dd",
+          "expression_id": "71cd0bb7-a982-4102-a1e3-71c3a23b2cd8",
+          "id": "a4e10c8b-485b-4042-945f-ff0c7e976d94"
         },
         {
           "component_id": "5571c974-e874-457d-9a05-650faeae651b",
           "depends_on_component_id": "f0a87151-83ac-41fa-a57b-ab47b480d551",
+          "depends_on_data_source_item_id": "c10ee801-4e5b-45d9-b82d-d5fc167cb1a3",
           "expression_id": "593a31f5-a83e-4f08-8016-93a416424bae",
-          "id": "ab4daad3-50cb-4ade-a379-841ae5300904"
+          "id": "bea9d149-1184-4415-92ab-b2d7222ad279"
         },
         {
           "component_id": "22304888-7f6b-44c2-b73e-547e1c04378b",
           "depends_on_component_id": "5571c974-e874-457d-9a05-650faeae651b",
+          "depends_on_data_source_item_id": "d31dd20c-4c10-420a-afab-600f68219cc4",
           "expression_id": "7f17374d-0e02-4bea-8398-2835ab20a78e",
-          "id": "09e24ec7-5cdd-48eb-ab04-0a7d450d9f21"
+          "id": "405e34a4-95ba-4dee-83dd-bce78e130676"
+        },
+        {
+          "component_id": "3f86575e-901b-4cff-a95f-b064d2fb00ab",
+          "depends_on_component_id": "22304888-7f6b-44c2-b73e-547e1c04378b",
+          "depends_on_data_source_item_id": "8d1c87ad-a1b2-49c5-9352-ee214d367193",
+          "expression_id": "f84c9671-6b09-4ce3-bece-7a6e46affbc8",
+          "id": "92d9073f-5d1f-486c-9b57-df690c5d1680"
+        },
+        {
+          "component_id": "1a4fff3c-0340-428a-8a3f-3bc26215506b",
+          "depends_on_component_id": "5571c974-e874-457d-9a05-650faeae651b",
+          "depends_on_data_source_item_id": "910ab0c5-3401-4940-ae8c-ca318ced95e6",
+          "expression_id": "c5d07a72-a471-41f4-a62c-0231ec633000",
+          "id": "13651bdd-8211-4e34-807c-690269b09078"
+        },
+        {
+          "component_id": "6b247b27-9372-46b0-ab93-13893445b992",
+          "depends_on_component_id": "5571c974-e874-457d-9a05-650faeae651b",
+          "depends_on_data_source_item_id": "910ab0c5-3401-4940-ae8c-ca318ced95e6",
+          "expression_id": "791c4a9b-8bb4-41e0-9b7a-e76d18fb449d",
+          "id": "560043ef-e772-458f-9aa0-85ca126cc0d2"
+        },
+        {
+          "component_id": "6b247b27-9372-46b0-ab93-13893445b992",
+          "depends_on_component_id": "6b247b27-9372-46b0-ab93-13893445b992",
+          "expression_id": "2db7f35c-3258-4511-a3ed-7150d27cf204",
+          "id": "5a305afc-8776-4b0e-8338-2a3891800ca8"
+        },
+        {
+          "component_id": "39323a70-9b4a-4231-a3a3-b768add7995a",
+          "depends_on_component_id": "1a4fff3c-0340-428a-8a3f-3bc26215506b",
+          "expression_id": "46b27142-78b6-432e-95a4-3bc4128f7d3c",
+          "id": "fa61793f-ce48-4016-b51f-48be6db3ffe3"
+        },
+        {
+          "component_id": "07005828-3b88-49cc-9aba-904b82e0482d",
+          "depends_on_component_id": "1a4fff3c-0340-428a-8a3f-3bc26215506b",
+          "expression_id": "ef58364e-064f-4f7f-897b-ffc62626f508",
+          "id": "13288b01-698f-45af-b377-4a309e5c19df"
+        },
+        {
+          "component_id": "74758a79-3986-42eb-8342-700ea3f3e78c",
+          "depends_on_component_id": "5571c974-e874-457d-9a05-650faeae651b",
+          "depends_on_data_source_item_id": "910ab0c5-3401-4940-ae8c-ca318ced95e6",
+          "expression_id": "ea51e8a4-f2f3-419b-8d12-3ccb29cc675f",
+          "id": "293dbbf5-fbf6-430c-817d-055fb0a77031"
         },
         {
           "component_id": "fc126325-bbb2-4f21-9a4e-31251eb3697c",
           "depends_on_component_id": "5571c974-e874-457d-9a05-650faeae651b",
+          "depends_on_data_source_item_id": "910ab0c5-3401-4940-ae8c-ca318ced95e6",
           "expression_id": "3586d88a-e61b-445f-ac34-533170e8f4b1",
-          "id": "3822adf9-caa7-4f2b-847c-6b41f488ad29"
+          "id": "f2a1177e-54d8-4f70-a2bb-4850e171f313"
         },
         {
           "component_id": "e0ae0406-e445-45d3-be39-5d1e19c812d6",
           "depends_on_component_id": "fc126325-bbb2-4f21-9a4e-31251eb3697c",
+          "depends_on_data_source_item_id": "e5ea629f-d9ec-44b9-881b-160f0b3982d7",
           "expression_id": "920fd926-1b22-459b-b397-1f9d205b215c",
-          "id": "82109433-0bf7-4303-8924-811237e7fb57"
+          "id": "7d8962f4-74c9-411b-9d17-f137058a18f8"
+        },
+        {
+          "component_id": "c7f09d87-3ce0-40db-8bef-04305a506d95",
+          "depends_on_component_id": "e0ae0406-e445-45d3-be39-5d1e19c812d6",
+          "depends_on_data_source_item_id": "05cb8ddf-8877-47d9-8bd3-d77af3eae32e",
+          "expression_id": "31e7fb1a-cec9-4666-b1ff-abfa61f0b337",
+          "id": "36ab45d2-c039-45d8-b47d-722ec566574e"
         },
         {
           "component_id": "d88b714e-9b30-4039-9e2c-e520a25385f8",
           "depends_on_component_id": "fc126325-bbb2-4f21-9a4e-31251eb3697c",
+          "depends_on_data_source_item_id": "c4ce11f4-6879-43a0-8815-79ea6d190060",
           "expression_id": "145666ef-07bb-4662-94b8-73a83433921f",
-          "id": "50ef5ed1-03c2-42b8-aa22-67a7bc4c7846"
+          "id": "33701eb0-e7c6-4428-a4e2-ff89dddab811"
+        },
+        {
+          "component_id": "d88b714e-9b30-4039-9e2c-e520a25385f8",
+          "depends_on_component_id": "fc126325-bbb2-4f21-9a4e-31251eb3697c",
+          "depends_on_data_source_item_id": "e5ea629f-d9ec-44b9-881b-160f0b3982d7",
+          "expression_id": "145666ef-07bb-4662-94b8-73a83433921f",
+          "id": "bac4ac55-b22e-49e4-aa1b-e68fc76a7ecb"
+        },
+        {
+          "component_id": "7c7a9f51-13af-4722-80dd-9adb657333f2",
+          "depends_on_component_id": "d88b714e-9b30-4039-9e2c-e520a25385f8",
+          "depends_on_data_source_item_id": "69d2fa7c-a196-4ee0-97b7-3ae909ec3670",
+          "expression_id": "ce208a2d-d6ed-4088-a30f-18f80b330fdb",
+          "id": "20fca3ad-3364-43fe-8675-56ea863b0192"
+        },
+        {
+          "component_id": "cede84c3-b4aa-429d-b5f8-0e167956298e",
+          "depends_on_component_id": "14f1872c-c092-4680-a3fa-60b09d9cced9",
+          "expression_id": "2563e468-7b3c-481b-ab5f-2101a71585de",
+          "id": "ff31938f-32a6-47cf-87eb-55d6d256b20d"
+        },
+        {
+          "component_id": "cede84c3-b4aa-429d-b5f8-0e167956298e",
+          "depends_on_component_id": "0faf4b7b-bed2-4c29-b4f9-90fe3a9d2768",
+          "expression_id": "67e0bb24-865b-4cbb-b106-8e1af42cbe7a",
+          "id": "acb22cf0-374d-495b-847f-203d05d1d67b"
         },
         {
           "component_id": "c89af7cf-9e5e-49d4-bb4f-9d611eb6bd98",
           "depends_on_component_id": "bbb1a854-1c4f-4985-ad7d-20b75f7b4fd6",
+          "depends_on_data_source_item_id": "eacc8f98-9a3e-4d50-8dd2-90ff60144b55",
           "expression_id": "4fc80c64-ca6f-47ac-9732-4455314fe5d2",
-          "id": "bcd609cb-28c0-4b29-be63-263ec54b1c86"
+          "id": "56a708f9-a6ad-439e-993d-43397aa40c63"
+        },
+        {
+          "component_id": "1ab4ab60-1ee0-4f43-b054-196b83266653",
+          "depends_on_component_id": "c89af7cf-9e5e-49d4-bb4f-9d611eb6bd98",
+          "depends_on_data_source_item_id": "f5589c72-adc3-4829-b2d9-b38a3e1760b2",
+          "expression_id": "bb4959e4-0601-4b8f-9934-cee303c94f81",
+          "id": "a3be2147-de3d-419e-beea-2f458e66c8ab"
         },
         {
           "component_id": "d1ab24a4-d46e-4638-8699-8be3c79e4946",
           "depends_on_component_id": "bbb1a854-1c4f-4985-ad7d-20b75f7b4fd6",
+          "depends_on_data_source_item_id": "f1e0e4c1-3590-439f-a4b1-1a7ff623bca1",
           "expression_id": "0a6e7dc4-34d3-40bd-85ff-6e8eb3b367b9",
-          "id": "aacf2b2f-93b6-415b-bd86-72c9e557b25f"
+          "id": "b54500ad-d558-48c4-bcc8-7ad65a3466a9"
         },
         {
           "component_id": "77f6d299-9d08-4daf-8efd-373195cb5689",
           "depends_on_component_id": "d1ab24a4-d46e-4638-8699-8be3c79e4946",
+          "depends_on_data_source_item_id": "43e2c21d-bb29-40f4-a643-0081a2e7e7f3",
           "expression_id": "e167202b-6cc5-4db5-a9d6-8d094d6b1700",
-          "id": "8b20a439-2495-43a9-a094-7d2bfe7c631d"
+          "id": "bdbdec94-15bb-4bce-877e-cc28c1d0413c"
+        },
+        {
+          "component_id": "8ed711df-51c2-415b-ba12-ab09c75a7fc4",
+          "depends_on_component_id": "77f6d299-9d08-4daf-8efd-373195cb5689",
+          "depends_on_data_source_item_id": "411474bf-7e2d-469d-8d14-253a092230fb",
+          "expression_id": "2a0161e3-b5c0-4830-b4aa-fb1c7f1c22a0",
+          "id": "0174097b-73a8-4e52-814d-7fc99161a063"
+        },
+        {
+          "component_id": "88d2443a-736b-456c-aaf1-ef87aa09d9ee",
+          "depends_on_component_id": "d1ab24a4-d46e-4638-8699-8be3c79e4946",
+          "depends_on_data_source_item_id": "3bdfbac6-6068-4b44-89de-014b029ec772",
+          "expression_id": "bdb14c3d-01f2-429b-b755-f3c5abc6dcac",
+          "id": "4d4acb59-8c65-4f06-a518-14dee12e4e15"
+        },
+        {
+          "component_id": "a9e3b7d0-323b-4173-9396-f704fe271d50",
+          "depends_on_component_id": "88d2443a-736b-456c-aaf1-ef87aa09d9ee",
+          "expression_id": "e9b917e4-71de-4153-89d3-27fbcb744a43",
+          "id": "ee939685-e476-40b1-9fc4-26f9a53af618"
+        },
+        {
+          "component_id": "bcf1ec8b-de3b-4ee5-ab2d-86f053395a0d",
+          "depends_on_component_id": "88d2443a-736b-456c-aaf1-ef87aa09d9ee",
+          "expression_id": "13731386-14c6-4dff-bc81-fd26dfc89d1b",
+          "id": "f0ac9164-7ac5-410c-acdf-3ebf59485a7b"
+        },
+        {
+          "component_id": "7678f973-65b3-44b4-93bd-f3d04c54a927",
+          "depends_on_component_id": "d1ab24a4-d46e-4638-8699-8be3c79e4946",
+          "depends_on_data_source_item_id": "3bdfbac6-6068-4b44-89de-014b029ec772",
+          "expression_id": "a6b697f5-5c67-4802-bda3-93ecf76d4234",
+          "id": "85c685c7-6eab-43c6-8938-3f4a75b4e35b"
+        },
+        {
+          "component_id": "7678f973-65b3-44b4-93bd-f3d04c54a927",
+          "depends_on_component_id": "7678f973-65b3-44b4-93bd-f3d04c54a927",
+          "expression_id": "ad6bbffb-358b-43cb-8254-f47d01ae890d",
+          "id": "73c12923-2bff-4d28-aec0-a5eecb2e85a7"
+        },
+        {
+          "component_id": "af2006de-ee0c-4016-9d02-2a0ba0b3433a",
+          "depends_on_component_id": "d1ab24a4-d46e-4638-8699-8be3c79e4946",
+          "depends_on_data_source_item_id": "3bdfbac6-6068-4b44-89de-014b029ec772",
+          "expression_id": "0a5a07a5-c83a-4b0c-a954-7d50ff3d33b4",
+          "id": "b95d69a7-b215-4ee9-b377-b7dae7383dae"
+        },
+        {
+          "component_id": "191bb1a6-4d21-498c-a6dd-8720255e07d5",
+          "depends_on_component_id": "88d2443a-736b-456c-aaf1-ef87aa09d9ee",
+          "expression_id": "c258fa0c-3245-4198-b86f-e1bfed93257a",
+          "id": "8810b444-3f5e-4755-b2ab-fb516237e8fa"
+        },
+        {
+          "component_id": "ef5444ca-8295-49c8-903b-c752f195238c",
+          "depends_on_component_id": "88d2443a-736b-456c-aaf1-ef87aa09d9ee",
+          "expression_id": "7c7e1b09-c217-49aa-92a0-a8fddbc59c69",
+          "id": "755cd82e-7bea-4dd5-994a-6d50a7b9de3e"
+        },
+        {
+          "component_id": "53db4e6d-b1b3-49d6-bc8c-8f091e969fba",
+          "depends_on_component_id": "88d2443a-736b-456c-aaf1-ef87aa09d9ee",
+          "expression_id": "610013e0-dc60-4a69-b8d2-2606f50f8a24",
+          "id": "dad4c67b-bfd6-43bf-94a6-9460984c2bcc"
+        },
+        {
+          "component_id": "4870c573-a952-40ae-83f3-03dcbeef948a",
+          "depends_on_component_id": "88d2443a-736b-456c-aaf1-ef87aa09d9ee",
+          "expression_id": "b4f9f622-f4d1-4380-b630-450f312c7541",
+          "id": "58413d19-5a22-404f-a14b-9ab9ab48e671"
         },
         {
           "component_id": "c478266e-514c-4e76-b345-ccfba158ee4b",
           "depends_on_component_id": "d1ab24a4-d46e-4638-8699-8be3c79e4946",
+          "depends_on_data_source_item_id": "3bdfbac6-6068-4b44-89de-014b029ec772",
           "expression_id": "5780b20e-669f-490e-9e52-67bb1c6ddb9d",
-          "id": "c6f1d28d-4a6d-497b-8e24-cce47cde5e2a"
+          "id": "a806c96f-05f7-416a-9e40-188de3737565"
         },
         {
           "component_id": "daec248d-53bf-4d9b-8f64-7c032b73733a",
           "depends_on_component_id": "c478266e-514c-4e76-b345-ccfba158ee4b",
+          "depends_on_data_source_item_id": "4b466281-7837-4c09-ac5c-5c80ea7608c9",
           "expression_id": "ea76361a-4cd8-4bcb-a96a-075b418179b1",
-          "id": "453b0a70-a6ee-4b37-bf6b-588372ca80b7"
+          "id": "7f784230-07db-430a-ac77-39916611d4fa"
+        },
+        {
+          "component_id": "239e5174-8c86-4b8a-8f6e-15eb91b737a4",
+          "depends_on_component_id": "daec248d-53bf-4d9b-8f64-7c032b73733a",
+          "depends_on_data_source_item_id": "9644b96b-8e34-42e6-8ea4-0e978bd464f0",
+          "expression_id": "143ccc9b-c0ee-4b0d-960c-3c65e17254ec",
+          "id": "a264bbbf-0311-4d85-a494-0cc0b0737819"
         },
         {
           "component_id": "b57e7d88-b163-4a5e-8864-91d4f55e3a5a",
           "depends_on_component_id": "c478266e-514c-4e76-b345-ccfba158ee4b",
+          "depends_on_data_source_item_id": "1c7b439f-1408-47e9-b9f2-a5fa86589e4d",
           "expression_id": "161656f2-60b8-4fac-8add-eae45154c649",
-          "id": "798a002b-8475-4f40-8971-9de76c256238"
+          "id": "4df75289-5978-42fa-aba0-aa65cf6d1966"
+        },
+        {
+          "component_id": "b57e7d88-b163-4a5e-8864-91d4f55e3a5a",
+          "depends_on_component_id": "c478266e-514c-4e76-b345-ccfba158ee4b",
+          "depends_on_data_source_item_id": "4b466281-7837-4c09-ac5c-5c80ea7608c9",
+          "expression_id": "161656f2-60b8-4fac-8add-eae45154c649",
+          "id": "d74f6e44-4122-4e72-b052-a980cb1fa9e0"
+        },
+        {
+          "component_id": "6956c65d-8bd0-4321-a64a-4690a3e65e11",
+          "depends_on_component_id": "b57e7d88-b163-4a5e-8864-91d4f55e3a5a",
+          "depends_on_data_source_item_id": "1eee4395-818b-4d23-8487-c1ee7706dfc8",
+          "expression_id": "43e459f3-1ec0-4408-8221-5eac73fa3284",
+          "id": "342bb6ef-71bf-43a6-9726-5c7bce78629b"
+        },
+        {
+          "component_id": "6745d6af-76fd-4c5c-a847-f55e00108cec",
+          "depends_on_component_id": "14f1872c-c092-4680-a3fa-60b09d9cced9",
+          "expression_id": "67a4962a-8368-4e9c-9922-d3274f5b0421",
+          "id": "23989a92-674d-4373-a77c-94319abb56b0"
+        },
+        {
+          "component_id": "6745d6af-76fd-4c5c-a847-f55e00108cec",
+          "depends_on_component_id": "0faf4b7b-bed2-4c29-b4f9-90fe3a9d2768",
+          "expression_id": "e149ff25-77bd-4bc6-9531-d88445fe7d08",
+          "id": "ac8887f8-b2b5-4c7c-b807-1996810a1833"
         },
         {
           "component_id": "0608dbc6-b72d-40a9-a620-be533528b31e",
           "depends_on_component_id": "50848909-069a-4205-b2d3-9f2ac9017ef7",
+          "depends_on_data_source_item_id": "f17fa64e-1b08-40e9-a86c-caac6b343605",
           "expression_id": "0a613c08-3b0f-4d3f-ac94-900308b94140",
-          "id": "c496d565-6a09-49d5-b4e7-147a57a6ada5"
+          "id": "fd084514-dc0a-4e5e-8372-8184527b8d95"
+        },
+        {
+          "component_id": "218c8652-d6ad-48ac-8dc1-498c7748c390",
+          "depends_on_component_id": "0608dbc6-b72d-40a9-a620-be533528b31e",
+          "depends_on_data_source_item_id": "473053c8-b49a-4907-aebd-865ae016232b",
+          "expression_id": "177c7b78-3f11-4fa8-9519-20ace15465ef",
+          "id": "5aaf8a77-cb86-49c4-96a6-3e175ff2b8af"
         },
         {
           "component_id": "15fb67b7-34a5-4ccc-ba08-6c123a6e9d99",
           "depends_on_component_id": "50848909-069a-4205-b2d3-9f2ac9017ef7",
+          "depends_on_data_source_item_id": "d2405306-a6ff-491a-af65-2e10829752af",
           "expression_id": "8bfb533b-0ce7-4b3f-8e05-8ca242b8732a",
-          "id": "6a97fb53-f0b4-44dd-b139-f0270cff4b7c"
+          "id": "71dcb608-3b5a-417c-a098-8a8e05a91993"
         },
         {
           "component_id": "87b53086-1443-4abd-ac67-9055b0bea28f",
           "depends_on_component_id": "15fb67b7-34a5-4ccc-ba08-6c123a6e9d99",
+          "depends_on_data_source_item_id": "c570c187-b88a-4fc6-b6de-11877b6fb378",
           "expression_id": "f2ccb607-ff48-4e89-9834-1f7f97bf0c50",
-          "id": "003def45-68e7-4f01-81b6-43e1692de617"
+          "id": "6052c1ab-734d-4fcc-b65f-572c99763c9e"
+        },
+        {
+          "component_id": "5766e9d1-a28f-4516-88b5-9989b4933362",
+          "depends_on_component_id": "87b53086-1443-4abd-ac67-9055b0bea28f",
+          "depends_on_data_source_item_id": "00bec21e-6ebf-4cba-ad8b-ab38b43d090c",
+          "expression_id": "3747200c-1ca1-4ba5-9718-6b802c8ce0b4",
+          "id": "65f024a5-fb29-4469-af91-b14b10480edb"
+        },
+        {
+          "component_id": "acd8807a-8654-4a82-9228-a6e4b48c06be",
+          "depends_on_component_id": "15fb67b7-34a5-4ccc-ba08-6c123a6e9d99",
+          "depends_on_data_source_item_id": "45738560-a5fd-4e99-afb6-dc4dcd831cfd",
+          "expression_id": "2b3fd4e8-2329-4c3b-85fb-fad92137a0c8",
+          "id": "69ea971c-e228-4201-9225-eb0b17f2efc3"
+        },
+        {
+          "component_id": "58aa1813-fdf4-4ee0-811b-7807e74e7c8e",
+          "depends_on_component_id": "acd8807a-8654-4a82-9228-a6e4b48c06be",
+          "expression_id": "b84485e1-42c0-4a59-bcd6-365e3037bfc6",
+          "id": "1cc25f7e-1952-4d82-9248-986d27f8a613"
+        },
+        {
+          "component_id": "2878dfe1-fc25-4b81-a019-cb115f5be10c",
+          "depends_on_component_id": "acd8807a-8654-4a82-9228-a6e4b48c06be",
+          "expression_id": "c793fe9e-40f9-46b6-92f4-88b8886e4201",
+          "id": "9efcc5c4-b0ce-453c-9a59-79d4aae6e495"
+        },
+        {
+          "component_id": "0d1a77e6-cce3-484f-b68b-adc4e3ebc04d",
+          "depends_on_component_id": "15fb67b7-34a5-4ccc-ba08-6c123a6e9d99",
+          "depends_on_data_source_item_id": "45738560-a5fd-4e99-afb6-dc4dcd831cfd",
+          "expression_id": "4c9284c5-6b8d-476d-a88b-70c912096325",
+          "id": "be4ac59a-72a1-4e38-8af8-dd7152295062"
+        },
+        {
+          "component_id": "0d1a77e6-cce3-484f-b68b-adc4e3ebc04d",
+          "depends_on_component_id": "0d1a77e6-cce3-484f-b68b-adc4e3ebc04d",
+          "expression_id": "168fcc23-6235-47da-a90a-295dcfcc81ec",
+          "id": "8344488e-c7cd-4a2c-a565-0526cc0e0a92"
+        },
+        {
+          "component_id": "bdf30b15-9877-4072-b709-0ee3a4457f9e",
+          "depends_on_component_id": "15fb67b7-34a5-4ccc-ba08-6c123a6e9d99",
+          "depends_on_data_source_item_id": "45738560-a5fd-4e99-afb6-dc4dcd831cfd",
+          "expression_id": "c255691e-9eb4-403c-951c-114b152cf907",
+          "id": "abe74232-4be1-4bbc-9d3c-b74da8368e6a"
+        },
+        {
+          "component_id": "38fd255b-9a46-42be-b50f-90106fd361b7",
+          "depends_on_component_id": "acd8807a-8654-4a82-9228-a6e4b48c06be",
+          "expression_id": "36d5ec27-ed1b-425e-8a06-a84fe1e558ff",
+          "id": "826e41f7-d52c-4a0c-8207-c73e6ab5772d"
+        },
+        {
+          "component_id": "f8cae694-514e-4a79-87b8-152195d2cd05",
+          "depends_on_component_id": "acd8807a-8654-4a82-9228-a6e4b48c06be",
+          "expression_id": "f1b153b1-b257-485a-9223-23dfe5cfb99d",
+          "id": "ead2d105-881a-4a08-8aae-11172d143bc9"
+        },
+        {
+          "component_id": "8719a617-9c0a-4f54-a860-e1fa681c9683",
+          "depends_on_component_id": "acd8807a-8654-4a82-9228-a6e4b48c06be",
+          "expression_id": "d6697add-c8f8-4ec1-8e8e-6ce038ec701a",
+          "id": "4ffaffbf-72d2-4be2-acc1-97937da2493e"
+        },
+        {
+          "component_id": "ae20e798-46e9-4945-8fec-f93f8c763e3c",
+          "depends_on_component_id": "acd8807a-8654-4a82-9228-a6e4b48c06be",
+          "expression_id": "56803314-037e-4ce3-9754-e3d678ff4e06",
+          "id": "447fe813-652d-4aa5-a82c-81be7fff660a"
         },
         {
           "component_id": "476da932-931b-4400-8dc4-0d099a600b2e",
           "depends_on_component_id": "15fb67b7-34a5-4ccc-ba08-6c123a6e9d99",
+          "depends_on_data_source_item_id": "45738560-a5fd-4e99-afb6-dc4dcd831cfd",
           "expression_id": "a814bfba-7567-4d0e-933a-f0f1ca87c6f6",
-          "id": "40001d55-766a-4de3-ab49-d8b1f350885c"
+          "id": "e18f5aba-1121-48d1-a4e5-5b2276db9168"
         },
         {
           "component_id": "a8dc7b13-c97f-44c6-9126-8e8cb30d0cbd",
           "depends_on_component_id": "476da932-931b-4400-8dc4-0d099a600b2e",
+          "depends_on_data_source_item_id": "24a26150-e2cc-405b-bd36-4d664b1d410e",
           "expression_id": "116ac303-4bab-4d34-a40c-54da4ea81d71",
-          "id": "b5c5534f-fa27-4e5f-8be5-9ab9a4dfbb07"
+          "id": "55618626-77f3-4521-996c-6e06f26674e8"
+        },
+        {
+          "component_id": "e5449989-5e6b-428e-97f5-589a7d52b44c",
+          "depends_on_component_id": "a8dc7b13-c97f-44c6-9126-8e8cb30d0cbd",
+          "depends_on_data_source_item_id": "92249e23-150f-4820-9ded-58729b1e77f4",
+          "expression_id": "9f4e1f6b-f335-4bde-a3a1-e288b1adea1f",
+          "id": "beec601b-bbab-478f-9f9f-18aad34a534a"
         },
         {
           "component_id": "8c620851-63ba-4e45-90ea-5be7323e72dc",
           "depends_on_component_id": "476da932-931b-4400-8dc4-0d099a600b2e",
+          "depends_on_data_source_item_id": "13e2cd90-7e61-4fff-bf79-acb82b4d8b00",
           "expression_id": "b28c623b-6664-4069-b0a4-dc3006ef8f94",
-          "id": "60f55675-6e2b-47aa-9df2-4cc2269c4e9b"
+          "id": "73d36adc-4a4b-4613-aad3-ff6ba2cdd363"
+        },
+        {
+          "component_id": "8c620851-63ba-4e45-90ea-5be7323e72dc",
+          "depends_on_component_id": "476da932-931b-4400-8dc4-0d099a600b2e",
+          "depends_on_data_source_item_id": "24a26150-e2cc-405b-bd36-4d664b1d410e",
+          "expression_id": "b28c623b-6664-4069-b0a4-dc3006ef8f94",
+          "id": "296f3ece-3878-45d7-9693-561f5846c10d"
+        },
+        {
+          "component_id": "6c694870-6040-4014-9aed-8f4a7f4c07a2",
+          "depends_on_component_id": "8c620851-63ba-4e45-90ea-5be7323e72dc",
+          "depends_on_data_source_item_id": "71fadc1a-463b-4fb2-b28d-968c3ed6f2fc",
+          "expression_id": "2f1f79b0-5ba1-4c11-88af-a4a041272124",
+          "id": "2d1321d2-5057-48b5-94db-ca1d07e4c76e"
+        },
+        {
+          "component_id": "07e51af2-57b1-411a-bc5c-efdfaa808347",
+          "depends_on_component_id": "14f1872c-c092-4680-a3fa-60b09d9cced9",
+          "expression_id": "722cee4d-f1ff-43f9-98ae-21bd58a05fd0",
+          "id": "7cb85071-41a2-46d2-bd91-7f63fe8f4de1"
+        },
+        {
+          "component_id": "07e51af2-57b1-411a-bc5c-efdfaa808347",
+          "depends_on_component_id": "0faf4b7b-bed2-4c29-b4f9-90fe3a9d2768",
+          "expression_id": "56b5efc4-f323-4bd3-8d90-0f7ca1ee2bf3",
+          "id": "da72f6b8-2d7a-4c40-8424-13c7507325dd"
         },
         {
           "component_id": "2ca17f58-bc73-454d-b4ac-0eb64483e16c",
           "depends_on_component_id": "4d5445bb-adfc-424f-9497-80d1fe293fba",
+          "depends_on_data_source_item_id": "f5564fa6-004c-49db-9bcf-5915be18aaed",
           "expression_id": "4c584a4d-92da-40d8-9124-effee01584a8",
-          "id": "65203e81-a34b-41f5-ad06-fcdeae939579"
+          "id": "927918a2-7edc-44da-b0a6-6ca72aaee7c0"
+        },
+        {
+          "component_id": "0a3f4f11-e08a-4e57-8163-9e8a6b2d0929",
+          "depends_on_component_id": "2ca17f58-bc73-454d-b4ac-0eb64483e16c",
+          "depends_on_data_source_item_id": "9abddcb7-b020-42bc-897a-e7cd7d41f0d3",
+          "expression_id": "3bb0c2a8-306c-4183-a587-30700e740f3a",
+          "id": "a8a2687c-d992-4387-bb98-f39148537ad0"
         },
         {
           "component_id": "e360f77a-35e8-4b7b-b9ea-b0d84a2309ca",
           "depends_on_component_id": "4d5445bb-adfc-424f-9497-80d1fe293fba",
+          "depends_on_data_source_item_id": "2af007c5-4326-4893-a4ad-dbe55606334d",
           "expression_id": "df264d83-ad48-433d-b204-b340f13f4ac9",
-          "id": "2ae6e035-b111-460e-a692-1a947363524d"
+          "id": "34f7554c-c956-4f38-b198-83e402784d3b"
         },
         {
           "component_id": "464484ab-318e-47b5-942e-9f2896426e60",
           "depends_on_component_id": "e360f77a-35e8-4b7b-b9ea-b0d84a2309ca",
+          "depends_on_data_source_item_id": "05a5cff8-1f08-46f0-b5e9-c140b4f120b1",
           "expression_id": "f12601cd-2bb6-4b89-8d89-63ddc5bc40cb",
-          "id": "b9e7e4d8-f681-4930-906d-18fcd23d96e3"
+          "id": "a6061c04-07a2-48dc-a1d4-fdc7202c5581"
+        },
+        {
+          "component_id": "8df69bd9-3c7a-4844-8bc5-507fbb50466b",
+          "depends_on_component_id": "464484ab-318e-47b5-942e-9f2896426e60",
+          "depends_on_data_source_item_id": "42147f50-b54e-488c-a84d-9558904892b4",
+          "expression_id": "240d8206-54e5-4fb3-b2ed-f8f2bb0c573b",
+          "id": "cdd0105f-a24f-492f-b904-a761a9ae4281"
+        },
+        {
+          "component_id": "f1e917d3-f83a-49f1-97de-8cbbf59af27a",
+          "depends_on_component_id": "e360f77a-35e8-4b7b-b9ea-b0d84a2309ca",
+          "depends_on_data_source_item_id": "6a0bab20-0d5e-4eba-9ec6-8a157511e17a",
+          "expression_id": "2f534f5f-9095-4aae-9b0a-87b413198ecf",
+          "id": "230e1d89-5fef-4d26-bac4-cd9295cbca16"
+        },
+        {
+          "component_id": "c58eedbb-664d-456c-8168-87c8f8868a03",
+          "depends_on_component_id": "f1e917d3-f83a-49f1-97de-8cbbf59af27a",
+          "expression_id": "2019d4d5-eed3-4944-b5eb-ab838634d13d",
+          "id": "9de1135c-a75c-444f-a00d-674728ebe70b"
+        },
+        {
+          "component_id": "52667551-c1a7-4563-9c5c-1dc2690c308d",
+          "depends_on_component_id": "f1e917d3-f83a-49f1-97de-8cbbf59af27a",
+          "expression_id": "87e0021c-06b6-49bb-8694-930f6959336d",
+          "id": "f0472f6d-5caf-4513-8b49-3092c1433dfa"
+        },
+        {
+          "component_id": "2bcb76f7-2faf-42c6-bedb-baacc0fc3d51",
+          "depends_on_component_id": "e360f77a-35e8-4b7b-b9ea-b0d84a2309ca",
+          "depends_on_data_source_item_id": "6a0bab20-0d5e-4eba-9ec6-8a157511e17a",
+          "expression_id": "b334c289-16b4-4560-af7d-51835509a84d",
+          "id": "072fe685-8741-4f40-9f0b-f2fb035be16a"
+        },
+        {
+          "component_id": "2bcb76f7-2faf-42c6-bedb-baacc0fc3d51",
+          "depends_on_component_id": "2bcb76f7-2faf-42c6-bedb-baacc0fc3d51",
+          "expression_id": "f4dd24d2-df69-46a3-9f29-a3e5958bac43",
+          "id": "5a3d0efe-d8fc-4ea7-b3dc-c8079523c287"
+        },
+        {
+          "component_id": "282ae6be-6f74-4e50-bea4-9cd63a37efd1",
+          "depends_on_component_id": "e360f77a-35e8-4b7b-b9ea-b0d84a2309ca",
+          "depends_on_data_source_item_id": "6a0bab20-0d5e-4eba-9ec6-8a157511e17a",
+          "expression_id": "9714f75b-fe5e-46d8-9064-90b904e2898b",
+          "id": "f80af9a8-23d4-477a-8d9d-28e87d088607"
+        },
+        {
+          "component_id": "6217dff6-ae78-4e27-8ad7-59b5860c66b4",
+          "depends_on_component_id": "f1e917d3-f83a-49f1-97de-8cbbf59af27a",
+          "expression_id": "b2860cca-87e8-48d8-85f6-30b7c9fa3c92",
+          "id": "2b2887dc-889b-4221-98d6-b314b8fa9959"
+        },
+        {
+          "component_id": "7c3a7d6f-a7fa-464f-bec3-c25a78036589",
+          "depends_on_component_id": "f1e917d3-f83a-49f1-97de-8cbbf59af27a",
+          "expression_id": "d51ddd4c-2aba-4d66-b947-1ed897730e5e",
+          "id": "a837dd61-2faa-4ff4-bafe-19df0e2fde8f"
+        },
+        {
+          "component_id": "d7a464e9-3e12-4263-a644-555fe4366804",
+          "depends_on_component_id": "f1e917d3-f83a-49f1-97de-8cbbf59af27a",
+          "expression_id": "fb76e413-cff6-4e9d-afff-6bd602826ba3",
+          "id": "024f4533-9c8c-4360-9556-1474497145de"
+        },
+        {
+          "component_id": "fe9c8f1d-c690-480c-8f4f-43b8140c8d49",
+          "depends_on_component_id": "f1e917d3-f83a-49f1-97de-8cbbf59af27a",
+          "expression_id": "5ad9aae7-9d84-429f-aa2e-d0b207ea32b2",
+          "id": "1668760b-2ae4-47aa-b2b5-d5dc095cb986"
         },
         {
           "component_id": "f9f98dc9-bda4-4b54-98a4-f45d18fa737f",
           "depends_on_component_id": "e360f77a-35e8-4b7b-b9ea-b0d84a2309ca",
+          "depends_on_data_source_item_id": "6a0bab20-0d5e-4eba-9ec6-8a157511e17a",
           "expression_id": "3fe5e155-c32d-490f-bc5f-51040f5cf2d8",
-          "id": "077a49b3-c21b-49f0-957c-1bd1b6f32d9e"
+          "id": "977e2cf0-06fb-4c9c-a63e-9fcfe056b0e4"
         },
         {
           "component_id": "2b46de4a-b94f-4984-a435-a82e40618a84",
           "depends_on_component_id": "f9f98dc9-bda4-4b54-98a4-f45d18fa737f",
+          "depends_on_data_source_item_id": "4f60f583-0a01-432c-b16e-30c477c98f62",
           "expression_id": "b3865837-9ef4-4b6a-8d41-764084f96bd8",
-          "id": "ee8a0017-4272-47f9-8f8c-f1abb587b9b9"
+          "id": "38ba2ff0-e528-40ae-b946-4b10967f34f5"
+        },
+        {
+          "component_id": "d1f228cb-653c-4950-9640-caf4835a69ef",
+          "depends_on_component_id": "2b46de4a-b94f-4984-a435-a82e40618a84",
+          "depends_on_data_source_item_id": "9c293e02-ed88-4d97-950c-eb0613bddbea",
+          "expression_id": "cdb56073-e8e5-410c-8bf0-30a7f2dfaac1",
+          "id": "3409ac32-79c1-4dfe-adbe-4d14b35536be"
         },
         {
           "component_id": "0978070e-a3b0-4210-8983-19c6882f917e",
           "depends_on_component_id": "f9f98dc9-bda4-4b54-98a4-f45d18fa737f",
+          "depends_on_data_source_item_id": "6fd1507d-dcdf-4ac1-8fcf-a3b1a4b50c1a",
           "expression_id": "3a1c96c6-6522-4f62-91fd-fee806f6b2cc",
-          "id": "daf475d8-e00a-4436-99f8-48f8e7472972"
+          "id": "89ab11d6-b028-47ea-84f0-adeb441ad975"
+        },
+        {
+          "component_id": "0978070e-a3b0-4210-8983-19c6882f917e",
+          "depends_on_component_id": "f9f98dc9-bda4-4b54-98a4-f45d18fa737f",
+          "depends_on_data_source_item_id": "4f60f583-0a01-432c-b16e-30c477c98f62",
+          "expression_id": "3a1c96c6-6522-4f62-91fd-fee806f6b2cc",
+          "id": "5778d7b9-3da4-459c-8d49-84de63e42cf7"
+        },
+        {
+          "component_id": "78b0c934-81b6-4744-8618-05fd9551d405",
+          "depends_on_component_id": "0978070e-a3b0-4210-8983-19c6882f917e",
+          "depends_on_data_source_item_id": "b938d3ea-2326-4397-918a-070c07e69c01",
+          "expression_id": "06867361-a815-403a-a787-88a3d2d2f156",
+          "id": "e1a198eb-dbbb-47bd-87ea-8b5a9c070207"
+        },
+        {
+          "component_id": "a4e76995-a833-402a-a964-faf0658f5a6a",
+          "depends_on_component_id": "14f1872c-c092-4680-a3fa-60b09d9cced9",
+          "expression_id": "fe549110-fd8d-4e8a-b422-129102773484",
+          "id": "58f58841-b6c8-4546-bc10-274676fc266b"
+        },
+        {
+          "component_id": "a4e76995-a833-402a-a964-faf0658f5a6a",
+          "depends_on_component_id": "0faf4b7b-bed2-4c29-b4f9-90fe3a9d2768",
+          "expression_id": "0583f353-5b8e-4f6e-ad4b-250ad547bb6c",
+          "id": "08fa68b0-55fd-4984-a6e2-e923b74fd1c1"
         },
         {
           "component_id": "10484a3a-3b98-4350-8a46-b72895a43519",
           "depends_on_component_id": "bd1649ca-b738-483a-8051-f92d6e7ac0c9",
+          "depends_on_data_source_item_id": "2c8c14ea-4a0d-4d01-b38d-598d85d50072",
           "expression_id": "338d5764-ce69-423b-a9f9-6c5bcae20151",
-          "id": "2fc92ff6-e6a3-4d24-b98a-7c2b813c0e25"
+          "id": "09d3d380-6023-4e9e-8c4c-2f43b2f13afd"
+        },
+        {
+          "component_id": "3487979e-ee4d-4fac-832d-dc5b04a35c44",
+          "depends_on_component_id": "10484a3a-3b98-4350-8a46-b72895a43519",
+          "depends_on_data_source_item_id": "40d36f94-4f50-43f2-b5b0-998aa3aa6a89",
+          "expression_id": "544554b0-40d6-4a4f-bdd6-d40bc8837402",
+          "id": "86839482-b3b2-4530-8734-fb4caee5b973"
         },
         {
           "component_id": "63fd61ba-1f22-47af-8d79-a634bde591ce",
           "depends_on_component_id": "bd1649ca-b738-483a-8051-f92d6e7ac0c9",
+          "depends_on_data_source_item_id": "6623b7ea-84af-4415-b6e3-87b5dd734d37",
           "expression_id": "4630e201-7cdc-4551-8af2-f5ccd16e468a",
-          "id": "2759f11d-2094-4c02-bdb4-c800a410b13f"
+          "id": "31474765-32c4-4271-b058-6b7335b7c6f5"
         },
         {
           "component_id": "7ebb6a6e-c978-460d-a705-9a997ef5d659",
           "depends_on_component_id": "63fd61ba-1f22-47af-8d79-a634bde591ce",
+          "depends_on_data_source_item_id": "136b6de8-914d-412c-a12a-c6b6411ff440",
           "expression_id": "023b7e11-adca-4ca0-95de-b4545786a769",
-          "id": "2981582a-4932-421a-9d86-524177ed8fe2"
+          "id": "799e207d-9319-4aab-99f8-df82d63b0936"
+        },
+        {
+          "component_id": "2abf6efb-445a-4582-9bc5-cfeb89c8c76c",
+          "depends_on_component_id": "7ebb6a6e-c978-460d-a705-9a997ef5d659",
+          "depends_on_data_source_item_id": "987f1896-996c-4ccc-bbb7-e5bed207a93f",
+          "expression_id": "e3b172cf-4e25-4a4b-9ad7-1fb7ffb7f0ed",
+          "id": "9b0bfb17-22cf-4438-b514-e848612807ad"
+        },
+        {
+          "component_id": "65992575-7dbf-4f25-82d4-49ee76301d09",
+          "depends_on_component_id": "63fd61ba-1f22-47af-8d79-a634bde591ce",
+          "depends_on_data_source_item_id": "b43afd76-36f9-45c3-ba8d-64c0cd6c5685",
+          "expression_id": "d20f8dff-f64b-4659-8519-cda209622681",
+          "id": "f3d86235-bab2-4a25-a334-c73650eba04a"
+        },
+        {
+          "component_id": "b30fffe9-edb2-4cd0-a9fe-1767f3694e49",
+          "depends_on_component_id": "65992575-7dbf-4f25-82d4-49ee76301d09",
+          "expression_id": "1e40cf20-73d6-49d9-bac4-5cdaf3108006",
+          "id": "ccf220b2-a6a2-4b33-a609-1a565911e158"
+        },
+        {
+          "component_id": "3d3f5db9-c8cf-448a-a292-fc256a110942",
+          "depends_on_component_id": "65992575-7dbf-4f25-82d4-49ee76301d09",
+          "expression_id": "b8b8dce4-20d1-48f7-af1b-f27a74d347bc",
+          "id": "5b46da7a-2585-447a-ab04-67fda7919bb3"
+        },
+        {
+          "component_id": "77b8d5ca-8fe1-488e-97fa-e35cd1aebf5e",
+          "depends_on_component_id": "63fd61ba-1f22-47af-8d79-a634bde591ce",
+          "depends_on_data_source_item_id": "b43afd76-36f9-45c3-ba8d-64c0cd6c5685",
+          "expression_id": "e2f6e448-7a72-4c4b-818d-350444405b50",
+          "id": "f26b3623-3de9-4a80-8ec8-a843359c9204"
+        },
+        {
+          "component_id": "77b8d5ca-8fe1-488e-97fa-e35cd1aebf5e",
+          "depends_on_component_id": "77b8d5ca-8fe1-488e-97fa-e35cd1aebf5e",
+          "expression_id": "4b91f083-a97e-4b31-b955-8189ca7172f4",
+          "id": "31a565ee-d2ad-4689-bbe4-9ef5a74b23c8"
+        },
+        {
+          "component_id": "706cbfc7-7867-4439-bebf-2ea7a2bb149f",
+          "depends_on_component_id": "63fd61ba-1f22-47af-8d79-a634bde591ce",
+          "depends_on_data_source_item_id": "b43afd76-36f9-45c3-ba8d-64c0cd6c5685",
+          "expression_id": "5cd47057-18f4-491e-b471-193b60ede9d4",
+          "id": "21b189a4-1187-4666-9cb5-db9a56e1816b"
+        },
+        {
+          "component_id": "19e6d06a-0193-4c83-be09-31df7744636c",
+          "depends_on_component_id": "65992575-7dbf-4f25-82d4-49ee76301d09",
+          "expression_id": "3094312a-98b7-43f9-918a-beec30e0b24a",
+          "id": "83d1adcc-09ac-4df0-9689-a28952f4d38c"
+        },
+        {
+          "component_id": "d60d280c-4c9f-4520-949b-ab6a33ec7d7f",
+          "depends_on_component_id": "65992575-7dbf-4f25-82d4-49ee76301d09",
+          "expression_id": "cbe02225-261a-41ee-be68-58aa0e760be1",
+          "id": "f973497d-7777-4ef5-9186-74dc6a7edad1"
+        },
+        {
+          "component_id": "f155c6c8-f33e-407a-9d29-cbd1f29ca806",
+          "depends_on_component_id": "65992575-7dbf-4f25-82d4-49ee76301d09",
+          "expression_id": "77cf370e-7c1a-4d68-b616-711fba8aca51",
+          "id": "e29335b2-c469-4b3b-a9c2-a178faab629d"
+        },
+        {
+          "component_id": "8825470d-39ec-47cc-a641-1b99c73f49de",
+          "depends_on_component_id": "65992575-7dbf-4f25-82d4-49ee76301d09",
+          "expression_id": "d63908dc-6cf9-4f6b-9324-cfe25d081063",
+          "id": "047a9dce-ee07-44ec-b423-51d566ab4254"
         },
         {
           "component_id": "44904406-7db2-41ac-a14a-b805c0573142",
           "depends_on_component_id": "63fd61ba-1f22-47af-8d79-a634bde591ce",
+          "depends_on_data_source_item_id": "b43afd76-36f9-45c3-ba8d-64c0cd6c5685",
           "expression_id": "82c2378f-c681-4733-bb1c-954f418d5f36",
-          "id": "2b4be1a6-0bff-482c-90c6-5d7a8a30eb3b"
+          "id": "f59654a3-19e5-4f74-8884-1090d9e8cf31"
         },
         {
           "component_id": "68a54922-7b04-46e1-8965-e9c24892a0b2",
           "depends_on_component_id": "44904406-7db2-41ac-a14a-b805c0573142",
+          "depends_on_data_source_item_id": "ad683240-c778-4f36-a0d5-c4e9185d0615",
           "expression_id": "26fb781b-00dd-4477-9ee9-ad5a7587522e",
-          "id": "85eb585d-990b-46e4-86c2-891c5bab541c"
+          "id": "e2e8b090-4d5f-49d4-898e-3937c5146d38"
+        },
+        {
+          "component_id": "9e726168-83c3-4cb8-b229-e745fb868d7e",
+          "depends_on_component_id": "68a54922-7b04-46e1-8965-e9c24892a0b2",
+          "depends_on_data_source_item_id": "ef445b4d-18f6-49b4-b146-29ad36a2ef54",
+          "expression_id": "e5d090ac-a0e7-4329-b4a0-5ded2e747ce6",
+          "id": "9b52257b-e47c-479c-9129-397103efa17e"
         },
         {
           "component_id": "224a66d9-a3eb-44d0-90f1-9eb6a28b08b9",
           "depends_on_component_id": "44904406-7db2-41ac-a14a-b805c0573142",
+          "depends_on_data_source_item_id": "88997f69-079c-4b1e-9120-47d72cd9de1c",
           "expression_id": "5fa8c945-b8d4-4a42-a13e-57cc6ce67443",
-          "id": "aa948577-66ad-4e95-b4e9-d36c61d195e7"
+          "id": "5e1eb5cd-6a9e-43d1-abfa-36d1281c1207"
+        },
+        {
+          "component_id": "224a66d9-a3eb-44d0-90f1-9eb6a28b08b9",
+          "depends_on_component_id": "44904406-7db2-41ac-a14a-b805c0573142",
+          "depends_on_data_source_item_id": "ad683240-c778-4f36-a0d5-c4e9185d0615",
+          "expression_id": "5fa8c945-b8d4-4a42-a13e-57cc6ce67443",
+          "id": "da27c96c-b55a-4b9f-beb5-de1eedbf64bd"
+        },
+        {
+          "component_id": "b9e44ca2-e629-4039-9650-92a8cbbae80c",
+          "depends_on_component_id": "224a66d9-a3eb-44d0-90f1-9eb6a28b08b9",
+          "depends_on_data_source_item_id": "db453919-67b2-4520-ba8d-f404c54aa341",
+          "expression_id": "e2f0ce70-e85b-4572-b842-ad89dc2ba907",
+          "id": "761908e0-d92e-4022-b4ab-ad5b4f1ede35"
+        },
+        {
+          "component_id": "712e138a-e795-40b7-93ff-4e8ffaf09df4",
+          "depends_on_component_id": "14f1872c-c092-4680-a3fa-60b09d9cced9",
+          "expression_id": "ad924e95-6645-4602-860d-584a9529e882",
+          "id": "bdf63bff-2a2a-4e22-9826-e9a80ee02290"
+        },
+        {
+          "component_id": "712e138a-e795-40b7-93ff-4e8ffaf09df4",
+          "depends_on_component_id": "0faf4b7b-bed2-4c29-b4f9-90fe3a9d2768",
+          "expression_id": "1a5914d5-20bc-42f5-ac91-cc77569061da",
+          "id": "54dbc217-34db-4ee7-99ba-1f98392fa403"
         },
         {
           "component_id": "5c938513-f61f-4494-8c4e-fcf67ef5c3e2",
           "depends_on_component_id": "48e1a5da-33e2-48f5-bac4-2ddf685d206c",
+          "depends_on_data_source_item_id": "51d3e73f-a647-439d-9cd2-d642b4d4c711",
           "expression_id": "1a9b0763-8bb8-4c15-93ae-4336f8722fc3",
-          "id": "2ab7116a-dc19-42cc-a1c6-7f35f3b3078c"
+          "id": "68598583-1de4-40d4-ba94-2a01bb84bf97"
+        },
+        {
+          "component_id": "f5a642f5-866b-46f4-aa34-2cbc3830cbca",
+          "depends_on_component_id": "5c938513-f61f-4494-8c4e-fcf67ef5c3e2",
+          "depends_on_data_source_item_id": "0f1c7957-a63f-43d0-b686-1045a2bdc15b",
+          "expression_id": "3590ab8f-0222-4e01-ba6d-ae8e2a4a85f8",
+          "id": "7c72abdb-1993-4bbb-8662-ea0507aeb4bd"
         },
         {
           "component_id": "c9315cc3-343b-4725-8f39-2783d57b08ee",
           "depends_on_component_id": "48e1a5da-33e2-48f5-bac4-2ddf685d206c",
+          "depends_on_data_source_item_id": "10d600e2-3d93-4661-91cd-7ded3f11b274",
           "expression_id": "93e19ace-bef7-426a-9fe2-4e144a5bc092",
-          "id": "1c22f90d-5371-479c-b317-6a3fc3d1f666"
+          "id": "60ee9922-6e7b-418c-8a98-5ec5df09df61"
         },
         {
           "component_id": "4bc54c85-8f53-49ee-98a8-a465006626e0",
           "depends_on_component_id": "c9315cc3-343b-4725-8f39-2783d57b08ee",
+          "depends_on_data_source_item_id": "eca29432-643f-436e-b3c8-2ff81add8c98",
           "expression_id": "b0b1399a-d6bb-4392-94e4-79927c0a77ae",
-          "id": "faec9967-7412-47fa-b905-78ef5497c8d7"
+          "id": "8afce4ea-744e-4969-960b-d3d3c0e4a366"
+        },
+        {
+          "component_id": "be9f6855-e639-4e36-b9e5-2dcc93d26423",
+          "depends_on_component_id": "4bc54c85-8f53-49ee-98a8-a465006626e0",
+          "depends_on_data_source_item_id": "b6dc14de-cda9-4b1c-b061-4d4efc8c3522",
+          "expression_id": "e7ea8337-85fe-436d-a0f9-5c07666de372",
+          "id": "f87e5989-ccba-45c8-b977-58288ce82233"
+        },
+        {
+          "component_id": "932ef7b6-b6e4-4386-8d44-579b71a03307",
+          "depends_on_component_id": "c9315cc3-343b-4725-8f39-2783d57b08ee",
+          "depends_on_data_source_item_id": "53862201-f437-45de-bb20-fa48d0925783",
+          "expression_id": "cd20b7f7-5246-452c-a764-a0cf26cbc393",
+          "id": "32095343-eae2-48ac-9696-a47fcdd7acda"
+        },
+        {
+          "component_id": "3a1caf91-5d26-4406-80cf-6a292032c29e",
+          "depends_on_component_id": "932ef7b6-b6e4-4386-8d44-579b71a03307",
+          "expression_id": "8c069c0b-8778-430c-8c3d-1df7c10921d9",
+          "id": "cb9f5f15-9ad9-4980-b3ca-1140bd2fb76a"
+        },
+        {
+          "component_id": "dc4b8dfb-0d84-4733-bc5c-018a061ba394",
+          "depends_on_component_id": "932ef7b6-b6e4-4386-8d44-579b71a03307",
+          "expression_id": "9546b7f3-f10f-428f-a675-35de3d76b71d",
+          "id": "9bab7fd7-5cff-4eeb-82e0-806660349574"
+        },
+        {
+          "component_id": "3b116a62-fe3d-4d71-9bfa-836ff30209ec",
+          "depends_on_component_id": "c9315cc3-343b-4725-8f39-2783d57b08ee",
+          "depends_on_data_source_item_id": "53862201-f437-45de-bb20-fa48d0925783",
+          "expression_id": "673f53f7-987f-4fb0-9ee0-b3fc059b0be6",
+          "id": "1ae16535-f9ab-4a73-9ea5-4d1b34b72a86"
+        },
+        {
+          "component_id": "3b116a62-fe3d-4d71-9bfa-836ff30209ec",
+          "depends_on_component_id": "3b116a62-fe3d-4d71-9bfa-836ff30209ec",
+          "expression_id": "475f3d0e-a2d0-465d-a64d-c851bc4a11bf",
+          "id": "3e3e1577-565a-49b5-bd77-bc57e3523c08"
+        },
+        {
+          "component_id": "76f321df-35c4-47ba-a7d0-fbe4fa60a2a2",
+          "depends_on_component_id": "c9315cc3-343b-4725-8f39-2783d57b08ee",
+          "depends_on_data_source_item_id": "53862201-f437-45de-bb20-fa48d0925783",
+          "expression_id": "d23b33e5-3ce6-4a74-a0f5-498b34f00359",
+          "id": "9b4e5c44-f763-48dd-a551-6cad9bb8e1c2"
+        },
+        {
+          "component_id": "c701300b-8510-4a78-a15a-ebc1a249eab9",
+          "depends_on_component_id": "932ef7b6-b6e4-4386-8d44-579b71a03307",
+          "expression_id": "455fa9b8-d3b2-41c8-8eb5-ecaf71a73c01",
+          "id": "c88d8fd4-b30b-42e7-abd8-c79e4c0418e8"
+        },
+        {
+          "component_id": "bf3f3459-5440-4750-8fb7-ad910dac6a76",
+          "depends_on_component_id": "932ef7b6-b6e4-4386-8d44-579b71a03307",
+          "expression_id": "18a90ad4-012c-419e-8af9-ed932c091063",
+          "id": "5f09e96b-2fc5-4635-8966-a5eb5361a7ab"
+        },
+        {
+          "component_id": "c2778019-d15e-442a-a9f2-bda0b95149fd",
+          "depends_on_component_id": "932ef7b6-b6e4-4386-8d44-579b71a03307",
+          "expression_id": "4f0124dd-9e1e-4290-93cc-210daa253481",
+          "id": "2d86594c-1bc2-4aa1-a030-4faf911dbc2c"
+        },
+        {
+          "component_id": "de104e6f-521d-455d-aa28-2fa983162f24",
+          "depends_on_component_id": "932ef7b6-b6e4-4386-8d44-579b71a03307",
+          "expression_id": "6ffee199-662e-4dcd-91b9-6500fd4b9cc8",
+          "id": "a48a4993-a51b-484d-87ae-b02ac6663a1d"
         },
         {
           "component_id": "35797a4a-2786-4c35-8b95-bbf97bf862f5",
           "depends_on_component_id": "c9315cc3-343b-4725-8f39-2783d57b08ee",
+          "depends_on_data_source_item_id": "53862201-f437-45de-bb20-fa48d0925783",
           "expression_id": "6edd87d4-649a-4b41-9b81-531d76b074f9",
-          "id": "54574427-54f1-4adc-93ae-d023244d52d8"
+          "id": "276dc7da-0c16-4d06-af68-62f79d74c19c"
         },
         {
           "component_id": "99f1463d-ef2c-4d5f-8887-0b7e52a7b95f",
           "depends_on_component_id": "35797a4a-2786-4c35-8b95-bbf97bf862f5",
+          "depends_on_data_source_item_id": "1ca890dd-5c72-4aeb-88cb-291b31312d3c",
           "expression_id": "125c449c-04b2-4761-8f5a-58ffa055b461",
-          "id": "ca3377e2-d748-4401-a886-d49083aa3133"
+          "id": "3140456d-ebb8-41ff-ae0f-9570e0fe7298"
+        },
+        {
+          "component_id": "bf097aa7-3a56-41bc-be24-5227524806b2",
+          "depends_on_component_id": "99f1463d-ef2c-4d5f-8887-0b7e52a7b95f",
+          "depends_on_data_source_item_id": "349c40d4-85a5-45c5-8573-2be68b79f422",
+          "expression_id": "488c24f5-6d38-446c-b927-13e3a0d2abde",
+          "id": "0572fba9-8733-4236-bf67-2469aaf71add"
         },
         {
           "component_id": "9f6d8899-f9b1-43bb-8880-e4958af1c246",
           "depends_on_component_id": "35797a4a-2786-4c35-8b95-bbf97bf862f5",
+          "depends_on_data_source_item_id": "9491f929-751f-4f07-8a0a-7bbe877c4209",
           "expression_id": "d0aac74a-7b1a-4ee8-a13d-b543b5b245b9",
-          "id": "29a6c77c-a176-4d1a-a7e9-6ee6e7b7b49a"
+          "id": "c15c4bf7-9bd1-4591-84c8-85fdc35e08b5"
+        },
+        {
+          "component_id": "9f6d8899-f9b1-43bb-8880-e4958af1c246",
+          "depends_on_component_id": "35797a4a-2786-4c35-8b95-bbf97bf862f5",
+          "depends_on_data_source_item_id": "1ca890dd-5c72-4aeb-88cb-291b31312d3c",
+          "expression_id": "d0aac74a-7b1a-4ee8-a13d-b543b5b245b9",
+          "id": "a64670bc-1682-40d1-aa29-c828b2d6cf34"
+        },
+        {
+          "component_id": "ad4ee1a1-38ee-4c1e-80bc-bd056be965b9",
+          "depends_on_component_id": "9f6d8899-f9b1-43bb-8880-e4958af1c246",
+          "depends_on_data_source_item_id": "bb5bbed4-0ced-4bc2-a0a0-54a6effb276d",
+          "expression_id": "5be0a4e1-eb53-49a6-8bf1-b95218099a03",
+          "id": "07c2abc0-b56e-4341-93f3-0cbe4cf252df"
+        },
+        {
+          "component_id": "42128c9e-4d6d-4376-8592-cd857c331234",
+          "depends_on_component_id": "14f1872c-c092-4680-a3fa-60b09d9cced9",
+          "expression_id": "49e46602-eb15-4284-9a0d-4e6177bd223c",
+          "id": "b304e0e2-d106-495e-8133-347aefa9ca3b"
+        },
+        {
+          "component_id": "42128c9e-4d6d-4376-8592-cd857c331234",
+          "depends_on_component_id": "0faf4b7b-bed2-4c29-b4f9-90fe3a9d2768",
+          "expression_id": "c0ffdd51-78c9-41a1-a64d-816a684ce937",
+          "id": "f64a74e4-d0b9-4406-bf2c-0aa996ce0fd1"
         },
         {
           "component_id": "3264d996-d5df-437f-bbf9-3f56bfb775df",
           "depends_on_component_id": "3bbec300-d427-4d00-9eda-d8fa885fec4b",
+          "depends_on_data_source_item_id": "e000b362-f710-4d2f-9f47-dc5f47e11e49",
           "expression_id": "f0211d5c-bddf-48f1-91e9-dc899ebda121",
-          "id": "134a6dc9-77e2-42db-879e-a5e7f737e7c5"
+          "id": "86cfc61f-3fff-4939-8bf3-7d343669c75b"
+        },
+        {
+          "component_id": "44783134-446c-49cb-8ef0-013e103391d3",
+          "depends_on_component_id": "3264d996-d5df-437f-bbf9-3f56bfb775df",
+          "depends_on_data_source_item_id": "bd2e5bae-7e8c-457b-8524-dc86e274d3eb",
+          "expression_id": "1e576777-f199-47d6-9f33-dcbdd22c1b7e",
+          "id": "3b086b05-e0dc-4b24-a366-6103bfb4876b"
         },
         {
           "component_id": "02cb0ee6-a52a-4a63-9877-ccdfa240f05c",
           "depends_on_component_id": "3bbec300-d427-4d00-9eda-d8fa885fec4b",
+          "depends_on_data_source_item_id": "3bcb9dff-86a3-40ed-bcc0-1b2077972400",
           "expression_id": "06965856-d37a-4a15-87b2-d0e1566bc619",
-          "id": "c5156035-ffc1-4279-ac0f-9d3292aaa689"
+          "id": "c2b0b30b-290b-4ce8-bf76-00746fdb7498"
         },
         {
           "component_id": "c7f2e4b7-41e4-4745-a6a8-eab3e4ae9b9d",
           "depends_on_component_id": "02cb0ee6-a52a-4a63-9877-ccdfa240f05c",
+          "depends_on_data_source_item_id": "dcbf06d3-e841-41c5-88de-785c256d6001",
           "expression_id": "11f26acf-946f-4c27-9777-73f6be550da1",
-          "id": "60856289-0940-4197-a29f-4ff9de5aa86c"
+          "id": "6688e5b2-2fda-44e9-ad7d-7a8751c7719f"
+        },
+        {
+          "component_id": "17e7a9b1-0109-4215-ac17-324f8179bfd2",
+          "depends_on_component_id": "c7f2e4b7-41e4-4745-a6a8-eab3e4ae9b9d",
+          "depends_on_data_source_item_id": "d0f3a014-466a-4dbc-9790-8f7bda6d22d7",
+          "expression_id": "e1c1d096-e436-4b30-a3e2-ca9da8702f30",
+          "id": "ae6d6548-8410-469d-8a69-c965f24aedae"
+        },
+        {
+          "component_id": "bc0ffd15-49b6-4538-96f9-d364428cc228",
+          "depends_on_component_id": "02cb0ee6-a52a-4a63-9877-ccdfa240f05c",
+          "depends_on_data_source_item_id": "4bdb59c0-725d-4733-87f0-5f6d52edaafd",
+          "expression_id": "3299c322-79bf-467a-8c65-750b54b0f3a8",
+          "id": "36a654b0-7b94-49a8-8c42-9c9e60532fdc"
+        },
+        {
+          "component_id": "8deed989-e828-45b7-9119-563652785fdb",
+          "depends_on_component_id": "bc0ffd15-49b6-4538-96f9-d364428cc228",
+          "expression_id": "fd06de54-831f-44a2-b2b8-a4c583668752",
+          "id": "f33a8f5c-0ad4-4806-8539-2eeeabf80e48"
+        },
+        {
+          "component_id": "fc7e9303-5867-4088-90e7-6b73f569f8a7",
+          "depends_on_component_id": "bc0ffd15-49b6-4538-96f9-d364428cc228",
+          "expression_id": "4c631fbc-f174-4619-8172-e1588e8bbfc2",
+          "id": "7305c52f-cabb-4227-8c0e-40cc870158c9"
+        },
+        {
+          "component_id": "b29dfbe7-fd80-4d57-8b42-98beddcb6f66",
+          "depends_on_component_id": "02cb0ee6-a52a-4a63-9877-ccdfa240f05c",
+          "depends_on_data_source_item_id": "4bdb59c0-725d-4733-87f0-5f6d52edaafd",
+          "expression_id": "8bd8ed7f-0251-4b7a-b050-09b4f1ea08ba",
+          "id": "7130a3ae-4b57-4c58-9b9b-c8dc2c6ae63f"
+        },
+        {
+          "component_id": "b29dfbe7-fd80-4d57-8b42-98beddcb6f66",
+          "depends_on_component_id": "b29dfbe7-fd80-4d57-8b42-98beddcb6f66",
+          "expression_id": "2538d220-8203-490b-979b-82c518194f0c",
+          "id": "a9a72d3a-ecd1-497e-81ad-5b93de328744"
+        },
+        {
+          "component_id": "d7c943a6-bbde-4561-81f9-7221b1de1887",
+          "depends_on_component_id": "02cb0ee6-a52a-4a63-9877-ccdfa240f05c",
+          "depends_on_data_source_item_id": "4bdb59c0-725d-4733-87f0-5f6d52edaafd",
+          "expression_id": "5d50263f-0681-4afb-8d16-715711a5de27",
+          "id": "dc9607b8-9e2b-4816-af03-21edd88897b5"
+        },
+        {
+          "component_id": "0c739d11-5bc5-4ddc-9f5b-d1429fb124a1",
+          "depends_on_component_id": "bc0ffd15-49b6-4538-96f9-d364428cc228",
+          "expression_id": "4de526a5-c342-4eac-8aec-12f2e5b6445e",
+          "id": "e87d32fe-8970-4c22-b799-06869aed9173"
+        },
+        {
+          "component_id": "5290cc54-e3e8-4fa7-b2c0-c60d3fd6e4a4",
+          "depends_on_component_id": "bc0ffd15-49b6-4538-96f9-d364428cc228",
+          "expression_id": "44f8a896-6ca3-4b06-8552-7a7615939124",
+          "id": "3bc804fe-818b-45a0-bc94-754c6a7f8415"
+        },
+        {
+          "component_id": "8b085ce7-ce36-4dd7-b194-961730d585a7",
+          "depends_on_component_id": "bc0ffd15-49b6-4538-96f9-d364428cc228",
+          "expression_id": "26e051ff-bc3e-4e36-aa97-9949d763f4e2",
+          "id": "70be258d-43d2-483a-8998-b7a33deaa0cf"
+        },
+        {
+          "component_id": "11039718-680b-45bd-956a-830a07fc6c8f",
+          "depends_on_component_id": "bc0ffd15-49b6-4538-96f9-d364428cc228",
+          "expression_id": "bfc7150c-1b11-4afb-805e-af45ac2d4df6",
+          "id": "5af99004-2783-4bb3-8c84-e1fefacf7fd7"
         },
         {
           "component_id": "936fe1a3-05ef-4131-801a-ae338392974d",
           "depends_on_component_id": "02cb0ee6-a52a-4a63-9877-ccdfa240f05c",
+          "depends_on_data_source_item_id": "4bdb59c0-725d-4733-87f0-5f6d52edaafd",
           "expression_id": "e604cafe-ba9d-4c0f-9044-a0c965f051ca",
-          "id": "e0ca188d-0f4e-42fd-bfea-a0be860b1cdd"
+          "id": "922d5c4a-13e6-4ee3-95e6-e04b909eaf6b"
         },
         {
           "component_id": "50ea5880-a22a-4cfa-b74f-f8cb916722d3",
           "depends_on_component_id": "936fe1a3-05ef-4131-801a-ae338392974d",
+          "depends_on_data_source_item_id": "8f341570-7f88-43eb-a142-ba25222fee07",
           "expression_id": "36cc394f-89d1-4326-a148-68e253e0453a",
-          "id": "e303ca60-c835-48c2-a93c-5ade2010a532"
+          "id": "9027a765-5a5d-49f3-8267-de296d158a82"
+        },
+        {
+          "component_id": "2285b8b2-7003-4173-a3bd-1fdd464aff9a",
+          "depends_on_component_id": "50ea5880-a22a-4cfa-b74f-f8cb916722d3",
+          "depends_on_data_source_item_id": "c945e590-3e3c-4255-92a2-5b4e93437b0b",
+          "expression_id": "3cc9ea7b-b645-4fee-b7e9-d815324ee9e0",
+          "id": "887ec86a-f321-4b3b-b8eb-2d5567d7d1dc"
         },
         {
           "component_id": "b1e39c24-e432-4553-9f7a-3f2f1acf3c06",
           "depends_on_component_id": "936fe1a3-05ef-4131-801a-ae338392974d",
+          "depends_on_data_source_item_id": "275fd80b-31cc-46ab-898a-237cc9602bf9",
           "expression_id": "6ed438d4-fc71-47ae-a23c-90e83acf2ddf",
-          "id": "e530869d-76c0-4629-9b03-50f445ee9469"
+          "id": "ab1157ef-75e6-4332-a377-3e968b913158"
+        },
+        {
+          "component_id": "b1e39c24-e432-4553-9f7a-3f2f1acf3c06",
+          "depends_on_component_id": "936fe1a3-05ef-4131-801a-ae338392974d",
+          "depends_on_data_source_item_id": "8f341570-7f88-43eb-a142-ba25222fee07",
+          "expression_id": "6ed438d4-fc71-47ae-a23c-90e83acf2ddf",
+          "id": "a3fc392d-8933-4397-87ce-206dea86a2b4"
+        },
+        {
+          "component_id": "9fe22dee-1512-47a4-9411-6a4652b4146f",
+          "depends_on_component_id": "b1e39c24-e432-4553-9f7a-3f2f1acf3c06",
+          "depends_on_data_source_item_id": "49ab7fbe-f653-4321-8baa-b177dbb97443",
+          "expression_id": "3bf87612-0e2c-431c-be86-90f16e7a2e1f",
+          "id": "8b61c826-3606-48c2-9e07-c2bd7cdc1990"
+        },
+        {
+          "component_id": "6be23fde-70ab-4a92-b86a-d7b7c927ba30",
+          "depends_on_component_id": "14f1872c-c092-4680-a3fa-60b09d9cced9",
+          "expression_id": "e5441e02-0079-448c-b7e3-8091d99c9893",
+          "id": "7005fa4e-b35a-4b71-b389-dfd0a02e2810"
+        },
+        {
+          "component_id": "6be23fde-70ab-4a92-b86a-d7b7c927ba30",
+          "depends_on_component_id": "0faf4b7b-bed2-4c29-b4f9-90fe3a9d2768",
+          "expression_id": "8fcd9a2d-9cf0-4072-94ac-061fa88cf9ce",
+          "id": "c5bff448-3b8c-47d4-beb8-58dd0f38b124"
         },
         {
           "component_id": "b60911f3-0fc5-4a4b-83c0-172621a4add1",
           "depends_on_component_id": "b252b233-3e6e-4eab-91a6-29526c507750",
+          "depends_on_data_source_item_id": "d0b4880d-306e-4e28-bdaa-1ef96eded5f5",
           "expression_id": "2ee80d2a-f600-4796-bc35-a98ab9ca744b",
-          "id": "308854f8-106c-4d65-8b63-af189c3cd543"
+          "id": "1740d252-fa01-40ad-a05b-c51047158612"
+        },
+        {
+          "component_id": "9fa1692d-39bb-4613-ab50-8ffc21dde725",
+          "depends_on_component_id": "b60911f3-0fc5-4a4b-83c0-172621a4add1",
+          "depends_on_data_source_item_id": "5a7d2bd3-c176-4433-9eec-cef2a3fe7402",
+          "expression_id": "183a8f27-79cc-4c41-af34-e66ea3b96232",
+          "id": "1de80361-a7d0-4d08-97c8-89bfa91c6afc"
         },
         {
           "component_id": "9435c337-48af-40f7-9501-133c5e3a698d",
           "depends_on_component_id": "b252b233-3e6e-4eab-91a6-29526c507750",
+          "depends_on_data_source_item_id": "b042f0bc-bb58-40e0-9cf5-a834bbc9657e",
           "expression_id": "4a315251-f88a-4469-be32-3527ddd29c72",
-          "id": "138288f9-7a1e-4cbc-81e9-e80aa1f05998"
+          "id": "6b2f1467-463b-4710-ad5b-8f904a6c8136"
         },
         {
           "component_id": "19964ced-e0d1-440b-aad8-163996324d72",
           "depends_on_component_id": "9435c337-48af-40f7-9501-133c5e3a698d",
+          "depends_on_data_source_item_id": "4f601a3d-1e96-4aa6-b99f-87d21e2789e2",
           "expression_id": "c9d443b5-b85f-45fe-b175-393e37fc81b8",
-          "id": "24a004c9-21ba-4282-9339-3b4f4075df5a"
+          "id": "37d3c0c4-dccb-4d05-b52b-76b9228f14a9"
+        },
+        {
+          "component_id": "60c1d985-cf1a-4e4f-afdc-cf81188f11cc",
+          "depends_on_component_id": "19964ced-e0d1-440b-aad8-163996324d72",
+          "depends_on_data_source_item_id": "6230b72e-0710-48a6-b6f3-e32c068da61e",
+          "expression_id": "37cdd8f6-17c9-4ce4-a27c-cd97cd0c085f",
+          "id": "f4c59179-40d4-4861-ab33-527b60087ac3"
+        },
+        {
+          "component_id": "4d1cf41b-3f1e-4782-bb06-3942e0f3374e",
+          "depends_on_component_id": "9435c337-48af-40f7-9501-133c5e3a698d",
+          "depends_on_data_source_item_id": "298674ee-cd92-475b-9ef2-2c0c3b818d39",
+          "expression_id": "1bc974a6-aef2-49ca-a49a-905ec444f4f6",
+          "id": "56b1e85a-b5d2-4fe4-955a-806dbe9dda16"
+        },
+        {
+          "component_id": "6f46a1c8-8e88-40c7-9988-f31e42840b51",
+          "depends_on_component_id": "4d1cf41b-3f1e-4782-bb06-3942e0f3374e",
+          "expression_id": "6665e5f7-1c01-410c-9624-58862c301178",
+          "id": "6fe0bb26-1a44-4ab8-a9a5-3fd0d5cd00b3"
+        },
+        {
+          "component_id": "59acce0b-51b6-440f-897b-2da2a8fd5458",
+          "depends_on_component_id": "4d1cf41b-3f1e-4782-bb06-3942e0f3374e",
+          "expression_id": "678d6538-b2ee-4323-be6a-8a55633d2e95",
+          "id": "830dfe22-ac79-4637-85cf-d6f6f27f7343"
+        },
+        {
+          "component_id": "5dbedfd0-fff4-4741-ac9c-172ffadbcc68",
+          "depends_on_component_id": "9435c337-48af-40f7-9501-133c5e3a698d",
+          "depends_on_data_source_item_id": "298674ee-cd92-475b-9ef2-2c0c3b818d39",
+          "expression_id": "4cf73bc8-0f01-4c48-83d2-36ab48cbf8bc",
+          "id": "09b50968-6750-4607-8615-c15bdf5253bf"
+        },
+        {
+          "component_id": "5dbedfd0-fff4-4741-ac9c-172ffadbcc68",
+          "depends_on_component_id": "5dbedfd0-fff4-4741-ac9c-172ffadbcc68",
+          "expression_id": "c028c9f9-f44c-4801-bee5-b5c02ce72479",
+          "id": "81c7a624-f513-42d1-a2c1-420ce7d184d8"
+        },
+        {
+          "component_id": "8eccc1ef-13db-49c0-aad5-181964b1661a",
+          "depends_on_component_id": "9435c337-48af-40f7-9501-133c5e3a698d",
+          "depends_on_data_source_item_id": "298674ee-cd92-475b-9ef2-2c0c3b818d39",
+          "expression_id": "a252497f-82c4-44ed-bb5b-2cffa5005420",
+          "id": "c4cd6925-71a5-4d48-82cc-80038eba6ff6"
+        },
+        {
+          "component_id": "9b2aa1b3-ab2c-42c0-9a5e-8a91c1938e5d",
+          "depends_on_component_id": "4d1cf41b-3f1e-4782-bb06-3942e0f3374e",
+          "expression_id": "e549136b-9e3c-4f7d-b835-268d42a1cc39",
+          "id": "e7ce3584-12ca-460f-8a74-993e645d8e31"
+        },
+        {
+          "component_id": "6213cde1-43ae-4829-bb12-cb664e8c9ac3",
+          "depends_on_component_id": "4d1cf41b-3f1e-4782-bb06-3942e0f3374e",
+          "expression_id": "433c5510-b0ae-4e3c-adf8-8f5a436e8dd4",
+          "id": "58877b84-cea9-41f0-adfb-b202f92fd3ce"
+        },
+        {
+          "component_id": "7ac65d64-facc-4479-bb74-45ed59d0a43b",
+          "depends_on_component_id": "4d1cf41b-3f1e-4782-bb06-3942e0f3374e",
+          "expression_id": "81f5cb1a-7141-4aad-8ab5-139c69db61d7",
+          "id": "cf73e448-9887-4b2d-bc52-02caa70e2d46"
+        },
+        {
+          "component_id": "40425461-58cc-4cde-b983-e97a58169f06",
+          "depends_on_component_id": "4d1cf41b-3f1e-4782-bb06-3942e0f3374e",
+          "expression_id": "8432a894-1c9b-49dd-bbbe-043b88424008",
+          "id": "ad0a49c5-5026-4f29-940e-1dbfe029a145"
         },
         {
           "component_id": "469c222e-1b8d-4df6-9c89-7a4478b19807",
           "depends_on_component_id": "9435c337-48af-40f7-9501-133c5e3a698d",
+          "depends_on_data_source_item_id": "298674ee-cd92-475b-9ef2-2c0c3b818d39",
           "expression_id": "bb89f98b-066d-4f3f-b686-14bb7dc1d4e5",
-          "id": "5f77cd3d-5e3f-4513-bef3-4193540b39cb"
+          "id": "e9f6245a-4711-4ec6-8b41-e80fe52ee268"
         },
         {
           "component_id": "879e465b-f0b0-4ead-be95-054aad8894e1",
           "depends_on_component_id": "469c222e-1b8d-4df6-9c89-7a4478b19807",
+          "depends_on_data_source_item_id": "3f71872f-795b-463b-8774-63a4dbcfa61d",
           "expression_id": "c094ed25-cb77-4592-b535-210a5d051642",
-          "id": "f50cbe53-ba93-4174-b635-610f48538549"
+          "id": "2fb600f5-4b71-4ddd-8eec-a7ad1de4438f"
+        },
+        {
+          "component_id": "ff5fb940-2d69-4f86-be7b-480fb2692aae",
+          "depends_on_component_id": "879e465b-f0b0-4ead-be95-054aad8894e1",
+          "depends_on_data_source_item_id": "7311d0b8-0cef-41b3-a611-ff0703665986",
+          "expression_id": "52dfd769-57e4-4dee-914c-192e914b73d3",
+          "id": "b98ceafc-bf45-4e7e-976a-b12edc2d08e1"
         },
         {
           "component_id": "faa9e407-7dae-4ab3-b1cd-f2d789e9c64b",
           "depends_on_component_id": "469c222e-1b8d-4df6-9c89-7a4478b19807",
+          "depends_on_data_source_item_id": "b05bb136-7767-4d6a-bf68-c6ad7fd43492",
           "expression_id": "4e35ff66-57cd-48ce-8a74-0a0989ecd77b",
-          "id": "00a06ba9-2c8f-4532-8a0d-ee1cab4b0340"
+          "id": "0ff75a03-a204-4d06-9645-b75137d649ea"
+        },
+        {
+          "component_id": "faa9e407-7dae-4ab3-b1cd-f2d789e9c64b",
+          "depends_on_component_id": "469c222e-1b8d-4df6-9c89-7a4478b19807",
+          "depends_on_data_source_item_id": "3f71872f-795b-463b-8774-63a4dbcfa61d",
+          "expression_id": "4e35ff66-57cd-48ce-8a74-0a0989ecd77b",
+          "id": "73edd1d6-80c0-4a63-88b6-6e1a7749adf3"
+        },
+        {
+          "component_id": "c0a9decf-fb9a-4922-8f36-3d77ed8c7b67",
+          "depends_on_component_id": "faa9e407-7dae-4ab3-b1cd-f2d789e9c64b",
+          "depends_on_data_source_item_id": "35066d20-b86d-45de-b7c1-301d48dd5bc9",
+          "expression_id": "c5c5737d-dc6d-48c4-963b-65e2de5a98b0",
+          "id": "11d8acdb-af12-4705-be96-87e69fa6f837"
+        },
+        {
+          "component_id": "39408f9e-c154-4eb0-ad43-0e2af2ca139d",
+          "depends_on_component_id": "14f1872c-c092-4680-a3fa-60b09d9cced9",
+          "expression_id": "66adff0d-415c-411c-a3c2-c6d8e3d58bb3",
+          "id": "bdad8487-bbda-4cb6-8c3b-e402402a0d37"
+        },
+        {
+          "component_id": "39408f9e-c154-4eb0-ad43-0e2af2ca139d",
+          "depends_on_component_id": "0faf4b7b-bed2-4c29-b4f9-90fe3a9d2768",
+          "expression_id": "92e5021a-bb1d-40ae-ba1f-529d82f811e6",
+          "id": "7ab97b83-3405-41ea-bc39-3429a509c8bd"
         },
         {
           "component_id": "809898a4-98de-4247-972a-35e270d05cef",
           "depends_on_component_id": "c3d08b10-15db-416f-bb7c-5e72b6744c9a",
+          "depends_on_data_source_item_id": "803ace2d-2c54-4ba8-8e53-0f0430c2a753",
           "expression_id": "bc32f36d-1436-4c8a-afa8-06963611582d",
-          "id": "3aa810ea-ecb3-43d1-9fc5-1045997e7b44"
+          "id": "96351e51-3108-4eb6-8321-d25a30bf070f"
+        },
+        {
+          "component_id": "b31ad25a-f42c-4768-ae2b-577042ac2473",
+          "depends_on_component_id": "809898a4-98de-4247-972a-35e270d05cef",
+          "depends_on_data_source_item_id": "d22af7a6-f46b-43e7-9f54-913579a47360",
+          "expression_id": "dd6fece3-43ec-4cc6-9d2b-80ee8809ed1e",
+          "id": "46176813-d553-4f6a-91ca-eb2b322b703a"
         },
         {
           "component_id": "116fad4c-ff25-42b5-95bf-2e003c4478f7",
           "depends_on_component_id": "c3d08b10-15db-416f-bb7c-5e72b6744c9a",
+          "depends_on_data_source_item_id": "7649c9ba-8513-4805-b1f1-88fb6029204a",
           "expression_id": "9bdd2cd6-b1b7-4c4a-8c74-9e99ea222e82",
-          "id": "7f573ea3-818a-4281-85f5-51e8c3ab1e07"
+          "id": "c64f01b8-9529-454a-bdae-dcb9794809f7"
         },
         {
           "component_id": "9ffa1b0f-2b65-4c8a-aa93-2baca979b121",
           "depends_on_component_id": "116fad4c-ff25-42b5-95bf-2e003c4478f7",
+          "depends_on_data_source_item_id": "088eb142-be35-4f9d-b1f2-2aa867ca309e",
           "expression_id": "63403169-567e-47d0-8b4d-8f3bb936306e",
-          "id": "7b01a74d-adf6-4b06-80fb-0f8afc2863a3"
+          "id": "3a73c147-76ff-4b88-afa5-f711eb262471"
+        },
+        {
+          "component_id": "78747e00-73ea-4b47-9d5a-87210bb190c4",
+          "depends_on_component_id": "9ffa1b0f-2b65-4c8a-aa93-2baca979b121",
+          "depends_on_data_source_item_id": "4cd2fb14-f927-47ae-9d38-a3cce44c8b4e",
+          "expression_id": "93629a6a-1012-44d2-98e4-87a00a27ee48",
+          "id": "824ebf54-dfa3-472d-bb14-4fa3f1f55ead"
+        },
+        {
+          "component_id": "22d94769-fa42-4674-bf6f-1b8670d08740",
+          "depends_on_component_id": "116fad4c-ff25-42b5-95bf-2e003c4478f7",
+          "depends_on_data_source_item_id": "3da8275c-2968-4e53-bad8-477c1c11a476",
+          "expression_id": "bd1c3d03-4310-4b7f-ad11-af237fbacd78",
+          "id": "3d53e2a0-3c3c-4734-8960-492588f373de"
+        },
+        {
+          "component_id": "c44d2933-b656-4968-9c23-7c365a0b7e48",
+          "depends_on_component_id": "22d94769-fa42-4674-bf6f-1b8670d08740",
+          "expression_id": "5ddbb845-7468-4ea1-9314-83affaf67a86",
+          "id": "6f4e7a89-9698-4fa0-9056-a9498ea0076e"
+        },
+        {
+          "component_id": "5e9a6254-1f62-4226-b641-017e8b4515b0",
+          "depends_on_component_id": "22d94769-fa42-4674-bf6f-1b8670d08740",
+          "expression_id": "a11a2403-1d9f-4d29-877c-afb5ecea4403",
+          "id": "d431ac7b-bcc2-484b-b0b8-4530b9c9f27b"
+        },
+        {
+          "component_id": "5cdf009c-2831-4f78-bd01-cc68a8b5128c",
+          "depends_on_component_id": "116fad4c-ff25-42b5-95bf-2e003c4478f7",
+          "depends_on_data_source_item_id": "3da8275c-2968-4e53-bad8-477c1c11a476",
+          "expression_id": "1d4e3a6f-055b-4472-9be6-d5521ca544f9",
+          "id": "f5dbb375-72f8-42bc-9bb7-46648f7da3a6"
+        },
+        {
+          "component_id": "5cdf009c-2831-4f78-bd01-cc68a8b5128c",
+          "depends_on_component_id": "5cdf009c-2831-4f78-bd01-cc68a8b5128c",
+          "expression_id": "c99dc916-1601-4d8d-816f-82e3a5cf286c",
+          "id": "04cf2cb2-e3a5-41de-9b73-c8a5bc4a4594"
+        },
+        {
+          "component_id": "3adeab1e-b168-4c1c-8530-878c673619b3",
+          "depends_on_component_id": "116fad4c-ff25-42b5-95bf-2e003c4478f7",
+          "depends_on_data_source_item_id": "3da8275c-2968-4e53-bad8-477c1c11a476",
+          "expression_id": "bc192c50-4373-40c1-9550-5feba357d5d2",
+          "id": "c328f5ca-9184-4953-a2d6-cb4acc9bd0ac"
+        },
+        {
+          "component_id": "850568e4-2567-4859-bb6d-1b8082a0f777",
+          "depends_on_component_id": "22d94769-fa42-4674-bf6f-1b8670d08740",
+          "expression_id": "24e0cd91-4048-4d07-95d0-5b47e1157393",
+          "id": "ec5130ea-5ab8-4854-b79f-32d608945155"
+        },
+        {
+          "component_id": "02bf7f90-b56f-4977-8f9d-128f993ea6c7",
+          "depends_on_component_id": "22d94769-fa42-4674-bf6f-1b8670d08740",
+          "expression_id": "5c0cdc69-b36d-4527-8f22-e16a49d87ce1",
+          "id": "831317d1-1120-4583-9143-51250f2cdf4f"
+        },
+        {
+          "component_id": "e0faeb6d-fa14-4fc3-ae55-bfd698d33637",
+          "depends_on_component_id": "22d94769-fa42-4674-bf6f-1b8670d08740",
+          "expression_id": "167ec046-9d17-43e6-a90b-dc08ff32c846",
+          "id": "69530c29-1664-4124-9647-142bd9f2878a"
+        },
+        {
+          "component_id": "222b5511-fb28-4a06-a5ef-6ea63fd37255",
+          "depends_on_component_id": "22d94769-fa42-4674-bf6f-1b8670d08740",
+          "expression_id": "c2bebecc-264f-4ab3-8eba-01f0d96c8ed0",
+          "id": "48e079e8-b14a-4955-9047-add6f6499637"
         },
         {
           "component_id": "68430940-6e9f-48ab-a090-60894958a04d",
           "depends_on_component_id": "116fad4c-ff25-42b5-95bf-2e003c4478f7",
+          "depends_on_data_source_item_id": "3da8275c-2968-4e53-bad8-477c1c11a476",
           "expression_id": "f5c285bf-fe4a-4deb-b85f-58ae4380a2df",
-          "id": "004e6aa0-9f89-4256-9669-34ca1d11b1c4"
+          "id": "1bb26ea1-4bdf-492a-bed9-6c65e6f656bb"
         },
         {
           "component_id": "f63782e3-b9b5-4e21-afd1-b653bfe6ed38",
           "depends_on_component_id": "68430940-6e9f-48ab-a090-60894958a04d",
+          "depends_on_data_source_item_id": "fab091a3-6e9c-437b-a612-672c2a79c397",
           "expression_id": "3dbfbef3-f59b-4f7f-8c05-7042a1716151",
-          "id": "fc2f557f-a208-4e28-a876-8476ae6e6d83"
+          "id": "8a067836-76be-4f44-b40c-f9eb9e883711"
+        },
+        {
+          "component_id": "474fb534-25c7-4c42-93c8-43b26fdea0e9",
+          "depends_on_component_id": "f63782e3-b9b5-4e21-afd1-b653bfe6ed38",
+          "depends_on_data_source_item_id": "9078f54c-5493-4f31-b7dd-e1a147b9da46",
+          "expression_id": "53822838-3753-44fb-9fc6-1e369629a4cd",
+          "id": "c9168185-a9a7-4f52-88e9-c70f10cddaae"
         },
         {
           "component_id": "908ae5f1-4488-4f8c-ba9e-5903764f959a",
           "depends_on_component_id": "68430940-6e9f-48ab-a090-60894958a04d",
+          "depends_on_data_source_item_id": "46e884d6-baf4-441d-9d3d-535b2de3d5d0",
           "expression_id": "98939fdf-55b8-4bce-8731-473fc397d1cb",
-          "id": "d353e89e-8fc1-4c72-a76b-2fc548ad0390"
+          "id": "0c687b95-31d1-4dbf-9a5b-221bd8ccb4ec"
+        },
+        {
+          "component_id": "908ae5f1-4488-4f8c-ba9e-5903764f959a",
+          "depends_on_component_id": "68430940-6e9f-48ab-a090-60894958a04d",
+          "depends_on_data_source_item_id": "fab091a3-6e9c-437b-a612-672c2a79c397",
+          "expression_id": "98939fdf-55b8-4bce-8731-473fc397d1cb",
+          "id": "7efc84e2-65e8-47a7-81ea-5b8e7a9acf0a"
+        },
+        {
+          "component_id": "5ed5623e-4f3f-4637-b48c-79079b6b2749",
+          "depends_on_component_id": "908ae5f1-4488-4f8c-ba9e-5903764f959a",
+          "depends_on_data_source_item_id": "4973ead6-baca-458e-b2ec-74359fb52983",
+          "expression_id": "206a2b7e-415c-4e6d-97e6-70619107074f",
+          "id": "8db91537-00cd-4e3c-9ffe-d0ad6309e8e3"
+        },
+        {
+          "component_id": "dc767bbc-75f4-4736-a17a-5e08ad6ee844",
+          "depends_on_component_id": "14f1872c-c092-4680-a3fa-60b09d9cced9",
+          "expression_id": "1d4ae472-5e11-4ac4-9e21-e9ce1a272cbb",
+          "id": "cd09dd17-c2d7-4697-bbc1-fe16f72fae34"
+        },
+        {
+          "component_id": "dc767bbc-75f4-4736-a17a-5e08ad6ee844",
+          "depends_on_component_id": "0faf4b7b-bed2-4c29-b4f9-90fe3a9d2768",
+          "expression_id": "485c233b-9d2b-474a-b911-f67ad31f7ef9",
+          "id": "2b2f05da-978c-459b-95b3-7f62fdfbee05"
         },
         {
           "component_id": "67b6100e-9846-4c50-84c7-bd49eedc4410",
           "depends_on_component_id": "2796c1e7-5333-4c67-82fe-8dd1951d5842",
+          "depends_on_data_source_item_id": "d9f2dc98-683e-46d7-aa09-7314c474a00d",
           "expression_id": "ad159625-faf7-435e-a9c3-499994fb74db",
-          "id": "afcde708-76e2-4e39-a67d-ea15ea79ec41"
+          "id": "a2a928c6-cd55-4a6d-99f4-a2e017e2b0f9"
+        },
+        {
+          "component_id": "5b79b68c-3366-494b-9f4a-99321853222c",
+          "depends_on_component_id": "67b6100e-9846-4c50-84c7-bd49eedc4410",
+          "depends_on_data_source_item_id": "e5dde274-88aa-4237-ad40-7db059a4f0aa",
+          "expression_id": "3fbe84f3-4b27-4e2d-9f7b-d397aff212eb",
+          "id": "7d9eb0ce-fe88-44a3-873c-9840c3d18543"
         },
         {
           "component_id": "6c85eb6f-a9d8-4afa-a117-759186908d11",
           "depends_on_component_id": "2796c1e7-5333-4c67-82fe-8dd1951d5842",
+          "depends_on_data_source_item_id": "1601036d-2350-48b7-8b12-0fff25e1020e",
           "expression_id": "834eebba-b796-4268-9138-87ae713ede0d",
-          "id": "73588356-c593-46cd-8fcd-5dee1459047d"
+          "id": "90c956e5-c98c-4e90-a14d-cf437c465969"
         },
         {
           "component_id": "0cf6b8e0-b8c5-4968-a7c7-5c37bb51e2b9",
           "depends_on_component_id": "6c85eb6f-a9d8-4afa-a117-759186908d11",
+          "depends_on_data_source_item_id": "fa55ff3e-766f-4966-8e5f-e4b66b605f1c",
           "expression_id": "d84939b1-f9e3-420f-a350-e08c7ec4ac24",
-          "id": "904dfa26-f8c9-49c8-8e59-0f25c70fb591"
+          "id": "03dfbcf9-9d28-430d-bd04-828b6b68fab8"
+        },
+        {
+          "component_id": "0336ddf3-6c9a-40c8-8438-8a8565f74d19",
+          "depends_on_component_id": "0cf6b8e0-b8c5-4968-a7c7-5c37bb51e2b9",
+          "depends_on_data_source_item_id": "8f9359f8-cd6b-40db-8cd1-1a3114984e9e",
+          "expression_id": "7bf86fca-560d-4b73-8e12-35c6aa472b96",
+          "id": "a20a4456-a069-4cb1-bd31-18a79b0e6e63"
+        },
+        {
+          "component_id": "ef49f950-abf3-47f8-9b93-39c155876e6f",
+          "depends_on_component_id": "6c85eb6f-a9d8-4afa-a117-759186908d11",
+          "depends_on_data_source_item_id": "b43b42c2-782d-433d-b991-4bff6a4342fd",
+          "expression_id": "91a0315a-a464-4703-a7cc-0f3336cfa352",
+          "id": "e1d2470b-1ea3-42f9-97f5-7797648c1173"
+        },
+        {
+          "component_id": "5588a671-49fe-4f4a-a7a7-2f3ce16cae18",
+          "depends_on_component_id": "ef49f950-abf3-47f8-9b93-39c155876e6f",
+          "expression_id": "8dceac07-da52-4536-9677-ad56297caa43",
+          "id": "566a0a7e-259c-42ec-ac1c-6fc45bf1de88"
+        },
+        {
+          "component_id": "e60dc62f-0ec1-4f83-986b-f1728d4cc66e",
+          "depends_on_component_id": "ef49f950-abf3-47f8-9b93-39c155876e6f",
+          "expression_id": "4c46c49b-2db9-42fa-b2f1-39811f80a9b2",
+          "id": "1f3a0274-8917-4e3d-9715-14e9847d997d"
+        },
+        {
+          "component_id": "2f1654bd-cc69-4410-8a1a-6fb9e14adc6a",
+          "depends_on_component_id": "6c85eb6f-a9d8-4afa-a117-759186908d11",
+          "depends_on_data_source_item_id": "b43b42c2-782d-433d-b991-4bff6a4342fd",
+          "expression_id": "a2803731-bbcf-45f6-b20b-843190f791ab",
+          "id": "fdfdc455-8cd0-4d40-aebb-d824f7c75353"
+        },
+        {
+          "component_id": "2f1654bd-cc69-4410-8a1a-6fb9e14adc6a",
+          "depends_on_component_id": "2f1654bd-cc69-4410-8a1a-6fb9e14adc6a",
+          "expression_id": "67d4fe68-fb55-4500-9db1-e3accf123dfe",
+          "id": "337df48e-c982-43b4-b262-aaacfac56853"
+        },
+        {
+          "component_id": "b07a66e6-323d-4996-ab3b-cbef5ed630b2",
+          "depends_on_component_id": "6c85eb6f-a9d8-4afa-a117-759186908d11",
+          "depends_on_data_source_item_id": "b43b42c2-782d-433d-b991-4bff6a4342fd",
+          "expression_id": "502cc78b-97e3-472f-8e8c-e8885a0264bb",
+          "id": "8ee49827-c8e5-4865-9d5d-16b308f7acbc"
+        },
+        {
+          "component_id": "5330ffbc-a222-4f12-ae8c-e15d86859334",
+          "depends_on_component_id": "ef49f950-abf3-47f8-9b93-39c155876e6f",
+          "expression_id": "b4ab76b6-d9b8-4c43-b75a-bcb954dfbb18",
+          "id": "50a3cbbe-d6dd-4426-93ef-917f09dfb87a"
+        },
+        {
+          "component_id": "f92e2568-2e9a-48d7-bc52-280950f2a047",
+          "depends_on_component_id": "ef49f950-abf3-47f8-9b93-39c155876e6f",
+          "expression_id": "94ae43c1-a010-4904-ba1d-da0e8cc86a73",
+          "id": "f3457a29-9b15-4bfa-8661-6b47c1f356c1"
+        },
+        {
+          "component_id": "ed63b684-7125-4db2-8a6e-658966d3fe44",
+          "depends_on_component_id": "ef49f950-abf3-47f8-9b93-39c155876e6f",
+          "expression_id": "1ab38213-cb57-452e-98e2-45e48e7902b8",
+          "id": "e297cd8e-678e-49c5-9252-24a3340bd75e"
+        },
+        {
+          "component_id": "34b74410-8e70-478d-8858-6148f85ebc27",
+          "depends_on_component_id": "ef49f950-abf3-47f8-9b93-39c155876e6f",
+          "expression_id": "db613aad-478b-4a1b-a46a-fedb9625060b",
+          "id": "097f38be-01cd-42f2-9c65-7a2534704dde"
         },
         {
           "component_id": "6e10a5dd-0db4-4a98-9d8a-6229c711e5c6",
           "depends_on_component_id": "6c85eb6f-a9d8-4afa-a117-759186908d11",
+          "depends_on_data_source_item_id": "b43b42c2-782d-433d-b991-4bff6a4342fd",
           "expression_id": "86366137-d945-4bd3-8ee9-baee101d41ab",
-          "id": "d7272b26-2ff4-49d5-b938-0265741c7b41"
+          "id": "273bc146-5126-420e-ac84-b00dc7ff1d5e"
         },
         {
           "component_id": "da515367-b3a9-4d78-8ed0-416e16214276",
           "depends_on_component_id": "6e10a5dd-0db4-4a98-9d8a-6229c711e5c6",
+          "depends_on_data_source_item_id": "4a5e10cf-8c82-4071-b68a-79a9f68e6a5c",
           "expression_id": "cd9c41a4-9a24-42a7-a8f3-0b626d40675a",
-          "id": "84c63baa-5ea0-4cf5-9773-642567cbd87a"
+          "id": "5e84191a-df90-478e-863c-177477d61ad4"
+        },
+        {
+          "component_id": "7308d133-0514-430a-8265-154209381b39",
+          "depends_on_component_id": "da515367-b3a9-4d78-8ed0-416e16214276",
+          "depends_on_data_source_item_id": "7305bdae-0585-4bef-b8b2-503546b2f299",
+          "expression_id": "d4f34ad2-35d5-4fa1-83c8-21bedabec6fd",
+          "id": "a9f44a53-f055-4dda-bcfb-cd722284978c"
         },
         {
           "component_id": "87b57cd9-538e-4fe1-b051-82f817b54579",
           "depends_on_component_id": "6e10a5dd-0db4-4a98-9d8a-6229c711e5c6",
+          "depends_on_data_source_item_id": "93ec2873-0e4f-4428-94b1-0dd2d5f5338d",
           "expression_id": "a86daf2d-e500-448a-aa8b-d5fbc4901b27",
-          "id": "4a5b9c98-65c4-4ee0-92ca-b8e5b932d902"
+          "id": "4aefdf39-0c28-44c7-9214-80f03d70b902"
+        },
+        {
+          "component_id": "87b57cd9-538e-4fe1-b051-82f817b54579",
+          "depends_on_component_id": "6e10a5dd-0db4-4a98-9d8a-6229c711e5c6",
+          "depends_on_data_source_item_id": "4a5e10cf-8c82-4071-b68a-79a9f68e6a5c",
+          "expression_id": "a86daf2d-e500-448a-aa8b-d5fbc4901b27",
+          "id": "1ce94d9c-0500-4e96-819a-4ea2c143c4aa"
+        },
+        {
+          "component_id": "f47dd0b2-493c-4e0b-8652-fa05bbe975df",
+          "depends_on_component_id": "87b57cd9-538e-4fe1-b051-82f817b54579",
+          "depends_on_data_source_item_id": "e788e5a7-d3ba-4a45-a227-2c9b9f3b0a54",
+          "expression_id": "1bbf2cc0-dca1-4251-adfa-9714f964e08f",
+          "id": "807ae0eb-e21b-4830-9920-d2c75f6ce711"
         },
         {
           "component_id": "ad5778cf-c5e7-4acf-8d15-58f5ba0745c5",
           "depends_on_component_id": "0faf4b7b-bed2-4c29-b4f9-90fe3a9d2768",
           "expression_id": "5e64ca3e-7957-4a6b-b689-52325bcc772b",
-          "id": "7b6206bf-9e03-49ba-b5d7-28d1e35c7051"
+          "id": "1f1ea966-c2a2-4f80-9181-be9bb6de00f5"
+        },
+        {
+          "component_id": "515f5527-25eb-43b9-8707-bf69063232fc",
+          "depends_on_component_id": "ad5778cf-c5e7-4acf-8d15-58f5ba0745c5",
+          "depends_on_data_source_item_id": "ad82169e-8a46-4bfa-8427-7cf484837f12",
+          "expression_id": "18f191dd-b272-4c4c-bac2-3dacca7061ce",
+          "id": "e6799a0d-8a5c-4547-8866-57bd28c44a5e"
+        },
+        {
+          "component_id": "eb959f1d-45cb-4499-8025-e69c481f790d",
+          "depends_on_component_id": "ad5778cf-c5e7-4acf-8d15-58f5ba0745c5",
+          "depends_on_data_source_item_id": "8ccda5ff-b1f5-4dff-9720-38dea6bb55ff",
+          "expression_id": "fd81e893-ac66-4e91-a155-f3dec42e6110",
+          "id": "2bf99b2e-19b7-40b8-bf6d-b81e58ecce5e"
+        },
+        {
+          "component_id": "4ff702ff-f65f-4f8e-95a6-7af8d6854523",
+          "depends_on_component_id": "ad5778cf-c5e7-4acf-8d15-58f5ba0745c5",
+          "depends_on_data_source_item_id": "68d510eb-1f24-424c-bf33-4c0ebed2042c",
+          "expression_id": "bbc9b30e-82cb-4558-b96d-f707a6c5ccad",
+          "id": "5f1f6994-d19e-48e1-8906-c3b412caa1be"
         }
       ],
       "data_source_item_references": [
@@ -12429,7 +13743,14 @@
           "version": 1
         }
       ],
-      "component_references": [],
+      "component_references": [
+        {
+          "component_id": "fa33970e-caee-47a2-b939-45ba17d40a94",
+          "depends_on_component_id": "fa33970e-caee-47a2-b939-45ba17d40a94",
+          "expression_id": "0bf6f0b8-c512-4d10-a462-8767b01b34f8",
+          "id": "480d8a4b-5523-4ee9-a347-76e9405beace"
+        }
+      ],
       "data_source_item_references": [],
       "data_source_items": [],
       "data_sources": [],

--- a/tests/integration/common/data/test_models.py
+++ b/tests/integration/common/data/test_models.py
@@ -1,11 +1,12 @@
 import pytest
 from psycopg.errors import ForeignKeyViolation
+from sqlalchemy import delete
 from sqlalchemy.exc import IntegrityError
 
 from app import QuestionDataType
-from app.common.data.models import ComponentReference, Expression, Group
+from app.common.data.models import ComponentReference, DataSourceItemReference, Expression, Group
 from app.common.data.types import ExpressionType, QuestionPresentationOptions, SubmissionModeEnum
-from app.common.expressions.managed import GreaterThan
+from app.common.expressions.managed import GreaterThan, Specifically
 
 
 class TestSubmissionModel:
@@ -172,6 +173,62 @@ class TestComponentReferenceModel:
             form=q1.form,
             expressions=[Expression.from_managed(GreaterThan(question_id=q1.id, minimum_value=3000), user)],
         )
+
+        db_session.delete(q2.expressions[0])
+        db_session.commit()
+
+        assert db_session.query(ComponentReference).count() == 0
+
+    def test_deleting_a_data_source_item_with_an_expression_reference_is_blocked(self, factories, db_session):
+        user = factories.user.create()
+        q1 = factories.question.create(data_type=QuestionDataType.RADIOS)
+        factories.question.create(
+            form=q1.form,
+            expressions=[
+                Expression.from_managed(
+                    Specifically(
+                        question_id=q1.id,
+                        item={
+                            "key": q1.data_source.items[0].key,
+                            "label": q1.data_source.items[0].label,
+                        },
+                    ),
+                    created_by=user,
+                ),
+            ],
+        )
+
+        db_session.execute(delete(DataSourceItemReference))  # TODO: remove me when table goes
+        db_session.commit()
+
+        with pytest.raises(IntegrityError) as e:
+            db_session.delete(q1.data_source.items[0])
+            db_session.commit()
+
+        assert isinstance(e.value.__cause__, ForeignKeyViolation)
+        assert 'update or delete on table "data_source_item" violates foreign key constraint' in str(e.value.__cause__)
+
+    def test_deleting_an_expression_holding_a_data_source_item_reference_is_allowed(self, factories, db_session):
+        user = factories.user.create()
+        q1 = factories.question.create(data_type=QuestionDataType.RADIOS)
+        q2 = factories.question.create(
+            form=q1.form,
+            expressions=[
+                Expression.from_managed(
+                    Specifically(
+                        question_id=q1.id,
+                        item={
+                            "key": q1.data_source.items[0].key,
+                            "label": q1.data_source.items[0].label,
+                        },
+                    ),
+                    created_by=user,
+                ),
+            ],
+        )
+
+        db_session.execute(delete(DataSourceItemReference))  # TODO: remove me when table goes
+        db_session.commit()
 
         db_session.delete(q2.expressions[0])
         db_session.commit()


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
There is a significant overlap in the concept behind both
DataSourceItemReference and ComponentReference as tables - they both record
relationships between entities in order to force the database to maintain
referential integrity in our forms.

We reckon that we can consolidate these tables into one to simplify management
of references between entities. This first patch adds optional data source item
tracking to the ComponentReference table, and the code will start identifying
these references.

The existing `sync-component-references` developer command can be run on
dev/test/prod environments to regenerate all references with the
data_source_item_id column values set where needed.

We can then start using those in place of DataSourceItemReference, and then
retire that table altogether.