### PR TITLE
FSPT-849 Remove from Add Another

### DIFF
--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -106,6 +106,22 @@ def update_collection(collection: Collection, *, name: str) -> Collection:
 
 
 @flush_and_rollback_on_exceptions
+def remove_add_another_answers_at_index(
+    submission: Submission, add_another_container: Component, add_another_index: int
+) -> Submission:
+    existing_answers = submission.data.get(str(add_another_container.id), [])
+    if add_another_index < 0 or add_another_index >= len(existing_answers):
+        raise ValueError(
+            f"Cannot remove answers at index {add_another_index} as there are "
+            f"only {len(existing_answers)} existing answers"
+        )
+
+    existing_answers.pop(add_another_index)
+    submission.data[str(add_another_container.id)] = existing_answers
+    return submission
+
+
+@flush_and_rollback_on_exceptions
 def update_submission_data(
     submission: Submission, question: Question, data: AllAnswerTypes, add_another_index: int | None = None
 ) -> Submission:
@@ -122,7 +138,7 @@ def update_submission_data(
     parent_container = question.add_another_container
     existing_answers = submission.data.get(str(parent_container.id), [])
 
-    if add_another_index > len(existing_answers):
+    if add_another_index > len(existing_answers) or add_another_index < 0:
         raise ValueError(
             f"Cannot update answers at index {add_another_index} as there are "
             f"only {len(existing_answers)} existing answers"

--- a/tests/models.py
+++ b/tests/models.py
@@ -476,6 +476,7 @@ class _CollectionFactory(SQLAlchemyModelFactory):
         test: int = 0,
         live: int = 0,
         use_random_data: bool = True,
+        number_of_add_another_answers: int = 5,
         **kwargs,
     ) -> None:
         if not test and not live:
@@ -531,7 +532,7 @@ class _CollectionFactory(SQLAlchemyModelFactory):
         )
 
         add_another_responses = []
-        for i in range(0, 5):
+        for i in range(0, number_of_add_another_answers):
             add_another_responses.append(
                 {
                     str(q3.id): TextSingleLineAnswer(  # ty:ignore[missing-argument]


### PR DESCRIPTION
## 🎫 Ticket
[FSPT-849](https://mhclgdigital.atlassian.net/browse/FSPT-855)

## 📝 Description
Builds on PR #835 to allow the removal of a set of add another answers from the specific point in the list of existing answers.

Includes validation of the supplied `add_another_index` to make sure that it's pointing to a valid set of answers.

No changes visible to users and the new function is not called anywhere yet.

## 🧪 Testing
- Unit tests

## 📋 Developer Checklist

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions


## 📚 Additional Notes
As per previous PR, will review the use of `ValueError` when we start connecting this up to the frontend.


[FSPT-849]: https://mhclgdigital.atlassian.net/browse/FSPT-849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