### PR TITLE
Fix `group_name_exists`

### DIFF
--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -759,7 +759,7 @@ def move_component_down(component: Component) -> Component:
 
 
 def group_name_exists(name: str, form_id: UUID) -> bool:
-    statement = select(Group).where(Group.name == name and Group.form_id == form_id)
+    statement = select(Group).where(Group.name == name, Group.form_id == form_id)
     group = db.session.scalar(statement)
     return group is not None
 

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -33,6 +33,7 @@ from app.common.data.interfaces.collections import (
     get_question_by_id,
     get_referenced_data_source_items_by_managed_expression,
     get_submission,
+    group_name_exists,
     is_component_dependency_order_valid,
     move_component_down,
     move_component_up,
@@ -411,6 +412,19 @@ class TestCreateGroup:
                 text="Child group Level 3",
                 parent=parent_group,
             )
+
+
+class TestGroupNameExists:
+    def test_group_name_exists(self, db_session, factories):
+        form = factories.form.create()
+        form2 = factories.form.create()
+        assert group_name_exists("Test group", form_id=form.id) is False
+        assert group_name_exists("Test group", form_id=form2.id) is False
+
+        factories.group.create(name="Test group", form=form)
+
+        assert group_name_exists("Test group", form_id=form.id) is True
+        assert group_name_exists("Test group", form_id=form2.id) is False
 
 
 class TestUpdateGroup:


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-882

## 📝 Description
Because of the misplaced `and` vs a comma, this was returning True if any group existed in the entire platform with that name, rather than within the specific form.