### PR TITLE
Adding formatting of scss files to pre-commit

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,4 @@
 # Prettier HTML format
 0b49b94fb1627006ef18f27ffcafec3f45fa75ef
+# Prettier JS, CSS, SASS and SCSS formatting
+da882497a948b394bbfb5a5bb8af878cdd0f006e

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ci:
   autofix_prs: false
-  skip: ["mypy", "format-html"]
+  skip: [ "mypy", "format-frontend" ]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -14,7 +14,7 @@ repos:
     rev: v0.13.3
     hooks:
       - id: ruff
-        args: [--fix]
+        args: [ --fix ]
       - id: ruff-format
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.5.0
@@ -40,15 +40,14 @@ repos:
       - id: mypy
         name: Run type checks
         language: system
-        types: [python]
+        types: [ python ]
         entry: uv run mypy
         pass_filenames: false
-      - id: format-html
-        name: Format Jinja HTML templates with Prettier
-        entry: make format-html
+      - id: format-frontend
+        name: Format frontend files with Prettier
+        entry: make format-frontend
         language: node
-        files: \.html$
         additional_dependencies:
-          - 'prettier@3.6.2'
-          - 'prettier-plugin-jinja-template@2.1.0'
+          - "prettier@3.6.2"
+          - "prettier-plugin-jinja-template@2.1.0"
         pass_filenames: false

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 app/assets/js/**/__fixtures__
+app/assets/dist

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,3 @@
 {
-  "plugins": ["prettier-plugin-jinja-template"]
+    "plugins": ["prettier-plugin-jinja-template"]
 }

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,14 @@ check-html:
 format-html:
 	npx prettier --plugin=prettier-plugin-jinja-template --parser=jinja-template --tab-width=2 --html-whitespace-sensitivity css --bracket-same-line=true --print-width=240 --write **/*.html
 
+.PHONY: format-css-js
+format-css-js:
+	npx prettier --tab-width=4 --write "**/*.{js,css,sass,scss}"
+
+.PHONY: format-frontend
+format-frontend: format-css-js format-html
+
+
 .PHONY: build
 build:
 	docker compose build

--- a/app/assets/css/context-aware-editor/_index.scss
+++ b/app/assets/css/context-aware-editor/_index.scss
@@ -3,169 +3,171 @@
 
 // Main wrapper for the context aware editor
 .app-context-aware-editor--wrapper {
-  position: relative;
-  display: block;
-  width: 100%;
+    position: relative;
+    display: block;
+    width: 100%;
 }
 
 // Toolbar container
 .app-context-aware-editor__toolbar-container {
-  // Toolbar styles adapted from markdown-editor-toolbar
-  .app-context-aware-editor__toolbar {
-    display: flex;
-    gap: 5px;
-    flex-flow: row wrap;
-    padding: 10px 3px;
+    // Toolbar styles adapted from markdown-editor-toolbar
+    .app-context-aware-editor__toolbar {
+        display: flex;
+        gap: 5px;
+        flex-flow: row wrap;
+        padding: 10px 3px;
 
-    &:focus-within {
-      box-shadow: inset 0 0 0 2px;
-      outline: 3px solid $govuk-focus-colour;
-      outline-offset: 0;
-    }
-  }
-
-  .app-context-aware-editor__toolbar-button-group {
-    display: flex;
-    gap: 0 govuk-px-to-rem(1);
-  }
-
-  .app-context-aware-editor__toolbar-button {
-    width: govuk-px-to-rem(40);
-    height: govuk-px-to-rem(40);
-    background-position: 50% 50%;
-    background-repeat: no-repeat;
-    background-size: 100% 100%;
-    margin: 0;
-
-    &--h2 {
-      background-image: url($govuk-images-path + "markdown-editor-h2.svg");
+        &:focus-within {
+            box-shadow: inset 0 0 0 2px;
+            outline: 3px solid $govuk-focus-colour;
+            outline-offset: 0;
+        }
     }
 
-    &--bullet-list {
-      background-image: url($govuk-images-path + "markdown-editor-bullet-list.svg");
+    .app-context-aware-editor__toolbar-button-group {
+        display: flex;
+        gap: 0 govuk-px-to-rem(1);
     }
 
-    &--numbered-list {
-      background-image: url($govuk-images-path + "markdown-editor-numbered-list.svg");
-    }
+    .app-context-aware-editor__toolbar-button {
+        width: govuk-px-to-rem(40);
+        height: govuk-px-to-rem(40);
+        background-position: 50% 50%;
+        background-repeat: no-repeat;
+        background-size: 100% 100%;
+        margin: 0;
 
-    &--link {
-      background-image: url($govuk-images-path + "markdown-editor-link.svg");
+        &--h2 {
+            background-image: url($govuk-images-path + "markdown-editor-h2.svg");
+        }
+
+        &--bullet-list {
+            background-image: url($govuk-images-path + "markdown-editor-bullet-list.svg");
+        }
+
+        &--numbered-list {
+            background-image: url($govuk-images-path + "markdown-editor-numbered-list.svg");
+        }
+
+        &--link {
+            background-image: url($govuk-images-path + "markdown-editor-link.svg");
+        }
     }
-  }
 }
 
 // Editor container (holds textarea and highlight overlay)
 .app-context-aware-editor__editor-container {
-  position: relative;
-  display: inline-block;
-  width: 100%;
+    position: relative;
+    display: inline-block;
+    width: 100%;
 }
 
 // Visible textarea (transparent text on top)
 .app-context-aware-editor__visible-textarea {
-  position: relative;
-  background-color: transparent !important;
-  color: transparent;
-  caret-color: black;
-  z-index: 1;
+    position: relative;
+    background-color: transparent !important;
+    color: transparent;
+    caret-color: black;
+    z-index: 1;
 }
 
 // Highlight overlay (behind textarea, shows styled text)
 .app-context-aware-editor__highlight-overlay {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  pointer-events: none;
-  box-sizing: border-box;
-  border: none;
-  padding: 7px;
-  overflow-y: auto;
-  white-space: pre-wrap;
-  word-wrap: break-word;
-  background: transparent;
-  color: black;
-  z-index: 0;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    box-sizing: border-box;
+    border: none;
+    padding: 7px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    background: transparent;
+    color: black;
+    z-index: 0;
 
-  // Match textarea font exactly
-  @include govuk-font($size: 19, $line-height: 1.25em);
+    // Match textarea font exactly
+    @include govuk-font($size: 19, $line-height: 1.25em);
 
-  // Style for valid references
-  .app-context-aware-editor--valid-reference {
-    background-color: govuk-colour("yellow");
-    border-radius: 2px;
-  }
+    // Style for valid references
+    .app-context-aware-editor--valid-reference {
+        background-color: govuk-colour("yellow");
+        border-radius: 2px;
+    }
 }
 
 // Notification area for screen readers (if needed for toolbar)
 .app-context-aware-editor__notification-area {
-  @include govuk-visually-hidden;
+    @include govuk-visually-hidden;
 }
 
 // Error message styling
 .app-context-aware-editor__error-message {
-  margin: 0;
+    margin: 0;
 }
 
 // Preview styles (from markdown-editor-component)
 .app-context-aware-editor__preview-area {
-  border: 2px solid $govuk-border-colour;
-  padding: 30px;
-  margin: 0 0 1em;
+    border: 2px solid $govuk-border-colour;
+    padding: 30px;
+    margin: 0 0 1em;
 }
 
 .app-context-aware-editor__preview-area :last-child {
-  margin-bottom: 0;
+    margin-bottom: 0;
 }
 
 .govuk-frontend-supported .app-context-aware-editor__preview-button {
-  display: none;
+    display: none;
 }
 
 .govuk-frontend-supported .app-context-aware-editor__preview-intro {
-  @include govuk-media-query($from: tablet) {
-    display: none;
-  }
+    @include govuk-media-query($from: tablet) {
+        display: none;
+    }
 }
 
 .govuk-frontend-supported .app-context-aware-editor__preview-area {
-  @include govuk-media-query($from: tablet) {
-    border: 0;
-    padding: 0;
-    margin-bottom: 0;
-  }
+    @include govuk-media-query($from: tablet) {
+        border: 0;
+        padding: 0;
+        margin-bottom: 0;
+    }
 }
 
 .govuk-frontend-supported .app-context-aware-editor__edit-link {
-  @include govuk-media-query($from: tablet) {
-    display: none;
-  }
+    @include govuk-media-query($from: tablet) {
+        display: none;
+    }
 }
 
 // Markdown example blocks (from markdown-editor-component)
 .app-context-aware-editor__markdown-example-block {
-  white-space: pre-wrap;
-  font-size: inherit;
-  font-family: inherit;
-
-  &-code {
+    white-space: pre-wrap;
     font-size: inherit;
     font-family: inherit;
-  }
+
+    &-code {
+        font-size: inherit;
+        font-family: inherit;
+    }
 }
 
 // When toolbar is disabled, ensure proper spacing
-.app-context-aware-editor--wrapper:not(.app-context-aware-editor--with-toolbar) {
-  .app-context-aware-editor__editor-container {
-    margin-top: 0;
-  }
+.app-context-aware-editor--wrapper:not(
+    .app-context-aware-editor--with-toolbar
+) {
+    .app-context-aware-editor__editor-container {
+        margin-top: 0;
+    }
 }
 
 // When toolbar is enabled, add class for styling
 .app-context-aware-editor--wrapper.app-context-aware-editor--with-toolbar {
-  .app-context-aware-editor__editor-container {
-    margin-top: 0; // Toolbar container handles its own spacing
-  }
+    .app-context-aware-editor__editor-container {
+        margin-top: 0; // Toolbar container handles its own spacing
+    }
 }

--- a/app/assets/js/ajax-markdown-preview/index.js
+++ b/app/assets/js/ajax-markdown-preview/index.js
@@ -1,151 +1,152 @@
-import debounce from '../utils/debounce'
+import debounce from "../utils/debounce";
 
 const store = {
-  target: null,
-  source: null,
-  csrfToken: null,
-  liveRegion: null,
-  errorArea: null
-}
+    target: null,
+    source: null,
+    csrfToken: null,
+    liveRegion: null,
+    errorArea: null,
+};
 
 const setLoadingStatus = () => {
-  store.liveRegion.setAttribute('aria-busy', 'true')
-  store.target.innerHTML = `<p>Preview loading...</p>`
-}
+    store.liveRegion.setAttribute("aria-busy", "true");
+    store.target.innerHTML = `<p>Preview loading...</p>`;
+};
 
 const setFailureStatus = () => {
-  store.target.innerHTML = `<p>There was an error</p>`
-  const retryButton = document.createElement('button')
-  retryButton.classList.add('govuk-button', 'govuk-button--secondary')
-  retryButton.innerHTML = 'Retry preview'
-  addEventListeners(retryButton, manuallyTriggerMarkdownPreview)
-  store.target.appendChild(retryButton)
-}
+    store.target.innerHTML = `<p>There was an error</p>`;
+    const retryButton = document.createElement("button");
+    retryButton.classList.add("govuk-button", "govuk-button--secondary");
+    retryButton.innerHTML = "Retry preview";
+    addEventListeners(retryButton, manuallyTriggerMarkdownPreview);
+    store.target.appendChild(retryButton);
+};
 
 const triggerAjaxMarkdownPreview = async () => {
-  try {
-    if (store.endpoint) {
-      const response = await window.fetch(store.endpoint, {
-        method: 'POST',
-        mode: 'same-origin',
-        cache: 'no-cache',
-        credentials: 'same-origin',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        redirect: 'follow',
-        referrerPolicy: 'same-origin',
-        body: JSON.stringify({
-          csrf_token: store.csrfToken,
-          guidance: store.source.value,
-        })
-      })
+    try {
+        if (store.endpoint) {
+            const response = await window.fetch(store.endpoint, {
+                method: "POST",
+                mode: "same-origin",
+                cache: "no-cache",
+                credentials: "same-origin",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                redirect: "follow",
+                referrerPolicy: "same-origin",
+                body: JSON.stringify({
+                    csrf_token: store.csrfToken,
+                    guidance: store.source.value,
+                }),
+            });
 
-      // insert the preview into the DOM
-      const json = await response.json()
-      store.target.innerHTML = json.guidance_html
-      if (json.errors.length > 0) {
-        addErrorToField(json.errors[0])
-        addErrorClass()
-      } else {
-        clearErrorsFromField()
-        removeErrorClass()
-      }
-      addNotification('Preview updated.')
-    } else {
-      throw new Error('No endpoint set')
+            // insert the preview into the DOM
+            const json = await response.json();
+            store.target.innerHTML = json.guidance_html;
+            if (json.errors.length > 0) {
+                addErrorToField(json.errors[0]);
+                addErrorClass();
+            } else {
+                clearErrorsFromField();
+                removeErrorClass();
+            }
+            addNotification("Preview updated.");
+        } else {
+            throw new Error("No endpoint set");
+        }
+    } catch {
+        setFailureStatus();
+        addNotification("Error loading preview");
     }
-  } catch {
-    setFailureStatus()
-    addNotification("Error loading preview")
-  }
-}
+};
 
-const manuallyTriggerMarkdownPreview = event => {
-  event?.preventDefault()
+const manuallyTriggerMarkdownPreview = (event) => {
+    event?.preventDefault();
 
-  triggerAjaxMarkdownPreview()
-}
+    triggerAjaxMarkdownPreview();
+};
 
 const addEventListeners = (trigger, callback) => {
-  trigger.addEventListener('click', callback)
-}
+    trigger.addEventListener("click", callback);
+};
 
 // debounce the AJAX request so we don't hammer the server with one request per keystroke
 const debouncedAjaxMarkdownPreview = debounce(() => {
-  triggerAjaxMarkdownPreview()
-}, 1000)
+    triggerAjaxMarkdownPreview();
+}, 1000);
 
 const inputEventListener = () => {
-  setLoadingStatus()
-  return debouncedAjaxMarkdownPreview()
-}
+    setLoadingStatus();
+    return debouncedAjaxMarkdownPreview();
+};
 
 const addLiveRegion = () => {
-  const liveRegion = document.createElement('div')
-  liveRegion.setAttribute('role', 'status')
-  liveRegion.classList.add('app-context-aware-editor__notification-area')
-  store.liveRegion = liveRegion
-  store.source.after(liveRegion)
-}
+    const liveRegion = document.createElement("div");
+    liveRegion.setAttribute("role", "status");
+    liveRegion.classList.add("app-context-aware-editor__notification-area");
+    store.liveRegion = liveRegion;
+    store.source.after(liveRegion);
+};
 
-const addNotification = text => {
-  store.liveRegion.setAttribute('aria-busy', 'false')
-  store.liveRegion.innerHTML = text
-  setTimeout(() => {
-    store.liveRegion.innerHTML = ''
-  }, 5000)
-}
+const addNotification = (text) => {
+    store.liveRegion.setAttribute("aria-busy", "false");
+    store.liveRegion.innerHTML = text;
+    setTimeout(() => {
+        store.liveRegion.innerHTML = "";
+    }, 5000);
+};
 
 const createErrorArea = () => {
-  // Use existing error area if there's a server side error present on the field
-  store.errorArea =
-    store.source
-      .closest('.govuk-form-group')
-      ?.querySelector('.govuk-error-message') ?? document.createElement('p')
-  store.errorArea.classList.add(
-    'govuk-error-message',
-    'app-context-aware-editor__error-message'
-  )
-  store.source.closest('.govuk-form-group').prepend(store.errorArea)
-  setAriaAttributesForError()
-}
+    // Use existing error area if there's a server side error present on the field
+    store.errorArea =
+        store.source
+            .closest(".govuk-form-group")
+            ?.querySelector(".govuk-error-message") ??
+        document.createElement("p");
+    store.errorArea.classList.add(
+        "govuk-error-message",
+        "app-context-aware-editor__error-message",
+    );
+    store.source.closest(".govuk-form-group").prepend(store.errorArea);
+    setAriaAttributesForError();
+};
 
 const setAriaAttributesForError = () => {
-  if (!store.errorArea.getAttribute('id')) {
-    const id = `${store.source.getAttribute('id')}-error`
-    store.errorArea.setAttribute('id', id)
-    store.source.setAttribute(
-      'aria-describedby',
-      `${id} ${store.source.getAttribute('aria-describedby')}`
-    )
-  }
-  store.errorArea.setAttribute('aria-live', 'polite')
-}
+    if (!store.errorArea.getAttribute("id")) {
+        const id = `${store.source.getAttribute("id")}-error`;
+        store.errorArea.setAttribute("id", id);
+        store.source.setAttribute(
+            "aria-describedby",
+            `${id} ${store.source.getAttribute("aria-describedby")}`,
+        );
+    }
+    store.errorArea.setAttribute("aria-live", "polite");
+};
 
-const addErrorToField = error => {
-  if (!store.errorArea) createErrorArea()
-  store.errorArea.innerHTML = `<span class="govuk-visually-hidden">Error:</span> ${error}`
-}
+const addErrorToField = (error) => {
+    if (!store.errorArea) createErrorArea();
+    store.errorArea.innerHTML = `<span class="govuk-visually-hidden">Error:</span> ${error}`;
+};
 
 const clearErrorsFromField = () => {
-  if (!store.errorArea) createErrorArea()
-  store.errorArea.innerHTML = ''
-}
+    if (!store.errorArea) createErrorArea();
+    store.errorArea.innerHTML = "";
+};
 
 const addErrorClass = () => {
-  store.source
-    .closest('.govuk-form-group')
-    ?.classList.add('govuk-form-group--error')
-  store.source.classList.add('govuk-textarea--error')
-}
+    store.source
+        .closest(".govuk-form-group")
+        ?.classList.add("govuk-form-group--error");
+    store.source.classList.add("govuk-textarea--error");
+};
 
 const removeErrorClass = () => {
-  store.source
-    .closest('.govuk-form-group--error')
-    ?.classList.remove('govuk-form-group--error')
-  store.source.classList.remove('govuk-textarea--error')
-}
+    store.source
+        .closest(".govuk-form-group--error")
+        ?.classList.remove("govuk-form-group--error");
+    store.source.classList.remove("govuk-textarea--error");
+};
 
 /**
  * Submits markdown held in the source element to the endpoint when the source changes, and replaces the target element's content with the result of the request.
@@ -154,22 +155,22 @@ const removeErrorClass = () => {
  * @param {string} endpoint - The URL for the endpoint that renders the markdown.
  */
 const ajaxMarkdownPreview = (target, source, endpoint) => {
-  store.target = target
-  store.source = source
-  store.endpoint = endpoint
-  store.csrfToken = document
-    .querySelector('input[name="csrf_token"]')
-    ?.getAttribute('value')
+    store.target = target;
+    store.source = source;
+    store.endpoint = endpoint;
+    store.csrfToken = document
+        .querySelector('input[name="csrf_token"]')
+        ?.getAttribute("value");
 
-  addLiveRegion()
-  createErrorArea()
+    addLiveRegion();
+    createErrorArea();
 
-  // run on page load
-  setLoadingStatus()
-  triggerAjaxMarkdownPreview()
+    // run on page load
+    setLoadingStatus();
+    triggerAjaxMarkdownPreview();
 
-  // run when the user types
-  source.addEventListener('input', inputEventListener)
-}
+    // run when the user types
+    source.addEventListener("input", inputEventListener);
+};
 
-export default ajaxMarkdownPreview
+export default ajaxMarkdownPreview;

--- a/app/assets/js/ajax-markdown-preview/index.test.js
+++ b/app/assets/js/ajax-markdown-preview/index.test.js
@@ -2,285 +2,294 @@
  * @vitest-environment jsdom
  */
 
-import 'regenerator-runtime/runtime'
-import ajaxMarkdownPreview from '.'
+import "regenerator-runtime/runtime";
+import ajaxMarkdownPreview from ".";
 
 import {
-  mockFetch,
-  mockFetchWithDelay,
-  mockFetchWithServerError
-} from '../../test/test-helpers'
+    mockFetch,
+    mockFetchWithDelay,
+    mockFetchWithServerError,
+} from "../../test/test-helpers";
 
-let source, target
+let source, target;
 
 const jsonResponse = {
-  guidance_html: '<h2 class="govuk-heading-m">This is a heading</h2>',
-  errors: []
-}
+    guidance_html: '<h2 class="govuk-heading-m">This is a heading</h2>',
+    errors: [],
+};
 
 const jsonResponseWithError = {
-  guidance_html: '<p>This is a level one heading</p>',
-  errors: [
-    'Guidance text can only contain formatting for links, subheadings (##), bulleted lists (*), or numbered lists (1.)'
-  ]
-}
+    guidance_html: "<p>This is a level one heading</p>",
+    errors: [
+        "Guidance text can only contain formatting for links, subheadings (##), bulleted lists (*), or numbered lists (1.)",
+    ],
+};
 
-const updateMarkdown = markdownContent => {
-  source.value = markdownContent
-  const event = new window.Event('input')
-  source.dispatchEvent(event)
-}
+const updateMarkdown = (markdownContent) => {
+    source.value = markdownContent;
+    const event = new window.Event("input");
+    source.dispatchEvent(event);
+};
 
 const generateSourceHTML = (markdownContent, includeServerSideError) => {
-  if (includeServerSideError) {
-    return `<div class="govuk-form-group govuk-form-group--error">
+    if (includeServerSideError) {
+        return `<div class="govuk-form-group govuk-form-group--error">
         <p class="govuk-error-message" id="markdown-field-error">
           <span class="govuk-visually-hidden">Error: </span>Guidance text can only contain formatting for links, subheadings (##), bulleted lists (*), or numbered lists (1.)
         </p>
         <textarea aria-describedby="markdown-field-error" data-ajax-markdown-source="true">${markdownContent}</textarea>
-      </div>`
-  } else {
-    return `<div class="govuk-form-group"><textarea data-ajax-markdown-source="true">${markdownContent}</textarea></div>`
-  }
-}
+      </div>`;
+    } else {
+        return `<div class="govuk-form-group"><textarea data-ajax-markdown-source="true">${markdownContent}</textarea></div>`;
+    }
+};
 
 const setupDocument = (markdownContent, includeServerSideError = false) => {
-  const sourceHTML = generateSourceHTML(markdownContent, includeServerSideError)
-  const targetHTML =
-    '<div data-ajax-markdown-target><p>Some old preview content</p></div>'
-  document.body.innerHTML = `<div data-module="ajax-markdown-preview" data-ajax-markdown-endpoint="/endpoint">
+    const sourceHTML = generateSourceHTML(
+        markdownContent,
+        includeServerSideError,
+    );
+    const targetHTML =
+        "<div data-ajax-markdown-target><p>Some old preview content</p></div>";
+    document.body.innerHTML = `<div data-module="ajax-markdown-preview" data-ajax-markdown-endpoint="/endpoint">
     ${sourceHTML}
     ${targetHTML}
     </div>
-  `
-  document
-    .querySelectorAll('[data-module="ajax-markdown-preview"]')
-    .forEach(element => {
-      ajaxMarkdownPreview(
-        element.querySelector('[data-ajax-markdown-target]'),
-        element.querySelector('[data-ajax-markdown-source]'),
-        element.getAttribute('data-ajax-markdown-endpoint'),
-      )
-    })
+  `;
+    document
+        .querySelectorAll('[data-module="ajax-markdown-preview"]')
+        .forEach((element) => {
+            ajaxMarkdownPreview(
+                element.querySelector("[data-ajax-markdown-target]"),
+                element.querySelector("[data-ajax-markdown-source]"),
+                element.getAttribute("data-ajax-markdown-endpoint"),
+            );
+        });
 
-  source = document.querySelector('[data-ajax-markdown-source]')
-  target = document.querySelector('[data-ajax-markdown-target]')
-}
+    source = document.querySelector("[data-ajax-markdown-source]");
+    target = document.querySelector("[data-ajax-markdown-target]");
+};
 
