### PR TITLE
Wait for this autocomplete to initialise

### DIFF
--- a/tests/e2e/reports_pages.py
+++ b/tests/e2e/reports_pages.py
@@ -882,17 +882,15 @@ class SelectDataSourceQuestionPage(ReportsBasePage):
         )
 
     def choose_question(self, question: str) -> None:
-        accessible_autocomplete = self.page.query_selector("[data-accessible-autocomplete]")
-        if accessible_autocomplete:
-            # there is a few ms of delay during the call to "enhanceSelectElement" which allows the select
-            # being progressively enhanced to be selected before its complete as playwright will act immediately
-            # on the role being available - this causes the test to fail particularly when there is network latency.
-            # Wait for the full input + options to be loaded before using it
-            expect(self.page.locator("[class='autocomplete__wrapper']")).to_be_attached()
-            element = self.page.get_by_role("combobox")
-            element.click()
-            element.fill(question)
-            element.press("Enter")
+        # there is a few ms of delay during the call to "enhanceSelectElement" which allows the select
+        # being progressively enhanced to be selected before its complete as playwright will act immediately
+        # on the role being available - this causes the test to fail particularly when there is network latency.
+        # Wait for the full input + options to be loaded before using it
+        expect(self.page.locator("[class='autocomplete__wrapper']")).to_be_attached()
+        element = self.page.get_by_role("combobox")
+        element.click()
+        element.fill(question)
+        element.press("Enter")
 
     def click_use_data(self) -> None:
         self.page.get_by_role("button", name="Use data").click()


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
e2e tests are currently failing on this page as they're skipping filling in the autocomplete. I can see from playwright traces that it's looking for the `data-accessible-autocomplete` attribute and then just immediately moving on, so it's not finding anything with that attribute. We don't need to look for it here - it's guaranteed to be there. So we can just wait for the JS to have run directly.

<img width="807" height="261" alt="image" src="https://github.com/user-attachments/assets/87c871e7-8bf1-4da3-9805-47c00ac10847" />
