### PR TITLE
FSPT-872: optimise package build

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -31,16 +31,6 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.CI_AWS_ACCOUNT }}:role/terraform-developer
           aws-region: eu-west-2  # adjust as needed
 
-      - name: Set up Python
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6
-        with:
-          python-version: 3.13.7
-
-      - name: vite
-        run: |
-          npm ci
-          npm run build
-
       - name: Login to Amazon ECR
         uses: aws-actions/amazon-ecr-login@d63b14614fe5d7fc5e5e52c523dea4e876816cc4
 

--- a/project.toml
+++ b/project.toml
@@ -1,18 +1,11 @@
 [_]
 schema-version = "0.2"
 
-[io.buildpacks]
-exclude = [
-    ".flaskenv",
-    ".git",
-    ".github",
-    ".vscode",
-    ".pullpreview",
-    ".pre-commit-config.yaml",
-    "tests"
-]
+[[io.buildpacks.group]]
+id = "heroku/nodejs"
 
-[[io.buildpacks.build.env]]
-# If updating the version here, also update in pyproject.toml, .python-version, Dockerfile
-name = "BP_CPYTHON_VERSION"
-value = "3.13.*"
+[[io.buildpacks.group]]
+id = "heroku/python"
+
+[[io.buildpacks.group]]
+id = "heroku/procfile"


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-872

## 📝 Description
Following #840 this introduces a number of optimisations to the buildpack usage
* Removes unsupported features from project.toml
* Moves static asset (vite) build into buildpack phase
* Sets major python version (to get security updates faster)

### After
With these changes build step is same speed or faster and produces same output https://github.com/communitiesuk/funding-service/actions/runs/18276232823/job/52028898931

## 🧪 Testing
Have tested on dev e.g. https://github.com/communitiesuk/funding-service/actions/runs/18276232823

