### PR TITLE
Bugfix: Update Guidance template for inserting context

### DIFF
--- a/app/deliver_grant_funding/forms.py
+++ b/app/deliver_grant_funding/forms.py
@@ -622,7 +622,7 @@ class AddGuidanceForm(FlaskForm):
         return result
 
     def is_submitted_to_add_context(self) -> bool:
-        return bool(self.is_submitted() and self.add_context.data and not self.submit.data)
+        return bool(self.is_submitted() and self.add_context.data and not (self.submit.data or self.preview.data))
 
     def get_component_form_data(self) -> dict[str, Any]:
         return {key: data for key, data in self.data.items() if key not in {"csrf_token", "submit"}}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/manage_guidance.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/manage_guidance.html
@@ -69,7 +69,7 @@
 
         {% set write_guidance_html %}
           {% set addDataButton %}
-            {{ form.add_context(params={"html": "Insert data <span class='govuk-visually-hidden'>in guidance</span>", "classes": "govuk-button--secondary app-context-aware--button"}) }}
+            {{ form.add_context(params={"html": "Insert data <span class='govuk-visually-hidden'>in guidance</span>", "classes": "govuk-button--secondary app-context-aware--button", "value": "guidance_body"}) }}
           {% endset %}
 
           <div data-module="context-aware-editor" data-toolbar-enabled="true" data-allow-headings="true" data-i18n="{}">


### PR DESCRIPTION
## 📝 Description
As part of the refactor in https://github.com/communitiesuk/funding-service/pull/858 we updated how inserting contextual data for question text/hint and guidance worked to consistently extract the entire form data and rebuild it when returning from the insert data flow.

We missed some small updates to initiating this flow from the manage_guidance pages, which meant clicking the `Insert data` button didn't actually kick off the flow as expected.