### PR TITLE
FSPT-901: Bootstrap Flask-Admin for platform admin pages

### DIFF
--- a/app/common/auth/authorisation_helper.py
+++ b/app/common/auth/authorisation_helper.py
@@ -31,6 +31,12 @@ class AuthorisationHelper:
 
     @staticmethod
     def is_platform_admin(user: User | AnonymousUserMixin) -> bool:
+        # TODO: This is currently all FSD_ADMIN users; we will soon have two separate Azure AD groups - one for
+        #       Funding Service users (who can eg create and manage monitoring reports) who will stay in FSD_ADMIN,
+        #       and another for Funding Service platform admins (FSD_PLATFORM_ADMIN) who will be able to access the
+        #       Flask-Admin panel for super-user tasks. We'll probably add a new permission/role PLATFORM_ADMIN for
+        #       that azure AD group, and then potentially have Funding Service admin users be managed through that
+        #       rather than the FSD_ADMIN group.
         if isinstance(user, AnonymousUserMixin):
             return False
         return any(

--- a/app/deliver_grant_funding/admin/__init__.py
+++ b/app/deliver_grant_funding/admin/__init__.py
@@ -1,0 +1,8 @@
+from flask_admin import Admin
+from flask_sqlalchemy_lite import SQLAlchemy
+
+from app.deliver_grant_funding.admin.entities import PlatformAdminUserView
+
+
+def register_admin_views(flask_admin: Admin, db: SQLAlchemy) -> None:
+    flask_admin.add_view(PlatformAdminUserView(db.session))

--- a/app/deliver_grant_funding/admin/entities.py
+++ b/app/deliver_grant_funding/admin/entities.py
@@ -1,0 +1,56 @@
+from abc import abstractmethod
+
+from flask_admin.contrib import sqla
+from flask_wtf import FlaskForm
+from sqlalchemy import orm
+
+from app.common.data.base import BaseModel
+from app.common.data.models_user import User
+from app.deliver_grant_funding.admin.mixins import FlaskAdminPlatformAdminAccessibleMixin
+
+
+class PlatformAdminModelView(FlaskAdminPlatformAdminAccessibleMixin, sqla.ModelView):
+    form_base_class = FlaskForm
+
+    page_size = 50
+    can_set_page_size = True
+
+    can_create = False
+    can_view_details = True
+    can_edit = False
+    can_delete = False
+    can_export = False
+
+    def __init__(
+        self,
+        session: orm.Session,
+        name: "str | None" = None,
+        category: "str | None" = None,
+        endpoint: "str | None" = None,
+        url: "str | None" = None,
+        static_folder: "str | None" = None,
+        menu_class_name: "str | None" = None,
+        menu_icon_type: "str | None" = None,
+        menu_icon_value: "str | None" = None,
+    ) -> None:
+        super().__init__(
+            self._model,
+            session,
+            name=name,
+            category=category,
+            endpoint=endpoint,
+            url=url,
+            static_folder=static_folder,
+            menu_class_name=menu_class_name,
+            menu_icon_type=menu_icon_type,
+            menu_icon_value=menu_icon_value,
+        )
+
+    @property
+    @abstractmethod
+    def _model(self) -> type[BaseModel]:
+        pass
+
+
+class PlatformAdminUserView(PlatformAdminModelView):
+    _model = User

--- a/app/deliver_grant_funding/admin/mixins.py
+++ b/app/deliver_grant_funding/admin/mixins.py
@@ -1,0 +1,7 @@
+from app.common.auth.authorisation_helper import AuthorisationHelper
+from app.common.data.interfaces.user import get_current_user
+
+
+class FlaskAdminPlatformAdminAccessibleMixin:
+    def is_accessible(self) -> bool:
+        return AuthorisationHelper.is_platform_admin(get_current_user())

--- a/app/deliver_grant_funding/routes/admin.py
+++ b/app/deliver_grant_funding/routes/admin.py
@@ -1,0 +1,7 @@
+from flask_admin import AdminIndexView
+
+from app.deliver_grant_funding.admin.mixins import FlaskAdminPlatformAdminAccessibleMixin
+
+
+class PlatformAdminIndexView(FlaskAdminPlatformAdminAccessibleMixin, AdminIndexView):
+    pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "num2words==0.5.14",
     "mistune==3.1.4",
     "faker==37.8.0",
+    "flask-admin==2.0.0a4",
 ]
 
 [dependency-groups]
