### PR TITLE
BAU: Filter condition question select dropdown

### DIFF
--- a/app/common/expressions/registry.py
+++ b/app/common/expressions/registry.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 from typing import TYPE_CHECKING
 
 from app.common.data.types import ManagedExpressionsEnum, QuestionDataType
+from app.common.forms.helpers import get_referenceable_questions
 
 if TYPE_CHECKING:
     from app.common.data.models import Component, Question
@@ -57,5 +58,9 @@ def register_managed_expression(cls: type["ManagedExpression"]) -> type["Managed
 
 
 def get_supported_form_questions(question: "Component") -> list["Question"]:
-    questions = question.form.cached_questions
-    return [q for q in questions if q.data_type in get_registered_data_types() and q.id != question.id]
+    form = question.form
+    return [
+        q
+        for q in get_referenceable_questions(form, question)
+        if q.data_type in get_registered_data_types() and q.id != question.id
+    ]

--- a/app/common/forms/helpers.py
+++ b/app/common/forms/helpers.py
@@ -1,0 +1,38 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.common.data.models import Component, Form, Question
+
+
+def questions_in_same_page_group(c1: "Component", c2: "Component") -> bool:
+    """
+    Check if two components are in the same group and that group shows on the same page.
+    If they are then they shouldn't reference each other.
+
+    Note: this relies on a current tech/product constraint that the "same page" setting can only be turned on for the
+    leaf group in a set of nested groups (so we don't have to check parent groups for the same-page setting).
+    """
+    return True if c1.parent and c2.parent and c1.parent == c2.parent and c1.parent.same_page else False
+
+
+def get_referenceable_questions(form: "Form", current_component: "Component | None" = None) -> list["Question"]:
+    """
+    Return a list of questions from the current form that could be referenced from the current component, determined by:
+    - Question comes before the current component in the form
+    - Question is not in the same 'same page' page group as the current component
+
+    If current component is None then return all cached questions in the form.
+    """
+    questions = form.cached_questions
+
+    if current_component is None:
+        return questions
+    else:
+        return [
+            q
+            for q in questions
+            if (
+                form.global_component_index(q) < form.global_component_index(current_component)
+                and not questions_in_same_page_group(q, current_component)
+            )
+        ]

--- a/app/deliver_grant_funding/routes/reports.py
+++ b/app/deliver_grant_funding/routes/reports.py
@@ -1175,7 +1175,7 @@ def manage_guidance(grant_id: UUID, question_id: UUID) -> ResponseReturnValue:
 def add_question_condition_select_question(grant_id: UUID, component_id: UUID) -> ResponseReturnValue:
     component = get_component_by_id(component_id)
     form = ConditionSelectQuestionForm(
-        question=component,
+        current_component=component,
         interpolate=SubmissionHelper.get_interpolator(collection=component.form.collection),
     )
 

--- a/tests/unit/common/forms/test_helpers.py
+++ b/tests/unit/common/forms/test_helpers.py
@@ -1,0 +1,72 @@
+from app.common.data.types import QuestionPresentationOptions
+from app.common.forms.helpers import get_referenceable_questions, questions_in_same_page_group
+
+
+class TestQuestionsInSamePageGroup:
+    def test_components_not_in_any_group(self, factories):
+        form = factories.form.build()
+        q1, q2 = factories.question.build_batch(2, form=form, parent=None)
+        assert questions_in_same_page_group(q1, q2) is False
+
+    def test_only_one_parent_component(self, factories):
+        form = factories.form.build()
+        group = factories.group.build(form=form)
+        q1 = factories.question.build(form=form, parent=None)
+        q2 = factories.question.build(form=form, parent=group)
+
+        assert questions_in_same_page_group(q1, q2) is False
+
+    def test_components_in_different_groups(self, factories):
+        form = factories.form.build()
+        group1 = factories.group.build(form=form)
+        group2 = factories.group.build(form=form)
+        q1 = factories.question.build(form=form, parent=group1)
+        q2 = factories.question.build(form=form, parent=group2)
+
+        assert questions_in_same_page_group(q1, q2) is False
+
+    def test_components_in_same_group_same_page(self, factories):
+        form = factories.form.build()
+        group = factories.group.build(
+            form=form, presentation_options=QuestionPresentationOptions(show_questions_on_the_same_page=True)
+        )
+        q1 = factories.question.build(form=form, parent=group)
+        q2 = factories.question.build(form=form, parent=group)
+
+        assert questions_in_same_page_group(q1, q2) is True
+
+
+class TestGetReferenceableQuestions:
+    def test_no_current_component_returns_all_questions(self, factories):
+        form = factories.form.build()
+        questions = factories.question.build_batch(3, form=form)
+
+        assert get_referenceable_questions(form, current_component=None) == questions
+
+    def test_single_question_returns_empty_list(self, factories):
+        """Test that a form with no questions returns empty list"""
+        form = factories.form.build()
+        current_question = factories.question.build(form=form)
+
+        assert get_referenceable_questions(form, current_component=current_question) == []
+
+    def test_filters_out_questions_that_come_after_current_component(self, factories):
+        form = factories.form.build()
+        q1, q2, q3 = factories.question.build_batch(3, form=form)
+
+        referenceable_questions = get_referenceable_questions(form, current_component=q2)
+
+        assert referenceable_questions == [q1]
+
+    def test_filters_out_questions_in_same_page_group(self, factories):
+        form = factories.form.build()
+        q1 = factories.question.build(form=form)
+        group = factories.group.build(
+            form=form, presentation_options=QuestionPresentationOptions(show_questions_on_the_same_page=True)
+        )
+        factories.question.build(form=form, parent=group)
+        q3 = factories.question.build(form=form, parent=group)
+
+        referenceable_questions = get_referenceable_questions(form, current_component=q3)
+
+        assert referenceable_questions == [q1]


### PR DESCRIPTION
## 📝 Description
Currently the select question dropdown when adding a condition displays all questions in a form as long as they don't have the same ID as the current component and are of a question type that can be used for conditions (eg. integers, dates, yes/no). However it doesn't currently filter out questions that come after the current component in the form or questions that are part of the same 'same page' group as the current component.

Selecting these does trigger validation errors but it could be a little confusing to the user to see these in the first place, and as we've started implementing this filtering for the Select Context Source question dropdown it makes sense to centralise this logic and enforce this in both places, and then allow additional checks for each where needed.

BAU but links to https://github.com/communitiesuk/funding-service/pull/885

## 📸 Show the thing (screenshots, gifs)

### Before
![2025-10-14 16 34 56](https://github.com/user-attachments/assets/1163d162-6315-4f69-89a8-6d1c478e4539)

### After
![2025-10-14 16 36 07](https://github.com/user-attachments/assets/71adb6e9-2478-4f3f-b31b-b21d50dc99e1)

## 🧪 Testing
- Go through the flow to add conditions and make sure you can't select questions that come after the current question or are in the the same 'same page' group.

## 📋 Developer Checklist

### Review Readiness
- [X] PR title and description provide sufficient context for reviewers
- [X] Commits are logical, self-contained, and have clear descriptions

### Testing
- [X] I have tested this change and it meets the acceptance criteria for the ticket
- ~[ ] I need the reviewer(s) to pull and run this change locally~
- [X] New (non-developer) functionality has appropriate unit and integration tests
- ~[ ] End-to-end tests have been updated (if applicable)~
- [X] Edge cases and error conditions are tested