### PR TITLE
FSPT-759: Updating the formatting of group names

### DIFF
--- a/app/assets/main.scss
+++ b/app/assets/main.scss
@@ -170,6 +170,7 @@ $app-destructive-link-active-colour: $govuk-text-colour;
     z-index: 1 !important;
     pointer-events: none;
 }
+
 .app-test-data-banner__action {
     position: absolute;
     right: 20px;
@@ -188,7 +189,11 @@ $app-destructive-link-active-colour: $govuk-text-colour;
     }
 }
 
-$inset-nested-rows: 15px;
+$inset-nested-rows: 30px;
+
+.govuk-summary-list__row dt {
+    padding-left: 5px;
+}
 
 .app-summary-list-group-row {
     background-color: govuk-colour("light-grey");
@@ -199,12 +204,19 @@ $inset-nested-rows: 15px;
 }
 
 .app-summary-list-group-row .govuk-summary-list__key {
-    padding-left: $inset-nested-rows;
     font-weight: bold !important;
 }
 
 .app-summary-list-group-nested {
     box-shadow: inset 4px 0 0 0 $govuk-border-colour;
+}
+
+.app-summary-list-group-nested dt::before {
+    content: "—";
+    margin-left: -28px;
+    color: #b1b4b6;
+    font-weight: bold;
+    font-size: 0.7em;
 }
 
 .app-summary-list-group-nested .govuk-summary-list__key {

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/macros/question_table.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/macros/question_table.html
@@ -70,7 +70,7 @@
         "actions": {
           "items": actions,
         } if actions else {},
-        "classes": "app-summary-list-group-row " if question.is_group and (question.parent.id == parent.id or not question.parent) else "" ~ ("app-summary-list-group-nested " if nested else "") ~ ("app-summary-list-group-nested--final " if nested_last else ""),
+        "classes": ("app-summary-list-group-row " if question.is_group else "") ~ ("app-summary-list-group-nested " if nested else "") ~ ("app-summary-list-group-nested--final " if nested_last else ""),
       })
     %}
   {% endfor %}


### PR DESCRIPTION
## 🎫 Ticket
[FSPT-759 Nested groups](https://mhclgdigital.atlassian.net/browse/FSPT-759)

## 📝 Description
Updates the display of group names and nested groups in the list of questions to better highlight the relationships between them

## 📸 Show the thing (screenshots, gifs)

### Before
<img width="995" height="574" alt="Screenshot 2025-10-07 at 11 38 39" src="https://github.com/user-attachments/assets/38842677-36f0-45d0-ae0b-0e39e56ae713" />


### After
<img width="997" height="564" alt="Screenshot 2025-10-07 at 11 38 14" src="https://github.com/user-attachments/assets/6dd96760-04d0-4779-a6bc-5a923b780ca9" />
