### PR TITLE
Allow commas when entering integers

### DIFF
--- a/app/common/collections/forms.py
+++ b/app/common/collections/forms.py
@@ -22,6 +22,7 @@ from app.common.data.models import Expression, Question
 from app.common.data.types import QuestionDataType
 from app.common.expressions import ExpressionContext, evaluate, interpolate
 from app.common.forms.fields import (
+    IntegerWithCommasField,
     MHCLGAccessibleAutocomplete,
     MHCLGApproximateDateInput,
     MHCLGCheckboxesInput,
@@ -29,7 +30,16 @@ from app.common.forms.fields import (
 )
 from app.common.forms.validators import FinalOptionExclusive, URLWithoutProtocol, WordRange
 
-_accepted_fields = EmailField | StringField | IntegerField | RadioField | SelectField | SelectMultipleField | DateField
+_accepted_fields = (
+    EmailField
+    | StringField
+    | IntegerField
+    | IntegerWithCommasField
+    | RadioField
+    | SelectField
+    | SelectMultipleField
+    | DateField
+)
 
 
 # FIXME: Ideally this would do an intersection between FlaskForm and QuestionFormProtocol, but type hinting in
@@ -174,7 +184,7 @@ def build_question_form(  # noqa: C901
                     filters=[lambda x: x.strip() if x else x],
                 )
             case QuestionDataType.INTEGER:
-                field = IntegerField(
+                field = IntegerWithCommasField(
                     label=interpolate(text=question.text, context=interpolation_context),
                     description=interpolate(text=question.hint or "", context=interpolation_context),
                     widget=GovTextInput(),

--- a/app/common/forms/fields.py
+++ b/app/common/forms/fields.py
@@ -3,6 +3,28 @@ from typing import Any
 from govuk_frontend_wtf.gov_form_base import GovFormBase, GovIterableBase
 from govuk_frontend_wtf.wtforms_widgets import GovSelect
 from wtforms import Field
+from wtforms.fields.numeric import IntegerField as WTFormsIntegerField
+
+
+class IntegerWithCommasField(WTFormsIntegerField):
+    """
+    IntegerField that accepts comma-separated input (e.g., "1,000,000").
+    Commas are stripped before integer conversion.
+    """
+
+    def process_formdata(self, valuelist: list[Any]) -> None:
+        """Override to strip commas from input before converting to integer."""
+        if not valuelist:
+            return
+
+        # Strip commas from the input string before conversion
+        cleaned_value = valuelist[0].replace(",", "") if isinstance(valuelist[0], str) else valuelist[0]
+
+        try:
+            self.data = int(cleaned_value)
+        except ValueError as exc:
+            self.data = None
+            raise ValueError(self.gettext("Not a valid integer value.")) from exc
 
 
 class MHCLGAccessibleAutocomplete(GovSelect):


### PR DESCRIPTION
When data providers are entering numbers into their submissions, it's very likely that some will insert commas for thousands/millions/etc. We should accept this input rather than throwing an unfriendly "Not an integer value" error.

## Before
![2025-10-10 13 48 14](https://github.com/user-attachments/assets/7484faa0-772b-48d5-b01f-90600a858c83)


 ## After
![2025-10-10 13 47 44](https://github.com/user-attachments/assets/aa4f0148-99f8-40a6-adde-248554ecef35)
