### PR TITLE
FSPT-852 Add Another - DB Migration and model changes

### DIFF
--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-005_drop_dsir_table
+006_add_another

--- a/app/common/data/migrations/versions/006_add_another.py
+++ b/app/common/data/migrations/versions/006_add_another.py
@@ -1,0 +1,25 @@
+"""Adding add_another column to component table
+
+Revision ID: 006_add_another
+Revises: 005_drop_dsir_table
+Create Date: 2025-09-29 11:34:07.731125
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "006_add_another"
+down_revision = "005_drop_dsir_table"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("component", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("add_another", sa.Boolean(), nullable=False, server_default=sa.text("false")))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("component", schema=None) as batch_op:
+        batch_op.drop_column("add_another")

--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -322,6 +322,20 @@ class Component(BaseModel):
 
     __mapper_args__ = {"polymorphic_on": type}
 
+    @property
+    def add_another_container(self) -> "Component | None":
+        if self.add_another:
+            return self
+
+        add_another_parent = self.parent
+        while add_another_parent and not add_another_parent.add_another:
+            add_another_parent = add_another_parent.parent
+
+        if add_another_parent and add_another_parent.add_another:
+            return add_another_parent
+
+        return None
+
 
 class Question(Component, SafeQidMixin):
     __mapper_args__ = {"polymorphic_identity": ComponentType.QUESTION}

--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -240,6 +240,7 @@ class Component(BaseModel):
     parent_id: Mapped[Optional[uuid.UUID]] = mapped_column(ForeignKey("component.id"))
     guidance_heading: Mapped[Optional[str]]
     guidance_body: Mapped[Optional[str]]
+    add_another: Mapped[bool] = mapped_column(default=False)
 
     # Relationships
     # todo: reason about if this should actually back populate _all_components as they might not

--- a/tests/models.py
+++ b/tests/models.py
@@ -549,6 +549,7 @@ class _QuestionFactory(SQLAlchemyModelFactory):
         lambda o: len(o.parent.components) if getattr(o, "parent", None) else len(o.form.components)
     )
     data_type = QuestionDataType.TEXT_SINGLE_LINE
+    add_another = False
 
     form = factory.SubFactory(_FormFactory)
     form_id = factory.LazyAttribute(lambda o: o.form.id)
@@ -611,6 +612,7 @@ class _GroupFactory(SQLAlchemyModelFactory):
 
     form = factory.SubFactory(_FormFactory)
     form_id = factory.LazyAttribute(lambda o: o.form.id)
+    add_another = False
 
     parent = None
     parent_id = factory.LazyAttribute(lambda o: o.parent.id if o.parent else None)

--- a/tests/models.py
+++ b/tests/models.py
@@ -562,6 +562,8 @@ class _QuestionFactory(SQLAlchemyModelFactory):
         yes_declaration=factory.RelatedFactory(_DataSourceFactory, factory_related_name="question"),
         no_declaration=None,
     )
+    parent = None
+    parent_id = factory.LazyAttribute(lambda o: o.parent.id if o.parent else None)
 
     presentation_options = factory.LazyFunction(lambda: QuestionPresentationOptions())
 

--- a/tests/unit/common/data/test_models.py
+++ b/tests/unit/common/data/test_models.py
@@ -72,3 +72,13 @@ class TestNestedComponents:
             q2,
         ]
         assert form.cached_questions == [q1, nested_q, q2]
+
+
+class TestAddAnother:
+    def test_add_another_false(self, factories):
+        question = factories.question.build()
+        assert question.add_another is False
+
+    def test_add_another_true(self, factories):
+        question = factories.question.build(add_another=True)
+        assert question.add_another is True

--- a/tests/unit/common/data/test_models.py
+++ b/tests/unit/common/data/test_models.py
@@ -82,3 +82,53 @@ class TestAddAnother:
     def test_add_another_true(self, factories):
         question = factories.question.build(add_another=True)
         assert question.add_another is True
+
+    def test_no_add_another_container(self, factories):
+        form = factories.form.build()
+        question1 = factories.question.build(form=form)
+
+        assert question1.add_another is False
+        assert question1.add_another_container is None
+
+        group1 = factories.group.build(form=form)
+        question2 = factories.question.build(parent=group1)
+        assert question2.add_another is False
+        assert question2.add_another_container is None
+        assert group1.add_another is False
+        assert group1.add_another_container is None
+
+        group2 = factories.group.build(parent=group1)
+        question3 = factories.question.build(parent=group2)
+        assert question3.add_another is False
+        assert question3.add_another_container is None
+        assert group2.add_another is False
+        assert group2.add_another_container is None
+
+    def test_add_another_container_is_self(self, factories):
+        form = factories.form.build()
+        question = factories.question.build(form=form, add_another=True)
+
+        assert question.add_another_container == question
+
+    def test_add_another_container_is_immediate_group_parent(self, factories):
+        form = factories.form.build()
+        group = factories.group.build(form=form, add_another=True)
+        question = factories.question.build(parent=group)
+
+        assert question.add_another is False
+        assert group.add_another is True
+        assert question.add_another_container == group
+        assert group.add_another_container == group
+
+    def test_add_another_container_is_ancestor_group(self, factories):
+        form = factories.form.build()
+        group1 = factories.group.build(form=form, add_another=True)
+        group2 = factories.group.build(parent=group1)
+        question = factories.question.build(parent=group2)
+
+        assert question.add_another is False
+        assert group1.add_another is True
+        assert group2.add_another is False
+        assert question.add_another_container == group1
+        assert group2.add_another_container == group1
+        assert group1.add_another_container == group1


### PR DESCRIPTION
## 🎫 Ticket
[Add Another - DB migration](https://mhclgdigital.atlassian.net/browse/FSPT-852)

## 📝 Description
First small part of the [add another ticket ](https://mhclgdigital.atlassian.net/browse/FSPT-849). This PR adds the column `add_another` to the Component table, with a property `add_another_container` to determine the containing component of this question if it exists in an add another context.

- If a single question is an add another question, the container is itself
- If a question or group is contained inside an add another group, the container is that add another group.

We are implementing a restriction to stop an add another group containing any further add anothers (groups or questions) so we also add a function to validate whether an add another component can be created.

All of the above is tested. There is no visible change to users or the journey, and nothing uses the new code or column yet.


## 🧪 Testing
- Unit and integration tests added, and factories updated

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [ x] PR title and description provide sufficient context for reviewers
- [x ] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- [ x] No N+1 query problems introduced
- [x ] Any new DB queries include appropriate where clauses based on the user's permissions