-describe('AJAX Markdown preview', () => {
-  beforeEach(() => {
-    vi.useFakeTimers()
-  })
-
-  afterEach(() => {
-    vi.clearAllMocks()
-    vi.runOnlyPendingTimers()
-    vi.useRealTimers()
-  })
-
-  describe('when the request returns the JSON response with no errors', () => {
+describe("AJAX Markdown preview", () => {
     beforeEach(() => {
-      global.fetch = mockFetch(jsonResponse)
-      setupDocument('## This is a markdown heading')
-    })
+        vi.useFakeTimers();
+    });
 
-    test('preview is called on page load', async () => {
-      expect(target.innerHTML).toBe(jsonResponse.guidance_html)
+    afterEach(() => {
+        vi.clearAllMocks();
+        vi.runOnlyPendingTimers();
+        vi.useRealTimers();
+    });
 
-      expect(global.fetch).toHaveBeenCalledWith('/endpoint', {
-        body: '{"guidance":"## This is a markdown heading"}',
-        cache: 'no-cache',
-        credentials: 'same-origin',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-CSRF-Token': undefined
-        },
-        method: 'POST',
-        mode: 'same-origin',
-        redirect: 'follow',
-        referrerPolicy: 'same-origin'
-      })
-      expect(global.fetch).toHaveBeenCalledTimes(1)
-    })
+    describe("when the request returns the JSON response with no errors", () => {
+        beforeEach(() => {
+            global.fetch = mockFetch(jsonResponse);
+            setupDocument("## This is a markdown heading");
+        });
 
-    test('preview event fires if the user makes a change', async () => {
-      expect(global.fetch).toHaveBeenCalledTimes(1)
+        test("preview is called on page load", async () => {
+            expect(target.innerHTML).toBe(jsonResponse.guidance_html);
 
-      updateMarkdown()
+            expect(global.fetch).toHaveBeenCalledWith("/endpoint", {
+                body: '{"guidance":"## This is a markdown heading"}',
+                cache: "no-cache",
+                credentials: "same-origin",
+                headers: {
+                    "Content-Type": "application/json",
+                    "X-CSRF-Token": undefined,
+                },
+                method: "POST",
+                mode: "same-origin",
+                redirect: "follow",
+                referrerPolicy: "same-origin",
+            });
+            expect(global.fetch).toHaveBeenCalledTimes(1);
+        });
 
-      await vi.runAllTimersAsync()
+        test("preview event fires if the user makes a change", async () => {
+            expect(global.fetch).toHaveBeenCalledTimes(1);
 
-      expect(global.fetch).toHaveBeenCalledTimes(2)
-    })
+            updateMarkdown();
 
-    test('preview event updates the content correctly', async () => {
-      target.innerHTML = ''
-      const event = new window.Event('input')
-      source.dispatchEvent(event)
+            await vi.runAllTimersAsync();
 
-      await vi.runAllTimersAsync()
+            expect(global.fetch).toHaveBeenCalledTimes(2);
+        });
 
-      expect(target.innerHTML).toBe(jsonResponse.guidance_html)
-    })
+        test("preview event updates the content correctly", async () => {
+            target.innerHTML = "";
+            const event = new window.Event("input");
+            source.dispatchEvent(event);
 
-    test('preview event only fires once if the user makes multiple changes in quick succession', async () => {
-      expect(global.fetch).toHaveBeenCalledTimes(1)
-      ;[...Array(100)].forEach(() => {
-        const event = new window.Event('input')
-        source.dispatchEvent(event)
-      })
+            await vi.runAllTimersAsync();
 
-      await vi.runAllTimersAsync()
+            expect(target.innerHTML).toBe(jsonResponse.guidance_html);
+        });
 
-      expect(global.fetch).toHaveBeenCalledTimes(2)
-    })
-  })
+        test("preview event only fires once if the user makes multiple changes in quick succession", async () => {
+            expect(global.fetch).toHaveBeenCalledTimes(1);
+            [...Array(100)].forEach(() => {
+                const event = new window.Event("input");
+                source.dispatchEvent(event);
+            });
 
-  describe('when the request returns the JSON response with errors', () => {
-    describe('when there is no server-side error message present', () => {
-      beforeEach(() => {
-        global.fetch = mockFetch(jsonResponseWithError)
-        setupDocument('# This is a level one heading')
-      })
+            await vi.runAllTimersAsync();
 
-      test('an error message is displayed', () => {
-        expect(document.querySelector('.govuk-error-message').textContent).toBe(
-          `Error: ${jsonResponseWithError.errors[0]}`
-        )
-      })
+            expect(global.fetch).toHaveBeenCalledTimes(2);
+        });
+    });
 
-      test('the error message is associated with the textarea using aria-described', () => {
-        expect(source.getAttribute('aria-describedby')).toContain(
-          document.querySelector('.govuk-error-message').getAttribute('id')
-        )
-      })
+    describe("when the request returns the JSON response with errors", () => {
+        describe("when there is no server-side error message present", () => {
+            beforeEach(() => {
+                global.fetch = mockFetch(jsonResponseWithError);
+                setupDocument("# This is a level one heading");
+            });
 
-      test('the form group has the error class', () => {
-        expect(
-          document.querySelectorAll('.govuk-form-group--error')
-        ).toHaveLength(1)
-      })
+            test("an error message is displayed", () => {
+                expect(
+                    document.querySelector(".govuk-error-message").textContent,
+                ).toBe(`Error: ${jsonResponseWithError.errors[0]}`);
+            });
 
-      describe('when the user fixes the error', () => {
-        beforeEach(async () => {
-          global.fetch = mockFetch(jsonResponse)
-          updateMarkdown('## This is a level two heading')
+            test("the error message is associated with the textarea using aria-described", () => {
+                expect(source.getAttribute("aria-describedby")).toContain(
+                    document
+                        .querySelector(".govuk-error-message")
+                        .getAttribute("id"),
+                );
+            });
 
-          await vi.runAllTimersAsync()
-        })
+            test("the form group has the error class", () => {
+                expect(
+                    document.querySelectorAll(".govuk-form-group--error"),
+                ).toHaveLength(1);
+            });
 
-        test('the error message is removed', () => {
-          expect(
-            document.querySelector('.govuk-error-message').textContent
-          ).toBe('')
-        })
+            describe("when the user fixes the error", () => {
+                beforeEach(async () => {
+                    global.fetch = mockFetch(jsonResponse);
+                    updateMarkdown("## This is a level two heading");
 
-        test('the form group does not have the error class', () => {
-          expect(
-            document.querySelectorAll('.govuk-form-group--error')
-          ).toHaveLength(0)
-        })
-      })
-    })
+                    await vi.runAllTimersAsync();
+                });
 
-    describe('when a server-side error is already present', () => {
-      beforeEach(() => {
-        global.fetch = mockFetch(jsonResponseWithError)
-        setupDocument('# This is a level one heading', true)
-      })
+                test("the error message is removed", () => {
+                    expect(
+                        document.querySelector(".govuk-error-message")
+                            .textContent,
+                    ).toBe("");
+                });
 
-      test('an error message is displayed', () => {
-        expect(document.querySelector('.govuk-error-message').textContent).toBe(
-          `Error: ${jsonResponseWithError.errors[0]}`
-        )
-      })
+                test("the form group does not have the error class", () => {
+                    expect(
+                        document.querySelectorAll(".govuk-form-group--error"),
+                    ).toHaveLength(0);
+                });
+            });
+        });
 
-      test('the error message is associated with the textarea using aria-described', () => {
-        expect(source.getAttribute('aria-describedby')).toContain(
-          document.querySelector('.govuk-error-message').getAttribute('id')
-        )
-      })
+        describe("when a server-side error is already present", () => {
+            beforeEach(() => {
+                global.fetch = mockFetch(jsonResponseWithError);
+                setupDocument("# This is a level one heading", true);
+            });
 
-      test('the form group has the error class', () => {
-        expect(
-          document.querySelectorAll('.govuk-form-group--error')
-        ).toHaveLength(1)
-      })
+            test("an error message is displayed", () => {
+                expect(
+                    document.querySelector(".govuk-error-message").textContent,
+                ).toBe(`Error: ${jsonResponseWithError.errors[0]}`);
+            });
 
-      describe('when the user fixes the error', () => {
-        beforeEach(async () => {
-          global.fetch = mockFetch(jsonResponse)
-          updateMarkdown('## This is a level two heading')
+            test("the error message is associated with the textarea using aria-described", () => {
+                expect(source.getAttribute("aria-describedby")).toContain(
+                    document
+                        .querySelector(".govuk-error-message")
+                        .getAttribute("id"),
+                );
+            });
 
-          await vi.runAllTimersAsync()
-        })
+            test("the form group has the error class", () => {
+                expect(
+                    document.querySelectorAll(".govuk-form-group--error"),
+                ).toHaveLength(1);
+            });
 
-        test('the error message is removed', () => {
-          expect(
-            document.querySelector('.govuk-error-message').textContent
-          ).toBe('')
-        })
+            describe("when the user fixes the error", () => {
+                beforeEach(async () => {
+                    global.fetch = mockFetch(jsonResponse);
+                    updateMarkdown("## This is a level two heading");
 
-        test('the form group does not have the error class', () => {
-          expect(
-            document.querySelectorAll('.govuk-form-group--error')
-          ).toHaveLength(0)
-        })
-      })
-    })
-  })
+                    await vi.runAllTimersAsync();
+                });
 
-  describe('when the AJAX request fails', () => {
-    beforeEach(() => {
-      global.fetch = mockFetchWithServerError()
+                test("the error message is removed", () => {
+                    expect(
+                        document.querySelector(".govuk-error-message")
+                            .textContent,
+                    ).toBe("");
+                });
 
-      setupDocument('## This is a markdown heading')
-    })
+                test("the form group does not have the error class", () => {
+                    expect(
+                        document.querySelectorAll(".govuk-form-group--error"),
+                    ).toHaveLength(0);
+                });
+            });
+        });
+    });
 
-    test('the error message is displayed', () => {
-      expect(target.innerHTML).toBe(
-        '<p>There was an error</p><button class="govuk-button govuk-button--secondary">Retry preview</button>'
-      )
-      const ariaLiveRegion = document.querySelector(
-        '.app-context-aware-editor__notification-area'
-      )
-      expect(ariaLiveRegion.getAttribute('aria-busy')).toBe('false')
-    })
+    describe("when the AJAX request fails", () => {
+        beforeEach(() => {
+            global.fetch = mockFetchWithServerError();
 
-    test('the retry button resends the request', () => {
-      expect(global.fetch).toHaveBeenCalledTimes(1)
+            setupDocument("## This is a markdown heading");
+        });
 
-      const retryButton = target.querySelector('button')
-      retryButton.click()
+        test("the error message is displayed", () => {
+            expect(target.innerHTML).toBe(
+                '<p>There was an error</p><button class="govuk-button govuk-button--secondary">Retry preview</button>',
+            );
+            const ariaLiveRegion = document.querySelector(
+                ".app-context-aware-editor__notification-area",
+            );
+            expect(ariaLiveRegion.getAttribute("aria-busy")).toBe("false");
+        });
 
-      expect(global.fetch).toHaveBeenCalledTimes(2)
-    })
-  })
+        test("the retry button resends the request", () => {
+            expect(global.fetch).toHaveBeenCalledTimes(1);
 
-  describe('when the request is loading', () => {
-    beforeEach(() => {
-      global.fetch = mockFetchWithDelay(jsonResponse, 500)
+            const retryButton = target.querySelector("button");
+            retryButton.click();
 
-      setupDocument('## This is a markdown heading')
-    })
+            expect(global.fetch).toHaveBeenCalledTimes(2);
+        });
+    });
 
-    test('Loading text is displayed before the response arrives', async () => {
-      expect(target.innerHTML).toBe('<p>Preview loading...</p>')
+    describe("when the request is loading", () => {
+        beforeEach(() => {
+            global.fetch = mockFetchWithDelay(jsonResponse, 500);
 
-      await vi.advanceTimersByTimeAsync(500)
+            setupDocument("## This is a markdown heading");
+        });
 
-      expect(target.innerHTML).toBe(jsonResponse.guidance_html)
-    })
+        test("Loading text is displayed before the response arrives", async () => {
+            expect(target.innerHTML).toBe("<p>Preview loading...</p>");
 
-    test('message is pushed to aria-live region when the page loads', async () => {
-      const ariaLiveRegion = document.querySelector(
-        '.app-context-aware-editor__notification-area'
-      )
-      expect(ariaLiveRegion.getAttribute('aria-busy')).toBe('true')
+            await vi.advanceTimersByTimeAsync(500);
 
-      await vi.advanceTimersByTimeAsync(500)
+            expect(target.innerHTML).toBe(jsonResponse.guidance_html);
+        });
 
-      expect(ariaLiveRegion.getAttribute('aria-busy')).toBe('false')
-    })
-  })
-})
+        test("message is pushed to aria-live region when the page loads", async () => {
+            const ariaLiveRegion = document.querySelector(
+                ".app-context-aware-editor__notification-area",
+            );
+            expect(ariaLiveRegion.getAttribute("aria-busy")).toBe("true");
+
+            await vi.advanceTimersByTimeAsync(500);
+
+            expect(ariaLiveRegion.getAttribute("aria-busy")).toBe("false");
+        });
+    });
+});

--- a/app/assets/js/context-aware-editor/highlighting.js
+++ b/app/assets/js/context-aware-editor/highlighting.js
@@ -1,281 +1,332 @@
 // Reference highlighting functionality
 // Refactored from reference-overlay to work as part of combined editor
 
-const REFERENCE_REGEX = /\(\([^)]+\)\)/g
+const REFERENCE_REGEX = /\(\([^)]+\)\)/g;
 
 const parseReferences = (text, mappings = null) => {
-  const references = []
-  let match
+    const references = [];
+    let match;
 
-  while ((match = REFERENCE_REGEX.exec(text)) !== null) {
-    const referenceContent = match[0].slice(2, -2) // Remove (( and ))
+    while ((match = REFERENCE_REGEX.exec(text)) !== null) {
+        const referenceContent = match[0].slice(2, -2); // Remove (( and ))
 
-    // Determine if this reference is resolved/valid
-    let isResolved = false
-    if (mappings) {
-      // In visible textarea: check if the human-readable content matches any mapping value
-      // In hidden textarea: check if the reference ID exists as a mapping key
+        // Determine if this reference is resolved/valid
+        let isResolved = false;
+        if (mappings) {
+            // In visible textarea: check if the human-readable content matches any mapping value
+            // In hidden textarea: check if the reference ID exists as a mapping key
 
-      // Check if this is a raw reference ID (key in mappings)
-      if (mappings.has(referenceContent)) {
-        isResolved = true
-      } else {
-        // Check if this human-readable text matches any mapping value
-        for (const [id, humanText] of mappings.entries()) {
-          if (humanText === match[0]) { // Compare full ((text)) format
-            isResolved = true
-            break
-          }
+            // Check if this is a raw reference ID (key in mappings)
+            if (mappings.has(referenceContent)) {
+                isResolved = true;
+            } else {
+                // Check if this human-readable text matches any mapping value
+                for (const [id, humanText] of mappings.entries()) {
+                    if (humanText === match[0]) {
+                        // Compare full ((text)) format
+                        isResolved = true;
+                        break;
+                    }
+                }
+            }
+        } else {
+            // When no mappings provided, treat everything as unresolved
+            isResolved = false;
         }
-      }
-    } else {
-      // When no mappings provided, treat everything as unresolved
-      isResolved = false
+
+        references.push({
+            match: match[0],
+            reference: referenceContent,
+            start: match.index,
+            end: match.index + match[0].length,
+            isResolved: isResolved,
+        });
     }
 
-    references.push({
-      match: match[0],
-      reference: referenceContent,
-      start: match.index,
-      end: match.index + match[0].length,
-      isResolved: isResolved
-    })
-  }
-
-  return references
-}
+    return references;
+};
 
 const resolveReference = (reference, mappings) => {
-  return mappings.get(reference) || null
-}
+    return mappings.get(reference) || null;
+};
 
 const transformTextToHumanReadable = (text, mappings) => {
-  let transformedText = text
-  const references = parseReferences(text, mappings)
+    let transformedText = text;
+    const references = parseReferences(text, mappings);
 
-  // Process references in reverse order to maintain string positions
-  references.reverse().forEach(ref => {
-    const humanReadableText = resolveReference(ref.reference, mappings)
+    // Process references in reverse order to maintain string positions
+    references.reverse().forEach((ref) => {
+        const humanReadableText = resolveReference(ref.reference, mappings);
 
-    if (humanReadableText) {
-      // Extract the human-readable part (remove (( and )))
-      const cleanText = humanReadableText.slice(2, -2)
-      const replacement = `((${cleanText}))`
-      transformedText = transformedText.substring(0, ref.start) + replacement + transformedText.substring(ref.end)
-    }
-  })
+        if (humanReadableText) {
+            // Extract the human-readable part (remove (( and )))
+            const cleanText = humanReadableText.slice(2, -2);
+            const replacement = `((${cleanText}))`;
+            transformedText =
+                transformedText.substring(0, ref.start) +
+                replacement +
+                transformedText.substring(ref.end);
+        }
+    });
 
-  return transformedText
-}
+    return transformedText;
+};
 
 const transformTextToRawReferences = (text, reverseMappings) => {
-  let transformedText = text
-  const references = parseReferences(text, reverseMappings)
+    let transformedText = text;
+    const references = parseReferences(text, reverseMappings);
 
-  // Process references in reverse order to maintain string positions
-  references.reverse().forEach(ref => {
-    const referenceId = reverseMappings.get(ref.match)
+    // Process references in reverse order to maintain string positions
+    references.reverse().forEach((ref) => {
+        const referenceId = reverseMappings.get(ref.match);
 
-    if (referenceId) {
-      transformedText = transformedText.substring(0, ref.start) + referenceId + transformedText.substring(ref.end)
-    }
-  })
+        if (referenceId) {
+            transformedText =
+                transformedText.substring(0, ref.start) +
+                referenceId +
+                transformedText.substring(ref.end);
+        }
+    });
 
-  return transformedText
-}
+    return transformedText;
+};
 
-const updateHighlightOverlay = (visibleTextarea, highlightOverlay, mappings) => {
-  const text = visibleTextarea.value
-  let highlightedHtml = text
-  const references = parseReferences(text, mappings)
+const updateHighlightOverlay = (
+    visibleTextarea,
+    highlightOverlay,
+    mappings,
+) => {
+    const text = visibleTextarea.value;
+    let highlightedHtml = text;
+    const references = parseReferences(text, mappings);
 
-  // Process references in reverse order to maintain string positions
-  references.reverse().forEach(ref => {
-    if (ref.isResolved) {
-      // Wrap valid references with highlight span
-      const replacement = `<span class="app-context-aware-editor--valid-reference">${ref.match}</span>`
-      highlightedHtml = highlightedHtml.substring(0, ref.start) + replacement + highlightedHtml.substring(ref.end)
-    }
-    // Invalid references remain unstyled (normal text)
-  })
+    // Process references in reverse order to maintain string positions
+    references.reverse().forEach((ref) => {
+        if (ref.isResolved) {
+            // Wrap valid references with highlight span
+            const replacement = `<span class="app-context-aware-editor--valid-reference">${ref.match}</span>`;
+            highlightedHtml =
+                highlightedHtml.substring(0, ref.start) +
+                replacement +
+                highlightedHtml.substring(ref.end);
+        }
+        // Invalid references remain unstyled (normal text)
+    });
 
-  // Escape HTML in text outside of our spans, but preserve our spans
-  const parts = highlightedHtml.split(/(<span class="app-context-aware-editor--valid-reference">.*?<\/span>)/g)
-  const escapedHtml = parts.map(part => {
-    if (part.startsWith('<span class="app-context-aware-editor--valid-reference">')) {
-      return part // Keep our highlight spans as-is
-    } else {
-      // Escape HTML in text content and convert newlines
-      return part.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/\n/g, '<br>')
-    }
-  }).join('')
+    // Escape HTML in text outside of our spans, but preserve our spans
+    const parts = highlightedHtml.split(
+        /(<span class="app-context-aware-editor--valid-reference">.*?<\/span>)/g,
+    );
+    const escapedHtml = parts
+        .map((part) => {
+            if (
+                part.startsWith(
+                    '<span class="app-context-aware-editor--valid-reference">',
+                )
+            ) {
+                return part; // Keep our highlight spans as-is
+            } else {
+                // Escape HTML in text content and convert newlines
+                return part
+                    .replace(/&/g, "&amp;")
+                    .replace(/</g, "&lt;")
+                    .replace(/>/g, "&gt;")
+                    .replace(/\n/g, "<br>");
+            }
+        })
+        .join("");
 
-  highlightOverlay.innerHTML = escapedHtml
+    highlightOverlay.innerHTML = escapedHtml;
 
-  // Sync scroll position
-  highlightOverlay.scrollTop = visibleTextarea.scrollTop
-  highlightOverlay.scrollLeft = visibleTextarea.scrollLeft
-}
+    // Sync scroll position
+    highlightOverlay.scrollTop = visibleTextarea.scrollTop;
+    highlightOverlay.scrollLeft = visibleTextarea.scrollLeft;
+};
 
 const getReferenceBoundaries = (text, mappings = null) => {
-  const references = parseReferences(text, mappings)
-  return references
-    .filter(ref => ref.isResolved) // Only include resolved references
-    .map(ref => ({ start: ref.start, end: ref.end }))
-    .sort((a, b) => a.start - b.start)
-}
+    const references = parseReferences(text, mappings);
+    return references
+        .filter((ref) => ref.isResolved) // Only include resolved references
+        .map((ref) => ({ start: ref.start, end: ref.end }))
+        .sort((a, b) => a.start - b.start);
+};
 
-const adjustCursorPosition = (textarea, newPosition, direction = 0, mappings = null) => {
-  const text = textarea.value
-  const boundaries = getReferenceBoundaries(text, mappings)
+const adjustCursorPosition = (
+    textarea,
+    newPosition,
+    direction = 0,
+    mappings = null,
+) => {
+    const text = textarea.value;
+    const boundaries = getReferenceBoundaries(text, mappings);
 
-  for (const boundary of boundaries) {
-    // If cursor is inside a reference, move to boundary
-    if (newPosition > boundary.start && newPosition < boundary.end) {
-      return direction >= 0 ? boundary.end : boundary.start
+    for (const boundary of boundaries) {
+        // If cursor is inside a reference, move to boundary
+        if (newPosition > boundary.start && newPosition < boundary.end) {
+            return direction >= 0 ? boundary.end : boundary.start;
+        }
+        // If moving right and hitting start of reference, jump to end
+        if (direction > 0 && newPosition === boundary.start) {
+            return boundary.end;
+        }
+        // If moving left and hitting end of reference, jump to start
+        if (direction < 0 && newPosition === boundary.end) {
+            return boundary.start;
+        }
     }
-    // If moving right and hitting start of reference, jump to end
-    if (direction > 0 && newPosition === boundary.start) {
-      return boundary.end
-    }
-    // If moving left and hitting end of reference, jump to start
-    if (direction < 0 && newPosition === boundary.end) {
-      return boundary.start
-    }
-  }
 
-  return newPosition
-}
+    return newPosition;
+};
 
 // Helper function to delete text in a way that preserves undo history
 const deleteTextPreservingUndo = (textarea, startPos, endPos) => {
-  // Select the range to delete
-  textarea.setSelectionRange(startPos, endPos)
+    // Select the range to delete
+    textarea.setSelectionRange(startPos, endPos);
 
-  // Use execCommand if available (for older browsers), otherwise use newer approach
-  if (document.execCommand) {
-    document.execCommand('delete', false, null)
-  } else {
-    // Modern approach: dispatch a deleteContentBackward input event
-    const inputEvent = new InputEvent('beforeinput', {
-      inputType: 'deleteContentBackward',
-      cancelable: true
-    })
+    // Use execCommand if available (for older browsers), otherwise use newer approach
+    if (document.execCommand) {
+        document.execCommand("delete", false, null);
+    } else {
+        // Modern approach: dispatch a deleteContentBackward input event
+        const inputEvent = new InputEvent("beforeinput", {
+            inputType: "deleteContentBackward",
+            cancelable: true,
+        });
 
-    if (textarea.dispatchEvent(inputEvent)) {
-      // If the beforeinput event wasn't cancelled, perform the deletion
-      textarea.setRangeText('', startPos, endPos, 'end')
+        if (textarea.dispatchEvent(inputEvent)) {
+            // If the beforeinput event wasn't cancelled, perform the deletion
+            textarea.setRangeText("", startPos, endPos, "end");
 
-      // Dispatch the input event to notify listeners
-      textarea.dispatchEvent(new InputEvent('input', {
-        inputType: 'deleteContentBackward'
-      }))
+            // Dispatch the input event to notify listeners
+            textarea.dispatchEvent(
+                new InputEvent("input", {
+                    inputType: "deleteContentBackward",
+                }),
+            );
+        }
     }
-  }
-}
+};
 
 const handleKeyDown = (textarea, event, mappings) => {
-  const { key, shiftKey } = event
-  const start = textarea.selectionStart
-  const end = textarea.selectionEnd
+    const { key, shiftKey } = event;
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
 
-  const boundaries = getReferenceBoundaries(textarea.value, mappings)
+    const boundaries = getReferenceBoundaries(textarea.value, mappings);
 
-  switch (key) {
-    case 'ArrowLeft':
-    case 'ArrowRight': {
-      if (start !== end && !shiftKey) return // Has selection, let default behavior handle it
+    switch (key) {
+        case "ArrowLeft":
+        case "ArrowRight": {
+            if (start !== end && !shiftKey) return; // Has selection, let default behavior handle it
 
-      const direction = key === 'ArrowRight' ? 1 : -1
-      const currentPos = key === 'ArrowRight' ? end : start
-      const newPos = adjustCursorPosition(textarea, currentPos, direction, mappings)
+            const direction = key === "ArrowRight" ? 1 : -1;
+            const currentPos = key === "ArrowRight" ? end : start;
+            const newPos = adjustCursorPosition(
+                textarea,
+                currentPos,
+                direction,
+                mappings,
+            );
 
-      if (newPos !== currentPos) {
-        event.preventDefault()
-        if (shiftKey) {
-          // Extend selection based on direction
-          if (direction > 0) {
-            // Moving right: extend from original start to new position
-            textarea.setSelectionRange(start, newPos)
-          } else {
-            // Moving left: extend from new position to original end
-            textarea.setSelectionRange(newPos, end)
-          }
-        } else {
-          // Move cursor
-          textarea.setSelectionRange(newPos, newPos)
+            if (newPos !== currentPos) {
+                event.preventDefault();
+                if (shiftKey) {
+                    // Extend selection based on direction
+                    if (direction > 0) {
+                        // Moving right: extend from original start to new position
+                        textarea.setSelectionRange(start, newPos);
+                    } else {
+                        // Moving left: extend from new position to original end
+                        textarea.setSelectionRange(newPos, end);
+                    }
+                } else {
+                    // Move cursor
+                    textarea.setSelectionRange(newPos, newPos);
+                }
+            }
+            break;
         }
-      }
-      break
+
+        case "Backspace": {
+            if (start !== end) return; // Has selection, let default behavior handle it
+
+            // Check if we're at the end of a reference
+            const refAtCursor = boundaries.find((b) => start === b.end);
+            if (refAtCursor) {
+                event.preventDefault();
+                // Delete entire reference using undo-friendly method
+                deleteTextPreservingUndo(
+                    textarea,
+                    refAtCursor.start,
+                    refAtCursor.end,
+                );
+            }
+            break;
+        }
+
+        case "Delete": {
+            if (start !== end) return; // Has selection, let default behavior handle it
+
+            // Check if we're at the start of a reference
+            const refAtCursor = boundaries.find((b) => start === b.start);
+            if (refAtCursor) {
+                event.preventDefault();
+                // Delete entire reference using undo-friendly method
+                deleteTextPreservingUndo(
+                    textarea,
+                    refAtCursor.start,
+                    refAtCursor.end,
+                );
+            }
+            break;
+        }
+
+        case "Home":
+        case "End": {
+            // Allow normal home/end behavior
+            break;
+        }
     }
-
-    case 'Backspace': {
-      if (start !== end) return // Has selection, let default behavior handle it
-
-      // Check if we're at the end of a reference
-      const refAtCursor = boundaries.find(b => start === b.end)
-      if (refAtCursor) {
-        event.preventDefault()
-        // Delete entire reference using undo-friendly method
-        deleteTextPreservingUndo(textarea, refAtCursor.start, refAtCursor.end)
-      }
-      break
-    }
-
-    case 'Delete': {
-      if (start !== end) return // Has selection, let default behavior handle it
-
-      // Check if we're at the start of a reference
-      const refAtCursor = boundaries.find(b => start === b.start)
-      if (refAtCursor) {
-        event.preventDefault()
-        // Delete entire reference using undo-friendly method
-        deleteTextPreservingUndo(textarea, refAtCursor.start, refAtCursor.end)
-      }
-      break
-    }
-
-    case 'Home':
-    case 'End': {
-      // Allow normal home/end behavior
-      break
-    }
-  }
-}
+};
 
 const handleClick = (textarea, event, mappings) => {
-  // Get click position
-  const clickPosition = textarea.selectionStart
-  const boundaries = getReferenceBoundaries(textarea.value, mappings)
+    // Get click position
+    const clickPosition = textarea.selectionStart;
+    const boundaries = getReferenceBoundaries(textarea.value, mappings);
 
-  // Check if click is inside a reference
-  const clickedRef = boundaries.find(b => clickPosition > b.start && clickPosition < b.end)
-  if (clickedRef) {
-    // Move cursor to nearest boundary
-    const distToStart = clickPosition - clickedRef.start
-    const distToEnd = clickedRef.end - clickPosition
-    const newPos = distToStart <= distToEnd ? clickedRef.start : clickedRef.end
+    // Check if click is inside a reference
+    const clickedRef = boundaries.find(
+        (b) => clickPosition > b.start && clickPosition < b.end,
+    );
+    if (clickedRef) {
+        // Move cursor to nearest boundary
+        const distToStart = clickPosition - clickedRef.start;
+        const distToEnd = clickedRef.end - clickPosition;
+        const newPos =
+            distToStart <= distToEnd ? clickedRef.start : clickedRef.end;
 
-    setTimeout(() => {
-      textarea.setSelectionRange(newPos, newPos)
-    }, 0)
-  }
-}
+        setTimeout(() => {
+            textarea.setSelectionRange(newPos, newPos);
+        }, 0);
+    }
+};
 
 const handleDoubleClick = (textarea, event, mappings) => {
-  const clickPosition = textarea.selectionStart
-  const boundaries = getReferenceBoundaries(textarea.value, mappings)
+    const clickPosition = textarea.selectionStart;
+    const boundaries = getReferenceBoundaries(textarea.value, mappings);
 
-  // Check if double-click is inside a reference
-  const clickedRef = boundaries.find(b => clickPosition >= b.start && clickPosition <= b.end)
-  if (clickedRef) {
-    event.preventDefault()
-    // Select entire reference - wrap in setTimeout to ensure it happens after the event is fully processed
-    setTimeout(() => {
-      textarea.setSelectionRange(clickedRef.start, clickedRef.end)
-    }, 0)
-  }
-}
+    // Check if double-click is inside a reference
+    const clickedRef = boundaries.find(
+        (b) => clickPosition >= b.start && clickPosition <= b.end,
+    );
+    if (clickedRef) {
+        event.preventDefault();
+        // Select entire reference - wrap in setTimeout to ensure it happens after the event is fully processed
+        setTimeout(() => {
+            textarea.setSelectionRange(clickedRef.start, clickedRef.end);
+        }, 0);
+    }
+};
 
 /**
  * Creates the highlighting overlay and sets up reference highlighting
@@ -285,52 +336,71 @@ const handleDoubleClick = (textarea, event, mappings) => {
  * @param {Map} reverseMappings - Reverse mappings (human text -> ID)
  * @returns {Object} Object containing the highlighting overlay and sync function
  */
-const createHighlighting = (visibleTextarea, hiddenTextarea, mappings, reverseMappings) => {
-  // Create highlight overlay
-  const highlightOverlay = document.createElement('div')
-  highlightOverlay.classList.add('app-context-aware-editor__highlight-overlay')
-  highlightOverlay.setAttribute('aria-hidden', 'true')
+const createHighlighting = (
+    visibleTextarea,
+    hiddenTextarea,
+    mappings,
+    reverseMappings,
+) => {
+    // Create highlight overlay
+    const highlightOverlay = document.createElement("div");
+    highlightOverlay.classList.add(
+        "app-context-aware-editor__highlight-overlay",
+    );
+    highlightOverlay.setAttribute("aria-hidden", "true");
 
-  // Transform initial content to human-readable
-  const humanReadableText = transformTextToHumanReadable(hiddenTextarea.value, mappings)
-  visibleTextarea.value = humanReadableText
+    // Transform initial content to human-readable
+    const humanReadableText = transformTextToHumanReadable(
+        hiddenTextarea.value,
+        mappings,
+    );
+    visibleTextarea.value = humanReadableText;
 
-  // Update highlight overlay initially
-  updateHighlightOverlay(visibleTextarea, highlightOverlay, mappings)
+    // Update highlight overlay initially
+    updateHighlightOverlay(visibleTextarea, highlightOverlay, mappings);
 
-  // Sync function to update hidden textarea and highlights
-  const syncVisibleToHidden = () => {
-    // Transform visible text back to raw references
-    const rawText = transformTextToRawReferences(visibleTextarea.value, reverseMappings)
-    hiddenTextarea.value = rawText
+    // Sync function to update hidden textarea and highlights
+    const syncVisibleToHidden = () => {
+        // Transform visible text back to raw references
+        const rawText = transformTextToRawReferences(
+            visibleTextarea.value,
+            reverseMappings,
+        );
+        hiddenTextarea.value = rawText;
 
-    // Trigger input event on hidden textarea to notify ajax-markdown-preview
-    const inputEvent = new Event('input', { bubbles: true })
-    hiddenTextarea.dispatchEvent(inputEvent)
+        // Trigger input event on hidden textarea to notify ajax-markdown-preview
+        const inputEvent = new Event("input", { bubbles: true });
+        hiddenTextarea.dispatchEvent(inputEvent);
 
-    // Update highlight overlay
-    updateHighlightOverlay(visibleTextarea, highlightOverlay, mappings)
-  }
+        // Update highlight overlay
+        updateHighlightOverlay(visibleTextarea, highlightOverlay, mappings);
+    };
 
-  // Add event listeners
-  visibleTextarea.addEventListener('input', syncVisibleToHidden)
+    // Add event listeners
+    visibleTextarea.addEventListener("input", syncVisibleToHidden);
 
-  // Add scroll sync for highlight overlay
-  visibleTextarea.addEventListener('scroll', () => {
-    highlightOverlay.scrollTop = visibleTextarea.scrollTop
-    highlightOverlay.scrollLeft = visibleTextarea.scrollLeft
-  })
+    // Add scroll sync for highlight overlay
+    visibleTextarea.addEventListener("scroll", () => {
+        highlightOverlay.scrollTop = visibleTextarea.scrollTop;
+        highlightOverlay.scrollLeft = visibleTextarea.scrollLeft;
+    });
 
-  // Add atomic reference handling
-  visibleTextarea.addEventListener('keydown', (event) => handleKeyDown(visibleTextarea, event, mappings))
-  visibleTextarea.addEventListener('click', (event) => handleClick(visibleTextarea, event, mappings))
-  visibleTextarea.addEventListener('dblclick', (event) => handleDoubleClick(visibleTextarea, event, mappings))
+    // Add atomic reference handling
+    visibleTextarea.addEventListener("keydown", (event) =>
+        handleKeyDown(visibleTextarea, event, mappings),
+    );
+    visibleTextarea.addEventListener("click", (event) =>
+        handleClick(visibleTextarea, event, mappings),
+    );
+    visibleTextarea.addEventListener("dblclick", (event) =>
+        handleDoubleClick(visibleTextarea, event, mappings),
+    );
 
-  return {
-    highlightOverlay,
-    syncVisibleToHidden
-  }
-}
+    return {
+        highlightOverlay,
+        syncVisibleToHidden,
+    };
+};
 
 /**
  * Parses reference mappings from JSON string
@@ -338,27 +408,35 @@ const createHighlighting = (visibleTextarea, hiddenTextarea, mappings, reverseMa
  * @returns {Object} Object containing mappings and reverseMappings Maps
  */
 const parseReferenceMappings = (mappingData) => {
-  let mappings = new Map()
-  let reverseMappings = new Map()
+    let mappings = new Map();
+    let reverseMappings = new Map();
 
-  if (mappingData && mappingData.trim() !== '') {
-    try {
-      const parsed = JSON.parse(mappingData)
-      // Convert object to Map
-      if (typeof parsed === 'object' && parsed !== null) {
-        mappings = new Map(Object.entries(parsed))
+    if (mappingData && mappingData.trim() !== "") {
+        try {
+            const parsed = JSON.parse(mappingData);
+            // Convert object to Map
+            if (typeof parsed === "object" && parsed !== null) {
+                mappings = new Map(Object.entries(parsed));
 
-        // Build reverse mappings (human-readable -> reference ID)
-        for (const [referenceId, humanReadableText] of mappings) {
-          reverseMappings.set(humanReadableText, `((${referenceId}))`)
+                // Build reverse mappings (human-readable -> reference ID)
+                for (const [referenceId, humanReadableText] of mappings) {
+                    reverseMappings.set(
+                        humanReadableText,
+                        `((${referenceId}))`,
+                    );
+                }
+            }
+        } catch (error) {
+            console.warn(
+                "Failed to parse reference mappings:",
+                error,
+                "Data:",
+                mappingData,
+            );
         }
-      }
-    } catch (error) {
-      console.warn('Failed to parse reference mappings:', error, 'Data:', mappingData)
     }
-  }
 
-  return { mappings, reverseMappings }
-}
+    return { mappings, reverseMappings };
+};
 
-export { createHighlighting, parseReferenceMappings }
+export { createHighlighting, parseReferenceMappings };

--- a/app/assets/js/context-aware-editor/index.js
+++ b/app/assets/js/context-aware-editor/index.js
@@ -14,189 +14,217 @@
 // the `data-context` attribute. When a reference, eg ((q_UUID)) is found in t2, it is replaced with the human-readable
 // label and highlighted for visual importance.
 
-
-import { createToolbarForTextArea } from './toolbar.js'
-import { createHighlighting, parseReferenceMappings } from './highlighting.js'
+import { createToolbarForTextArea } from "./toolbar.js";
+import { createHighlighting, parseReferenceMappings } from "./highlighting.js";
 
 const store = {
-  components: new Map() // Map container -> component data
-}
+    components: new Map(), // Map container -> component data
+};
 
 const createEditorStructure = (originalTextarea, container) => {
-  // Create main wrapper
-  const wrapper = document.createElement('div')
-  wrapper.classList.add('app-context-aware-editor--wrapper')
+    // Create main wrapper
+    const wrapper = document.createElement("div");
+    wrapper.classList.add("app-context-aware-editor--wrapper");
 
-  // Create toolbar container (initially hidden)
-  const toolbarContainer = document.createElement('div')
-  toolbarContainer.classList.add('app-context-aware-editor__toolbar-container')
-  toolbarContainer.style.display = 'none'
+    // Create toolbar container (initially hidden)
+    const toolbarContainer = document.createElement("div");
+    toolbarContainer.classList.add(
+        "app-context-aware-editor__toolbar-container",
+    );
+    toolbarContainer.style.display = "none";
 
-  // Create editor container for the textarea and highlight overlay
-  const editorContainer = document.createElement('div')
-  editorContainer.classList.add('app-context-aware-editor__editor-container')
+    // Create editor container for the textarea and highlight overlay
+    const editorContainer = document.createElement("div");
+    editorContainer.classList.add("app-context-aware-editor__editor-container");
 
-  // Create visible textarea (copy of original)
-  const visibleTextarea = originalTextarea.cloneNode(true)
-  visibleTextarea.classList.add('app-context-aware-editor__visible-textarea')
+    // Create visible textarea (copy of original)
+    const visibleTextarea = originalTextarea.cloneNode(true);
+    visibleTextarea.classList.add("app-context-aware-editor__visible-textarea");
 
-  // Remove conflicting attributes from visible textarea
-  visibleTextarea.removeAttribute('data-context-aware-editor-target')
-  originalTextarea.removeAttribute('data-module')
+    // Remove conflicting attributes from visible textarea
+    visibleTextarea.removeAttribute("data-context-aware-editor-target");
+    originalTextarea.removeAttribute("data-module");
 
-  // Ensure that form submissions submit the original (raw) textarea but anchors target the visible textarea (for eg
-  // error summaries).
-  originalTextarea.removeAttribute('id')
-  visibleTextarea.removeAttribute('name')
+    // Ensure that form submissions submit the original (raw) textarea but anchors target the visible textarea (for eg
+    // error summaries).
+    originalTextarea.removeAttribute("id");
+    visibleTextarea.removeAttribute("name");
 
-  // Hide original textarea but keep it in form
-  originalTextarea.style.display = 'none'
-  originalTextarea.setAttribute('aria-hidden', 'true')
+    // Hide original textarea but keep it in form
+    originalTextarea.style.display = "none";
+    originalTextarea.setAttribute("aria-hidden", "true");
 
-  // Build structure
-  wrapper.appendChild(toolbarContainer)
-  editorContainer.appendChild(visibleTextarea) // highlight overlay will be inserted before this
-  wrapper.appendChild(editorContainer)
+    // Build structure
+    wrapper.appendChild(toolbarContainer);
+    editorContainer.appendChild(visibleTextarea); // highlight overlay will be inserted before this
+    wrapper.appendChild(editorContainer);
 
-  // Insert wrapper after original textarea
-  originalTextarea.parentNode.insertBefore(wrapper, originalTextarea.nextSibling)
+    // Insert wrapper after original textarea
+    originalTextarea.parentNode.insertBefore(
+        wrapper,
+        originalTextarea.nextSibling,
+    );
 
-  return {
-    wrapper,
-    toolbarContainer,
-    editorContainer,
-    visibleTextarea
-  }
-}
+    return {
+        wrapper,
+        toolbarContainer,
+        editorContainer,
+        visibleTextarea,
+    };
+};
 
 const initializeContainer = (container) => {
-  // Skip if already processed
-  if (store.components.has(container)) return
+    // Skip if already processed
+    if (store.components.has(container)) return;
 
-  // Find target textarea
-  const originalTextarea = container.querySelector('[data-context-aware-editor-target]')
-  if (!originalTextarea) {
-    console.warn('No textarea with data-context-aware-editor-target found in container')
-    return
-  }
-
-  // Get configuration
-  const toolbarEnabled = container.getAttribute('data-toolbar-enabled') === 'true'
-  const allowHeadings = container.getAttribute('data-allow-headings') === 'true'
-  const i18nData = container.getAttribute('data-i18n') || '{}'
-  const referenceMappingsData = container.querySelector('[data-context]').textContent || ''
-
-  let i18n = {}
-  try {
-    i18n = JSON.parse(i18nData)
-  } catch (error) {
-    console.warn('Failed to parse i18n data:', error)
-  }
-
-  // Parse reference mappings
-  const { mappings, reverseMappings } = parseReferenceMappings(referenceMappingsData)
-
-  // Create editor structure
-  const { wrapper, toolbarContainer, editorContainer, visibleTextarea } = createEditorStructure(originalTextarea, container)
-
-  let toolbar = null
-  let highlighting = null
-
-  // Create toolbar if enabled
-  if (toolbarEnabled) {
-    toolbar = createToolbarForTextArea(visibleTextarea, i18n, allowHeadings)
-    toolbarContainer.appendChild(toolbar)
-    toolbarContainer.style.display = 'block'
-  }
-
-  // Create highlighting if reference mappings are provided
-  highlighting = createHighlighting(visibleTextarea, originalTextarea, mappings, reverseMappings)
-  // Insert highlight overlay before visible textarea
-  editorContainer.insertBefore(highlighting.highlightOverlay, visibleTextarea)
-
-  // Ensure overlay dimensions match the textarea
-  const syncDimensions = () => {
-    highlighting.highlightOverlay.style.width = `${visibleTextarea.offsetWidth}px`
-    highlighting.highlightOverlay.style.height = `${visibleTextarea.offsetHeight}px`
-  }
-
-  // Initial sync
-  syncDimensions()
-
-  // Create ResizeObserver to keep overlay in sync
-  const resizeObserver = new ResizeObserver(entries => {
-    for (let entry of entries) {
-      if (entry.target === visibleTextarea) {
-        syncDimensions()
-      }
+    // Find target textarea
+    const originalTextarea = container.querySelector(
+        "[data-context-aware-editor-target]",
+    );
+    if (!originalTextarea) {
+        console.warn(
+            "No textarea with data-context-aware-editor-target found in container",
+        );
+        return;
     }
-  })
-  resizeObserver.observe(visibleTextarea)
 
-  // If toolbar is present, sync changes through both highlighting and toolbar
-  if (toolbar) {
-    const originalSyncFunction = highlighting.syncVisibleToHidden
-    // Override toolbar button callbacks to trigger highlighting sync
-    const toolbarButtons = toolbar.querySelectorAll('button')
-    toolbarButtons.forEach(button => {
-      button.addEventListener('click', () => {
-        // Small delay to ensure text has been updated
-        setTimeout(originalSyncFunction, 0)
-      })
-    })
-  }
+    // Get configuration
+    const toolbarEnabled =
+        container.getAttribute("data-toolbar-enabled") === "true";
+    const allowHeadings =
+        container.getAttribute("data-allow-headings") === "true";
+    const i18nData = container.getAttribute("data-i18n") || "{}";
+    const referenceMappingsData =
+        container.querySelector("[data-context]").textContent || "";
 
-  // Store component data for cleanup
-  store.components.set(container, {
-    wrapper,
-    originalTextarea,
-    visibleTextarea,
-    toolbar,
-    highlighting
-  })
-}
+    let i18n = {};
+    try {
+        i18n = JSON.parse(i18nData);
+    } catch (error) {
+        console.warn("Failed to parse i18n data:", error);
+    }
+
+    // Parse reference mappings
+    const { mappings, reverseMappings } = parseReferenceMappings(
+        referenceMappingsData,
+    );
+
+    // Create editor structure
+    const { wrapper, toolbarContainer, editorContainer, visibleTextarea } =
+        createEditorStructure(originalTextarea, container);
+
+    let toolbar = null;
+    let highlighting = null;
+
+    // Create toolbar if enabled
+    if (toolbarEnabled) {
+        toolbar = createToolbarForTextArea(
+            visibleTextarea,
+            i18n,
+            allowHeadings,
+        );
+        toolbarContainer.appendChild(toolbar);
+        toolbarContainer.style.display = "block";
+    }
+
+    // Create highlighting if reference mappings are provided
+    highlighting = createHighlighting(
+        visibleTextarea,
+        originalTextarea,
+        mappings,
+        reverseMappings,
+    );
+    // Insert highlight overlay before visible textarea
+    editorContainer.insertBefore(
+        highlighting.highlightOverlay,
+        visibleTextarea,
+    );
+
+    // Ensure overlay dimensions match the textarea
+    const syncDimensions = () => {
+        highlighting.highlightOverlay.style.width = `${visibleTextarea.offsetWidth}px`;
+        highlighting.highlightOverlay.style.height = `${visibleTextarea.offsetHeight}px`;
+    };
+
+    // Initial sync
+    syncDimensions();
+
+    // Create ResizeObserver to keep overlay in sync
+    const resizeObserver = new ResizeObserver((entries) => {
+        for (let entry of entries) {
+            if (entry.target === visibleTextarea) {
+                syncDimensions();
+            }
+        }
+    });
+    resizeObserver.observe(visibleTextarea);
+
+    // If toolbar is present, sync changes through both highlighting and toolbar
+    if (toolbar) {
+        const originalSyncFunction = highlighting.syncVisibleToHidden;
+        // Override toolbar button callbacks to trigger highlighting sync
+        const toolbarButtons = toolbar.querySelectorAll("button");
+        toolbarButtons.forEach((button) => {
+            button.addEventListener("click", () => {
+                // Small delay to ensure text has been updated
+                setTimeout(originalSyncFunction, 0);
+            });
+        });
+    }
+
+    // Store component data for cleanup
+    store.components.set(container, {
+        wrapper,
+        originalTextarea,
+        visibleTextarea,
+        toolbar,
+        highlighting,
+    });
+};
 
 const cleanup = (container) => {
-  const componentData = store.components.get(container)
-  if (!componentData) return
+    const componentData = store.components.get(container);
+    if (!componentData) return;
 
-  const { wrapper, originalTextarea } = componentData
+    const { wrapper, originalTextarea } = componentData;
 
-  // Remove wrapper
-  if (wrapper && wrapper.parentNode) {
-    wrapper.parentNode.removeChild(wrapper)
-  }
+    // Remove wrapper
+    if (wrapper && wrapper.parentNode) {
+        wrapper.parentNode.removeChild(wrapper);
+    }
 
-  // Restore original textarea
-  originalTextarea.style.display = ''
-  originalTextarea.removeAttribute('aria-hidden')
+    // Restore original textarea
+    originalTextarea.style.display = "";
+    originalTextarea.removeAttribute("aria-hidden");
 
-  // Clean up storage
-  store.components.delete(container)
-}
+    // Clean up storage
+    store.components.delete(container);
+};
 
 /**
  * Initializes combined markdown editor for containers with data-module="context-aware-editor"
  * @param {HTMLElement|NodeList} containers - Container elements or selector
  */
 const combinedMarkdownEditor = (containers) => {
-  if (!containers) {
-    // Auto-initialize all containers with data-module="context-aware-editor"
-    containers = document.querySelectorAll('[data-module="context-aware-editor"]')
-  }
+    if (!containers) {
+        // Auto-initialize all containers with data-module="context-aware-editor"
+        containers = document.querySelectorAll(
+            '[data-module="context-aware-editor"]',
+        );
+    }
 
-  if (containers.length !== undefined) {
-    // Handle NodeList
-    containers.forEach(container => {
-      initializeContainer(container)
-    })
-  } else {
-    // Handle single container
-    initializeContainer(containers)
-  }
-}
+    if (containers.length !== undefined) {
+        // Handle NodeList
+        containers.forEach((container) => {
+            initializeContainer(container);
+        });
+    } else {
+        // Handle single container
+        initializeContainer(containers);
+    }
+};
 
 // Export both the main function and cleanup for testing
-combinedMarkdownEditor.cleanup = cleanup
+combinedMarkdownEditor.cleanup = cleanup;
 
-export default combinedMarkdownEditor
+export default combinedMarkdownEditor;

--- a/app/assets/js/context-aware-editor/index.test.js
+++ b/app/assets/js/context-aware-editor/index.test.js
@@ -1,228 +1,256 @@
 /**
  * @vitest-environment jsdom
  */
-import contextAwareEditor from '.'
+import contextAwareEditor from ".";
 
 // Mock ResizeObserver for the test environment
 global.ResizeObserver = class ResizeObserver {
-  constructor(callback) {
-    this.callback = callback
-  }
-  observe() {}
-  unobserve() {}
-  disconnect() {}
-}
+    constructor(callback) {
+        this.callback = callback;
+    }
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+};
 
 // Mock reference mappings for testing
 const mockReferenceMappings = {
-  'ref-1': '((Sample Reference 1))',
-  'ref-2': '((Another Reference))',
-  'ref-3': '((Third Reference))'
-}
+    "ref-1": "((Sample Reference 1))",
+    "ref-2": "((Another Reference))",
+    "ref-3": "((Third Reference))",
+};
 
