### PR TITLE
FSPT-781: Allow custom templates for managed expression form rendering

### DIFF
--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/managed_expressions/between.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/managed_expressions/between.html
@@ -1,0 +1,6 @@
+<div class="govuk-form-group">
+  {{ form.between_bottom_of_range(params={"classes": "govuk-input--width-10" }) }}
+  {{ form.between_bottom_inclusive() }}
+  {{ form.between_top_of_range(params={"classes": "govuk-input--width-10" }) }}
+  {{ form.between_top_inclusive() }}
+</div>

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/managed_expressions/between_dates.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/managed_expressions/between_dates.html
@@ -1,0 +1,7 @@
+<div class="govuk-form-group">
+  {{ form.between_bottom_of_range() }}
+  {{ form.between_bottom_inclusive() }}
+
+  {{ form.between_top_of_range() }}
+  {{ form.between_top_inclusive() }}
+</div>

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/managed_expressions/greater_than.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/managed_expressions/greater_than.html
@@ -1,0 +1,4 @@
+<div class="govuk-form-group">
+  {{ form.greater_than_value(params={"classes": "govuk-input--width-10" }) }}
+  {{ form.greater_than_inclusive() }}
+</div>

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/managed_expressions/is_after.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/managed_expressions/is_after.html
@@ -1,0 +1,4 @@
+<div class="govuk-form-group">
+  {{ form.earliest_value() }}
+  {{ form.earliest_value_inclusive() }}
+</div>

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/managed_expressions/is_before.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/managed_expressions/is_before.html
@@ -1,0 +1,4 @@
+<div class="govuk-form-group">
+  {{ form.latest_value() }}
+  {{ form.latest_value_inclusive() }}
+</div>

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/managed_expressions/less_than.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/managed_expressions/less_than.html
@@ -1,0 +1,4 @@
+<div class="govuk-form-group">
+  {{ form.less_than_value(params={"classes": "govuk-input--width-10"}) }}
+  {{ form.less_than_inclusive() }}
+</div>


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
As we build out the context-aware conditions and validation flows, we know that we'll need some non-trivial form rendering logic (to switch between users inserting static values and having configured expression statements). To allow this logic to be isolated in templates, we provide the ability to set a managed expression form template.

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [-] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [x] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested