### PR TITLE
Bau refactor expression param names

### DIFF
--- a/app/common/expressions/__init__.py
+++ b/app/common/expressions/__init__.py
@@ -99,7 +99,7 @@ class ExpressionContext(ChainMap[str, Any]):
     def build_expression_context(
         collection: "Collection",
         mode: Literal["evaluation", "interpolation"],
-        collection_question_limit: Optional["Component"] = None,
+        expression_context_end_point: Optional["Component"] = None,
         submission_helper: Optional["SubmissionHelper"] = None,
     ) -> "ExpressionContext":
         """Pulls together all of the context that we want to be able to expose to an expression when evaluating it."""
@@ -121,10 +121,10 @@ class ExpressionContext(ChainMap[str, Any]):
                 for form in submission_helper.collection.forms
                 for question in form.cached_questions
                 if (
-                    collection_question_limit is None
+                    expression_context_end_point is None
                     or (
-                        collection_question_limit.form == form
-                        and form.global_component_index(collection_question_limit)
+                        expression_context_end_point.form == form
+                        and form.global_component_index(expression_context_end_point)
                         >= form.global_component_index(question)
                     )
                 )
@@ -136,9 +136,9 @@ class ExpressionContext(ChainMap[str, Any]):
         if mode == "interpolation":
             for form in collection.forms:
                 for question in form.cached_questions:
-                    if collection_question_limit and (
-                        collection_question_limit.form != form
-                        or form.global_component_index(collection_question_limit)
+                    if expression_context_end_point and (
+                        expression_context_end_point.form != form
+                        or form.global_component_index(expression_context_end_point)
                         <= form.global_component_index(question)
                     ):
                         continue
@@ -149,7 +149,7 @@ class ExpressionContext(ChainMap[str, Any]):
 
     @staticmethod
     def get_context_keys_and_labels(
-        collection: "Collection", collection_question_limit: Optional["Component"] = None
+        collection: "Collection", expression_context_end_point: Optional["Component"] = None
     ) -> dict[str, str]:
         """A dict mapping the reference variables (eg question safe_qids) to human-readable labels
 
@@ -157,7 +157,7 @@ class ExpressionContext(ChainMap[str, Any]):
         find a way to include labels for eg DB model columns, such as the grant name
         """
         ec = ExpressionContext.build_expression_context(
-            collection=collection, mode="interpolation", collection_question_limit=collection_question_limit
+            collection=collection, mode="interpolation", expression_context_end_point=expression_context_end_point
         )
         return {k: v for k, v in ec.items()}
 

--- a/app/common/expressions/__init__.py
+++ b/app/common/expressions/__init__.py
@@ -103,7 +103,6 @@ class ExpressionContext(ChainMap[str, Any]):
         submission_helper: Optional["SubmissionHelper"] = None,
     ) -> "ExpressionContext":
         """Pulls together all of the context that we want to be able to expose to an expression when evaluating it."""
-        fallback_question_names = mode == "interpolation"
 
         assert len(ExpressionContext.ContextSources) == 1, (
             "When defining a new source of context for expressions, "
@@ -134,7 +133,7 @@ class ExpressionContext(ChainMap[str, Any]):
             if submission_helper
             else {}
         )
-        if fallback_question_names:
+        if mode == "interpolation":
             for form in collection.forms:
                 for question in form.cached_questions:
                     if collection_question_limit and (

--- a/app/deliver_grant_funding/routes/reports.py
+++ b/app/deliver_grant_funding/routes/reports.py
@@ -987,7 +987,7 @@ def edit_question(grant_id: UUID, question_id: UUID) -> ResponseReturnValue:  # 
         managed_validation_available=get_managed_validators_by_data_type(question.data_type),
         interpolate=SubmissionHelper.get_interpolator(collection=question.form.collection),
         context_keys_and_labels=ExpressionContext.get_context_keys_and_labels(
-            collection=question.form.collection, collection_question_limit=question
+            collection=question.form.collection, expression_context_end_point=question
         ),
     )
 
@@ -1071,7 +1071,7 @@ def manage_guidance(grant_id: UUID, question_id: UUID) -> ResponseReturnValue:
         form=form,
         interpolate=SubmissionHelper.get_interpolator(collection=question.form.collection),
         context_keys_and_labels=ExpressionContext.get_context_keys_and_labels(
-            collection=question.form.collection, collection_question_limit=question
+            collection=question.form.collection, expression_context_end_point=question
         ),
     )
 


### PR DESCRIPTION
Renames a local variable and a parameter to `ExpressionContext.get_context_keys_and_labels` and `ExpressionContext.build_expression_context` to improve readability, as per this discussion: https://github.com/communitiesuk/funding-service/pull/846#discussion_r2405613224