-describe('Context Aware Editor', () => {
-  let container, context, textarea
-
-  beforeEach(() => {
-    // Clean up any existing components
-    document.body.innerHTML = ''
-
-    // Create container and textarea elements
-    container = document.createElement('div')
-    container.setAttribute('data-module', 'context-aware-editor')
-    container.setAttribute('data-toolbar-enabled', 'true')
-    container.setAttribute('data-allow-headings', 'true')
-
-    context = document.createElement('div')
-    context.setAttribute('data-context', 'true')
-    context.textContent = JSON.stringify(mockReferenceMappings)
-
-    textarea = document.createElement('textarea')
-    textarea.setAttribute('data-context-aware-editor-target', '')
-    textarea.id = 'test-textarea'
-    textarea.name = 'test-textarea'
-    textarea.value = 'Some text with ((ref-1)) reference in the middle.'
-
-    container.appendChild(context)
-    container.appendChild(textarea)
-    document.body.appendChild(container)
-  })
-
-  afterEach(() => {
-    // Clean up
-    contextAwareEditor.cleanup(container)
-    document.body.innerHTML = ''
-  })
-
-  describe('Reference deletion and undo functionality', () => {
-    let visibleTextarea
+describe("Context Aware Editor", () => {
+    let container, context, textarea;
 
     beforeEach(() => {
-      // Initialize the combined editor
-      contextAwareEditor(container)
+        // Clean up any existing components
+        document.body.innerHTML = "";
 
-      // Get the visible textarea that was created
-      visibleTextarea = container.querySelector('.app-context-aware-editor__visible-textarea')
-    })
+        // Create container and textarea elements
+        container = document.createElement("div");
+        container.setAttribute("data-module", "context-aware-editor");
+        container.setAttribute("data-toolbar-enabled", "true");
+        container.setAttribute("data-allow-headings", "true");
 
-    test('should create visible textarea with human-readable references', () => {
-      expect(visibleTextarea).toBeTruthy()
-      expect(visibleTextarea.value).toBe('Some text with ((Sample Reference 1)) reference in the middle.')
-    })
+        context = document.createElement("div");
+        context.setAttribute("data-context", "true");
+        context.textContent = JSON.stringify(mockReferenceMappings);
 
-    test('should delete entire reference when backspacing from end of reference', () => {
-      // Position cursor at end of reference
-      const referenceEnd = visibleTextarea.value.indexOf('((Sample Reference 1))') + '((Sample Reference 1))'.length
-      visibleTextarea.setSelectionRange(referenceEnd, referenceEnd)
+        textarea = document.createElement("textarea");
+        textarea.setAttribute("data-context-aware-editor-target", "");
+        textarea.id = "test-textarea";
+        textarea.name = "test-textarea";
+        textarea.value = "Some text with ((ref-1)) reference in the middle.";
 
-      // Create and dispatch backspace event
-      const event = new KeyboardEvent('keydown', {
-        key: 'Backspace',
-        bubbles: true,
-        cancelable: true
-      })
+        container.appendChild(context);
+        container.appendChild(textarea);
+        document.body.appendChild(container);
+    });
 
-      visibleTextarea.dispatchEvent(event)
+    afterEach(() => {
+        // Clean up
+        contextAwareEditor.cleanup(container);
+        document.body.innerHTML = "";
+    });
 
-      // Reference should be deleted
-      expect(visibleTextarea.value).toBe('Some text with  reference in the middle.')
-    })
+    describe("Reference deletion and undo functionality", () => {
+        let visibleTextarea;
 
-    test('should delete entire reference when pressing delete from start of reference', () => {
-      // Position cursor at start of reference
-      const referenceStart = visibleTextarea.value.indexOf('((Sample Reference 1))')
-      visibleTextarea.setSelectionRange(referenceStart, referenceStart)
+        beforeEach(() => {
+            // Initialize the combined editor
+            contextAwareEditor(container);
 
-      // Create and dispatch delete event
-      const event = new KeyboardEvent('keydown', {
-        key: 'Delete',
-        bubbles: true,
-        cancelable: true
-      })
+            // Get the visible textarea that was created
+            visibleTextarea = container.querySelector(
+                ".app-context-aware-editor__visible-textarea",
+            );
+        });
 
-      visibleTextarea.dispatchEvent(event)
+        test("should create visible textarea with human-readable references", () => {
+            expect(visibleTextarea).toBeTruthy();
+            expect(visibleTextarea.value).toBe(
+                "Some text with ((Sample Reference 1)) reference in the middle.",
+            );
+        });
 
-      // Reference should be deleted
-      expect(visibleTextarea.value).toBe('Some text with  reference in the middle.')
-    })
+        test("should delete entire reference when backspacing from end of reference", () => {
+            // Position cursor at end of reference
+            const referenceEnd =
+                visibleTextarea.value.indexOf("((Sample Reference 1))") +
+                "((Sample Reference 1))".length;
+            visibleTextarea.setSelectionRange(referenceEnd, referenceEnd);
 
-    test('should support undo after reference deletion (modern approach)', () => {
-      // Skip this test if document.execCommand is available (older browsers)
-      if (document.execCommand) {
-        return
-      }
+            // Create and dispatch backspace event
+            const event = new KeyboardEvent("keydown", {
+                key: "Backspace",
+                bubbles: true,
+                cancelable: true,
+            });
 
-      const originalValue = visibleTextarea.value
+            visibleTextarea.dispatchEvent(event);
 
-      // Position cursor at end of reference
-      const referenceEnd = visibleTextarea.value.indexOf('((Sample Reference 1))') + '((Sample Reference 1))'.length
-      visibleTextarea.setSelectionRange(referenceEnd, referenceEnd)
+            // Reference should be deleted
+            expect(visibleTextarea.value).toBe(
+                "Some text with  reference in the middle.",
+            );
+        });
 
-      // Create and dispatch backspace event
-      const backspaceEvent = new KeyboardEvent('keydown', {
-        key: 'Backspace',
-        bubbles: true,
-        cancelable: true
-      })
+        test("should delete entire reference when pressing delete from start of reference", () => {
+            // Position cursor at start of reference
+            const referenceStart = visibleTextarea.value.indexOf(
+                "((Sample Reference 1))",
+            );
+            visibleTextarea.setSelectionRange(referenceStart, referenceStart);
 
-      visibleTextarea.dispatchEvent(backspaceEvent)
+            // Create and dispatch delete event
+            const event = new KeyboardEvent("keydown", {
+                key: "Delete",
+                bubbles: true,
+                cancelable: true,
+            });
 
-      // Reference should be deleted
-      expect(visibleTextarea.value).toBe('Some text with  reference in the middle.')
+            visibleTextarea.dispatchEvent(event);
 
-      // Now test undo functionality
-      // Simulate Ctrl+Z (or Cmd+Z on Mac)
-      const undoEvent = new KeyboardEvent('keydown', {
-        key: 'z',
-        ctrlKey: true,
-        metaKey: false, // Use ctrlKey for simplicity in test
-        bubbles: true,
-        cancelable: true
-      })
+            // Reference should be deleted
+            expect(visibleTextarea.value).toBe(
+                "Some text with  reference in the middle.",
+            );
+        });
 
-      // Mock the undo operation by checking if the deletion was done in an undo-friendly way
-      // In a real browser, this would restore the text automatically
-      // For our test, we verify that the deletion method preserves undo history
+        test("should support undo after reference deletion (modern approach)", () => {
+            // Skip this test if document.execCommand is available (older browsers)
+            if (document.execCommand) {
+                return;
+            }
 
-      // The fix ensures the deletion uses browser-native text manipulation
-      // which should be trackable in the undo stack
-      expect(visibleTextarea.value).toBe('Some text with  reference in the middle.')
-    })
+            const originalValue = visibleTextarea.value;
 
-    test('should support undo after reference deletion (legacy approach)', () => {
-      // Mock document.execCommand for testing legacy approach
-      const originalExecCommand = document.execCommand
-      let execCommandCalled = false
-      let execCommandArgs = []
+            // Position cursor at end of reference
+            const referenceEnd =
+                visibleTextarea.value.indexOf("((Sample Reference 1))") +
+                "((Sample Reference 1))".length;
+            visibleTextarea.setSelectionRange(referenceEnd, referenceEnd);
 
-      document.execCommand = vi.fn((command, showUI, value) => {
-        execCommandCalled = true
-        execCommandArgs = [command, showUI, value]
-        return true
-      })
+            // Create and dispatch backspace event
+            const backspaceEvent = new KeyboardEvent("keydown", {
+                key: "Backspace",
+                bubbles: true,
+                cancelable: true,
+            });
 
-      const originalValue = visibleTextarea.value
+            visibleTextarea.dispatchEvent(backspaceEvent);
 
-      // Position cursor at end of reference
-      const referenceEnd = visibleTextarea.value.indexOf('((Sample Reference 1))') + '((Sample Reference 1))'.length
-      visibleTextarea.setSelectionRange(referenceEnd, referenceEnd)
+            // Reference should be deleted
+            expect(visibleTextarea.value).toBe(
+                "Some text with  reference in the middle.",
+            );
 
-      // Create and dispatch backspace event
-      const backspaceEvent = new KeyboardEvent('keydown', {
-        key: 'Backspace',
-        bubbles: true,
-        cancelable: true
-      })
+            // Now test undo functionality
+            // Simulate Ctrl+Z (or Cmd+Z on Mac)
+            const undoEvent = new KeyboardEvent("keydown", {
+                key: "z",
+                ctrlKey: true,
+                metaKey: false, // Use ctrlKey for simplicity in test
+                bubbles: true,
+                cancelable: true,
+            });
 
-      visibleTextarea.dispatchEvent(backspaceEvent)
+            // Mock the undo operation by checking if the deletion was done in an undo-friendly way
+            // In a real browser, this would restore the text automatically
+            // For our test, we verify that the deletion method preserves undo history
 
-      // Verify that execCommand was called with 'delete'
-      expect(execCommandCalled).toBe(true)
-      expect(execCommandArgs).toEqual(['delete', false, null])
+            // The fix ensures the deletion uses browser-native text manipulation
+            // which should be trackable in the undo stack
+            expect(visibleTextarea.value).toBe(
+                "Some text with  reference in the middle.",
+            );
+        });
 
-      // Restore original execCommand
-      document.execCommand = originalExecCommand
-    })
+        test("should support undo after reference deletion (legacy approach)", () => {
+            // Mock document.execCommand for testing legacy approach
+            const originalExecCommand = document.execCommand;
+            let execCommandCalled = false;
+            let execCommandArgs = [];
 
-    test('should move cursor to reference boundaries when clicking inside reference', () => {
-      // This test would require more complex DOM manipulation to simulate click positions
-      // For now, we'll test the boundary detection logic
+            document.execCommand = vi.fn((command, showUI, value) => {
+                execCommandCalled = true;
+                execCommandArgs = [command, showUI, value];
+                return true;
+            });
 
-      const referenceText = '((Sample Reference 1))'
-      const referenceStart = visibleTextarea.value.indexOf(referenceText)
-      const referenceEnd = referenceStart + referenceText.length
-      const middleOfReference = referenceStart + Math.floor(referenceText.length / 2)
+            const originalValue = visibleTextarea.value;
 
-      // Position cursor in middle of reference
-      visibleTextarea.setSelectionRange(middleOfReference, middleOfReference)
+            // Position cursor at end of reference
+            const referenceEnd =
+                visibleTextarea.value.indexOf("((Sample Reference 1))") +
+                "((Sample Reference 1))".length;
+            visibleTextarea.setSelectionRange(referenceEnd, referenceEnd);
 
-      // Create and dispatch click event
-      const clickEvent = new MouseEvent('click', {
-        bubbles: true,
-        cancelable: true
-      })
+            // Create and dispatch backspace event
+            const backspaceEvent = new KeyboardEvent("keydown", {
+                key: "Backspace",
+                bubbles: true,
+                cancelable: true,
+            });
 
-      visibleTextarea.dispatchEvent(clickEvent)
+            visibleTextarea.dispatchEvent(backspaceEvent);
 
-      // After our fix, cursor should be moved to one of the boundaries
-      // (We can't easily test the exact position without mocking more browser APIs)
-      expect(visibleTextarea.selectionStart).toBeDefined()
-    })
-  })
+            // Verify that execCommand was called with 'delete'
+            expect(execCommandCalled).toBe(true);
+            expect(execCommandArgs).toEqual(["delete", false, null]);
 
-  describe('Toolbar functionality', () => {
-    let visibleTextarea, toolbar
+            // Restore original execCommand
+            document.execCommand = originalExecCommand;
+        });
 
-    beforeEach(() => {
-      // Initialize the combined editor with toolbar enabled
-      contextAwareEditor(container)
+        test("should move cursor to reference boundaries when clicking inside reference", () => {
+            // This test would require more complex DOM manipulation to simulate click positions
+            // For now, we'll test the boundary detection logic
 
-      // Get the visible textarea and toolbar that were created
-      visibleTextarea = container.querySelector('.app-context-aware-editor__visible-textarea')
-      toolbar = container.querySelector('.app-context-aware-editor__toolbar')
+            const referenceText = "((Sample Reference 1))";
+            const referenceStart = visibleTextarea.value.indexOf(referenceText);
+            const referenceEnd = referenceStart + referenceText.length;
+            const middleOfReference =
+                referenceStart + Math.floor(referenceText.length / 2);
 
-      // Set up test content
-      const textAreaContent = `
+            // Position cursor in middle of reference
+            visibleTextarea.setSelectionRange(
+                middleOfReference,
+                middleOfReference,
+            );
+
+            // Create and dispatch click event
+            const clickEvent = new MouseEvent("click", {
+                bubbles: true,
+                cancelable: true,
+            });
+
+            visibleTextarea.dispatchEvent(clickEvent);
+
+            // After our fix, cursor should be moved to one of the boundaries
+            // (We can't easily test the exact position without mocking more browser APIs)
+            expect(visibleTextarea.selectionStart).toBeDefined();
+        });
+    });
+
+    describe("Toolbar functionality", () => {
+        let visibleTextarea, toolbar;
+
+        beforeEach(() => {
+            // Initialize the combined editor with toolbar enabled
+            contextAwareEditor(container);
+
+            // Get the visible textarea and toolbar that were created
+            visibleTextarea = container.querySelector(
+                ".app-context-aware-editor__visible-textarea",
+            );
+            toolbar = container.querySelector(
+                ".app-context-aware-editor__toolbar",
+            );
+
+            // Set up test content
+            const textAreaContent = `
 
     Grid references
 
@@ -241,298 +269,356 @@ describe('Context Aware Editor', () => {
     The 10 figure grid reference is the first reference shown, in an orange font.
 
 
-    `
-      visibleTextarea.value = textAreaContent
-      textarea.value = textAreaContent
-    })
+    `;
+            visibleTextarea.value = textAreaContent;
+            textarea.value = textAreaContent;
+        });
 
-    const selectText = (textArea, text) => {
-      textArea.setSelectionRange(
-        textArea.value.indexOf(text),
-        textArea.value.indexOf(text) + text.length
-      )
-    }
+        const selectText = (textArea, text) => {
+            textArea.setSelectionRange(
+                textArea.value.indexOf(text),
+                textArea.value.indexOf(text) + text.length,
+            );
+        };
 
-    const prefixes = ['## ', '### ', '* ', '- ', '1. ']
+        const prefixes = ["## ", "### ", "* ", "- ", "1. "];
 
-    test('toolbar is created when enabled', () => {
-      expect(toolbar).not.toBeNull()
-    })
+        test("toolbar is created when enabled", () => {
+            expect(toolbar).not.toBeNull();
+        });
 
-    test('toolbar has the correct label', () => {
-      expect(toolbar.getAttribute('aria-label')).toBe('Markdown formatting')
-    })
+        test("toolbar has the correct label", () => {
+            expect(toolbar.getAttribute("aria-label")).toBe(
+                "Markdown formatting",
+            );
+        });
 
-    test('toolbar has the required buttons', () => {
-      const buttonTexts = [
-        'Add a second-level heading',
-        'Add a link',
-        'Add a bulleted list',
-        'Add a numbered list'
-      ]
+        test("toolbar has the required buttons", () => {
+            const buttonTexts = [
+                "Add a second-level heading",
+                "Add a link",
+                "Add a bulleted list",
+                "Add a numbered list",
+            ];
 
-      buttonTexts.forEach(buttonText => {
-        const button = Array.from(toolbar.querySelectorAll('button')).find(
-          btn => btn.textContent.trim() === buttonText
-        )
-        expect(button).not.toBeNull()
-      })
-    })
+            buttonTexts.forEach((buttonText) => {
+                const button = Array.from(
+                    toolbar.querySelectorAll("button"),
+                ).find((btn) => btn.textContent.trim() === buttonText);
+                expect(button).not.toBeNull();
+            });
+        });
 
-    describe('arrow key navigation', () => {
-      const rightArrowPressEvent = new window.KeyboardEvent('keyup', {
-        key: 'ArrowRight',
-        code: 'ArrowRight'
-      })
-      const leftArrowPressEvent = new window.KeyboardEvent('keyup', {
-        key: 'ArrowLeft',
-        code: 'ArrowLeft'
-      })
+        describe("arrow key navigation", () => {
+            const rightArrowPressEvent = new window.KeyboardEvent("keyup", {
+                key: "ArrowRight",
+                code: "ArrowRight",
+            });
+            const leftArrowPressEvent = new window.KeyboardEvent("keyup", {
+                key: "ArrowLeft",
+                code: "ArrowLeft",
+            });
 
-      test('user can use the right arrow key to navigate to the next button', () => {
-        const buttons = toolbar.querySelectorAll('button')
+            test("user can use the right arrow key to navigate to the next button", () => {
+                const buttons = toolbar.querySelectorAll("button");
 
-        buttons[0].focus()
-        buttons[0].dispatchEvent(rightArrowPressEvent)
-        expect(document.activeElement).toBe(buttons[1])
-      })
+                buttons[0].focus();
+                buttons[0].dispatchEvent(rightArrowPressEvent);
+                expect(document.activeElement).toBe(buttons[1]);
+            });
 
-      test('user can use the left arrow key to navigate to the previous button', () => {
-        const buttons = toolbar.querySelectorAll('button')
+            test("user can use the left arrow key to navigate to the previous button", () => {
+                const buttons = toolbar.querySelectorAll("button");
 
-        buttons[buttons.length - 1].focus()
-        buttons[1].dispatchEvent(leftArrowPressEvent)
-        expect(document.activeElement).toBe(buttons[0])
-      })
+                buttons[buttons.length - 1].focus();
+                buttons[1].dispatchEvent(leftArrowPressEvent);
+                expect(document.activeElement).toBe(buttons[0]);
+            });
 
-      test('pressing left on the first button does not wrap to the last button', () => {
-        const buttons = toolbar.querySelectorAll('button')
+            test("pressing left on the first button does not wrap to the last button", () => {
+                const buttons = toolbar.querySelectorAll("button");
 
-        buttons[0].focus()
-        buttons[0].dispatchEvent(leftArrowPressEvent)
-        expect(document.activeElement).toBe(buttons[0])
-      })
+                buttons[0].focus();
+                buttons[0].dispatchEvent(leftArrowPressEvent);
+                expect(document.activeElement).toBe(buttons[0]);
+            });
 
-      test('pressing right on the last button does not wrap to the first button', () => {
-        const buttons = toolbar.querySelectorAll('button')
+            test("pressing right on the last button does not wrap to the first button", () => {
+                const buttons = toolbar.querySelectorAll("button");
 
-        buttons[buttons.length - 1].focus()
-        buttons[buttons.length - 1].dispatchEvent(rightArrowPressEvent)
-        expect(document.activeElement).toBe(buttons[buttons.length - 1])
-      })
-    })
+                buttons[buttons.length - 1].focus();
+                buttons[buttons.length - 1].dispatchEvent(rightArrowPressEvent);
+                expect(document.activeElement).toBe(
+                    buttons[buttons.length - 1],
+                );
+            });
+        });
 
-    describe('second-level heading button', () => {
-      test('formats the whole line if only a part of the line is selected', () => {
-        selectText(visibleTextarea, 'references')
+        describe("second-level heading button", () => {
+            test("formats the whole line if only a part of the line is selected", () => {
+                selectText(visibleTextarea, "references");
 
-        const headingButton = Array.from(toolbar.querySelectorAll('button')).find(
-          btn => btn.textContent.trim() === 'Add a second-level heading'
-        )
-        headingButton.click()
+                const headingButton = Array.from(
+                    toolbar.querySelectorAll("button"),
+                ).find(
+                    (btn) =>
+                        btn.textContent.trim() === "Add a second-level heading",
+                );
+                headingButton.click();
 
-        expect(
-          visibleTextarea.value.substring(visibleTextarea.selectionStart, visibleTextarea.selectionEnd)
-        ).toBe('## Grid references')
-      })
+                expect(
+                    visibleTextarea.value.substring(
+                        visibleTextarea.selectionStart,
+                        visibleTextarea.selectionEnd,
+                    ),
+                ).toBe("## Grid references");
+            });
 
-      test('adds placeholder text if there is no text on the selected line', () => {
-        visibleTextarea.setSelectionRange(
-          visibleTextarea.value.length - 1,
-          visibleTextarea.value.length - 1
-        )
+            test("adds placeholder text if there is no text on the selected line", () => {
+                visibleTextarea.setSelectionRange(
+                    visibleTextarea.value.length - 1,
+                    visibleTextarea.value.length - 1,
+                );
 
-        const headingButton = Array.from(toolbar.querySelectorAll('button')).find(
-          btn => btn.textContent.trim() === 'Add a second-level heading'
-        )
-        headingButton.click()
+                const headingButton = Array.from(
+                    toolbar.querySelectorAll("button"),
+                ).find(
+                    (btn) =>
+                        btn.textContent.trim() === "Add a second-level heading",
+                );
+                headingButton.click();
 
-        expect(
-          visibleTextarea.value.substring(visibleTextarea.selectionStart, visibleTextarea.selectionEnd)
-        ).toBe('## Heading text')
-      })
+                expect(
+                    visibleTextarea.value.substring(
+                        visibleTextarea.selectionStart,
+                        visibleTextarea.selectionEnd,
+                    ),
+                ).toBe("## Heading text");
+            });
 
-      test('removes the existing prefix', () => {
-        prefixes.forEach(prefix => {
-          visibleTextarea.value = `${prefix}This is an item with an existing markdown block style`
-          selectText(
-            visibleTextarea,
-            'This is an item with an existing markdown block style'
-          )
+            test("removes the existing prefix", () => {
+                prefixes.forEach((prefix) => {
+                    visibleTextarea.value = `${prefix}This is an item with an existing markdown block style`;
+                    selectText(
+                        visibleTextarea,
+                        "This is an item with an existing markdown block style",
+                    );
 
-          const headingButton = Array.from(toolbar.querySelectorAll('button')).find(
-            btn => btn.textContent.trim() === 'Add a second-level heading'
-          )
-          headingButton.click()
+                    const headingButton = Array.from(
+                        toolbar.querySelectorAll("button"),
+                    ).find(
+                        (btn) =>
+                            btn.textContent.trim() ===
+                            "Add a second-level heading",
+                    );
+                    headingButton.click();
 
-          expect(
-            visibleTextarea.value.substring(
-              visibleTextarea.selectionStart,
-              visibleTextarea.selectionEnd
-            )
-          ).toBe('## This is an item with an existing markdown block style')
-        })
-      })
-    })
+                    expect(
+                        visibleTextarea.value.substring(
+                            visibleTextarea.selectionStart,
+                            visibleTextarea.selectionEnd,
+                        ),
+                    ).toBe(
+                        "## This is an item with an existing markdown block style",
+                    );
+                });
+            });
+        });
 
-    describe('add numbered list button', () => {
-      test('formats the whole line if only a part of the line is selected', () => {
-        selectText(visibleTextarea, 'Grid Reference Finder')
+        describe("add numbered list button", () => {
+            test("formats the whole line if only a part of the line is selected", () => {
+                selectText(visibleTextarea, "Grid Reference Finder");
 
-        const numberedButton = Array.from(toolbar.querySelectorAll('button')).find(
-          btn => btn.textContent.trim() === 'Add a numbered list'
-        )
-        numberedButton.click()
+                const numberedButton = Array.from(
+                    toolbar.querySelectorAll("button"),
+                ).find(
+                    (btn) => btn.textContent.trim() === "Add a numbered list",
+                );
+                numberedButton.click();
 
-        expect(
-          visibleTextarea.value.substring(visibleTextarea.selectionStart, visibleTextarea.selectionEnd)
-        ).toBe('1. Go to the Grid Reference Finder website')
-      })
+                expect(
+                    visibleTextarea.value.substring(
+                        visibleTextarea.selectionStart,
+                        visibleTextarea.selectionEnd,
+                    ),
+                ).toBe("1. Go to the Grid Reference Finder website");
+            });
 
-      test('adds placeholder text if there is no text on the selected line', () => {
-        visibleTextarea.setSelectionRange(
-          visibleTextarea.value.length - 1,
-          visibleTextarea.value.length - 1
-        )
+            test("adds placeholder text if there is no text on the selected line", () => {
+                visibleTextarea.setSelectionRange(
+                    visibleTextarea.value.length - 1,
+                    visibleTextarea.value.length - 1,
+                );
 
-        const numberedButton = Array.from(toolbar.querySelectorAll('button')).find(
-          btn => btn.textContent.trim() === 'Add a numbered list'
-        )
-        numberedButton.click()
+                const numberedButton = Array.from(
+                    toolbar.querySelectorAll("button"),
+                ).find(
+                    (btn) => btn.textContent.trim() === "Add a numbered list",
+                );
+                numberedButton.click();
 
-        expect(
-          visibleTextarea.value.substring(visibleTextarea.selectionStart, visibleTextarea.selectionEnd)
-        ).toBe('1. List item')
-      })
+                expect(
+                    visibleTextarea.value.substring(
+                        visibleTextarea.selectionStart,
+                        visibleTextarea.selectionEnd,
+                    ),
+                ).toBe("1. List item");
+            });
 
-      test('removes the existing prefix', () => {
-        prefixes.forEach(prefix => {
-          visibleTextarea.value = `${prefix}This is an item with an existing markdown block style`
-          selectText(
-            visibleTextarea,
-            'This is an item with an existing markdown block style'
-          )
+            test("removes the existing prefix", () => {
+                prefixes.forEach((prefix) => {
+                    visibleTextarea.value = `${prefix}This is an item with an existing markdown block style`;
+                    selectText(
+                        visibleTextarea,
+                        "This is an item with an existing markdown block style",
+                    );
 
-          const numberedButton = Array.from(toolbar.querySelectorAll('button')).find(
-            btn => btn.textContent.trim() === 'Add a numbered list'
-          )
-          numberedButton.click()
+                    const numberedButton = Array.from(
+                        toolbar.querySelectorAll("button"),
+                    ).find(
+                        (btn) =>
+                            btn.textContent.trim() === "Add a numbered list",
+                    );
+                    numberedButton.click();
 
-          expect(
-            visibleTextarea.value.substring(
-              visibleTextarea.selectionStart,
-              visibleTextarea.selectionEnd
-            )
-          ).toBe('1. This is an item with an existing markdown block style')
-        })
-      })
-    })
+                    expect(
+                        visibleTextarea.value.substring(
+                            visibleTextarea.selectionStart,
+                            visibleTextarea.selectionEnd,
+                        ),
+                    ).toBe(
+                        "1. This is an item with an existing markdown block style",
+                    );
+                });
+            });
+        });
 
-    describe('add bullet list button', () => {
-      test('formats the whole line if only a part of the line is selected', () => {
-        selectText(visibleTextarea, 'Grid Reference Finder')
+        describe("add bullet list button", () => {
+            test("formats the whole line if only a part of the line is selected", () => {
+                selectText(visibleTextarea, "Grid Reference Finder");
 
-        const bulletButton = Array.from(toolbar.querySelectorAll('button')).find(
-          btn => btn.textContent.trim() === 'Add a bulleted list'
-        )
-        bulletButton.click()
+                const bulletButton = Array.from(
+                    toolbar.querySelectorAll("button"),
+                ).find(
+                    (btn) => btn.textContent.trim() === "Add a bulleted list",
+                );
+                bulletButton.click();
 
-        expect(
-          visibleTextarea.value.substring(visibleTextarea.selectionStart, visibleTextarea.selectionEnd)
-        ).toBe('* Go to the Grid Reference Finder website')
-      })
+                expect(
+                    visibleTextarea.value.substring(
+                        visibleTextarea.selectionStart,
+                        visibleTextarea.selectionEnd,
+                    ),
+                ).toBe("* Go to the Grid Reference Finder website");
+            });
 
-      test('adds placeholder text if there is no text on the selected line', () => {
-        visibleTextarea.setSelectionRange(
-          visibleTextarea.value.length - 1,
-          visibleTextarea.value.length - 1
-        )
+            test("adds placeholder text if there is no text on the selected line", () => {
+                visibleTextarea.setSelectionRange(
+                    visibleTextarea.value.length - 1,
+                    visibleTextarea.value.length - 1,
+                );
 
-        const bulletButton = Array.from(toolbar.querySelectorAll('button')).find(
-          btn => btn.textContent.trim() === 'Add a bulleted list'
-        )
-        bulletButton.click()
+                const bulletButton = Array.from(
+                    toolbar.querySelectorAll("button"),
+                ).find(
+                    (btn) => btn.textContent.trim() === "Add a bulleted list",
+                );
+                bulletButton.click();
 
-        expect(
-          visibleTextarea.value.substring(visibleTextarea.selectionStart, visibleTextarea.selectionEnd)
-        ).toBe('* List item')
-      })
+                expect(
+                    visibleTextarea.value.substring(
+                        visibleTextarea.selectionStart,
+                        visibleTextarea.selectionEnd,
+                    ),
+                ).toBe("* List item");
+            });
 
-      test('removes the existing prefix', () => {
-        prefixes.forEach(prefix => {
-          visibleTextarea.value = `${prefix}This is an item with an existing markdown block style`
-          selectText(
-            visibleTextarea,
-            'This is an item with an existing markdown block style'
-          )
+            test("removes the existing prefix", () => {
+                prefixes.forEach((prefix) => {
+                    visibleTextarea.value = `${prefix}This is an item with an existing markdown block style`;
+                    selectText(
+                        visibleTextarea,
+                        "This is an item with an existing markdown block style",
+                    );
 
-          const bulletButton = Array.from(toolbar.querySelectorAll('button')).find(
-            btn => btn.textContent.trim() === 'Add a bulleted list'
-          )
-          bulletButton.click()
+                    const bulletButton = Array.from(
+                        toolbar.querySelectorAll("button"),
+                    ).find(
+                        (btn) =>
+                            btn.textContent.trim() === "Add a bulleted list",
+                    );
+                    bulletButton.click();
 
-          expect(
-            visibleTextarea.value.substring(
-              visibleTextarea.selectionStart,
-              visibleTextarea.selectionEnd
-            )
-          ).toBe('* This is an item with an existing markdown block style')
-        })
-      })
-    })
+                    expect(
+                        visibleTextarea.value.substring(
+                            visibleTextarea.selectionStart,
+                            visibleTextarea.selectionEnd,
+                        ),
+                    ).toBe(
+                        "* This is an item with an existing markdown block style",
+                    );
+                });
+            });
+        });
 
-    describe('add link button', () => {
-      test('formats the selection', () => {
-        selectText(visibleTextarea, 'Grid Reference Finder website')
+        describe("add link button", () => {
+            test("formats the selection", () => {
+                selectText(visibleTextarea, "Grid Reference Finder website");
 
-        const linkButton = Array.from(toolbar.querySelectorAll('button')).find(
-          btn => btn.textContent.trim() === 'Add a link'
-        )
-        linkButton.click()
+                const linkButton = Array.from(
+                    toolbar.querySelectorAll("button"),
+                ).find((btn) => btn.textContent.trim() === "Add a link");
+                linkButton.click();
 
-        expect(
-          visibleTextarea.value.substring(visibleTextarea.selectionStart, visibleTextarea.selectionEnd)
-        ).toBe(
-          '[Grid Reference Finder website](https://www.gov.uk/link-text-url)'
-        )
-      })
+                expect(
+                    visibleTextarea.value.substring(
+                        visibleTextarea.selectionStart,
+                        visibleTextarea.selectionEnd,
+                    ),
+                ).toBe(
+                    "[Grid Reference Finder website](https://www.gov.uk/link-text-url)",
+                );
+            });
 
-      test('adds placeholder text if there is no text on the selected line', () => {
-        visibleTextarea.setSelectionRange(
-          visibleTextarea.value.length - 1,
-          visibleTextarea.value.length - 1
-        )
+            test("adds placeholder text if there is no text on the selected line", () => {
+                visibleTextarea.setSelectionRange(
+                    visibleTextarea.value.length - 1,
+                    visibleTextarea.value.length - 1,
+                );
 
-        const linkButton = Array.from(toolbar.querySelectorAll('button')).find(
-          btn => btn.textContent.trim() === 'Add a link'
-        )
-        linkButton.click()
+                const linkButton = Array.from(
+                    toolbar.querySelectorAll("button"),
+                ).find((btn) => btn.textContent.trim() === "Add a link");
+                linkButton.click();
 
-        expect(
-          visibleTextarea.value.substring(visibleTextarea.selectionStart, visibleTextarea.selectionEnd)
-        ).toBe('[Link text](https://www.gov.uk/link-text-url)')
-      })
+                expect(
+                    visibleTextarea.value.substring(
+                        visibleTextarea.selectionStart,
+                        visibleTextarea.selectionEnd,
+                    ),
+                ).toBe("[Link text](https://www.gov.uk/link-text-url)");
+            });
 
-      test('excludes the existing prefix from the link', () => {
-        prefixes.forEach(prefix => {
-          visibleTextarea.value = `${prefix}This is an item with an existing markdown block style`
-          selectText(visibleTextarea, visibleTextarea.value)
+            test("excludes the existing prefix from the link", () => {
+                prefixes.forEach((prefix) => {
+                    visibleTextarea.value = `${prefix}This is an item with an existing markdown block style`;
+                    selectText(visibleTextarea, visibleTextarea.value);
 
-          const linkButton = Array.from(toolbar.querySelectorAll('button')).find(
-            btn => btn.textContent.trim() === 'Add a link'
-          )
-          linkButton.click()
+                    const linkButton = Array.from(
+                        toolbar.querySelectorAll("button"),
+                    ).find((btn) => btn.textContent.trim() === "Add a link");
+                    linkButton.click();
 
-          expect(
-            visibleTextarea.value.substring(
-              visibleTextarea.selectionStart,
-              visibleTextarea.selectionEnd
-            )
-          ).toBe(
-            `${prefix}[This is an item with an existing markdown block style](https://www.gov.uk/link-text-url)`
-          )
-        })
-      })
-    })
-  })
-})
+                    expect(
+                        visibleTextarea.value.substring(
+                            visibleTextarea.selectionStart,
+                            visibleTextarea.selectionEnd,
+                        ),
+                    ).toBe(
+                        `${prefix}[This is an item with an existing markdown block style](https://www.gov.uk/link-text-url)`,
+                    );
+                });
+            });
+        });
+    });
+});

--- a/app/assets/js/context-aware-editor/toolbar.js
+++ b/app/assets/js/context-aware-editor/toolbar.js
@@ -1,202 +1,207 @@
 // Toolbar functionality for markdown editor
 // Refactored from markdown-editor-toolbar to work with any textarea
 
-const blockPrefixPattern = /^(## |### |\* |- |1. )/g
+const blockPrefixPattern = /^(## |### |\* |- |1. )/g;
 
 const addLink = (event, textArea) => {
-  event.preventDefault()
-  const { selection, selectionStart, selectionEnd } = getSelection(textArea)
-  const blockPrefix = selection.match(blockPrefixPattern)?.[0] ?? ''
-  const selectionWithoutPrefix = selection.replace(blockPrefix, '')
-  const linkMarkdown = `${blockPrefix}[${
-    selectionEnd === selectionStart ? 'Link text' : selectionWithoutPrefix
-  }](https://www.gov.uk/link-text-url)`
-  updateSelection(textArea, selectionStart, selectionEnd, linkMarkdown)
-}
+    event.preventDefault();
+    const { selection, selectionStart, selectionEnd } = getSelection(textArea);
+    const blockPrefix = selection.match(blockPrefixPattern)?.[0] ?? "";
+    const selectionWithoutPrefix = selection.replace(blockPrefix, "");
+    const linkMarkdown = `${blockPrefix}[${
+        selectionEnd === selectionStart ? "Link text" : selectionWithoutPrefix
+    }](https://www.gov.uk/link-text-url)`;
+    updateSelection(textArea, selectionStart, selectionEnd, linkMarkdown);
+};
 
 // You can only have one block style at a time, and it's always applied to the whole line.
 // Use this for currying when adding new block-level formatting options.
-const addBlockElement = transform => {
-  return (event, textArea) => {
-    event.preventDefault()
-    const { selection, selectionStart, selectionEnd } =
-      getFullLineForSelection(textArea)
-    const trimmedSelection = removeBlockPrefix(selection)
-    const markdown = transform(trimmedSelection)
-    updateSelection(textArea, selectionStart, selectionEnd, markdown)
-  }
-}
+const addBlockElement = (transform) => {
+    return (event, textArea) => {
+        event.preventDefault();
+        const { selection, selectionStart, selectionEnd } =
+            getFullLineForSelection(textArea);
+        const trimmedSelection = removeBlockPrefix(selection);
+        const markdown = transform(trimmedSelection);
+        updateSelection(textArea, selectionStart, selectionEnd, markdown);
+    };
+};
 
 const addH2 = addBlockElement(
-  selection => `## ${selection.length ? selection : 'Heading text'}`
-)
+    (selection) => `## ${selection.length ? selection : "Heading text"}`,
+);
 
 const addOrderedList = addBlockElement(
-  selection => `1. ${selection.length ? selection : 'List item'}`
-)
+    (selection) => `1. ${selection.length ? selection : "List item"}`,
+);
 
 const addUnorderedList = addBlockElement(
-  selection => `* ${selection.length ? selection : 'List item'}`
-)
+    (selection) => `* ${selection.length ? selection : "List item"}`,
+);
 
 const buttonGroupConfiguration = [
-  [
-    {
-      identifier: 'h2',
-      callback: addH2,
-      isHeading: true
-    }
-  ],
-  [{ identifier: 'link', callback: addLink, isHeading: false }],
-  [
-    {
-      identifier: 'bullet-list',
-      callback: addUnorderedList,
-      isHeading: false
-    },
-    {
-      identifier: 'numbered-list',
-      callback: addOrderedList,
-      isHeading: false
-    }
-  ]
-]
+    [
+        {
+            identifier: "h2",
+            callback: addH2,
+            isHeading: true,
+        },
+    ],
+    [{ identifier: "link", callback: addLink, isHeading: false }],
+    [
+        {
+            identifier: "bullet-list",
+            callback: addUnorderedList,
+            isHeading: false,
+        },
+        {
+            identifier: "numbered-list",
+            callback: addOrderedList,
+            isHeading: false,
+        },
+    ],
+];
 
 const createToolbar = (textArea) => {
-  const toolbar = document.createElement('div')
+    const toolbar = document.createElement("div");
 
-  toolbar.classList.add('app-context-aware-editor__toolbar')
-  toolbar.setAttribute('aria-controls', textArea.id)
-  toolbar.setAttribute('role', 'toolbar')
-  toolbar.setAttribute('aria-label', 'Markdown formatting')
+    toolbar.classList.add("app-context-aware-editor__toolbar");
+    toolbar.setAttribute("aria-controls", textArea.id);
+    toolbar.setAttribute("role", "toolbar");
+    toolbar.setAttribute("aria-label", "Markdown formatting");
 
-  return toolbar
-}
+    return toolbar;
+};
 
 const getButtonText = (identifier, i18n) => {
-  const snakeCaseIdentifier = identifier.replaceAll('-', '_')
-  return {h2: "Add a second-level heading", link: "Add a link", bullet_list: "Add a bulleted list", numbered_list: "Add a numbered list"}[snakeCaseIdentifier];
-}
+    const snakeCaseIdentifier = identifier.replaceAll("-", "_");
+    return {
+        h2: "Add a second-level heading",
+        link: "Add a link",
+        bullet_list: "Add a bulleted list",
+        numbered_list: "Add a numbered list",
+    }[snakeCaseIdentifier];
+};
 
 const createButtonGroup = (
-  configurationGroup,
-  textArea,
-  i18n,
-  allowHeadings
+    configurationGroup,
+    textArea,
+    i18n,
+    allowHeadings,
 ) => {
-  const buttonGroup = document.createElement('div')
-  buttonGroup.classList.add('app-context-aware-editor__toolbar-button-group')
-  const buttons = configurationGroup
-    .filter(button => allowHeadings || !button.isHeading)
-    .map(buttonConfig =>
-      createButton(
-        textArea,
-        getButtonText(buttonConfig.identifier, i18n),
-        buttonConfig.callback,
-        buttonConfig.identifier
-      )
-    )
+    const buttonGroup = document.createElement("div");
+    buttonGroup.classList.add("app-context-aware-editor__toolbar-button-group");
+    const buttons = configurationGroup
+        .filter((button) => allowHeadings || !button.isHeading)
+        .map((buttonConfig) =>
+            createButton(
+                textArea,
+                getButtonText(buttonConfig.identifier, i18n),
+                buttonConfig.callback,
+                buttonConfig.identifier,
+            ),
+        );
 
-  buttons.forEach(button => buttonGroup.appendChild(button))
-  return buttonGroup
-}
+    buttons.forEach((button) => buttonGroup.appendChild(button));
+    return buttonGroup;
+};
 
 const createButton = (textArea, linkText, callback, identifier) => {
-  const button = document.createElement('button')
-  button.innerHTML = `<span class='govuk-visually-hidden'>${linkText}</span>`
-  button.classList.add(
-    'govuk-button',
-    'govuk-button--secondary',
-    'app-context-aware-editor__toolbar-button',
-    `app-context-aware-editor__toolbar-button--${identifier}`
-  )
-  button.setAttribute('title', linkText)
-  addClickAndKeyboardEventListeners(textArea, button, callback)
-  return button
-}
+    const button = document.createElement("button");
+    button.innerHTML = `<span class='govuk-visually-hidden'>${linkText}</span>`;
+    button.classList.add(
+        "govuk-button",
+        "govuk-button--secondary",
+        "app-context-aware-editor__toolbar-button",
+        `app-context-aware-editor__toolbar-button--${identifier}`,
+    );
+    button.setAttribute("title", linkText);
+    addClickAndKeyboardEventListeners(textArea, button, callback);
+    return button;
+};
 
