### PR TITLE
bugfix + e2e test update for context-aware forms

### DIFF
--- a/app/deliver_grant_funding/routes/reports.py
+++ b/app/deliver_grant_funding/routes/reports.py
@@ -832,6 +832,7 @@ def select_context_source_question(grant_id: UUID, form_id: UUID) -> ResponseRet
                         grant_id=grant_id,
                         form_id=form_id,
                         parent_id=add_context_data.parent_id,
+                        question_data_type=add_context_data.data_type.name,
                     )
                     if add_context_data.question_id is None
                     else url_for(

--- a/tests/e2e/test_create_preview_collection.py
+++ b/tests/e2e/test_create_preview_collection.py
@@ -258,8 +258,8 @@ questions_to_test: dict[str, TQuestionToTest] = {
             body_heading="Guidance subheading",
             body_link_text="Design system link text",
             body_link_url="https://design-system.service.gov.uk",
-            body_ol_items=["UL item one", "UL item two"],
-            body_ul_items=["OL item one", "OL item two"],
+            body_ul_items=["UL item one", "UL item two"],
+            body_ol_items=["OL item one", "OL item two"],
         ),
     },
     "text-multi-line": {
@@ -312,8 +312,8 @@ questions_with_groups_to_test: dict[str, TQuestionToTest] = {
             body_heading="Guidance subheading",
             body_link_text="Design system link text",
             body_link_url="https://design-system.service.gov.uk",
-            body_ol_items=["UL item one", "UL item two"],
-            body_ul_items=["OL item one", "OL item two"],
+            body_ul_items=["UL item one", "UL item two"],
+            body_ol_items=["OL item one", "OL item two"],
         ),
         "condition": Condition(
             referenced_question="Do you want to show question groups?",

--- a/tests/e2e/test_create_preview_collection.py
+++ b/tests/e2e/test_create_preview_collection.py
@@ -62,10 +62,18 @@ class Condition:
     managed_expression: ManagedExpression
 
 
+@dataclasses.dataclass
+class TextFieldWithData:
+    prefix: str
+    data_from_question: str
+
+
 class QuestionDict(TypedDict):
     type: QuestionDataType
     text: str
     display_text: str
+    hint: NotRequired[TextFieldWithData]  # Allows testing the 'insert data' journey
+    display_hint: NotRequired[str]  # For use with the 'insert data' journey
     answers: list[_QuestionResponse]
     choices: NotRequired[list[str]]
     options: NotRequired[QuestionPresentationOptions]
@@ -107,8 +115,10 @@ questions_to_test: dict[str, TQuestionToTest] = {
     ),
     "approx_date": QuestionDict(
         type=QuestionDataType.DATE,
-        text="Enter an approximate date; your exact date was ((enter a date))",
-        display_text="Enter an approximate date; your exact date was Tuesday 5 April 2022",
+        text="Enter an approximate date",
+        display_text="Enter an approximate date",
+        hint=TextFieldWithData(prefix="You entered an exact date of", data_from_question="Enter a date"),
+        display_hint="You entered an exact date of Tuesday 5 April 2022",
         answers=[
             _QuestionResponse(
                 ["2003", "2"],
@@ -473,7 +483,18 @@ def create_question(
 
     question_details_page.fill_question_text(question_text)
     question_details_page.fill_question_name(question_text.lower())
-    question_details_page.fill_question_hint(f"Hint text for: {question_text}")
+
+    if hint := question_definition.get("hint"):
+        question_details_page.fill_question_hint(hint.prefix)
+        select_data_source_page = question_details_page.click_insert_data(
+            field_name="hint", question=hint.data_from_question
+        )
+        select_data_source_page.select_data_source("A previous question in this task")
+        select_question_page = select_data_source_page.click_select()
+        select_question_page.choose_question(hint.data_from_question)
+        select_question_page.click_use_data()
+    else:
+        question_details_page.fill_question_hint(f"Hint text for: {question_text}")
 
     if question_definition["type"] in [QuestionDataType.RADIOS, QuestionDataType.CHECKBOXES]:
         question_details_page.fill_data_source_items(question_definition["choices"])
@@ -671,6 +692,9 @@ def navigate_to_report_tasks_page(page: Page, domain: str, grant_name: str, repo
 
 
 def assert_question_visibility(question_page: RunnerQuestionPage, question_to_test: TQuestionToTest) -> None:
+    if display_hint := question_to_test.get("display_hint"):
+        expect(question_page.page.locator(".govuk-hint", has_text=display_hint)).to_be_visible()
+
     if question_to_test.get("guidance") is None:
         if "This question should not be shown" in question_to_test["text"]:
             expect(question_page.heading).not_to_be_visible()

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -1807,7 +1807,7 @@ class TestSelectContextSourceQuestion:
 
         with authenticated_grant_admin_client.session_transaction() as sess:
             sess["question"] = AddContextToQuestionSessionModel(
-                data_type=QuestionDataType.TEXT_SINGLE_LINE,
+                data_type=QuestionDataType.YES_NO,
                 text="Test question",
                 name="test_question",
                 hint="Test hint",
@@ -1822,8 +1822,12 @@ class TestSelectContextSourceQuestion:
                 form_id=form.id,
             ),
             data={"question": str(question.id)},
+            follow_redirects=False,
         )
         assert response.status_code == 302
+        assert response.location == AnyStringMatching(
+            r"^/deliver/grant/[a-z0-9-]{36}/task/[a-z0-9-]{36}/questions/add\?question_data_type=YES_NO$"
+        )
 
         with authenticated_grant_admin_client.session_transaction() as sess:
             question_data = sess.get("question")


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-780

## 📝 Description
Updates our e2e test to use the 'insert data' micro flow and add a reference to a previous question's answer in the current question.

Includes a fix for the journey that this test identified 🎉 

## Show it

Relevant timestamps:
- Creating question: 1:03
- Viewing/answering question: 2:40

[video.mp4](https://github.com/user-attachments/assets/9653abd3-d518-4356-b936-d875783b3d5e)

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- [x] No N+1 query problems introduced
- [x] Any new DB queries include appropriate where clauses based on the user's permissions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [-] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [x] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested