### PR TITLE
BAU: Switch email used for e2e magic link test

### DIFF
--- a/tests/e2e/test_magic_link_auth.py
+++ b/tests/e2e/test_magic_link_auth.py
@@ -13,7 +13,7 @@ def test_magic_link_redirect_journey(page: Page, domain: str, e2e_test_secrets: 
     # Magic link page is no longer the default unauthenticated redirect so just go through that flow.
     request_a_link_page = RequestALinkToSignInPage(page, domain)
     request_a_link_page.navigate()
-    request_a_link_page.fill_email_address("svc-Preaward-Funds@levellingup.gov.uk")
+    request_a_link_page.fill_email_address("fsd-post-award@levellingup.gov.uk")
     request_a_link_page.click_request_a_link()
 
     page.wait_for_url(re.compile(rf"{domain}/check-your-email/.+"))


### PR DESCRIPTION
## 📝 Description
We recently noticed that e2e test emails to the main service account are going undelivered due to an issue with the email account. This creates a lot of noise in notify and makes it difficult to know if the email failed to send because of something to do with our own app or due to the email address itself.

This swaps it out for a distribution list email which sends to no one but is still a valid email.

## 🧪 Testing
Pull the branch and test locally against the deployed environments (steps in README). The email should show as delivered in Notify.

### Review Readiness
- [X] PR title and description provide sufficient context for reviewers
- [X] Commits are logical, self-contained, and have clear descriptions

### Testing
- [X] I have tested this change and it meets the acceptance criteria for the ticket
- ~[ ] I need the reviewer(s) to pull and run this change locally~
- ~[ ] New (non-developer) functionality has appropriate unit and integration tests~
- [X] End-to-end tests have been updated (if applicable)
- ~[ ] Edge cases and error conditions are tested~