@@ -133,7 +134,7 @@ source_modules = [
     "app.types",
 ]
 ignore_imports = [
-    "app.developers.commands -> app.common.data.models"
+    "app.developers.commands -> app.common.data.models",
 ]
 # Unable to do `exhaustive` here unfortunately, so we won't get told if new modules are added and we forget to put them
 # in here. C'est la vie.
@@ -181,7 +182,7 @@ exclude = [".*test_.*"]
 
 [[tool.mypy.overrides]]
 module = [
-    "flask_wtf", "govuk_frontend_wtf.*", "testcontainers.*", "flask_babel", "sqlalchemy_utils", "flask_talisman.*", "flask_login", "msal.*", "num2words"
+    "flask_wtf", "govuk_frontend_wtf.*", "testcontainers.*", "flask_babel", "sqlalchemy_utils", "flask_talisman.*", "flask_login", "msal.*", "num2words", "flask_admin.*"
 ]
 ignore_missing_imports = true
 

--- a/tests/integration/deliver_grant_funding/routes/test_admin.py
+++ b/tests/integration/deliver_grant_funding/routes/test_admin.py
@@ -1,0 +1,73 @@
+import pytest
+
+
+class TestFlaskAdminAccess:
+    """Test that Flask-Admin pages are only accessible to platform admin users."""
+
+    @pytest.mark.parametrize(
+        "client_fixture, expected_code",
+        [
+            ("authenticated_platform_admin_client", 200),
+            ("authenticated_grant_admin_client", 403),
+            ("authenticated_grant_member_client", 403),
+            ("authenticated_no_role_client", 403),
+        ],
+    )
+    def test_admin_index_denied_for_non_platform_admin(self, client_fixture, expected_code, request):
+        """Non-platform admin authenticated users cannot access the admin index page."""
+        client = request.getfixturevalue(client_fixture)
+        response = client.get("/deliver/admin/")
+        assert response.status_code == expected_code
+
+    def test_admin_index_denied_for_anonymous(self, anonymous_client):
+        """Anonymous users cannot access the admin index page."""
+        response = anonymous_client.get("/deliver/admin/")
+        assert response.status_code == 403
+
+    @pytest.mark.parametrize(
+        "client_fixture, expected_code",
+        [
+            ("authenticated_platform_admin_client", 200),
+            ("authenticated_grant_admin_client", 403),
+            ("authenticated_grant_member_client", 403),
+            ("authenticated_no_role_client", 403),
+        ],
+    )
+    def test_admin_user_list_denied_for_non_platform_admin(self, client_fixture, expected_code, request):
+        """Non-platform admin authenticated users cannot access the user list page."""
+        client = request.getfixturevalue(client_fixture)
+        response = client.get("/deliver/admin/user/")
+        assert response.status_code == expected_code
+
+    def test_admin_user_list_denied_for_anonymous(self, anonymous_client):
+        """Anonymous users cannot access the user list page."""
+        response = anonymous_client.get("/deliver/admin/user/")
+        assert response.status_code == 403
+
+    @pytest.mark.parametrize(
+        "client_fixture, expected_code",
+        [
+            ("authenticated_platform_admin_client", 200),
+            ("authenticated_grant_admin_client", 403),
+            ("authenticated_grant_member_client", 403),
+            ("authenticated_no_role_client", 403),
+        ],
+    )
+    def test_admin_user_detail_denied_for_non_platform_admin(
+        self, client_fixture, expected_code, request, factories, db_session
+    ):
+        """Non-platform admin authenticated users cannot access user detail pages."""
+        client = request.getfixturevalue(client_fixture)
+        user = factories.user.create()
+        db_session.commit()
+
+        response = client.get(f"/deliver/admin/user/details/?id={user.id}", follow_redirects=True)
+        assert response.status_code == expected_code
+
+    def test_admin_user_detail_denied_for_anonymous(self, anonymous_client, factories, db_session):
+        """Anonymous users cannot access user detail pages."""
+        user = factories.user.create()
+        db_session.commit()
+
+        response = anonymous_client.get(f"/deliver/admin/user/details/?id={user.id}")
+        assert response.status_code == 403

--- a/tests/unit/test_all_routes_access.py
+++ b/tests/unit/test_all_routes_access.py
@@ -100,6 +100,19 @@ routes_with_no_expected_access_restrictions = [
     # \/ authorisation done within the endpoint, to avoid redirects+session hijacking \/
     "deliver_grant_funding.api.preview_guidance",
 ]