-const getSelection = element => {
-  const selectionStart = element.selectionStart
-  const selectionEnd = element.selectionEnd
-  const selection = element.value.substring(selectionStart, selectionEnd)
+const getSelection = (element) => {
+    const selectionStart = element.selectionStart;
+    const selectionEnd = element.selectionEnd;
+    const selection = element.value.substring(selectionStart, selectionEnd);
 
-  return { selection, selectionStart, selectionEnd }
-}
+    return { selection, selectionStart, selectionEnd };
+};
 
-const getFullLineForSelection = element => {
-  const {
-    selectionStart: initialSelectionStart,
-    selectionEnd: initialSelectionEnd
-  } = getSelection(element)
-  const linesBeforeInitialSelection = element.value
-    .substr(0, initialSelectionStart)
-    .split('\n')
-  const prefix =
-    linesBeforeInitialSelection[linesBeforeInitialSelection.length - 1]
+const getFullLineForSelection = (element) => {
+    const {
+        selectionStart: initialSelectionStart,
+        selectionEnd: initialSelectionEnd,
+    } = getSelection(element);
+    const linesBeforeInitialSelection = element.value
+        .substr(0, initialSelectionStart)
+        .split("\n");
+    const prefix =
+        linesBeforeInitialSelection[linesBeforeInitialSelection.length - 1];
 
-  const linesAfterInitialSelection = element.value
-    .substr(initialSelectionEnd, element.value.length - 1)
-    .split('\n')
-  const suffix = linesAfterInitialSelection[0]
+    const linesAfterInitialSelection = element.value
+        .substr(initialSelectionEnd, element.value.length - 1)
+        .split("\n");
+    const suffix = linesAfterInitialSelection[0];
 
-  const selectionStart = initialSelectionStart - prefix.length
-  const selectionEnd = initialSelectionEnd + suffix.length
-  const selection = element.value.substring(selectionStart, selectionEnd)
+    const selectionStart = initialSelectionStart - prefix.length;
+    const selectionEnd = initialSelectionEnd + suffix.length;
+    const selection = element.value.substring(selectionStart, selectionEnd);
 
-  return { selection, selectionStart, selectionEnd }
-}
+    return { selection, selectionStart, selectionEnd };
+};
 
 const updateSelection = (element, start, end, updatedText) => {
-  element.value = `${element.value.slice(
-    0,
-    start
-  )}${updatedText}${element.value.slice(end)}`
-  element.setSelectionRange(start, start + updatedText.length)
-  element.dispatchEvent(new window.InputEvent('input'))
-}
+    element.value = `${element.value.slice(
+        0,
+        start,
+    )}${updatedText}${element.value.slice(end)}`;
+    element.setSelectionRange(start, start + updatedText.length);
+    element.dispatchEvent(new window.InputEvent("input"));
+};
 
-const removeBlockPrefix = text => text.trim().replace(blockPrefixPattern, '')
+const removeBlockPrefix = (text) => text.trim().replace(blockPrefixPattern, "");
 
 const addClickAndKeyboardEventListeners = (textArea, element, callback) => {
-  element.addEventListener('click', event => {
-    callback(event, textArea)
-  })
-  element.addEventListener('keyup', event => {
-    const element = event.target
-    if (
-      [' ', 'Enter'].includes(event.key) &&
-      element instanceof window.HTMLElement &&
-      element.getAttribute('role') === 'button'
-    ) {
-      callback(event, textArea)
-    }
-  })
-}
-
-const addButtonFocusEvents = buttons => {
-  buttons.forEach((button, index) => {
-    button.setAttribute('tabindex', index === 0 ? 0 : -1)
-
-    if (index > 0) {
-      button.addEventListener('keyup', event => {
-        if (event.key === 'ArrowLeft') {
-          button.setAttribute('tabindex', -1)
-          buttons[index - 1].setAttribute('tabindex', 0)
-          buttons[index - 1].focus()
+    element.addEventListener("click", (event) => {
+        callback(event, textArea);
+    });
+    element.addEventListener("keyup", (event) => {
+        const element = event.target;
+        if (
+            [" ", "Enter"].includes(event.key) &&
+            element instanceof window.HTMLElement &&
+            element.getAttribute("role") === "button"
+        ) {
+            callback(event, textArea);
         }
-      })
-    }
-    if (index !== buttons.length - 1) {
-      button.addEventListener('keyup', event => {
-        if (event.key === 'ArrowRight') {
-          button.setAttribute('tabindex', -1)
-          buttons[index + 1].setAttribute('tabindex', 0)
-          buttons[index + 1].focus()
+    });
+};
+
+const addButtonFocusEvents = (buttons) => {
+    buttons.forEach((button, index) => {
+        button.setAttribute("tabindex", index === 0 ? 0 : -1);
+
+        if (index > 0) {
+            button.addEventListener("keyup", (event) => {
+                if (event.key === "ArrowLeft") {
+                    button.setAttribute("tabindex", -1);
+                    buttons[index - 1].setAttribute("tabindex", 0);
+                    buttons[index - 1].focus();
+                }
+            });
         }
-      })
-    }
-  })
-}
+        if (index !== buttons.length - 1) {
+            button.addEventListener("keyup", (event) => {
+                if (event.key === "ArrowRight") {
+                    button.setAttribute("tabindex", -1);
+                    buttons[index + 1].setAttribute("tabindex", 0);
+                    buttons[index + 1].focus();
+                }
+            });
+        }
+    });
+};
 
 /**
  * Creates and configures a toolbar for the given textarea
@@ -206,17 +211,22 @@ const addButtonFocusEvents = buttons => {
  * @returns {HTMLElement} The created toolbar element
  */
 const createToolbarForTextArea = (textArea, i18n, allowHeadings = true) => {
-  const toolbar = createToolbar(textArea)
+    const toolbar = createToolbar(textArea);
 
-  buttonGroupConfiguration
-    .map(buttonConfiguration =>
-      createButtonGroup(buttonConfiguration, textArea, i18n, allowHeadings)
-    )
-    .forEach(buttonGroup => toolbar.appendChild(buttonGroup))
+    buttonGroupConfiguration
+        .map((buttonConfiguration) =>
+            createButtonGroup(
+                buttonConfiguration,
+                textArea,
+                i18n,
+                allowHeadings,
+            ),
+        )
+        .forEach((buttonGroup) => toolbar.appendChild(buttonGroup));
 
-  addButtonFocusEvents(toolbar.querySelectorAll('button'))
+    addButtonFocusEvents(toolbar.querySelectorAll("button"));
 
-  return toolbar
-}
+    return toolbar;
+};
 
-export { createToolbarForTextArea }
+export { createToolbarForTextArea };

--- a/app/assets/js/paste-html-to-markdown/html-to-markdown.js
+++ b/app/assets/js/paste-html-to-markdown/html-to-markdown.js
@@ -1,359 +1,367 @@
 // Adapted from the [Paste HTML to govspeak](https://github.com/alphagov/paste-html-to-govspeak) package
 
-import TurndownService from 'turndown'
-import replaceBulletCharacters from './replace-bullet-characters'
+import TurndownService from "turndown";
+import replaceBulletCharacters from "./replace-bullet-characters";
 
 const service = new TurndownService({
-  bulletListMarker: '*',
-  listIndent: '   ' // 3 spaces
-})
+    bulletListMarker: "*",
+    listIndent: "   ", // 3 spaces
+});
 
 // define all the elements we want stripped from output
 const elementsToRemove = [
-  'title',
-  'script',
-  'noscript',
-  'style',
-  'video',
-  'audio',
-  'object',
-  'iframe'
-]
+    "title",
+    "script",
+    "noscript",
+    "style",
+    "video",
+    "audio",
+    "object",
+    "iframe",
+];
 
 for (const element of elementsToRemove) {
-  service.remove(element)
+    service.remove(element);
 }
 
 // As a user may have pasted markdown we rather crudley
 // stop all escaping
-service.escape = string => string
+service.escape = (string) => string;
 
 // turndown keeps title attribute attributes of links by default which isn't
 // what is expected in Forms Markdown
-service.addRule('link', {
-  filter: node => {
-    return node.nodeName.toLowerCase() === 'a' && node.getAttribute('href')
-  },
-  replacement: (content, node) => {
-    if (content.trim() === '') {
-      return ''
-    } else {
-      return `[${content}](${node.getAttribute('href')})`
-    }
-  }
-})
+service.addRule("link", {
+    filter: (node) => {
+        return node.nodeName.toLowerCase() === "a" && node.getAttribute("href");
+    },
+    replacement: (content, node) => {
+        if (content.trim() === "") {
+            return "";
+        } else {
+            return `[${content}](${node.getAttribute("href")})`;
+        }
+    },
+});
 
