### PR TITLE
FSPT-759 - nested groups integrity tests

### DIFF
--- a/tests/models.py
+++ b/tests/models.py
@@ -612,6 +612,9 @@ class _GroupFactory(SQLAlchemyModelFactory):
     form = factory.SubFactory(_FormFactory)
     form_id = factory.LazyAttribute(lambda o: o.form.id)
 
+    parent = None
+    parent_id = factory.LazyAttribute(lambda o: o.parent.id if o.parent else None)
+
     @factory.post_generation  # type: ignore[misc]
     def expressions(self, create: bool, extracted: list[Any], **kwargs: Any) -> None:
         if not extracted:


### PR DESCRIPTION
Writing integration tests for nested groups to check integrity rules:
- on moving a question above/below a nested group with dependencies
- on deleting a question with dependencies in a nested group