+routes_with_access_controlled_by_flask_admin = [
+    "platform_admin.index",
+    "platform_admin.static",
+    "user.action_view",
+    "user.ajax_lookup",
+    "user.ajax_update",
+    "user.create_view",
+    "user.delete_view",
+    "user.details_view",
+    "user.edit_view",
+    "user.export",
+    "user.index_view",
+]
 
 
 def test_accessibility_for_user_role_to_each_endpoint(app):
@@ -120,7 +133,9 @@ def test_accessibility_for_user_role_to_each_endpoint(app):
         elif rule.endpoint in routes_with_no_expected_access_restrictions:
             # If route is expected to be unauthenticated, check it doesn't have any auth decorators
             assert not any(decorator in all_auth_annotations for decorator in decorators)
-
+        elif rule.endpoint in routes_with_access_controlled_by_flask_admin:
+            # authentication of flask-admin routes is controlled by FlaskAdminPlatformAdminAccessibleMixin
+            pass
         else:
             raise pytest.fail(f"Unexpected endpoint {rule.endpoint}. Add this to the expected_route_access mapping.")  # ty: ignore[call-non-callable]
 
@@ -132,6 +147,7 @@ def test_routes_list_is_valid(app):
         + routes_with_expected_member_only_access
         + routes_with_expected_grant_admin_only_access
         + routes_with_expected_platform_admin_only_access
+        + routes_with_access_controlled_by_flask_admin
     )
 
     all_routes_in_app = [rule.endpoint for rule in app.url_map.iter_rules()]

--- a/uv.lock
+++ b/uv.lock
@@ -390,6 +390,22 @@ async = [
 ]
 
 [[package]]
+name = "flask-admin"
+version = "2.0.0a4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flask" },
+    { name = "jinja2" },
+    { name = "markupsafe" },
+    { name = "werkzeug" },
+    { name = "wtforms" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/63/5b4dcce35e696993e5c1319d4ac68e825b8496bb718b6a623785e023af6c/flask_admin-2.0.0a4.tar.gz", hash = "sha256:141cf19de079d26db6d2d674b9a470449d6561a2ba1252eff61e597d981b72c7", size = 5489076, upload-time = "2025-02-22T13:56:34.803Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/13/f4d637d4cdff5091c3d7d96796768b7c3d87af464534723abbabbfab878e/flask_admin-2.0.0a4-py3-none-any.whl", hash = "sha256:dbe430eec1ad8918d130d522265910db7e9f49a5d4c12438175e0f61eb02c2a3", size = 6403892, upload-time = "2025-02-22T13:56:31.807Z" },
+]
+
+[[package]]
 name = "flask-babel"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -523,6 +539,7 @@ dependencies = [
     { name = "babel" },
     { name = "faker" },
     { name = "flask" },
+    { name = "flask-admin" },
     { name = "flask-babel" },
     { name = "flask-login" },
     { name = "flask-migrate" },
@@ -585,6 +602,7 @@ requires-dist = [
     { name = "babel", specifier = "==2.17.0" },
     { name = "faker", specifier = "==37.8.0" },
     { name = "flask", specifier = "==3.1.2" },
+    { name = "flask-admin", specifier = "==2.0.0a4" },
     { name = "flask-babel", specifier = "==4.0.0" },
     { name = "flask-login", specifier = "==0.6.3" },
     { name = "flask-migrate", specifier = "==4.1.0" },


### PR DESCRIPTION
## 🎫 Ticket
[<!-- Link to Jira ticket, GitHub issue, or other tracking system -->](https://mhclgdigital.atlassian.net/browse/FSPT-901)

## 📝 Description
This patch integrates a baseline for Flask-Admin with a simple model view exposed to list users in the platform. We apply some default authorisation/authentication checks to validate that only platform admin users can see this part of the service.

For now this will be based on the ADMIN role in the service, which correlates to membership of the FSD_ADMIN AD group. We plan to create a FSD_PLATFORM_ADMIN AD group soon to allow us to further limit who can use platform admin pages, as FSD_ADMIN is more than just developers/privileged people.

Accessible through an unlinked URL path: `/deliver/admin`


## 📸 Show the thing (screenshots, gifs)
<img width="1162" height="623" alt="image" src="https://github.com/user-attachments/assets/bfb47af7-93c3-4460-a0a9-9a91ff25827d" />


## 🧪 Testing
<!-- Describe how you've tested this change, and how a reviewer can test it -->

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested