### PR TITLE
FSPT-850 Generate a single line summary for a given add another question group

### DIFF
--- a/app/common/data/types.py
+++ b/app/common/data/types.py
@@ -4,6 +4,7 @@ import enum
 import typing
 from enum import IntEnum
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
+from uuid import UUID
 
 from pydantic import BaseModel
 from sqlalchemy import TypeDecorator
@@ -158,6 +159,7 @@ class QuestionPresentationOptions(BaseModel):
 
     # Groups
     show_questions_on_the_same_page: bool | None = None
+    add_another_summary_line_question_ids: list[UUID] | None = None
 
     # Dates
     approximate_date: bool | None = None

--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from functools import cached_property, lru_cache, partial
 from io import StringIO
 from itertools import chain
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Union, cast
 from uuid import UUID
 
 from pydantic import BaseModel as PydanticBaseModel
@@ -460,6 +460,30 @@ class SubmissionHelper:
                 return next(question_iterator, None)
 
         raise ValueError(f"Could not find a question with id={current_question_id} in collection={self.collection}")
+
+    def get_summary_line_for_add_another(self, component: "Component", *, add_another_index: int) -> str:
+        if not component.add_another_container:
+            raise ValueError("summary lines can only be generated for components in an add another container")
+
+        questions = []
+        if component.add_another_container.is_group:
+            if component.add_another_container.presentation_options.add_another_summary_line_question_ids:
+                for qid in component.add_another_container.presentation_options.add_another_summary_line_question_ids:
+                    try:
+                        questions.append(self.get_question(qid))
+                    except ValueError:
+                        pass
+            questions = questions or cast("Group", component.add_another_container).cached_questions
+        else:
+            questions = [cast("Question", component)]
+
+        answers = []
+        for question in questions:
+            answer = self.cached_get_answer_for_question(question.id, add_another_index=add_another_index)
+            if answer:
+                answers.append(answer.get_value_for_text_export())
+
+        return ", ".join(answers)
 
 
 class CollectionHelper:

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -557,6 +557,22 @@ class TestUpdateGroup:
         assert updated_group.guidance_heading == "How to answer this question"
         assert updated_group.guidance_body == "This is detailed guidance with **markdown** formatting."
 
+    def test_update_group_with_add_another_presentation_options(self, db_session, factories):
+        form = factories.form.create()
+        group = create_group(form=form, text="Test group name")
+        q1 = factories.question.create(parent=group, form=group.form)
+        q2 = factories.question.create(parent=group, form=group.form)
+
+        assert group.presentation_options.add_another_summary_line_question_ids is None
+
+        updated_group = update_group(
+            group=group,
+            expression_context=ExpressionContext(),
+            presentation_options=QuestionPresentationOptions(add_another_summary_line_question_ids=[q1.id, q2.id]),
+        )
+
+        assert updated_group.presentation_options.add_another_summary_line_question_ids == [q1.id, q2.id]
+
     def test_synced_component_references(self, db_session, factories, mocker):
         form = factories.form.create()
         user = factories.user.create()

--- a/tests/unit/common/helpers/test_collections.py
+++ b/tests/unit/common/helpers/test_collections.py
@@ -2,7 +2,7 @@ import uuid
 
 import pytest
 
-from app.common.data.types import ExpressionType, QuestionDataType, SubmissionEventKey
+from app.common.data.types import ExpressionType, QuestionDataType, QuestionPresentationOptions, SubmissionEventKey
 from app.common.helpers.collections import SubmissionHelper
 from tests.utils import AnyStringMatching
 
@@ -578,3 +578,80 @@ class TestSubmissionHelper:
 
             helper = SubmissionHelper(submission)
             assert helper.get_count_for_add_another(group) == 3
+
+    class TestGetSummaryLineForAddAnother:
+        def test_valid_summary_line_no_option_gets_all(self, factories):
+            group = factories.group.build(add_another=True)
+            q1 = factories.question.build(parent=group)
+            q2 = factories.question.build(parent=group)
+            submission = factories.submission.build(collection=group.form.collection)
+            submission.data[str(group.id)] = [
+                {str(q1.id): "line 0 answer 0", str(q2.id): "line 0 answer 1"},
+                {str(q1.id): "line 1 answer 0", str(q2.id): "line 1 answer 1"},
+                {str(q1.id): "line 2 answer 0", str(q2.id): "line 2 answer 1"},
+            ]
+            helper = SubmissionHelper(submission)
+            assert (
+                helper.get_summary_line_for_add_another(group, add_another_index=0)
+                == "line 0 answer 0, line 0 answer 1"
+            )
+
+        def test_valid_summary_line_no_valid_options_gets_all(self, factories):
+            group = factories.group.build(add_another=True)
+            q1 = factories.question.build(parent=group)
+            q2 = factories.question.build(parent=group)
+
+            group.question_presentation_options = QuestionPresentationOptions(
+                add_another_summary_line_question_ids=[uuid.uuid4(), uuid.uuid4()]
+            )
+            submission = factories.submission.build(collection=group.form.collection)
+            submission.data[str(group.id)] = [
+                {str(q1.id): "line 0 answer 0", str(q2.id): "line 0 answer 1"},
+                {str(q1.id): "line 1 answer 0", str(q2.id): "line 1 answer 1"},
+                {str(q1.id): "line 2 answer 0", str(q2.id): "line 2 answer 1"},
+            ]
+            helper = SubmissionHelper(submission)
+            assert (
+                helper.get_summary_line_for_add_another(group, add_another_index=0)
+                == "line 0 answer 0, line 0 answer 1"
+            )
+
+        def test_valid_summary_line_valid_options_subselect_questions(self, factories):
+            group = factories.group.build(add_another=True)
+            q1 = factories.question.build(parent=group)
+            q2 = factories.question.build(parent=group)
+
+            group.presentation_options = QuestionPresentationOptions(add_another_summary_line_question_ids=[q1.id])
+            submission = factories.submission.build(collection=group.form.collection)
+            submission.data[str(group.id)] = [
+                {str(q1.id): "line 0 answer 0", str(q2.id): "line 0 answer 1"},
+                {str(q1.id): "line 1 answer 0", str(q2.id): "line 1 answer 1"},
+                {str(q1.id): "line 2 answer 0", str(q2.id): "line 2 answer 1"},
+            ]
+            helper = SubmissionHelper(submission)
+            assert helper.get_summary_line_for_add_another(group, add_another_index=0) == "line 0 answer 0"
+
+        def test_empty_for_no_answers(self, factories):
+            group = factories.group.build(add_another=True)
+            factories.question.build(parent=group)
+            submission = factories.submission.build(collection=group.form.collection)
+            helper = SubmissionHelper(submission)
+            submission.data = {str(group.id): [{}]}
+
+            assert helper.get_summary_line_for_add_another(group, add_another_index=0) == ""
+
+        def test_valid_summary_line_for_single_add_another_question(self, factories):
+            q1 = factories.question.build(add_another=True)
+            submission = factories.submission.build(collection=q1.form.collection)
+            submission.data = {str(q1.id): [{str(q1.id): "line 0 answer 0"}]}
+            helper = SubmissionHelper(submission)
+            assert helper.get_summary_line_for_add_another(q1, add_another_index=0) == "line 0 answer 0"
+
+        def test_raises_for_non_add_another(self, factories):
+            q1 = factories.question.build(add_another=False)
+            submission = factories.submission.build(collection=q1.form.collection)
+            helper = SubmissionHelper(submission)
+
+            with pytest.raises(ValueError) as e:
+                helper.get_summary_line_for_add_another(q1, add_another_index=0)
+            assert str(e.value) == "summary lines can only be generated for components in an add another container"


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-850

## 📝 Description
When there are multiple questions this helper can be used to generate a single line summary of all of their answers - as this is just stored in presentation options for now it might contain references to old questions so the helper is set up to default to returning a summary of everything if there is either no configuration or no valid configuration.

This will be used for a consistent header/ summary row of add another entries on the add another summary and check your answers pages (maybe data exports but not confirmed).

This proposes configuring this in the containing groups presentation options which would then be configurable by the form designer - this trades of the database integrity of adding this as a separate table + relationship with having this configuration loaded whenever we load the group being used.

Any questions that have been removed from the group whenever this is applied will just be ignored and no relevant questions in the configuration will result in all the answers used for the summary (which is the default option if the form designer has selected no questions).

When the presentation options are being configured, all of the groups questions will be shown and selected if there are no current presentation options or if the existing presentation options aren't relevant. If relevant question ids are stored in the presentation options only those will be selected.

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [x] Edge cases and error conditions are tested
