### PR TITLE
FSPT-918: use google registry mirror

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -63,6 +63,7 @@ jobs:
           ECR_IMAGE_URI="$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$REPO_NAME:$IMAGE_TAG"
           echo "::add-mask::$ECR_IMAGE_URI"
 
+          pack config registry-mirrors add index.docker.io --mirror "mirror.gcr.io"
           pack build "$ECR_IMAGE_URI" --builder heroku/builder:24 --publish
 
 


### PR DESCRIPTION
## 🎫 Ticket
N/A BAU

## 📝 Description
Docker Hub outage has drawn attention that the build will fail currently if docker hub is down.

This adds a mirror from google to use as an alternative before falling back to the docker hub default

## 📸 Show the thing (screenshots, gifs)
See example: https://github.com/communitiesuk/funding-service/actions/runs/18647612236/job/53158173566#step:7:22

## 🧪 Testing
Have tested as per above example

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->