### PR TITLE
Switch to using FS_PLATFORM_ADMINS group

### DIFF
--- a/app/common/auth/__init__.py
+++ b/app/common/auth/__init__.py
@@ -125,7 +125,7 @@ def sso_get_token() -> ResponseReturnValue:
     user = interfaces.user.get_user_by_azure_ad_subject_id(azure_ad_subject_id=sso_user["sub"])
 
     # Platform admin route
-    if "FSD_ADMIN" in sso_user.get("roles", []):
+    if "FS_PLATFORM_ADMIN" in sso_user.get("roles", []):
         user = interfaces.user.upsert_user_and_set_platform_admin_role(
             azure_ad_subject_id=sso_user["sub"], email_address=sso_user["preferred_username"], name=sso_user["name"]
         )

--- a/app/common/auth/authorisation_helper.py
+++ b/app/common/auth/authorisation_helper.py
@@ -20,12 +20,6 @@ class AuthorisationHelper:
 
     @staticmethod
     def is_platform_admin(user: User | AnonymousUserMixin) -> bool:
-        # TODO: This is currently all FSD_ADMIN users; we will soon have two separate Azure AD groups - one for
-        #       Funding Service users (who can eg create and manage monitoring reports) who will stay in FSD_ADMIN,
-        #       and another for Funding Service platform admins (FSD_PLATFORM_ADMIN) who will be able to access the
-        #       Flask-Admin panel for super-user tasks. We'll probably add a new permission/role PLATFORM_ADMIN for
-        #       that azure AD group, and then potentially have Funding Service admin users be managed through that
-        #       rather than the FSD_ADMIN group.
         if isinstance(user, AnonymousUserMixin):
             return False
         return any(

--- a/stubs/sso/__init__.py
+++ b/stubs/sso/__init__.py
@@ -161,7 +161,7 @@ def create_sso_stub_app() -> Flask:
                 "oid": "",
                 "preferred_username": email_address,
                 "rh": "",
-                "roles": ["FSD_ADMIN"] if is_platform_admin else [],
+                "roles": ["FS_PLATFORM_ADMIN"] if is_platform_admin else [],
                 "sid": "",
                 "sub": hashlib.md5(email_address.encode("utf_8")).hexdigest(),
                 "tid": "",

--- a/tests/integration/common/auth/test_auth.py
+++ b/tests/integration/common/auth/test_auth.py
@@ -203,7 +203,7 @@ class TestSSOSignInView:
 
 
 class TestSSOGetTokenView:
-    def test_get_without_fsd_admin_role_and_with_no_assigned_roles(self, app, anonymous_client):
+    def test_get_without_fs_platform_admin_role_and_with_no_assigned_roles(self, app, anonymous_client):
         with patch("app.common.auth.build_msal_app") as mock_build_msap_app:
             # Partially mock the expected return value; just enough for the test.
             mock_build_msap_app.return_value.acquire_token_by_auth_code_flow.return_value = {
@@ -270,7 +270,7 @@ class TestSSOGetTokenView:
                 "id_token_claims": {
                     "preferred_username": "test@test.communities.gov.uk",
                     "name": "SSO User",
-                    "roles": ["FSD_ADMIN"],
+                    "roles": ["FS_PLATFORM_ADMIN"],
                     "sub": "subject_id",
                 }
             }
@@ -294,7 +294,7 @@ class TestSSOGetTokenView:
                 "id_token_claims": {
                     "preferred_username": "test.member@communities.gov.uk",
                     "name": "SSO User",
-                    "roles": ["FSD_ADMIN"],
+                    "roles": ["FS_PLATFORM_ADMIN"],
                     "sub": "abc123",
                 }
             }
@@ -304,7 +304,7 @@ class TestSSOGetTokenView:
         assert response.status_code == 200
         assert AuthorisationHelper.is_platform_admin(user)
 
-    def test_platform_admin_with_fsd_admin_role_removed(self, anonymous_client, factories, db_session):
+    def test_platform_admin_with_fs_platform_admin_role_removed(self, anonymous_client, factories, db_session):
         with patch("app.common.auth.build_msal_app") as mock_build_msal_app:
             user = factories.user.create(email="test.member@communities.gov.uk", azure_ad_subject_id="abc123")
             factories.user_role.create(user=user, role=RoleEnum.ADMIN)
@@ -325,7 +325,7 @@ class TestSSOGetTokenView:
 
         assert response.status_code == 403
 
-    def test_platform_admin_with_grant_member_role_fsd_admin_role_removed(
+    def test_platform_admin_with_grant_member_role_fs_platform_admin_role_removed(
         self, anonymous_client, factories, db_session
     ):
         with patch("app.common.auth.build_msal_app") as mock_build_msal_app:
@@ -366,7 +366,7 @@ class TestSSOGetTokenView:
                 "id_token_claims": {
                     "preferred_username": "test.member@communities.gov.uk",
                     "name": "SSO User",
-                    "roles": ["FSD_ADMIN"],
+                    "roles": ["FS_PLATFORM_ADMIN"],
                     "sub": "wer234",
                 }
             }
@@ -389,7 +389,7 @@ class TestSSOGetTokenView:
                 "id_token_claims": {
                     "preferred_username": "test@communities.gov.uk",
                     "name": "SSO User",
-                    "roles": ["FSD_ADMIN"],
+                    "roles": ["FS_PLATFORM_ADMIN"],
                     "sub": "wer234",
                 }
             }


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-910

## 📝 Description
We now have a new Azure AD group specifically for platform admins on the new Funding Service platform. Previously we had an FSD_ADMINS group, but this was for more than just platform admins - it's also for form designers or any generic
  'funding service' staff/users.

We want to very tightly lock down access to the platform admin panel of the integrated service, so this new group will represent access to that.

All other users will be set up within the service itself, using the service's authorisation models (user/userrole).

After this is merged, anyone with the 'platform admin' permission in the system will have it stripped away if they login and aren't a member of FS_PLATFORM_ADMINS. This will be quite a few of our users; we can manually migrate them using the platform admin user role page.

### Todo

 - [x] After merging/releasing this, we need to run the 'make mhclg form designer' action in flask-admin for all of the relevant people.
 - [ ] And then raise a PR removing the two temporary actions from flask-admin.

## 📸 Show the thing (screenshots, gifs)
<!-- Include screenshots for UI changes, new features, or visual modifications -->
<!-- Use "Before" and "After" sections if showing changes to existing functionality -->

### Before
<!-- Screenshot or description of previous state -->

### After
<!-- Screenshot or description of new state -->

## 🧪 Testing
<!-- Describe how you've tested this change, and how a reviewer can test it -->

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- [x] No N+1 query problems introduced
- [x] Any new DB queries include appropriate where clauses based on the user's permissions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [ ] I need the reviewer(s) to pull and run this change locally
- [ ] New (non-developer) functionality has appropriate unit and integration tests
- [ ] End-to-end tests have been updated (if applicable)
- [ ] Edge cases and error conditions are tested

## 📚 Additional Notes
<!-- Any additional context, concerns, or considerations for reviewers -->
