### PR TITLE
Allow env var to override integration test timeout

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -183,7 +183,9 @@ def _integration_test_timeout(request: FixtureRequest) -> None:
     These tests may talk over the network (eg to the DB), so we need to make some allowance for that, but they should
     still be able to be fairly fast.
     """
-    request.node.add_marker(pytest.mark.fail_slow("250ms", enabled="CI" not in os.environ))
+    request.node.add_marker(
+        pytest.mark.fail_slow(os.environ.get("INTEGRATION_TIMEOUT_MS", "500ms" if "CI" not in os.environ else "1000ms"))
+    )
 
 
 @pytest.fixture(scope="function", autouse=True)


### PR DESCRIPTION
Following discussions in huddles this week we agreed to increase the timeout for integration tests so we get less distracting failures locally. This PR adds support for an environment variable `INTEGRATION_TIMEOUT_MS` to override the value used for the timeout so we get less noisy failures when locally developing. 

It also bumps the default timeout locally to `500ms`, and updates the configuration for CI to use a timeout of `1000ms` (previously there was no timeout)

## Before
<img width="1265" height="239" alt="Screenshot 2025-10-23 at 07 44 27" src="https://github.com/user-attachments/assets/24a7441f-0083-4194-869b-ed9711cc3798" />

`export INTEGRATION_TIMEOUT_MS=500ms`

## After

<img width="1195" height="364" alt="Screenshot 2025-10-23 at 07 49 54" src="https://github.com/user-attachments/assets/2aa90fe3-fba6-4a66-9a31-9598884460c2" />