-service.addRule('abbr', {
-  filter: node => {
-    return node.nodeName.toLowerCase() === 'abbr' && node.getAttribute('title')
-  },
-  replacement: function (content, node) {
-    this.references[content] = node.getAttribute('title')
-    return content
-  },
-  references: {},
-  append: function () {
-    if (Object.keys(this.references).length === 0) {
-      return ''
-    }
+service.addRule("abbr", {
+    filter: (node) => {
+        return (
+            node.nodeName.toLowerCase() === "abbr" && node.getAttribute("title")
+        );
+    },
+    replacement: function (content, node) {
+        this.references[content] = node.getAttribute("title");
+        return content;
+    },
+    references: {},
+    append: function () {
+        if (Object.keys(this.references).length === 0) {
+            return "";
+        }
 
-    let references = '\n\n'
-    for (const abbr in this.references) {
-      references += `*[${abbr}]: ${this.references[abbr]}\n`
-    }
-    this.references = {} // reset after appending
-    return references
-  }
-})
+        let references = "\n\n";
+        for (const abbr in this.references) {
+            references += `*[${abbr}]: ${this.references[abbr]}\n`;
+        }
+        this.references = {}; // reset after appending
+        return references;
+    },
+});
 
 // GOV.UK content authors are encouraged to only use h2 and h3 headers, this
 // converts other headers to be one of these (except h6 which is converted
 // to a paragraph
-service.addRule('heading', {
-  filter: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
-  replacement: (content, node) => {
-    let headingLevel = parseInt(node.nodeName.charAt(1))
-    headingLevel = headingLevel === 1 ? 2 : headingLevel
-    const prefix = Array(headingLevel + 1).join('#')
+service.addRule("heading", {
+    filter: ["h1", "h2", "h3", "h4", "h5", "h6"],
+    replacement: (content, node) => {
+        let headingLevel = parseInt(node.nodeName.charAt(1));
+        headingLevel = headingLevel === 1 ? 2 : headingLevel;
+        const prefix = Array(headingLevel + 1).join("#");
 
-    return `\n\n${prefix} ${content}\n\n`
-  }
-})
+        return `\n\n${prefix} ${content}\n\n`;
+    },
+});
 
 // remove images
 // this needs to be set as a rule rather than remove as it's part of turndown
 // commonmark rules that needs overriding
-service.addRule('img', {
-  filter: ['img'],
-  replacement: () => ''
-})
+service.addRule("img", {
+    filter: ["img"],
+    replacement: () => "",
+});
 
 // remove bold
-service.addRule('bold', {
-  filter: ['b', 'strong'],
-  replacement: content => content
-})
+service.addRule("bold", {
+    filter: ["b", "strong"],
+    replacement: (content) => content,
+});
 
 // remove italic
-service.addRule('italic', {
-  filter: ['i', 'em'],
-  replacement: content => content
-})
+service.addRule("italic", {
+    filter: ["i", "em"],
+    replacement: (content) => content,
+});
 
-service.addRule('removeEmptyParagraphs', {
-  filter: node => {
-    return node.nodeName.toLowerCase() === 'p' && node.textContent.trim() === ''
-  },
-  replacement: () => ''
-})
+service.addRule("removeEmptyParagraphs", {
+    filter: (node) => {
+        return (
+            node.nodeName.toLowerCase() === "p" &&
+            node.textContent.trim() === ""
+        );
+    },
+    replacement: () => "",
+});
 
 // strip paragraph elements within list items
-service.addRule('stripParagraphsInListItems', {
-  filter: node => {
-    return (
-      node.nodeName.toLowerCase() === 'p' &&
-      node.parentNode.nodeName.toLowerCase() === 'li'
-    )
-  },
-  replacement: content => content
-})
+service.addRule("stripParagraphsInListItems", {
+    filter: (node) => {
+        return (
+            node.nodeName.toLowerCase() === "p" &&
+            node.parentNode.nodeName.toLowerCase() === "li"
+        );
+    },
+    replacement: (content) => content,
+});
 
-service.addRule('cleanUpNestedLinks', {
-  filter: node => {
-    if (node.nodeName.toLowerCase() === 'a' && node.previousSibling) {
-      return node.previousSibling.textContent.match(/\]\($/)
-    }
-  },
-  replacement: (content, node) => {
-    return node.getAttribute('href')
-  }
-})
+service.addRule("cleanUpNestedLinks", {
+    filter: (node) => {
+        if (node.nodeName.toLowerCase() === "a" && node.previousSibling) {
+            return node.previousSibling.textContent.match(/\]\($/);
+        }
+    },
+    replacement: (content, node) => {
+        return node.getAttribute("href");
+    },
+});
 
 // Google docs has a habit of producing nested lists that are not nested
 // with valid HTML. Rather than embedding sub lists inside an <li> element they
 // are nested in the <ul> or <ol> element.
-service.addRule('invalidNestedLists', {
-  filter: node => {
-    const nodeName = node.nodeName.toLowerCase()
-    if (
-      (nodeName === 'ul' || nodeName === 'ol') &&
-      node.previousElementSibling
-    ) {
-      const previousNodeName =
-        node.previousElementSibling.nodeName.toLowerCase()
-      return previousNodeName === 'li'
-    }
-  },
-  replacement: (content, node, options) => {
-    content = content
-      .replace(/^\n+/, '') // remove leading newlines
-      .replace(/\n+$/, '') // replace trailing newlines
-      .replace(/\n/gm, `\n${options.listIndent}`) // indent all nested content in the list
+service.addRule("invalidNestedLists", {
+    filter: (node) => {
+        const nodeName = node.nodeName.toLowerCase();
+        if (
+            (nodeName === "ul" || nodeName === "ol") &&
+            node.previousElementSibling
+        ) {
+            const previousNodeName =
+                node.previousElementSibling.nodeName.toLowerCase();
+            return previousNodeName === "li";
+        }
+    },
+    replacement: (content, node, options) => {
+        content = content
+            .replace(/^\n+/, "") // remove leading newlines
+            .replace(/\n+$/, "") // replace trailing newlines
+            .replace(/\n/gm, `\n${options.listIndent}`); // indent all nested content in the list
 
-    // indent this list to match sibling
-    return options.listIndent + content + '\n'
-  }
-})
+        // indent this list to match sibling
+        return options.listIndent + content + "\n";
+    },
+});
 
 // This is ported from https://github.com/domchristie/turndown/blob/80297cebeae4b35c8d299b1741b383c74eddc7c1/src/commonmark-rules.js#L61-L80
 // It is modified in the following ways:
 // - Only determines ol ordering based on li elements
 // - Removes handling of ol start attribute as this doesn't affect Forms output
 // - Makes spacing consistent with gov.uk markdown guidance
-service.addRule('listItems', {
-  filter: 'li',
-  replacement: function (content, node, options) {
-    content = content
-      .replace(/^\n+/, '') // remove leading newlines
-      .replace(/\n+$/, '\n') // replace trailing newlines with just a single one
-      .replace(/\n/gm, `\n${options.listIndent}`) // indent all nested content in the list
+service.addRule("listItems", {
+    filter: "li",
+    replacement: function (content, node, options) {
+        content = content
+            .replace(/^\n+/, "") // remove leading newlines
+            .replace(/\n+$/, "\n") // replace trailing newlines with just a single one
+            .replace(/\n/gm, `\n${options.listIndent}`); // indent all nested content in the list
 
-    let prefix = options.bulletListMarker + ' '
-    const parent = node.parentNode
-    if (parent.nodeName.toLowerCase() === 'ol') {
-      const listItems = Array.prototype.filter.call(
-        parent.children,
-        element => element.nodeName.toLowerCase() === 'li'
-      )
-      const index = Array.prototype.indexOf.call(listItems, node)
-      prefix = (index + 1).toString() + '. '
-    }
-    return (
-      prefix +
-      content +
-      (node.nextSibling && !content.endsWith('\n') ? '\n' : '')
-    )
-  }
-})
+        let prefix = options.bulletListMarker + " ";
+        const parent = node.parentNode;
+        if (parent.nodeName.toLowerCase() === "ol") {
+            const listItems = Array.prototype.filter.call(
+                parent.children,
+                (element) => element.nodeName.toLowerCase() === "li",
+            );
+            const index = Array.prototype.indexOf.call(listItems, node);
+            prefix = (index + 1).toString() + ". ";
+        }
+        return (
+            prefix +
+            content +
+            (node.nextSibling && !content.endsWith("\n") ? "\n" : "")
+        );
+    },
+});
 
-service.addRule('removeMsWordCommentElements', {
-  filter: node => {
-    const nodeName = node.nodeName.toLowerCase()
-    const classList = node.classList
+service.addRule("removeMsWordCommentElements", {
+    filter: (node) => {
+        const nodeName = node.nodeName.toLowerCase();
+        const classList = node.classList;
 
-    if (nodeName === 'hr' && classList.contains('msocomoff')) {
-      return true
-    }
-    if (nodeName === 'span' && classList.contains('MsoCommentReference')) {
-      return true
-    }
-    if (nodeName === 'div' && classList.contains('msocomtxt')) {
-      return true
-    }
-  },
-  replacement: (content, node) => {
-    // comments can get caught with a non-breaking space trailing, so we'll
-    // manually remove it
-    if (node.flankingWhitespace) {
-      if (node.flankingWhitespace.leading === '\xA0') {
-        node.flankingWhitespace.leading = ''
-      }
-      if (node.flankingWhitespace.trailing === '\xA0') {
-        node.flankingWhitespace.trailing = ''
-      }
-    }
-    return ''
-  }
-})
+        if (nodeName === "hr" && classList.contains("msocomoff")) {
+            return true;
+        }
+        if (nodeName === "span" && classList.contains("MsoCommentReference")) {
+            return true;
+        }
+        if (nodeName === "div" && classList.contains("msocomtxt")) {
+            return true;
+        }
+    },
+    replacement: (content, node) => {
+        // comments can get caught with a non-breaking space trailing, so we'll
+        // manually remove it
+        if (node.flankingWhitespace) {
+            if (node.flankingWhitespace.leading === "\xA0") {
+                node.flankingWhitespace.leading = "";
+            }
+            if (node.flankingWhitespace.trailing === "\xA0") {
+                node.flankingWhitespace.trailing = "";
+            }
+        }
+        return "";
+    },
+});
 
-service.addRule('removeMsWordListBullets', {
-  filter: node => {
-    if (node.nodeName.toLowerCase() === 'span') {
-      const style = node.getAttribute('style')
-      return style ? style.match(/mso-list:ignore/i) : false
-    }
-  },
-  replacement: () => ''
-})
+service.addRule("removeMsWordListBullets", {
+    filter: (node) => {
+        if (node.nodeName.toLowerCase() === "span") {
+            const style = node.getAttribute("style");
+            return style ? style.match(/mso-list:ignore/i) : false;
+        }
+    },
+    replacement: () => "",
+});
 
 // Given a node it returns the Microsoft Word list level, returning undefined
 // for an item that isn't a MS Word list node
-const getMsWordListLevel = node => {
-  if (node.nodeName.toLowerCase() !== 'p') {
-    return
-  }
+const getMsWordListLevel = (node) => {
+    if (node.nodeName.toLowerCase() !== "p") {
+        return;
+    }
 
-  const style = node.getAttribute('style')
-  const levelMatch = style?.match(/mso-list/i)
-    ? style.match(/level(\d+)/)
-    : null
-  return levelMatch ? parseInt(levelMatch[1], 10) : undefined
-}
+    const style = node.getAttribute("style");
+    const levelMatch = style?.match(/mso-list/i)
+        ? style.match(/level(\d+)/)
+        : null;
+    return levelMatch ? parseInt(levelMatch[1], 10) : undefined;
+};
 
-const isMsWordListItem = node => {
-  return !!getMsWordListLevel(node)
-}
+const isMsWordListItem = (node) => {
+    return !!getMsWordListLevel(node);
+};
 
 // Based on a node that is a list item in a MS Word document, this returns
 // the marker for the list.
 const msWordListMarker = (node, bulletListMarker) => {
-  const markerElement = node.querySelector('span[style="mso-list:Ignore"]')
+    const markerElement = node.querySelector('span[style="mso-list:Ignore"]');
 
-  // assume the presence of a period in a marker is an indicator of an
-  // ordered list
-  if (!markerElement?.textContent.match(/\./)) {
-    return bulletListMarker
-  }
-
-  const nodeLevel = getMsWordListLevel(node)
-
-  let item = 1
-  let potentialListItem = node.previousElementSibling
-
-  // loop through previous siblings to count list items
-  while (potentialListItem) {
-    const itemLevel = getMsWordListLevel(potentialListItem)
-
-    // if there are no more list items or we encounter the lists parent
-    // we don't need to count further
-    if (!itemLevel || itemLevel < nodeLevel) {
-      break
+    // assume the presence of a period in a marker is an indicator of an
+    // ordered list
+    if (!markerElement?.textContent.match(/\./)) {
+        return bulletListMarker;
     }
 
-    // if on same level increment the list items
-    if (nodeLevel === itemLevel) {
-      item += 1
+    const nodeLevel = getMsWordListLevel(node);
+
+    let item = 1;
+    let potentialListItem = node.previousElementSibling;
+
+    // loop through previous siblings to count list items
+    while (potentialListItem) {
+        const itemLevel = getMsWordListLevel(potentialListItem);
+
+        // if there are no more list items or we encounter the lists parent
+        // we don't need to count further
+        if (!itemLevel || itemLevel < nodeLevel) {
+            break;
+        }
+
+        // if on same level increment the list items
+        if (nodeLevel === itemLevel) {
+            item += 1;
+        }
+
+        potentialListItem = potentialListItem.previousElementSibling;
     }
 
-    potentialListItem = potentialListItem.previousElementSibling
-  }
+    return `${item}.`;
+};
 
-  return `${item}.`
-}
+service.addRule("addMsWordListItem", {
+    filter: (node) => isMsWordListItem(node),
+    replacement: (content, node, options) => {
+        const firstListItem =
+            !node.previousElementSibling ||
+            !isMsWordListItem(node.previousElementSibling);
+        let prefix = firstListItem ? "\n\n" : "";
 
-service.addRule('addMsWordListItem', {
-  filter: node => isMsWordListItem(node),
-  replacement: (content, node, options) => {
-    const firstListItem =
-      !node.previousElementSibling ||
-      !isMsWordListItem(node.previousElementSibling)
-    let prefix = firstListItem ? '\n\n' : ''
+        // we can determine the nesting of a list by a mso-list style attribute
+        // with a level
+        const nodeLevel = getMsWordListLevel(node);
+        for (let i = 1; i < nodeLevel; i++) {
+            prefix += options.listIndent;
+        }
 
-    // we can determine the nesting of a list by a mso-list style attribute
-    // with a level
-    const nodeLevel = getMsWordListLevel(node)
-    for (let i = 1; i < nodeLevel; i++) {
-      prefix += options.listIndent
-    }
+        const lastListItem =
+            !node.nextElementSibling ||
+            !isMsWordListItem(node.nextElementSibling);
+        const suffix = lastListItem ? "\n\n" : "\n";
+        const listMarker = msWordListMarker(node, options.bulletListMarker);
 
-    const lastListItem =
-      !node.nextElementSibling || !isMsWordListItem(node.nextElementSibling)
-    const suffix = lastListItem ? '\n\n' : '\n'
-    const listMarker = msWordListMarker(node, options.bulletListMarker)
-
-    return `${prefix}${listMarker} ${content.trim()}${suffix}`
-  }
-})
+        return `${prefix}${listMarker} ${content.trim()}${suffix}`;
+    },
+});
 
 // Remove links that have same href as link text and are the only content
 // in a pasted document. This is because we assume here that they're trying
 // to paste just a plain text URL.
-service.addRule('removeAddressBarLinks', {
-  filter: (node, options) => {
-    if (node.nodeName.toLowerCase() !== 'a' || !node.getAttribute('href')) {
-      return
-    }
+service.addRule("removeAddressBarLinks", {
+    filter: (node, options) => {
+        if (node.nodeName.toLowerCase() !== "a" || !node.getAttribute("href")) {
+            return;
+        }
 
-    const href = node.getAttribute('href').trim()
+        const href = node.getAttribute("href").trim();
 
-    return (
-      href === node.textContent.trim() &&
-      href === node.ownerDocument.body.textContent.trim()
-    )
-  },
-  replacement: content => content
-})
+        return (
+            href === node.textContent.trim() &&
+            href === node.ownerDocument.body.textContent.trim()
+        );
+    },
+    replacement: (content) => content,
+});
 
-const removeBrParagraphs = markdown => {
-  // This finds places where we have a br in a paragraph on it's own and
-  // removes it.
-  //
-  // E.g. if we have HTML of <b><p>Text</p><br><p>More text</p></b> (as google
-  // docs can easily produce) which produces markdown of
-  // "Text\n\n  \n\nMore Text". This regexp can strip this back to be
-  // Text\n\nMore Text
-  const regExp = new RegExp(`\n(${service.options.br}\n)+\n?`, 'g')
-  return markdown.replace(regExp, '\n')
-}
+const removeBrParagraphs = (markdown) => {
+    // This finds places where we have a br in a paragraph on it's own and
+    // removes it.
+    //
+    // E.g. if we have HTML of <b><p>Text</p><br><p>More text</p></b> (as google
+    // docs can easily produce) which produces markdown of
+    // "Text\n\n  \n\nMore Text". This regexp can strip this back to be
+    // Text\n\nMore Text
+    const regExp = new RegExp(`\n(${service.options.br}\n)+\n?`, "g");
+    return markdown.replace(regExp, "\n");
+};
 
-const extractHeadingsFromLists = markdown => {
-  // This finds instances of headings within ordered lists and replaces them
-  // with the headings only. This only applies to H2 and H3.
-  const headingsInListsRegExp = /\d\.\s(#{2,3})/g
-  return markdown.replace(headingsInListsRegExp, '$1')
-}
+const extractHeadingsFromLists = (markdown) => {
+    // This finds instances of headings within ordered lists and replaces them
+    // with the headings only. This only applies to H2 and H3.
+    const headingsInListsRegExp = /\d\.\s(#{2,3})/g;
+    return markdown.replace(headingsInListsRegExp, "$1");
+};
 
-const postProcess = markdown => {
-  const markdownWithExtractedHeadings = extractHeadingsFromLists(markdown)
-  const bulletsReplaced = replaceBulletCharacters(markdownWithExtractedHeadings)
-  const brsRemoved = removeBrParagraphs(bulletsReplaced)
-  const whitespaceStripped = brsRemoved.trim()
-  return whitespaceStripped
-}
+const postProcess = (markdown) => {
+    const markdownWithExtractedHeadings = extractHeadingsFromLists(markdown);
+    const bulletsReplaced = replaceBulletCharacters(
+        markdownWithExtractedHeadings,
+    );
+    const brsRemoved = removeBrParagraphs(bulletsReplaced);
+    const whitespaceStripped = brsRemoved.trim();
+    return whitespaceStripped;
+};
 
-const htmlToMarkdown = html => {
-  const markdown = service.turndown(html)
-  return postProcess(markdown)
-}
+const htmlToMarkdown = (html) => {
+    const markdown = service.turndown(html);
+    return postProcess(markdown);
+};
 
-export default htmlToMarkdown
+export default htmlToMarkdown;

--- a/app/assets/js/paste-html-to-markdown/html-to-markdown.test.js
+++ b/app/assets/js/paste-html-to-markdown/html-to-markdown.test.js
@@ -2,211 +2,211 @@
  * @vitest-environment jsdom
  */
 
-import { htmlToMarkdown } from '.'
-import fs from 'fs'
-import path from 'path'
+import { htmlToMarkdown } from ".";
+import fs from "fs";
+import path from "path";
 
-function openFixture (fixturePath) {
-  const filePath = path.join(__dirname, '__fixtures__', fixturePath)
-  return fs.readFileSync(filePath, 'utf8')
+function openFixture(fixturePath) {
+    const filePath = path.join(__dirname, "__fixtures__", fixturePath);
+    return fs.readFileSync(filePath, "utf8");
 }
 
-it('converts HTML to markdown', () => {
-  expect(htmlToMarkdown('<p>Hello</p>')).toEqual('Hello')
-})
+it("converts HTML to markdown", () => {
+    expect(htmlToMarkdown("<p>Hello</p>")).toEqual("Hello");
+});
 
 it("doesn't escape markdown", () => {
-  const html = '<p>[Markdown](link)</p>'
-  expect(htmlToMarkdown(html)).toEqual('[Markdown](link)')
-})
+    const html = "<p>[Markdown](link)</p>";
+    expect(htmlToMarkdown(html)).toEqual("[Markdown](link)");
+});
 
-it('removes empty links', () => {
-  expect(htmlToMarkdown('<a href="https://www.gov.uk"><a>')).toEqual('')
-})
+it("removes empty links", () => {
+    expect(htmlToMarkdown('<a href="https://www.gov.uk"><a>')).toEqual("");
+});
 
-it('ignores title attributes of links', () => {
-  const html = '<a href="https://www.gov.uk" title="GOV.UK">www.gov.uk<a>'
-  expect(htmlToMarkdown(html)).toEqual('[www.gov.uk](https://www.gov.uk)')
-})
+it("ignores title attributes of links", () => {
+    const html = '<a href="https://www.gov.uk" title="GOV.UK">www.gov.uk<a>';
+    expect(htmlToMarkdown(html)).toEqual("[www.gov.uk](https://www.gov.uk)");
+});
 
-it('converts lists to an asterisk bullet style', () => {
-  const html = `
+it("converts lists to an asterisk bullet style", () => {
+    const html = `
     <ul>
       <li>Item 1</li>
       <li>Item 2</li>
     </ul>
-  `
-  expect(htmlToMarkdown(html)).toEqual('* Item 1\n* Item 2')
-})
+  `;
+    expect(htmlToMarkdown(html)).toEqual("* Item 1\n* Item 2");
+});
 
-it('converts h1 headers to h2', () => {
-  expect(htmlToMarkdown('<h1>Hello</h1>')).toEqual('## Hello')
-})
+it("converts h1 headers to h2", () => {
+    expect(htmlToMarkdown("<h1>Hello</h1>")).toEqual("## Hello");
+});
 
-it('maintains headers from h2 to h6 headers', () => {
-  expect(htmlToMarkdown('<h2>Hello</h2>')).toEqual('## Hello')
-  expect(htmlToMarkdown('<h3>Hello</h3>')).toEqual('### Hello')
-  expect(htmlToMarkdown('<h4>Hello</h4>')).toEqual('#### Hello')
-  expect(htmlToMarkdown('<h5>Hello</h5>')).toEqual('##### Hello')
-  expect(htmlToMarkdown('<h6>Hello</h6>')).toEqual('###### Hello')
-})
+it("maintains headers from h2 to h6 headers", () => {
+    expect(htmlToMarkdown("<h2>Hello</h2>")).toEqual("## Hello");
+    expect(htmlToMarkdown("<h3>Hello</h3>")).toEqual("### Hello");
+    expect(htmlToMarkdown("<h4>Hello</h4>")).toEqual("#### Hello");
+    expect(htmlToMarkdown("<h5>Hello</h5>")).toEqual("##### Hello");
+    expect(htmlToMarkdown("<h6>Hello</h6>")).toEqual("###### Hello");
+});
 
-it('strips b and strong elements', () => {
-  expect(htmlToMarkdown('<p>With <b>bold</b> text</p>')).toEqual(
-    'With bold text'
-  )
-  expect(htmlToMarkdown('<p>With <strong>strong</strong> text</p>')).toEqual(
-    'With strong text'
-  )
-})
+it("strips b and strong elements", () => {
+    expect(htmlToMarkdown("<p>With <b>bold</b> text</p>")).toEqual(
+        "With bold text",
+    );
+    expect(htmlToMarkdown("<p>With <strong>strong</strong> text</p>")).toEqual(
+        "With strong text",
+    );
+});
 
-it('strips i and em elements', () => {
-  expect(htmlToMarkdown('<p>With <i>italic</i> text</p>')).toEqual(
-    'With italic text'
-  )
-  expect(htmlToMarkdown('<p>With <em>emphasised</em> text</p>')).toEqual(
-    'With emphasised text'
-  )
-})
+it("strips i and em elements", () => {
+    expect(htmlToMarkdown("<p>With <i>italic</i> text</p>")).toEqual(
+        "With italic text",
+    );
+    expect(htmlToMarkdown("<p>With <em>emphasised</em> text</p>")).toEqual(
+        "With emphasised text",
+    );
+});
 
-it('removes image elements', () => {
-  expect(htmlToMarkdown('<img src="image.jpg" alt="" />')).toEqual('')
-})
+it("removes image elements", () => {
+    expect(htmlToMarkdown('<img src="image.jpg" alt="" />')).toEqual("");
+});
 
-it('removes title elements', () => {
-  expect(htmlToMarkdown('<title>Title</title>')).toEqual('')
-})
+it("removes title elements", () => {
+    expect(htmlToMarkdown("<title>Title</title>")).toEqual("");
+});
 
-it('removes script elements', () => {
-  expect(htmlToMarkdown('<script>alert("hi")</script>')).toEqual('')
-})
+it("removes script elements", () => {
+    expect(htmlToMarkdown('<script>alert("hi")</script>')).toEqual("");
+});
 
-it('removes noscript elements', () => {
-  expect(htmlToMarkdown('<noscript>Enable JS</noscript>')).toEqual('')
-})
+it("removes noscript elements", () => {
+    expect(htmlToMarkdown("<noscript>Enable JS</noscript>")).toEqual("");
+});
 
-it('removes style elements', () => {
-  expect(htmlToMarkdown('<style>p {color:red;}</style>')).toEqual('')
-})
+it("removes style elements", () => {
+    expect(htmlToMarkdown("<style>p {color:red;}</style>")).toEqual("");
+});
 
-it('removes video elements', () => {
-  const html = `
+it("removes video elements", () => {
+    const html = `
     <video width="320" height="240" controls>
       <source src="movie.mp4" type="video/mp4">
       <source src="movie.ogg" type="video/ogg">
       Fallback text
     </video>
-  `
+  `;
 
-  expect(htmlToMarkdown(html)).toEqual('')
-})
+    expect(htmlToMarkdown(html)).toEqual("");
+});
 
