### PR TITLE
Fixing too-high rows for groups in question table

### DIFF
--- a/app/deliver_grant_funding/templates/deliver_grant_funding/macros/question_table.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/macros/question_table.html
@@ -62,11 +62,16 @@
         })
       %}
     {% endif %}
+    {% if question.is_group %}
+      {% set value_item={"classes":"govuk-visually-hidden" } %}
+    {% else %}
+      {% set value_item={"text":question.data_type } %}
+    {% endif %}
     {%
       do rows.append(
       {
         "key": {"html": keyHtml, "classes": "govuk-!-width-one-half " + ("govuk-!-font-weight-regular" if not question.is_group else "") },
-        "value": {"text": question.data_type if not question.is_group else "", "classes": "govuk-!-width-one-third" if not actions else ""},
+        "value": value_item,
         "actions": {
           "items": actions,
         } if actions else {},


### PR DESCRIPTION
## 📝 Description
Sometimes we were seeing the grey rows for a nested group take up too much height in the question table. This is because the empty 'value' column (where we would display data type for a question row) was taking up some space. I've made this `visually-hidden` when it's not used (ie for groups) and it gives it enough breathing room to put the links on the same line now.

Could do with further investigation on why that hidden cell still takes up space in the row at some point

## 📸 Show the thing (screenshots, gifs)

### Before
<img width="998" height="365" alt="Screenshot 2025-10-23 at 13 37 03" src="https://github.com/user-attachments/assets/a0072bde-829f-491e-acde-32cad419f6c2" />

### After
<img width="1039" height="315" alt="Screenshot 2025-10-23 at 13 37 31" src="https://github.com/user-attachments/assets/0a71ecd6-3b77-46c4-ad4e-be20eb079a1f" />

