### PR TITLE
FSPT-916: set proxy fix host on deployed envs

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -111,7 +111,7 @@ class _SharedConfig(_BaseConfig):
     SECRET_KEY: str
     WTF_CSRF_ENABLED: bool = True
     PROXY_FIX_PROTO: int = 1  # CloudFront for AWS environments; Caddy for PullPreview
-    PROXY_FIX_HOST: int = 0  # CloudFront doesn't set X-Forwarded-For
+    PROXY_FIX_HOST: int = 1  # We inject X-Forwarded-For using Cloudfront custom headings
     SERVER_NAME: str
 
     # Basic auth


### PR DESCRIPTION
## 🎫 Ticket
[FSPT-916](https://mhclgdigital.atlassian.net/browse/FSPT-916)

## 📝 Description
DEPENDS ON https://github.com/communitiesuk/funding-service-terraform/pull/56 

Add proxyfix host now we are setting X-Forwarded-For header

## 📸 Show the thing (screenshots, gifs)
Have tested on Dev

<img width="364" height="144" alt="Screenshot 2025-10-23 at 13 28 19" src="https://github.com/user-attachments/assets/91f60f81-d794-47cc-9f8b-02ddcda3ea5f" />

Also fixes domain in logs e.g.
<img width="1191" height="30" alt="image (10)" src="https://github.com/user-attachments/assets/de4d7a25-d72d-41fc-818f-f0199f4bf075" />

## 🧪 Testing

Go to the 'User role' tab: https://funding.test.communities.gov.uk/deliver/admin/userrole/
Check one of the entries
Click actions -> delete
It should work (not 403) as base URL is set correctly


[FSPT-916]: https://mhclgdigital.atlassian.net/browse/FSPT-916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