### PR TITLE
FSPT-781: Refactor and standardise context in session model

### DIFF
--- a/app/deliver_grant_funding/forms.py
+++ b/app/deliver_grant_funding/forms.py
@@ -237,7 +237,6 @@ class QuestionForm(FlaskForm):
         filters=[strip_string_if_not_empty, strip_newlines],
         widget=GovTextArea(),
     )
-    text_add_context = SubmitField(widget=GovSubmitInput())
     hint = StringField(
         "Question hint (optional)",
         filters=[strip_string_if_not_empty],
@@ -247,7 +246,6 @@ class QuestionForm(FlaskForm):
         ),
         render_kw={"params": {"rows": 2}},
     )
-    hint_add_context = SubmitField(widget=GovSubmitInput())
     name = StringField(
         "Question name",
         validators=[DataRequired("Enter the question name")],
@@ -257,6 +255,7 @@ class QuestionForm(FlaskForm):
         filters=[strip_string_if_not_empty, strip_newlines],
         widget=GovTextInput(),
     )
+    add_context = StringField(widget=GovSubmitInput())
 
     # Note: the next fields all read from properties on the `Question` model because the names match. This
     # implicit connection needs to be maintained.
@@ -396,7 +395,10 @@ class QuestionForm(FlaskForm):
             raise ValidationError("Remove the prefix if you need a suffix")
 
     def is_submitted_to_add_context(self) -> bool:
-        return self.is_submitted() and (self.text_add_context.data or self.hint_add_context.data)
+        return bool(self.is_submitted() and self.add_context.data and not self.submit.data)
+
+    def get_component_form_data(self) -> dict[str, Any]:
+        return {key: data for key, data in self.data.items() if key not in {"csrf_token", "submit"}}
 
 
 class AddContextSelectSourceForm(FlaskForm):
@@ -600,7 +602,7 @@ class AddGuidanceForm(FlaskForm):
         widget=GovTextArea(),
         filters=[strip_string_if_not_empty],
     )
-    add_context = SubmitField(widget=GovSubmitInput())
+    add_context = StringField(widget=GovSubmitInput())
 
     preview = SubmitField("Save and preview guidance", widget=GovSubmitInput())
     submit = SubmitField("Save guidance", widget=GovSubmitInput())
@@ -620,7 +622,10 @@ class AddGuidanceForm(FlaskForm):
         return result
 
     def is_submitted_to_add_context(self) -> bool:
-        return self.is_submitted() and self.add_context.data
+        return bool(self.is_submitted() and self.add_context.data and not self.submit.data)
+
+    def get_component_form_data(self) -> dict[str, Any]:
+        return {key: data for key, data in self.data.items() if key not in {"csrf_token", "submit"}}
 
 
 class PreviewGuidanceForm(FlaskForm):

--- a/app/deliver_grant_funding/session_models.py
+++ b/app/deliver_grant_funding/session_models.py
@@ -29,11 +29,8 @@ class AddContextToComponentSessionModel(BaseModel):
     model_config = ConfigDict(validate_assignment=True)
 
     data_type: QuestionDataType
-    text: str
-    name: str
-    hint: str
-
-    field: Literal["text", "hint"]
+    field: Literal["component"] = "component"
+    component_form_data: dict[str, Any]
 
     data_source: ExpressionContext.ContextSources | None = None
 
@@ -45,9 +42,8 @@ class AddContextToComponentGuidanceSessionModel(BaseModel):
     model_config = ConfigDict(validate_assignment=True)
 
     field: Literal["guidance"] = "guidance"
+    component_form_data: dict[str, Any]
 
     component_id: UUID | None = None
-    guidance_body: str
-    guidance_heading: str
 
     data_source: ExpressionContext.ContextSources | None = None

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/add_question.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/add_question.html
@@ -33,7 +33,7 @@
         <div data-module="context-aware-editor" data-toolbar-enabled="false" data-i18n="{}">
           <div class="govuk-!-display-none" data-context nonce="{{ csp_nonce() }}">{{ context_keys_and_labels | tojson }}</div>
           {% set addDataButton %}
-            {{ form.text_add_context(params={"html": "Insert data <span class='govuk-visually-hidden'>in question name</span>", "classes": "govuk-button--secondary app-context-aware--button"}) }}
+            {{ form.add_context(params={"html": "Insert data <span class='govuk-visually-hidden'>in question name</span>", "classes": "govuk-button--secondary app-context-aware--button", "value": "text"}) }}
           {% endset %}
           {{ form.text(params={"label": {"classes": "govuk-!-font-weight-bold"}, "attributes": {"data-module": "textarea-no-newlines", "data-context-aware-editor-target": ""}, "formGroup": {"classes": "app-context-aware--container", "afterInput": {"html": addDataButton} } }) }}
 
