### PR TITLE
FSPT-781: Restrict select context source dropdown for expressions

### DIFF
--- a/app/deliver_grant_funding/forms.py
+++ b/app/deliver_grant_funding/forms.py
@@ -461,6 +461,7 @@ class SelectDataSourceQuestionForm(FlaskForm):
         form: "Form",
         interpolate: Callable[[str], str],
         current_component: TOptional["Component"],
+        expression: bool = False,
         *args: Any,
         **kwargs: Any,
     ) -> None:
@@ -476,7 +477,8 @@ class SelectDataSourceQuestionForm(FlaskForm):
         self.question.choices = [("", "")] + [
             (str(question.id), interpolate(question.text))
             for question in get_referenceable_questions(form, current_component)
-        ]  # type: ignore[assignment]
+            if (not expression or question.data_type == current_component.data_type)  # type: ignore[assignment, union-attr]
+        ]
 
 
 class GrantAddUserForm(FlaskForm):


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-781

## 📝 Description
When we're selecting a context source for question text/hint or guidance we generally want all previous questions in the form to be available as context (with the exception of same-page questions in a group).

However when selecting a context source for expressions we should only show questions of the same question type (integers for integers, dates for dates) for the expression evaluation to not be completely broken. This change allows a boolean to be passed to the form set up to identify if it's being used for an expression, and if so restricts the question list to those of the same datatype.

Also a small fix so if we're referencing data for an expression we pass in the `depends_on_question` as the current component for the dropdown so form designers can't accidentally select questions that come later in the form/the depends on question itself.

## 📸 Show the thing (screenshots, gifs)

_NB. The initial add condition 'select question' dropdown still shows all questions in the form and questions from the same page group - this is addressed in https://github.com/communitiesuk/funding-service/pull/889_

### Before
| Validations | Conditions |
| -------- | ------- |
|  ![2025-10-14 09 24 26](https://github.com/user-attachments/assets/c42d20df-909f-4c26-9f64-4a9a9f4a9419) | ![2025-10-14 16 48 30](https://github.com/user-attachments/assets/86b80b03-96fe-4506-9341-d640bf3b7fb4)  |

### After
| Validations | Conditions |
| -------- | ------- |
|  ![2025-10-14 09 27 23](https://github.com/user-attachments/assets/1cfada32-78a6-4b40-ad39-4b624eb40f87) |    ![2025-10-14 16 49 57](https://github.com/user-attachments/assets/29478b02-eeef-4446-83e2-ca0fc131f593)  |

## 🧪 Testing
### Validations
- Create a task with multiple integer and/or date questions, as well as some other question types
- Add a validation to an integer question in the middle, and click to reference data in the expression
- The 'select context source' dropdown should only show integer questions that come before the current one
### Conditions
- Likewise for conditions, select any question you want to make conditional
- Select an integer or date question for the 'depends on' question
- The 'select context source' dropdown should only show questions of that data type that come before the 'depends on' question
### Question Groups
- The expected behaviour with same-page question groups (ie. not being able to select them in the 'select context source' dropdown should be maintained in all situations

## 📋 Developer Checklist

### Review Readiness
- [X] PR title and description provide sufficient context for reviewers
- [X] Commits are logical, self-contained, and have clear descriptions

### Testing
- [X] I have tested this change and it meets the acceptance criteria for the ticket
- ~[ ] I need the reviewer(s) to pull and run this change locally~
- [X] New (non-developer) functionality has appropriate unit and integration tests
- ~[ ] End-to-end tests have been updated (if applicable)~
- [X] Edge cases and error conditions are tested