-it('removes audio elements', () => {
-  const html = `
+it("removes audio elements", () => {
+    const html = `
     <audio controls src="/media/examples/t-rex-roar.mp3">
       Fallback text
     </audio>
-  `
+  `;
 
-  expect(htmlToMarkdown(html)).toEqual('')
-})
+    expect(htmlToMarkdown(html)).toEqual("");
+});
 
-it('removes object elements', () => {
-  const html = `
+it("removes object elements", () => {
+    const html = `
     <object type="application/pdf"
       data="/media/examples/In-CC0.pdf"
       width="250"
       height="200">
       Fallback text
     </object>
-  `
+  `;
 
-  expect(htmlToMarkdown(html)).toEqual('')
-})
+    expect(htmlToMarkdown(html)).toEqual("");
+});
 
-it('removes iframe elements', () => {
-  const html = `
+it("removes iframe elements", () => {
+    const html = `
     <iframe src="./file">Fallback text</iframe>
-  `
+  `;
 
-  expect(htmlToMarkdown(html)).toEqual('')
-})
+    expect(htmlToMarkdown(html)).toEqual("");
+});
 
-it('converts abbr elements to references', () => {
-  const html = `
+it("converts abbr elements to references", () => {
+    const html = `
     <p>
       Documents on the web are wrote using
       <abbr title="Hypertext Markup Language">HTML</abbr> and styled with
       <abbr title="Cascading Style Sheets">CSS</abbr>. These are both examples
       of web standards.
     <p>
-  `
+  `;
 
-  expect(htmlToMarkdown(html)).toEqual(
-    'Documents on the web are wrote using HTML and styled with CSS. These ' +
-      'are both examples of web standards.\n\n' +
-      '*[HTML]: Hypertext Markup Language\n' +
-      '*[CSS]: Cascading Style Sheets'
-  )
-})
+    expect(htmlToMarkdown(html)).toEqual(
+        "Documents on the web are wrote using HTML and styled with CSS. These " +
+            "are both examples of web standards.\n\n" +
+            "*[HTML]: Hypertext Markup Language\n" +
+            "*[CSS]: Cascading Style Sheets",
+    );
+});
 
-it('removes empty paragraphs', () => {
-  const html = `
+it("removes empty paragraphs", () => {
+    const html = `
     <p>Not empty</p>
     <p><br /></p>
     <p>  </p>
     <p>  <br />  </p>
     <p>Not empty either</p>
-  `
-  expect(htmlToMarkdown(html)).toEqual('Not empty\n\nNot empty either')
-})
+  `;
+    expect(htmlToMarkdown(html)).toEqual("Not empty\n\nNot empty either");
+});
 
-it('removes rogue br elements', () => {
-  const html = `
+it("removes rogue br elements", () => {
+    const html = `
     <p>Not empty</p>
     <br>
     <span><br></span>
     <p>Not empty either</p>
-  `
-  expect(htmlToMarkdown(html)).toEqual('Not empty\n\nNot empty either')
-})
+  `;
+    expect(htmlToMarkdown(html)).toEqual("Not empty\n\nNot empty either");
+});
 
-it('extracts headers from lists', () => {
-  const html = `
+it("extracts headers from lists", () => {
+    const html = `
     <ol>
       <li><h2>Item 1</h2></li>
       <li><h3>Item 2</h3></li>
     </ol>
-  `
-  expect(htmlToMarkdown(html)).toEqual('## Item 1\n   \n### Item 2')
-})
+  `;
+    expect(htmlToMarkdown(html)).toEqual("## Item 1\n   \n### Item 2");
+});
 
-it('strips paragraph elements within a list item', () => {
-  const html = `
+it("strips paragraph elements within a list item", () => {
+    const html = `
     <ul>
       <li><p>Item 1</p></li>
       <li><p>Item 2</p></li>
     </ul>
-  `
-  expect(htmlToMarkdown(html)).toEqual('* Item 1\n* Item 2')
-})
+  `;
+    expect(htmlToMarkdown(html)).toEqual("* Item 1\n* Item 2");
+});
 
-it('removes nested links when link markdown text is wrapped in an element', () => {
-  const html = `
+it("removes nested links when link markdown text is wrapped in an element", () => {
+    const html = `
     <span>[nested link](</span><a href="https://www.gov.uk/">https://www.gov.uk/</a>)
-  `
-  expect(htmlToMarkdown(html)).toEqual('[nested link](https://www.gov.uk/)')
-})
+  `;
+    expect(htmlToMarkdown(html)).toEqual("[nested link](https://www.gov.uk/)");
+});
 
-it('removes nested links when link markdown text is not wrapped in an element', () => {
-  const html = `
+it("removes nested links when link markdown text is not wrapped in an element", () => {
+    const html = `
     [nested link](<a href="https://www.gov.uk/">https://www.gov.uk/</a>)
-  `
-  expect(htmlToMarkdown(html)).toEqual('[nested link](https://www.gov.uk/)')
-})
+  `;
+    expect(htmlToMarkdown(html)).toEqual("[nested link](https://www.gov.uk/)");
+});
 
-it('fixes an invalid nested unordered list that Google Docs produces', () => {
-  const html = `
+it("fixes an invalid nested unordered list that Google Docs produces", () => {
+    const html = `
     <ul>
       <li>Parent</li>
       <ul>
@@ -217,14 +217,17 @@ it('fixes an invalid nested unordered list that Google Docs produces', () => {
       </ul>
       <li>Parent sibling</li>
     </ul>
-  `
-  expect(htmlToMarkdown(html)).toEqual(
-    '* Parent\n' + '   * Child\n' + '      * Grand child\n' + '* Parent sibling'
-  )
-})
+  `;
+    expect(htmlToMarkdown(html)).toEqual(
+        "* Parent\n" +
+            "   * Child\n" +
+            "      * Grand child\n" +
+            "* Parent sibling",
+    );
+});
 
-it('fixes an invalid nested ordered list that Google Docs produces', () => {
-  const html = `
+it("fixes an invalid nested ordered list that Google Docs produces", () => {
+    const html = `
     <ol>
       <li>Parent</li>
       <ol>
@@ -238,75 +241,75 @@ it('fixes an invalid nested ordered list that Google Docs produces', () => {
       </ol>
       <li>Parent sibling</li>
     </ol>
-  `
-  expect(htmlToMarkdown(html)).toEqual(
-    '1. Parent\n' +
-      '   1. Child 1\n' +
-      '      1. Grand child 1\n' +
-      '      2. Grand child 2\n' +
-      '   2. Child 2\n' +
-      '   3. Child 3\n' +
-      '2. Parent sibling'
-  )
-})
+  `;
+    expect(htmlToMarkdown(html)).toEqual(
+        "1. Parent\n" +
+            "   1. Child 1\n" +
+            "      1. Grand child 1\n" +
+            "      2. Grand child 2\n" +
+            "   2. Child 2\n" +
+            "   3. Child 3\n" +
+            "2. Parent sibling",
+    );
+});
 
-it('resolves duplicated whitespace inside an empty element', () => {
-  const html = 'Some text <span> </span> and some more text'
-  expect(htmlToMarkdown(html)).toEqual('Some text and some more text')
-})
+it("resolves duplicated whitespace inside an empty element", () => {
+    const html = "Some text <span> </span> and some more text";
+    expect(htmlToMarkdown(html)).toEqual("Some text and some more text");
+});
 
 // The presence of elements preceeding text that is rendered can cause
 // preceeding whitespace. Typically this is caused by elements in the <head>
 // that are to be stripped out.
-it('strips whitespace caused by surrounding, non-visual elements', () => {
-  const html = `
+it("strips whitespace caused by surrounding, non-visual elements", () => {
+    const html = `
     <meta charset="utf-8">
     <title>Title</title>
     <p>Some text</p>
-  `
-  expect(htmlToMarkdown(html)).toEqual('Some text')
-})
+  `;
+    expect(htmlToMarkdown(html)).toEqual("Some text");
+});
 
-it('removes MS Word comments', () => {
-  const html = openFixture('ms-word-2016-comments.html')
+it("removes MS Word comments", () => {
+    const html = openFixture("ms-word-2016-comments.html");
 
-  expect(htmlToMarkdown(html)).toEqual('A document with a comment')
-})
+    expect(htmlToMarkdown(html)).toEqual("A document with a comment");
+});
 
-it('Converts a MS Word unordered list to a markdown list', () => {
-  const html = openFixture('ms-word-2016-unordered-list.html')
+it("Converts a MS Word unordered list to a markdown list", () => {
+    const html = openFixture("ms-word-2016-unordered-list.html");
 
-  expect(htmlToMarkdown(html)).toEqual(
-    '* Item 1\n' + '* Item 2\n' + '* Item 3\n' + '* Item 4'
-  )
-})
+    expect(htmlToMarkdown(html)).toEqual(
+        "* Item 1\n" + "* Item 2\n" + "* Item 3\n" + "* Item 4",
+    );
+});
 
-it('Converts a MS Word ordered list to a markdown list', () => {
-  const html = openFixture('ms-word-2016-ordered-list.html')
+it("Converts a MS Word ordered list to a markdown list", () => {
+    const html = openFixture("ms-word-2016-ordered-list.html");
 
-  expect(htmlToMarkdown(html)).toEqual(
-    '1. Item 1\n' + '2. Item 2\n' + '3. Item 3\n' + '4. Item 4'
-  )
-})
+    expect(htmlToMarkdown(html)).toEqual(
+        "1. Item 1\n" + "2. Item 2\n" + "3. Item 3\n" + "4. Item 4",
+    );
+});
 
-it('Converts a MS Word nested list to a markdown list', () => {
-  const html = openFixture('ms-word-2016-nested-list.html')
+it("Converts a MS Word nested list to a markdown list", () => {
+    const html = openFixture("ms-word-2016-nested-list.html");
 
-  expect(htmlToMarkdown(html)).toEqual(
-    '1. Parent 1\n' +
-      '   1. Parent 1 Child 1\n' +
-      '      1. Parent 1 Child 1 Grandchild 1\n' +
-      '      2. Parent 1 Child 1 Grandchild 2\n' +
-      '      3. Parent 1 Child 1 Grandchild 3\n' +
-      '   2. Parent 1 Child 2\n' +
-      '2. Parent 2\n' +
-      '   1. Parent 2 Child 1'
-  )
-})
+    expect(htmlToMarkdown(html)).toEqual(
+        "1. Parent 1\n" +
+            "   1. Parent 1 Child 1\n" +
+            "      1. Parent 1 Child 1 Grandchild 1\n" +
+            "      2. Parent 1 Child 1 Grandchild 2\n" +
+            "      3. Parent 1 Child 1 Grandchild 3\n" +
+            "   2. Parent 1 Child 2\n" +
+            "2. Parent 2\n" +
+            "   1. Parent 2 Child 1",
+    );
+});
 
-it('Converts a MS Word list that uses msoNormal classes', () => {
-  // simplified version of the HTML MS Word creates
-  const html = `
+it("Converts a MS Word list that uses msoNormal classes", () => {
+    // simplified version of the HTML MS Word creates
+    const html = `
     <p class="MsoNormal" style="mso-list:l0 level1 1fo1">
       <span>
         <span style="mso-list:Ignore">·</span>
@@ -319,23 +322,25 @@ it('Converts a MS Word list that uses msoNormal classes', () => {
         <span>Item 2</span>
       </span>
     </p>
-  `
+  `;
 
-  expect(htmlToMarkdown(html)).toEqual('* Item 1\n' + '* Item 2')
-})
+    expect(htmlToMarkdown(html)).toEqual("* Item 1\n" + "* Item 2");
+});
 
-it('Converts bullet characters to markdown bullets', () => {
-  const html = `<p>• bullet content</p>
-  <p>•bullet content</p>`
+it("Converts bullet characters to markdown bullets", () => {
+    const html = `<p>• bullet content</p>
+  <p>•bullet content</p>`;
 
-  expect(htmlToMarkdown(html)).toEqual('* bullet content\n\n* bullet content')
-})
+    expect(htmlToMarkdown(html)).toEqual(
+        "* bullet content\n\n* bullet content",
+    );
+});
 
 it("Doesn't preserve markdown that is only a link with similar text to the link", () => {
-  // If you paste the URL from the address bar of chrome this is the HTML created
-  const html = `
+    // If you paste the URL from the address bar of chrome this is the HTML created
+    const html = `
     <meta charset='utf-8'><a href="https://www.forms.service.gov.uk/">https://www.forms.service.gov.uk/</a>
-  `
+  `;
 
-  expect(htmlToMarkdown(html)).toEqual('https://www.forms.service.gov.uk/')
-})
+    expect(htmlToMarkdown(html)).toEqual("https://www.forms.service.gov.uk/");
+});

--- a/app/assets/js/paste-html-to-markdown/index.js
+++ b/app/assets/js/paste-html-to-markdown/index.js
@@ -1,62 +1,66 @@
 // Adapted from the [Paste HTML to govspeak](https://github.com/alphagov/paste-html-to-govspeak) package.
 
-import htmlToMarkdown from './html-to-markdown'
-import replaceBulletCharacters from './replace-bullet-characters'
+import htmlToMarkdown from "./html-to-markdown";
+import replaceBulletCharacters from "./replace-bullet-characters";
 
 const insertTextAtCursor = (field, contentToInsert) => {
-  const selectionStart = field.selectionStart
-  const selectionEnd = field.selectionEnd
-  if (selectionStart || selectionStart === '0' || selectionStart === 0) {
-    const contentBeforeSelection = field.value.substring(0, selectionStart)
-    const contentAfterSelection = field.value.substring(
-      selectionEnd,
-      field.value.length
-    )
-    field.value = `${contentBeforeSelection}${contentToInsert}${contentAfterSelection}`
-  } else {
-    field.value += contentToInsert
-  }
+    const selectionStart = field.selectionStart;
+    const selectionEnd = field.selectionEnd;
+    if (selectionStart || selectionStart === "0" || selectionStart === 0) {
+        const contentBeforeSelection = field.value.substring(0, selectionStart);
+        const contentAfterSelection = field.value.substring(
+            selectionEnd,
+            field.value.length,
+        );
+        field.value = `${contentBeforeSelection}${contentToInsert}${contentAfterSelection}`;
+    } else {
+        field.value += contentToInsert;
+    }
 
-  field.dispatchEvent(new window.InputEvent('input'))
-}
+    field.dispatchEvent(new window.InputEvent("input"));
+};
 
-const htmlFromPasteEvent = event => {
-  return event.clipboardData.getData('text/html')
-}
+const htmlFromPasteEvent = (event) => {
+    return event.clipboardData.getData("text/html");
+};
 
-const textFromPasteEvent = event => {
-  return event.clipboardData.getData('text/plain')
-}
+const textFromPasteEvent = (event) => {
+    return event.clipboardData.getData("text/plain");
+};
 
 const triggerPasteEvent = (element, eventName, detail) => {
-  const params = { bubbles: false, cancelable: false, detail: detail || null }
-  const event = new window.CustomEvent(eventName, params)
+    const params = {
+        bubbles: false,
+        cancelable: false,
+        detail: detail || null,
+    };
+    const event = new window.CustomEvent(eventName, params);
 
-  element.dispatchEvent(event)
-}
+    element.dispatchEvent(event);
+};
 
-const pasteListener = event => {
-  if (event.clipboardData) {
-    let contentToPaste
-    event.preventDefault()
-    const element = event.target
+const pasteListener = (event) => {
+    if (event.clipboardData) {
+        let contentToPaste;
+        event.preventDefault();
+        const element = event.target;
 
-    const html = htmlFromPasteEvent(event)
-    triggerPasteEvent(element, 'htmlpaste', html)
+        const html = htmlFromPasteEvent(event);
+        triggerPasteEvent(element, "htmlpaste", html);
 
-    const text = textFromPasteEvent(event)
-    triggerPasteEvent(element, 'textpaste', text)
+        const text = textFromPasteEvent(event);
+        triggerPasteEvent(element, "textpaste", text);
 
-    if (html?.length) {
-      const markdown = htmlToMarkdown(html)
-      triggerPasteEvent(element, 'markdown', markdown)
+        if (html?.length) {
+            const markdown = htmlToMarkdown(html);
+            triggerPasteEvent(element, "markdown", markdown);
 
-      contentToPaste = markdown
-    } else if (text?.length) {
-      contentToPaste = replaceBulletCharacters(text)
+            contentToPaste = markdown;
+        } else if (text?.length) {
+            contentToPaste = replaceBulletCharacters(text);
+        }
+        insertTextAtCursor(element, contentToPaste);
     }
-    insertTextAtCursor(element, contentToPaste)
-  }
-}
+};
 
-export { pasteListener, htmlToMarkdown }
+export { pasteListener, htmlToMarkdown };

--- a/app/assets/js/paste-html-to-markdown/index.test.js
+++ b/app/assets/js/paste-html-to-markdown/index.test.js
@@ -2,152 +2,152 @@
  * @vitest-environment jsdom
  */
 
-import { pasteListener } from '.'
+import { pasteListener } from ".";
 
-let textarea
+let textarea;
 
 beforeEach(() => {
-  textarea = document.createElement('textarea')
-  textarea.addEventListener('paste', pasteListener)
-})
+    textarea = document.createElement("textarea");
+    textarea.addEventListener("paste", pasteListener);
+});
 
 const createHtmlPasteEvent = (html = null, text = null) => {
-  const event = new window.Event('paste')
-  event.clipboardData = {
-    getData: type => {
-      if (type === 'text/html') {
-        return html
-      }
-      if (type === 'text/plain') {
-        return text
-      }
-    }
-  }
+    const event = new window.Event("paste");
+    event.clipboardData = {
+        getData: (type) => {
+            if (type === "text/html") {
+                return html;
+            }
+            if (type === "text/plain") {
+                return text;
+            }
+        },
+    };
 
-  return event
-}
+    return event;
+};
 
 it("maintains browser default behaviour if HTML isn't pasted", () => {
-  const event = new window.Event('paste')
-  event.preventDefault = vi.fn()
-  textarea.dispatchEvent(event)
+    const event = new window.Event("paste");
+    event.preventDefault = vi.fn();
+    textarea.dispatchEvent(event);
 
-  expect(event.preventDefault).not.toHaveBeenCalled()
-})
+    expect(event.preventDefault).not.toHaveBeenCalled();
+});
 
-it('converts HTML to govspeak if HTML is pasted', () => {
-  textarea.dispatchEvent(createHtmlPasteEvent('<h2>Hello</h2>'))
-  expect(textarea.value).toEqual('## Hello')
-})
+it("converts HTML to govspeak if HTML is pasted", () => {
+    textarea.dispatchEvent(createHtmlPasteEvent("<h2>Hello</h2>"));
+    expect(textarea.value).toEqual("## Hello");
+});
 
-it('converts bullet characters to markdown bullets if text is pasted', () => {
-  textarea.dispatchEvent(
-    createHtmlPasteEvent(null, '• bullet text\n•bullet text')
-  )
-  expect(textarea.value).toEqual('* bullet text\n* bullet text')
-})
+it("converts bullet characters to markdown bullets if text is pasted", () => {
+    textarea.dispatchEvent(
+        createHtmlPasteEvent(null, "• bullet text\n•bullet text"),
+    );
+    expect(textarea.value).toEqual("* bullet text\n* bullet text");
+});
 
-describe('htmlpaste event', () => {
-  it('has raw HTML as the detail if HTML is pasted', () => {
-    const listener = vi.fn()
-    const html = '<script>alert("hi")</script>'
+describe("htmlpaste event", () => {
+    it("has raw HTML as the detail if HTML is pasted", () => {
+        const listener = vi.fn();
+        const html = '<script>alert("hi")</script>';
 
-    textarea.addEventListener('htmlpaste', listener)
-    textarea.dispatchEvent(createHtmlPasteEvent(html))
+        textarea.addEventListener("htmlpaste", listener);
+        textarea.dispatchEvent(createHtmlPasteEvent(html));
 
-    expect(listener).toHaveBeenCalledWith(
-      expect.objectContaining({
-        detail: html
-      })
-    )
-  })
+        expect(listener).toHaveBeenCalledWith(
+            expect.objectContaining({
+                detail: html,
+            }),
+        );
+    });
 
-  it('has null as the detail if no HTML is pasted', () => {
-    const listener = vi.fn()
+    it("has null as the detail if no HTML is pasted", () => {
+        const listener = vi.fn();
 
-    textarea.addEventListener('htmlpaste', listener)
-    textarea.dispatchEvent(createHtmlPasteEvent())
+        textarea.addEventListener("htmlpaste", listener);
+        textarea.dispatchEvent(createHtmlPasteEvent());
 
-    expect(listener).toHaveBeenCalledWith(
-      expect.objectContaining({
-        detail: null
-      })
-    )
-  })
-})
+        expect(listener).toHaveBeenCalledWith(
+            expect.objectContaining({
+                detail: null,
+            }),
+        );
+    });
+});
 
-describe('textpaste event', () => {
-  it('has text as the detail if text is available is pasted', () => {
-    const listener = vi.fn()
-    const text = 'Hello'
+describe("textpaste event", () => {
+    it("has text as the detail if text is available is pasted", () => {
+        const listener = vi.fn();
+        const text = "Hello";
 
-    textarea.addEventListener('textpaste', listener)
-    textarea.dispatchEvent(createHtmlPasteEvent('<h2>Hello</h2>', text))
+        textarea.addEventListener("textpaste", listener);
+        textarea.dispatchEvent(createHtmlPasteEvent("<h2>Hello</h2>", text));
 
-    expect(listener).toHaveBeenCalledWith(
-      expect.objectContaining({
-        detail: text
-      })
-    )
-  })
+        expect(listener).toHaveBeenCalledWith(
+            expect.objectContaining({
+                detail: text,
+            }),
+        );
+    });
 
-  it('has null as the detail if no text is pasted', () => {
-    const listener = vi.fn()
+    it("has null as the detail if no text is pasted", () => {
+        const listener = vi.fn();
 
-    textarea.addEventListener('textpaste', listener)
-    textarea.dispatchEvent(createHtmlPasteEvent())
+        textarea.addEventListener("textpaste", listener);
+        textarea.dispatchEvent(createHtmlPasteEvent());
 
-    expect(listener).toHaveBeenCalledWith(
-      expect.objectContaining({
-        detail: null
-      })
-    )
-  })
-})
+        expect(listener).toHaveBeenCalledWith(
+            expect.objectContaining({
+                detail: null,
+            }),
+        );
+    });
+});
 
-describe('markdown event', () => {
-  it('has markdown as the event detail', () => {
-    const listener = vi.fn()
-    const html = '<h2>Title</h2>'
+describe("markdown event", () => {
+    it("has markdown as the event detail", () => {
+        const listener = vi.fn();
+        const html = "<h2>Title</h2>";
 
-    textarea.addEventListener('markdown', listener)
-    textarea.dispatchEvent(createHtmlPasteEvent(html))
+        textarea.addEventListener("markdown", listener);
+        textarea.dispatchEvent(createHtmlPasteEvent(html));
 
-    expect(listener).toHaveBeenCalledWith(
-      expect.objectContaining({
-        detail: '## Title'
-      })
-    )
-  })
+        expect(listener).toHaveBeenCalledWith(
+            expect.objectContaining({
+                detail: "## Title",
+            }),
+        );
+    });
 
-  it("isn't called if no HTML is pasted", () => {
-    const listener = vi.fn()
+    it("isn't called if no HTML is pasted", () => {
+        const listener = vi.fn();
 
-    textarea.addEventListener('markdown', listener)
-    textarea.dispatchEvent(createHtmlPasteEvent(null))
+        textarea.addEventListener("markdown", listener);
+        textarea.dispatchEvent(createHtmlPasteEvent(null));
 
-    expect(listener).not.toHaveBeenCalled()
-  })
-})
+        expect(listener).not.toHaveBeenCalled();
+    });
+});
 
-describe('input event', () => {
-  it('is sent when the user pastes HTML', () => {
-    const listener = vi.fn()
-    const html = '<h2>Title</h2>'
+describe("input event", () => {
+    it("is sent when the user pastes HTML", () => {
+        const listener = vi.fn();
+        const html = "<h2>Title</h2>";
 
-    textarea.addEventListener('input', listener)
-    textarea.dispatchEvent(createHtmlPasteEvent(html))
+        textarea.addEventListener("input", listener);
+        textarea.dispatchEvent(createHtmlPasteEvent(html));
 
-    expect(listener).toHaveBeenCalled()
-  })
+        expect(listener).toHaveBeenCalled();
+    });
 
-  it('is sent when the user pastes text', () => {
-    const listener = vi.fn()
-    const text = 'Title'
+    it("is sent when the user pastes text", () => {
+        const listener = vi.fn();
+        const text = "Title";
 
-    textarea.addEventListener('input', listener)
-    textarea.dispatchEvent(createHtmlPasteEvent(null, text))
+        textarea.addEventListener("input", listener);
+        textarea.dispatchEvent(createHtmlPasteEvent(null, text));
 
-    expect(listener).toHaveBeenCalled()
-  })
-})
+        expect(listener).toHaveBeenCalled();
+    });
+});

