### PR TITLE
Add interpolation highlighting for form builder

### DIFF
--- a/app/assets/css/context-aware-editor/_index.scss
+++ b/app/assets/css/context-aware-editor/_index.scss
@@ -91,12 +91,17 @@
 
     // Match textarea font exactly
     @include govuk-font($size: 19, $line-height: 1.25em);
+}
 
-    // Style for valid references
-    .app-context-aware-editor--valid-reference {
-        background-color: govuk-colour("yellow");
-        border-radius: 2px;
-    }
+// Style for valid references
+.app-context-aware-editor--valid-reference {
+    background-color: govuk-colour("yellow");
+    border-radius: 2px;
+}
+
+// Improve text contrast when references are within links
+.govuk-link .app-context-aware-editor--valid-reference {
+    color: govuk-colour("dark-blue");
 }
 
 // Notification area for screen readers (if needed for toolbar)

--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -101,7 +101,8 @@ class SubmissionHelper:
 
     @staticmethod
     def get_interpolator(
-        collection: "Collection", submission_helper: Optional["SubmissionHelper"] = None
+        collection: "Collection",
+        submission_helper: Optional["SubmissionHelper"] = None,
     ) -> Callable[[str], str]:
         return partial(
             interpolate,

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/macros/question_table.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/macros/question_table.html
@@ -25,9 +25,9 @@
     {% set keyHtml %}
       {% if role_can_edit %}
         {% set edit_link = url_for("deliver_grant_funding.edit_question", grant_id=grant.id, question_id=question.id) if not question.is_group else url_for("deliver_grant_funding.list_group_questions", grant_id=grant.id, group_id=question.id) %}
-        <a class="govuk-link govuk-link--no-visited-state" href="{{ edit_link }}">{{ interpolate(question.text) }}</a>
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ edit_link }}">{{ interpolate(question.text, with_interpolation_highlighting=True) }}</a>
       {% else %}
-        {{ interpolate(question.text) }}
+        {{ interpolate(question.text, with_interpolation_highlighting=True) }}
       {% endif %}
       {% if role_can_edit and question.conditions %}
         {{

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/edit_question.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/edit_question.html
@@ -169,14 +169,14 @@
 
             {% set key_html %}
               {# todo: would users find it useful to be able to link to the question being depended on from here? #}
-              <span>{{ interpolate(depends_on.text) }}</span>
+              <span>{{ interpolate(depends_on.text, with_interpolation_highlighting=True) }}</span>
             {% endset %}
 
 
             {% set value_html %}
               <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.edit_question_condition', grant_id=grant.id, component_id=question.id, expression_id=condition.id) }}">
                 <span class="govuk-visually-hidden">Change condition for</span>
-                {{ interpolate(condition.managed.message) }}
+                {{ interpolate(condition.managed.message, with_interpolation_highlighting=True) }}
               </a>
             {% endset %}
             {% do rows.append({ "key": { "html": key_html }, "value": { "html": value_html } }) %}
@@ -210,7 +210,7 @@
               {% set value_html %}
                 <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.edit_question_validation', grant_id=grant.id, question_id=question.id, expression_id=validation.id) }}" disabled>
                   <span class="govuk-visually-hidden">Change validation for</span>
-                  {{ interpolate(validation.managed.message) }}
+                  {{ interpolate(validation.managed.message, with_interpolation_highlighting=True) }}
                 </a>
               {% endset %}
               {%

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_group_questions.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_group_questions.html
@@ -149,14 +149,14 @@
 
           {% set key_html %}
             {# todo: would users find it useful to be able to link to the question being depended on from here? #}
-            <span>{{ depends_on.text }}</span>
+            <span>{{ interpolate(depends_on.text, with_interpolation_highlighting=True) }}</span>
           {% endset %}
 
 
           {% set value_html %}
             <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.edit_question_condition', grant_id=grant.id, expression_id=condition.id) }}">
               <span class="govuk-visually-hidden">Change condition for</span>
-              {{ condition.managed.message }}
+              {{ interpolate(condition.managed.message, with_interpolation_highlighting=True) }}
             </a>
           {% endset %}
           {% do rows.append({ "key": { "html": key_html }, "value": { "html": value_html } }) %}

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -959,7 +959,8 @@ class TestListGroupQuestions:
         )
 
         assert response.status_code == 200
-        assert "Reference to ((my question name))" in response.text
+        soup = BeautifulSoup(response.data, "html.parser")
+        assert "Reference to ((my question name))" in soup.text
 
     def test_delete_confirmation_banner(self, authenticated_grant_admin_client, factories, db_session):
         report = factories.collection.create(grant=authenticated_grant_admin_client.grant, name="Test Report")


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
Add highlighting to any data references when they are shown to form designers in links/etc on the page. We do this by adding a parameter to the `interpolate` function which will cause it to return Markup instead of a static string. Because this markup will be treated as safe when rendered in templates, we need to escape the values, which theoretically could contain 

## 📸 Show the thing (screenshots, gifs)
<!-- Include screenshots for UI changes, new features, or visual modifications -->
<!-- Use "Before" and "After" sections if showing changes to existing functionality -->

| Place | Before | After |
|---|---|---|
| List questions in task page | <img width="1056" height="1305" alt="image" src="https://github.com/user-attachments/assets/92101920-b936-44a8-b9c4-58e7df7aba4c" /> | <img width="1027" height="1220" alt="image" src="https://github.com/user-attachments/assets/7ad6246c-fdc6-460c-bcb3-8c08673f9918" /> |
| List questions in task page (grant team member) | <img width="1051" height="959" alt="image" src="https://github.com/user-attachments/assets/775d6688-735e-40ca-91ec-cdf5d7d97b41" /> | <img width="1056" height="963" alt="image" src="https://github.com/user-attachments/assets/d684e77d-7cc7-4b26-bce8-da419f46882a" /> |
| List questions in group page | <img width="1055" height="1368" alt="image" src="https://github.com/user-attachments/assets/5a084c56-cee1-4ca1-ac71-49f17e67a872" /> |  <img width="1034" height="1383" alt="image" src="https://github.com/user-attachments/assets/aaeeeba4-10a8-491e-b7d7-0bdd4f8cbded" /> |
| Edit question page | <img width="739" height="658" alt="image" src="https://github.com/user-attachments/assets/60c38bb8-d26c-4e5b-a559-18b5a0817478" /> |  <img width="731" height="656" alt="image" src="https://github.com/user-attachments/assets/43954594-4736-4852-960a-dac26db7e1de" /> |

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [x] Edge cases and error conditions are tested