@@ -43,7 +43,7 @@
         <div data-module="context-aware-editor" data-toolbar-enabled="false" data-i18n="{}">
           <div class="govuk-!-display-none" data-context nonce="{{ csp_nonce() }}">{{ context_keys_and_labels | tojson }}</div>
           {% set addDataButton %}
-            {{ form.hint_add_context(params={"html": "Insert data <span class='govuk-visually-hidden'>in question hint</span>", "classes": "govuk-button--secondary app-context-aware--button"}) }}
+            {{ form.add_context(params={"html": "Insert data <span class='govuk-visually-hidden'>in question hint</span>", "classes": "govuk-button--secondary app-context-aware--button", "value": "hint"}) }}
           {% endset %}
           {{ form.hint(params={"label": {"classes": "govuk-!-font-weight-bold"}, "attributes": {"data-module": "textarea-no-newlines", "data-context-aware-editor-target": ""}, "formGroup": {"classes": "app-context-aware--container", "afterInput": {"html": addDataButton} } }) }}
         </div>

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/edit_question.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/edit_question.html
@@ -102,7 +102,7 @@
         <div data-module="context-aware-editor" data-toolbar-enabled="false" data-i18n="{}">
           <div class="govuk-!-display-none" data-context nonce="{{ csp_nonce() }}">{{ context_keys_and_labels | tojson }}</div>
           {% set addDataButton %}
-            {{ form.text_add_context(params={"html": "Insert data <span class='govuk-visually-hidden'>in question name</span>", "classes": "govuk-button--secondary app-context-aware--button"}) }}
+            {{ form.add_context(params={"html": "Insert data <span class='govuk-visually-hidden'>in question name</span>", "classes": "govuk-button--secondary app-context-aware--button", "value": "text"}) }}
           {% endset %}
           {{ form.text(params={"label": {"classes": "govuk-!-font-weight-bold"}, "attributes": {"data-module": "textarea-no-newlines", "data-context-aware-editor-target": ""}, "formGroup": {"classes": "app-context-aware--container", "afterInput": {"html": addDataButton} } }) }}
         </div>
@@ -112,7 +112,7 @@
         <div data-module="context-aware-editor" data-toolbar-enabled="false" data-i18n="{}">
           <div class="govuk-!-display-none" data-context nonce="{{ csp_nonce() }}">{{ context_keys_and_labels | tojson }}</div>
           {% set addDataButton %}
-            {{ form.hint_add_context(params={"html": "Insert data <span class='govuk-visually-hidden'>in question hint</span>", "classes": "govuk-button--secondary app-context-aware--button"}) }}
+            {{ form.add_context(params={"html": "Insert data <span class='govuk-visually-hidden'>in question hint</span>", "classes": "govuk-button--secondary app-context-aware--button", "value": "hint"}) }}
           {% endset %}
           {{ form.hint(params={"label": {"classes": "govuk-!-font-weight-bold"}, "attributes": {"data-module": "textarea-no-newlines", "data-context-aware-editor-target": ""}, "formGroup": {"classes": "app-context-aware--container", "afterInput": {"html": addDataButton} } }) }}
         </div>

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -1424,14 +1424,14 @@ class TestAddQuestion:
                 "text": "Updated question",
                 "hint": "Updated hint",
                 "name": "Updated name",
-                f"{context_field}_add_context": "y",
+                "add_context": context_field,
             },
             question_type=QuestionDataType.TEXT_SINGLE_LINE,
         )
         spy_validate = mocker.spy(interfaces.collections, "_validate_and_sync_component_references")
         response = authenticated_grant_admin_client.post(
             url_for("deliver_grant_funding.add_question", grant_id=grant.id, form_id=db_form.id),
-            data=get_form_data(form),
+            data=get_form_data(form, submit=""),
             follow_redirects=False,
         )
 
@@ -1442,7 +1442,7 @@ class TestAddQuestion:
         assert spy_validate.call_count == 0
 
         with authenticated_grant_admin_client.session_transaction() as sess:
-            assert sess["question"]["field"] == context_field
+            assert sess["question"]["field"] == "component"
 
     def test_post_from_add_context_success_cleans_that_bit_of_session(
         self, authenticated_grant_admin_client, factories, db_session
@@ -1453,10 +1453,12 @@ class TestAddQuestion:
 
         session_data = AddContextToComponentSessionModel(
             data_type=QuestionDataType.TEXT_SINGLE_LINE,
-            text="Test question text",
-            name="Test question name",
-            hint="Test question hint",
-            field="text",
+            component_form_data={
+                "text": "Test question text",
+                "name": "Test question name",
+                "hint": "Test question hint",
+                "add_context": "text",
+            },
         )
 
         with authenticated_grant_admin_client.session_transaction() as sess:
@@ -1529,10 +1531,12 @@ class TestAddQuestion:
 
         session_data = AddContextToComponentSessionModel(
             data_type=QuestionDataType.TEXT_SINGLE_LINE,
-            text="Test question text",
-            name="Test question name",
-            hint="Test question hint",
-            field="text",
+            component_form_data={
+                "text": "Test question text",
+                "name": "Test question name",
+                "hint": "Test question hint",
+                "add_context": "text",
+            },
             parent_id=group.id,
         )
 
@@ -1704,10 +1708,12 @@ class TestSelectContextSource:
         with authenticated_grant_admin_client.session_transaction() as sess:
             sess["question"] = AddContextToComponentSessionModel(
                 data_type=QuestionDataType.TEXT_SINGLE_LINE,
-                text="Test question",
-                name="test_question",
-                hint="Test hint",
-                field="text",
+                component_form_data={
+                    "text": "Test question text",
+                    "name": "Test question name",
+                    "hint": "Test question hint",
+                    "add_context": "text",
+                },
             ).model_dump(mode="json")
 
         response = authenticated_grant_admin_client.get(
@@ -1732,10 +1738,12 @@ class TestSelectContextSource:
         with authenticated_grant_admin_client.session_transaction() as sess:
             sess["question"] = AddContextToComponentSessionModel(
                 data_type=QuestionDataType.TEXT_SINGLE_LINE,
-                text="Test question",
-                name="test_question",
-                hint="Test hint",
-                field="text",
+                component_form_data={
+                    "text": "Test text",
+                    "name": "Test name",
+                    "hint": "Test hint",
+                    "add_context": "text",
+                },
                 component_id=group.id,
             ).model_dump(mode="json")
 
@@ -1761,10 +1769,12 @@ class TestSelectContextSource:
         with authenticated_grant_admin_client.session_transaction() as sess:
             sess["question"] = AddContextToComponentSessionModel(
                 data_type=QuestionDataType.TEXT_SINGLE_LINE,
-                text="Test question",
-                name="test_question",
-                hint="Test hint",
-                field="text",
+                component_form_data={
+                    "text": "Test text",
+                    "name": "Test name",
+                    "hint": "Test hint",
+                    "add_context": "text",
+                },
             ).model_dump(mode="json")
 
         response = authenticated_grant_admin_client.post(
@@ -1808,10 +1818,12 @@ class TestSelectContextSourceQuestion:
         with authenticated_grant_admin_client.session_transaction() as sess:
             sess["question"] = AddContextToComponentSessionModel(
                 data_type=QuestionDataType.TEXT_SINGLE_LINE,
-                text="Test question",
-                name="test_question",
-                hint="Test hint",
-                field="text",
+                component_form_data={
+                    "text": "Test text",
+                    "name": "Test name",
+                    "hint": "Test hint",
+                    "add_context": "text",
+                },
                 data_source=ExpressionContext.ContextSources.TASK,
             ).model_dump(mode="json")
 
@@ -1837,10 +1849,12 @@ class TestSelectContextSourceQuestion:
         with authenticated_grant_admin_client.session_transaction() as sess:
             sess["question"] = AddContextToComponentSessionModel(
                 data_type=QuestionDataType.YES_NO,
-                text="Test question",
-                name="test_question",
-                hint="Test hint",
-                field="text",
+                component_form_data={
+                    "text": "Test text",
+                    "name": "Test name",
+                    "hint": "Test hint",
+                    "add_context": "text",
+                },
                 data_source=ExpressionContext.ContextSources.TASK,
             ).model_dump(mode="json")
 
@@ -1861,7 +1875,7 @@ class TestSelectContextSourceQuestion:
         with authenticated_grant_admin_client.session_transaction() as sess:
             question_data = sess.get("question")
             assert question_data is not None
-            assert question_data["text"] == f"Test question (({question.safe_qid}))"
+            assert question_data["component_form_data"]["text"] == f"Test text (({question.safe_qid}))"
 
 
 class TestEditQuestion:
@@ -2054,7 +2068,7 @@ class TestEditQuestion:
                 "text": "Updated question",
                 "hint": "Updated hint",
                 "name": "Updated name",
-                f"{context_field}_add_context": "y",
+                "add_context": context_field,
             },
             question_type=QuestionDataType.TEXT_SINGLE_LINE,
         )
@@ -2065,7 +2079,7 @@ class TestEditQuestion:
                 grant_id=grant.id,
                 question_id=question.id,
             ),
-            data=get_form_data(form),
+            data=get_form_data(form, submit=""),
             follow_redirects=False,
         )
 
@@ -2076,7 +2090,7 @@ class TestEditQuestion:
         assert spy_validate.call_count == 0
 
         with authenticated_grant_admin_client.session_transaction() as sess:
-            assert sess["question"]["field"] == context_field
+            assert sess["question"]["field"] == "component"
 
     def test_post_from_add_context_success_cleans_that_bit_of_session(
         self, authenticated_grant_admin_client, factories, db_session
@@ -2094,10 +2108,11 @@ class TestEditQuestion:
 
         session_data = AddContextToComponentSessionModel(
             data_type=QuestionDataType.TEXT_SINGLE_LINE,
-            text="Test question text",
-            name="Test question name",
-            hint="Test question hint",
-            field="text",
+            component_form_data={
+                "text": "Test question text",
+                "name": "Test question name",
+                "hint": "Test question hint",
+            },
             component_id=question.id,
         )
 
@@ -2153,10 +2168,12 @@ class TestEditQuestion:
 
         session_data = AddContextToComponentSessionModel(
             data_type=QuestionDataType.TEXT_SINGLE_LINE,
-            text="Updated question text from session",
-            name="Updated question name from session",
-            hint="Updated question hint from session",
-            field="text",
+            component_form_data={
+                "text": "Updated question text from session",
+                "name": "Updated question name from session",
+                "hint": "Updated question hint from session",
+                "add_context": "text",
+            },
             component_id=question.id,
             parent_id=None,
         )
@@ -3331,7 +3348,9 @@ class TestManageGuidance:
         question = factories.question.create(form__collection__grant=authenticated_grant_admin_client.grant)
 
         form = AddGuidanceForm(
-            guidance_heading="How to answer", guidance_body="Please provide detailed information", add_context="y"
+            guidance_heading="How to answer",
+            guidance_body="Please provide detailed information",
+            add_context="guidance_body",
         )
         response = authenticated_grant_admin_client.post(
             url_for(
@@ -3339,7 +3358,7 @@ class TestManageGuidance:
                 grant_id=authenticated_grant_admin_client.grant.id,
                 question_id=question.id,
             ),
-            data=get_form_data(form),
+            data=get_form_data(form, submit=""),
             follow_redirects=False,
         )
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -144,7 +144,7 @@ def page_has_button(soup: BeautifulSoup, button_text: str) -> Tag | None:
     return None
 
 
-def get_form_data(form: FlaskForm) -> dict[str, Any]:
+def get_form_data(form: FlaskForm, submit: str = "y") -> dict[str, Any]:
     """Get the data from a flask form suitable for passing as `data` to a Flask test client's `post` method.
 
     Specifically we need to strip out any null/falsey data, which can be stringified into eg `"False"` and ends up
@@ -153,7 +153,7 @@ def get_form_data(form: FlaskForm) -> dict[str, Any]:
     data = {k: v for k, v in form.data.items() if v}
 
     # If we're getting the form data, we want to submit the form
-    if hasattr(form, "submit"):
+    if hasattr(form, "submit") and submit:
         data["submit"] = "y"
 
     return data


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-781

## 📝 Description
In preparation for allowing contextual data in managed expressions, we're doing some tidying up and bugfixes of how the current context and session models are used in add/edit questions and guidance.

Refactor forms to use a standard 'add_context' named button in all forms; pass through a 'value' on that button to associate it with which field is the target of the 'insert data' micro journey. Also refactors the session models to extract the entire form data for the relevant form so any new context is inserted into the form data dict and then rebuilt consistently when the user is returned to the page they were editing.

This also fixes up a small bug in which any changes to other fields (eg. Additional formatting, data source items) weren't being preserved when initiating the insert context journey.

## 🧪 Testing
- Pull the branch
- Go through the flow of adding some context to question text/hint/guidance
- Make other changes to the question (eg. Additional formatting, data source items) and check that these changes are preserved when you're returned from the insert data journey.

## 📋 Developer Checklist

### Review Readiness
- [X] PR title and description provide sufficient context for reviewers
- [X] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- ~[ ] I need the reviewer(s) to pull and run this change locally~
- [X] New (non-developer) functionality has appropriate unit and integration tests
- [X] End-to-end tests have been updated (if applicable)
- [X] Edge cases and error conditions are tested