--- a/app/assets/js/paste-html-to-markdown/replace-bullet-characters.js
+++ b/app/assets/js/paste-html-to-markdown/replace-bullet-characters.js
@@ -1,5 +1,5 @@
-const replaceBulletCharacters = markdown => {
-  return markdown.replaceAll(/[^\S\r\n]*•\s*/g, '* ')
-}
+const replaceBulletCharacters = (markdown) => {
+    return markdown.replaceAll(/[^\S\r\n]*•\s*/g, "* ");
+};
 
-export default replaceBulletCharacters
+export default replaceBulletCharacters;

--- a/app/assets/js/paste-html-to-markdown/replace-bullet-characters.test.js
+++ b/app/assets/js/paste-html-to-markdown/replace-bullet-characters.test.js
@@ -2,12 +2,12 @@
  * @vitest-environment jsdom
  */
 
-import replaceBulletCharacters from './replace-bullet-characters'
+import replaceBulletCharacters from "./replace-bullet-characters";
 
-it('converts bullet characters to markdown bullets', () => {
-  expect(replaceBulletCharacters('•')).toEqual('* ')
-})
+it("converts bullet characters to markdown bullets", () => {
+    expect(replaceBulletCharacters("•")).toEqual("* ");
+});
 
-it('converts bullet characters with appended whitespace to markdown bullets', () => {
-  expect(replaceBulletCharacters('• ')).toEqual('* ')
-})
+it("converts bullet characters with appended whitespace to markdown bullets", () => {
+    expect(replaceBulletCharacters("• ")).toEqual("* ");
+});

--- a/app/assets/js/textarea-no-newlines/index.js
+++ b/app/assets/js/textarea-no-newlines/index.js
@@ -1,9 +1,9 @@
 const textareaNoNewlines = (textArea) => {
-    textArea.addEventListener('keydown', function(event) {
-        if (event.key === 'Enter') {
+    textArea.addEventListener("keydown", function (event) {
+        if (event.key === "Enter") {
             event.preventDefault();
         }
     });
-}
+};
 
 export default textareaNoNewlines;

--- a/app/assets/js/textarea-no-newlines/index.test.js
+++ b/app/assets/js/textarea-no-newlines/index.test.js
@@ -2,84 +2,84 @@
  * @vitest-environment jsdom
  */
 
-import textareaNoNewlines from '.'
+import textareaNoNewlines from ".";
 
-describe('textareaNoNewlines', () => {
-  let textarea
+describe("textareaNoNewlines", () => {
+    let textarea;
 
-  beforeEach(() => {
-    document.body.innerHTML = '<textarea></textarea>'
-    textarea = document.querySelector('textarea')
-    textareaNoNewlines(textarea)
-  })
+    beforeEach(() => {
+        document.body.innerHTML = "<textarea></textarea>";
+        textarea = document.querySelector("textarea");
+        textareaNoNewlines(textarea);
+    });
 
-  test('prevents Enter key from inserting newlines', () => {
-    const enterEvent = new KeyboardEvent('keydown', {
-      key: 'Enter',
-      bubbles: true,
-      cancelable: true
-    })
+    test("prevents Enter key from inserting newlines", () => {
+        const enterEvent = new KeyboardEvent("keydown", {
+            key: "Enter",
+            bubbles: true,
+            cancelable: true,
+        });
 
-    const preventDefaultSpy = vi.spyOn(enterEvent, 'preventDefault')
+        const preventDefaultSpy = vi.spyOn(enterEvent, "preventDefault");
 
-    textarea.dispatchEvent(enterEvent)
+        textarea.dispatchEvent(enterEvent);
 
-    expect(preventDefaultSpy).toHaveBeenCalled()
-  })
+        expect(preventDefaultSpy).toHaveBeenCalled();
+    });
 
-  test('allows other keys to work normally', () => {
-    const spaceEvent = new KeyboardEvent('keydown', {
-      key: ' ',
-      bubbles: true,
-      cancelable: true
-    })
+    test("allows other keys to work normally", () => {
+        const spaceEvent = new KeyboardEvent("keydown", {
+            key: " ",
+            bubbles: true,
+            cancelable: true,
+        });
 
-    const preventDefaultSpy = vi.spyOn(spaceEvent, 'preventDefault')
+        const preventDefaultSpy = vi.spyOn(spaceEvent, "preventDefault");
 
-    textarea.dispatchEvent(spaceEvent)
+        textarea.dispatchEvent(spaceEvent);
 
-    expect(preventDefaultSpy).not.toHaveBeenCalled()
-  })
+        expect(preventDefaultSpy).not.toHaveBeenCalled();
+    });
 
-  test('allows Tab key to work normally', () => {
-    const tabEvent = new KeyboardEvent('keydown', {
-      key: 'Tab',
-      bubbles: true,
-      cancelable: true
-    })
+    test("allows Tab key to work normally", () => {
+        const tabEvent = new KeyboardEvent("keydown", {
+            key: "Tab",
+            bubbles: true,
+            cancelable: true,
+        });
 
-    const preventDefaultSpy = vi.spyOn(tabEvent, 'preventDefault')
+        const preventDefaultSpy = vi.spyOn(tabEvent, "preventDefault");
 
-    textarea.dispatchEvent(tabEvent)
+        textarea.dispatchEvent(tabEvent);
 
-    expect(preventDefaultSpy).not.toHaveBeenCalled()
-  })
+        expect(preventDefaultSpy).not.toHaveBeenCalled();
+    });
 
-  test('allows Escape key to work normally', () => {
-    const escapeEvent = new KeyboardEvent('keydown', {
-      key: 'Escape',
-      bubbles: true,
-      cancelable: true
-    })
+    test("allows Escape key to work normally", () => {
+        const escapeEvent = new KeyboardEvent("keydown", {
+            key: "Escape",
+            bubbles: true,
+            cancelable: true,
+        });
 
-    const preventDefaultSpy = vi.spyOn(escapeEvent, 'preventDefault')
+        const preventDefaultSpy = vi.spyOn(escapeEvent, "preventDefault");
 
-    textarea.dispatchEvent(escapeEvent)
+        textarea.dispatchEvent(escapeEvent);
 
-    expect(preventDefaultSpy).not.toHaveBeenCalled()
-  })
+        expect(preventDefaultSpy).not.toHaveBeenCalled();
+    });
 
-  test('allows Backspace key to work normally', () => {
-    const backspaceEvent = new KeyboardEvent('keydown', {
-      key: 'Backspace',
-      bubbles: true,
-      cancelable: true
-    })
+    test("allows Backspace key to work normally", () => {
+        const backspaceEvent = new KeyboardEvent("keydown", {
+            key: "Backspace",
+            bubbles: true,
+            cancelable: true,
+        });
 
-    const preventDefaultSpy = vi.spyOn(backspaceEvent, 'preventDefault')
+        const preventDefaultSpy = vi.spyOn(backspaceEvent, "preventDefault");
 
-    textarea.dispatchEvent(backspaceEvent)
+        textarea.dispatchEvent(backspaceEvent);
 
-    expect(preventDefaultSpy).not.toHaveBeenCalled()
-  })
-})
+        expect(preventDefaultSpy).not.toHaveBeenCalled();
+    });
+});

--- a/app/assets/js/utils/debounce/index.js
+++ b/app/assets/js/utils/debounce/index.js
@@ -1,15 +1,15 @@
 const debounce = (functionToDebounce, waitTime) => {
-  let timeout
+    let timeout;
 
-  return function debouncedFunction (...args) {
-    const later = () => {
-      clearTimeout(timeout)
-      functionToDebounce(...args)
-    }
+    return function debouncedFunction(...args) {
+        const later = () => {
+            clearTimeout(timeout);
+            functionToDebounce(...args);
+        };
 
-    clearTimeout(timeout)
-    timeout = setTimeout(later, waitTime)
-  }
-}
+        clearTimeout(timeout);
+        timeout = setTimeout(later, waitTime);
+    };
+};
 
-export default debounce
+export default debounce;

--- a/app/assets/js/utils/debounce/index.test.js
+++ b/app/assets/js/utils/debounce/index.test.js
@@ -1,34 +1,34 @@
-import debounce from '.'
+import debounce from ".";
 
 // Tell Vitest to mock all timeout functions
-vi.useFakeTimers()
+vi.useFakeTimers();
 
-describe('debounce', () => {
-  let functionToDebounce
-  let debouncedFunc
+describe("debounce", () => {
+    let functionToDebounce;
+    let debouncedFunc;
 
-  beforeEach(() => {
-    functionToDebounce = vi.fn()
-    debouncedFunc = debounce(functionToDebounce, 1000)
-  })
+    beforeEach(() => {
+        functionToDebounce = vi.fn();
+        debouncedFunc = debounce(functionToDebounce, 1000);
+    });
 
-  test('when called once the function executes once', () => {
-    debouncedFunc()
+    test("when called once the function executes once", () => {
+        debouncedFunc();
 
-    // Fast-forward time
-    vi.runAllTimers()
+        // Fast-forward time
+        vi.runAllTimers();
 
-    expect(functionToDebounce).toBeCalledTimes(1)
-  })
+        expect(functionToDebounce).toBeCalledTimes(1);
+    });
 
-  test('when called multiple times the function only executes once', () => {
-    ;[...Array(100)].forEach(() => {
-      debouncedFunc()
-    })
+    test("when called multiple times the function only executes once", () => {
+        [...Array(100)].forEach(() => {
+            debouncedFunc();
+        });
 
-    // Fast-forward time
-    vi.runAllTimers()
+        // Fast-forward time
+        vi.runAllTimers();
 
-    expect(functionToDebounce).toBeCalledTimes(1)
-  })
-})
+        expect(functionToDebounce).toBeCalledTimes(1);
+    });
+});

--- a/app/assets/main.js
+++ b/app/assets/main.js
@@ -1,7 +1,7 @@
-import { initAll } from 'govuk-frontend';
-import accessibleAutocomplete from 'accessible-autocomplete';
-import { pasteListener } from './js/paste-html-to-markdown';
-import ajaxMarkdownPreview from './js/ajax-markdown-preview';
+import { initAll } from "govuk-frontend";
+import accessibleAutocomplete from "accessible-autocomplete";
+import { pasteListener } from "./js/paste-html-to-markdown";
+import ajaxMarkdownPreview from "./js/ajax-markdown-preview";
 import textareaNoNewlines from "./js/textarea-no-newlines/index.js";
 import contextAwareEditor from "./js/context-aware-editor/index.js";
 
@@ -13,9 +13,15 @@ for (let el of document.querySelectorAll("[data-accessible-autocomplete]")) {
     // If we've set up a fallback option on the accessible autocomplete, it should *always* be shown regardless of the
     // query the user has entered. This is used for "Other"-style answers, to help make sure they're always
     // discoverable for users.
-    const availableOptions = [].filter.call(el.options, option => (option.value)).map(option => option.textContent || option.innerText);
+    const availableOptions = [].filter
+        .call(el.options, (option) => option.value)
+        .map((option) => option.textContent || option.innerText);
     const suggest = (query, populateResults) => {
-        const filteredResults = availableOptions.filter(option => option.toLowerCase().indexOf(query.toLowerCase()) !== -1 || option === fallbackOption);
+        const filteredResults = availableOptions.filter(
+            (option) =>
+                option.toLowerCase().indexOf(query.toLowerCase()) !== -1 ||
+                option === fallbackOption,
+        );
         return populateResults(filteredResults);
     };
 
@@ -29,34 +35,36 @@ for (let el of document.querySelectorAll("[data-accessible-autocomplete]")) {
 }
 
 document
-  .querySelectorAll('[data-module="ajax-markdown-preview"]')
-  .forEach(element => {
-    ajaxMarkdownPreview(
-      element.querySelector('[data-ajax-markdown-target]'),
-      element.querySelector('[data-ajax-markdown-source]'),
-      element.getAttribute('data-ajax-markdown-endpoint')
-    )
-  })
+    .querySelectorAll('[data-module="ajax-markdown-preview"]')
+    .forEach((element) => {
+        ajaxMarkdownPreview(
+            element.querySelector("[data-ajax-markdown-target]"),
+            element.querySelector("[data-ajax-markdown-source]"),
+            element.getAttribute("data-ajax-markdown-endpoint"),
+        );
+    });
 
 document
     .querySelectorAll('[data-module="context-aware-editor"]')
-    .forEach(element => {
+    .forEach((element) => {
         contextAwareEditor(element);
         // Add paste listener for markdown conversion
-        const textarea = element.querySelector('[data-context-aware-editor-target]');
+        const textarea = element.querySelector(
+            "[data-context-aware-editor-target]",
+        );
         if (textarea) {
-            textarea.addEventListener('paste', pasteListener);
+            textarea.addEventListener("paste", pasteListener);
         }
     });
 
 document
     .querySelectorAll('[data-module="paste-html-bullets-as-markdown"]')
-    .forEach(element => {
-        element.addEventListener('paste', pasteListener);
+    .forEach((element) => {
+        element.addEventListener("paste", pasteListener);
     });
 
 document
     .querySelectorAll('[data-module="textarea-no-newlines"]')
-    .forEach(element => {
+    .forEach((element) => {
         textareaNoNewlines(element);
     });

--- a/app/assets/main.scss
+++ b/app/assets/main.scss
@@ -29,7 +29,7 @@ $govuk-brand-colour: #00625e;
     min-height: 300px;
     background-repeat: repeat;
     background-size: 150px 150px;
-    background-image: url($govuk-images-path + 'watermark-developer.svg');
+    background-image: url($govuk-images-path + "watermark-developer.svg");
 }
 
 // Needed to make the watermark above visible
@@ -42,9 +42,8 @@ body.govuk-template__body:has(div.app-body__watermark) {
     background-color: rgba(255, 255, 255, 0.5);
 }
 
-
 .app-move-up-down-table__actions {
-    width: 50%
+    width: 50%;
 }
 
 .app-move-up-down-table__action--disabled {
@@ -109,34 +108,34 @@ $app-destructive-link-active-colour: $govuk-text-colour;
 //
 // Note: all destructive actions must have a confirmation step these links navigate to
 @mixin app-link-style-destructive-no-visited-state {
-  &:link,
-  &:visited {
-    color: $app-destructive-link-colour;
-  }
+    &:link,
+    &:visited {
+        color: $app-destructive-link-colour;
+    }
 
-  &:hover {
-    color: $app-destructive-link-hover-colour;
-  }
+    &:hover {
+        color: $app-destructive-link-hover-colour;
+    }
 
-  // When focussed, the text colour needs to be darker to ensure that colour
-  // contrast is still acceptable against the focus colour
-  // Activated links are usually focused so this applies to them as well
-  &:active,
-  &:focus {
-    color: $app-destructive-link-active-colour;
-  }
+    // When focussed, the text colour needs to be darker to ensure that colour
+    // contrast is still acceptable against the focus colour
+    // Activated links are usually focused so this applies to them as well
+    &:active,
+    &:focus {
+        color: $app-destructive-link-active-colour;
+    }
 }
 
 .app-link--destructive {
-  @include app-link-style-destructive-no-visited-state;
+    @include app-link-style-destructive-no-visited-state;
 }
 
 .app-service-navigation__wrapper--sectional {
-  flex: 1;
+    flex: 1;
 
-  .govuk-service-navigation__item:last-child {
-    margin-left: auto;
-  }
+    .govuk-service-navigation__item:last-child {
+        margin-left: auto;
+    }
 }
 
 .app-tasklist-builder {
@@ -168,87 +167,86 @@ $app-destructive-link-active-colour: $govuk-text-colour;
 }
 
 .autocomplete__dropdown-arrow-down {
-  z-index: 1 !important;
-  pointer-events: none;
+    z-index: 1 !important;
+    pointer-events: none;
 }
 .app-test-data-banner__action {
-  position: absolute;
-  right: 20px;
+    position: absolute;
+    right: 20px;
 }
 
 .move-up-down-link-hidden {
-  visibility: hidden;
+    visibility: hidden;
 }
 
 .app-notification-banner--destructive {
-  border-color: $govuk-error-colour;
-  background-color: $govuk-error-colour;
+    border-color: $govuk-error-colour;
+    background-color: $govuk-error-colour;
 
-  .app-notification-banner__link {
-    @include govuk-link-style-error;
-  }
+    .app-notification-banner__link {
+        @include govuk-link-style-error;
+    }
 }
 
 $inset-nested-rows: 15px;
 
 .app-summary-list-group-row {
-  background-color: govuk-colour("light-grey");
+    background-color: govuk-colour("light-grey");
 }
 
 .app-summary-list-group-row:first-child {
-  border-top: 1px solid $govuk-border-colour;
+    border-top: 1px solid $govuk-border-colour;
 }
 
 .app-summary-list-group-row .govuk-summary-list__key {
-  padding-left: $inset-nested-rows;
-  font-weight: bold !important;
+    padding-left: $inset-nested-rows;
+    font-weight: bold !important;
 }
 
 .app-summary-list-group-nested {
-  box-shadow: inset 4px 0 0 0 $govuk-border-colour;
+    box-shadow: inset 4px 0 0 0 $govuk-border-colour;
 }
 
 .app-summary-list-group-nested .govuk-summary-list__key {
-  padding-left: $inset-nested-rows;
+    padding-left: $inset-nested-rows;
 }
 
 .app-summary-list-group-nested--final {
-  border-bottom: 2px solid $govuk-border-colour;
+    border-bottom: 2px solid $govuk-border-colour;
 }
 
 .app-pre-markdown {
-  @include govuk-font(19);
-  white-space: pre-line;
-  margin-top: 0px;
+    @include govuk-font(19);
+    white-space: pre-line;
+    margin-top: 0px;
 }
-
 
 // Temporary: return notification banners to their correct colours. We have set `govuk-brand-colour`, and currently
 // the notification banner uses that as its border colour. This has been confirmed as unintended by the GDS Design System
 // team. See: https://github.com/alphagov/govuk-design-system/issues/4877
 .govuk-notification-banner {
-  border-color: govuk-colour("blue");
-  background-color: govuk-colour("blue");
+    border-color: govuk-colour("blue");
+    background-color: govuk-colour("blue");
 }
 
 .govuk-notification-banner--success {
-  border-color: $govuk-success-colour;
-  background-color: $govuk-success-colour;
+    border-color: $govuk-success-colour;
+    background-color: $govuk-success-colour;
 }
 
 .app-context-aware--container {
-  margin-bottom: govuk-spacing(0);
+    margin-bottom: govuk-spacing(0);
 }
 
 // Position "Insert data" buttons at bottom-right corner of text inputs
 .app-context-aware--button {
-  position: relative;
-  float: right;
-  width: auto;
-  margin: -50px - govuk-spacing(4) 10px 10px;
-  z-index: 1;
+    position: relative;
+    float: right;
+    width: auto;
+    margin: -50px - govuk-spacing(4) 10px 10px;
+    z-index: 1;
 
-  @include govuk-media-query($from: tablet) {
-    margin-top: -50px - govuk-spacing(6);
-  }
+    @include govuk-media-query($from: tablet) {
+        margin-top: -50px - govuk-spacing(6);
+    }
 }

--- a/app/assets/test/setup.js
+++ b/app/assets/test/setup.js
@@ -1,14 +1,14 @@
-import { beforeEach, vi } from 'vitest'
+import { beforeEach, vi } from "vitest";
 
 beforeEach(() => {
-  // in some cases the console.error is called immediately after the test is
-  // run, so we have to do this here instead of an afterEach block
-  vi.restoreAllMocks()
+    // in some cases the console.error is called immediately after the test is
+    // run, so we have to do this here instead of an afterEach block
+    vi.restoreAllMocks();
 
-  // mock console.error and make it throw a real error in the test suite context
-  vi.spyOn(console, 'error').mockImplementation(message => {
-    throw new Error(
-      `Failing due to test calling console.error with message: ${message}`
-    )
-  })
-})
+    // mock console.error and make it throw a real error in the test suite context
+    vi.spyOn(console, "error").mockImplementation((message) => {
+        throw new Error(
+            `Failing due to test calling console.error with message: ${message}`,
+        );
+    });
+});

--- a/app/assets/test/test-helpers.js
+++ b/app/assets/test/test-helpers.js
@@ -1,33 +1,33 @@
-const fetchStub = jsonResponse => {
-  return {
-    ok: () => Promise.resolve(true),
-    json: () => Promise.resolve(jsonResponse)
-  }
-}
+const fetchStub = (jsonResponse) => {
+    return {
+        ok: () => Promise.resolve(true),
+        json: () => Promise.resolve(jsonResponse),
+    };
+};
 
 const delayedFetchStub = (jsonResponse, delayTime) => {
-  return new Promise(resolve => {
-    setTimeout(() => {
-      resolve(fetchStub(jsonResponse))
-    }, delayTime)
-  })
-}
+    return new Promise((resolve) => {
+        setTimeout(() => {
+            resolve(fetchStub(jsonResponse));
+        }, delayTime);
+    });
+};
 
-const mockFetch = jsonResponse =>
-  vi.fn().mockImplementation(() => fetchStub(jsonResponse))
+const mockFetch = (jsonResponse) =>
+    vi.fn().mockImplementation(() => fetchStub(jsonResponse));
 
 const mockFetchWithDelay = (jsonResponse, delayTime) =>
-  vi.fn().mockImplementation(() => delayedFetchStub(jsonResponse, delayTime))
+    vi.fn().mockImplementation(() => delayedFetchStub(jsonResponse, delayTime));
 
 const mockFetchWithServerError = (jsonResponse, delayTime) =>
-  vi.fn().mockImplementation(() => {
-    return Promise.reject(new Error('API is down'))
-  })
+    vi.fn().mockImplementation(() => {
+        return Promise.reject(new Error("API is down"));
+    });
 
 export {
-  fetchStub,
-  delayedFetchStub,
-  mockFetch,
-  mockFetchWithDelay,
-  mockFetchWithServerError
-}
+    fetchStub,
+    delayedFetchStub,
+    mockFetch,
+    mockFetchWithDelay,
+    mockFetchWithServerError,
+};

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,52 +1,52 @@
-import path from "node:path"
-import { viteStaticCopy } from "vite-plugin-static-copy"
+import path from "node:path";
+import { viteStaticCopy } from "vite-plugin-static-copy";
 
-import { defineConfig } from "vite"
+import { defineConfig } from "vite";
 
 export default defineConfig({
-  base: "/static",
-  build: {
-    outDir: path.join(__dirname, "app/assets/dist"),
-    manifest: "manifest.json",
-    rollupOptions: {
-      input: ["app/assets/main.scss", "app/assets/main.js"],
-      external: [
-        /assets\/fonts\/.*\.(woff|woff2)$/,
-        /assets\/images\/.*\.svg$/,
-      ],
-    },
-    emptyOutDir: true,
-  },
-  css: {
-    preprocessorOptions: {
-      scss: {
-        silenceDeprecations: [
-          "global-builtin",
-          "slash-div",
-          "import",
-          "color-functions",
-        ],
-      },
-    },
-  },
-  plugins: [
-    viteStaticCopy({
-      targets: [
-        {
-          src: "node_modules/govuk-frontend/dist/govuk/assets/*",
-          dest: "./assets",
+    base: "/static",
+    build: {
+        outDir: path.join(__dirname, "app/assets/dist"),
+        manifest: "manifest.json",
+        rollupOptions: {
+            input: ["app/assets/main.scss", "app/assets/main.js"],
+            external: [
+                /assets\/fonts\/.*\.(woff|woff2)$/,
+                /assets\/images\/.*\.svg$/,
+            ],
         },
-        {
-          src: "app/assets/images",
-          dest: "./assets"
-        }
-      ],
-    }),
-  ],
-  test: {
-    globals: true,
-    setupFiles: ['app/assets/test/setup.js']
-  },
-  clearScreen: false,
-  appType: "custom"
-})
+        emptyOutDir: true,
+    },
+    css: {
+        preprocessorOptions: {
+            scss: {
+                silenceDeprecations: [
+                    "global-builtin",
+                    "slash-div",
+                    "import",
+                    "color-functions",
+                ],
+            },
+        },
+    },
+    plugins: [
+        viteStaticCopy({
+            targets: [
+                {
+                    src: "node_modules/govuk-frontend/dist/govuk/assets/*",
+                    dest: "./assets",
+                },
+                {
+                    src: "app/assets/images",
+                    dest: "./assets",
+                },
+            ],
+        }),
+    ],
+    test: {
+        globals: true,
+        setupFiles: ["app/assets/test/setup.js"],
+    },
+    clearScreen: false,
+    appType: "custom",
+});


### PR DESCRIPTION
- Adds 2 new make targets:
    - format-css: runs prettier on our scss files to update them with standard formatting rules
    - format-frontend: runs both the new format-css target and the existing format-html to format all our frontend files

Also updates our scss files to use this new formatting so future PRs won't introduce whitespace changes, making it harder to review
