### PR TITLE
Remove old admin actions; revoke permissions+invitations

### DIFF
--- a/app/logging.py
+++ b/app/logging.py
@@ -8,6 +8,7 @@ from logging.config import dictConfig
 from os import getpid
 from threading import get_ident as get_thread_ident
 from typing import Any, cast
+from uuid import UUID
 
 from flask import Flask, Response, current_app, request
 from flask.ctx import has_request_context
@@ -175,7 +176,7 @@ class RejectMutableDataStructuresFilter(logging.Filter):
             return record
 
         for _k, v in logging_msg_args.items():
-            if not isinstance(v, str | int | float | bool | None):
+            if not isinstance(v, str | int | float | bool | UUID | None):
                 # We want to only allow basic data types to be logged. There is a security/data protection risk that
                 # comes with logging more complex types like lists and dicts; it is easier to accidentally include
                 # PII, or to make a change in the future that adds it without realising we'll end up logging it out.


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
At the moment we can only revoke invitations by deleting them entirely. It'd be nice to retain the record that an invitation was created, but still make it unusable. We can do this by moving the `expires_at_utc` date forward.

Also makes it possible to remove all permissions from a user. This is a catch-all and we have more fine-grained ability to do this from the User Role tab.

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [-] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested