### PR TITLE
FSPT-850 Add another check your answers page

### DIFF
--- a/app/common/templates/common/macros/collections.html
+++ b/app/common/templates/common/macros/collections.html
@@ -142,10 +142,11 @@
   {% set add_another_contexts = [] %}
   {% set summary_list_rows = [] %}
 
-  {% set context = submission.cached_evaluation_context if add_another_index is none else submission.cached_evaluation_context.with_add_another_context(container, submission, add_another_index=add_another_index) %}
-  {% for question in submission.cached_get_ordered_visible_questions(container, override_context=context if add_another_index is not none else none) %}
-    {# fixme: set if we're in an add another context at the top of this macro and use that everywhere we do add_another_index is not none #}
-    {% if question.add_another_container and add_another_index is none %}
+  {% set is_add_another_group = add_another_index is not none %}
+  {% set context = submission.cached_evaluation_context if not is_add_another_group else submission.cached_evaluation_context.with_add_another_context(container, submission, add_another_index=add_another_index) %}
+
+  {% for question in submission.cached_get_ordered_visible_questions(container, override_context=context if is_add_another_group else none) %}
+    {% if question.add_another_container and not is_add_another_group %}
       {# for the add another context we'll just include one row with a link to the full answers below #}
       {% if question.add_another_container not in (add_another_contexts | map(attribute="container")) %}
         {% set count = submission.get_count_for_add_another(question.add_another_container) %}
@@ -178,7 +179,7 @@
             <p class="govuk-body">You have added {% trans count=count %}{{ count }} answer{% pluralize %}{{ count }} answers{% endtrans %}</p>
 
             <p class="govuk-body">
-              <a href="#{{ question.add_another_container.id }}-answers" class="govuk-link govuk-link--no-visited-state">Answers for {{ question.add_another_container.name | lower }}</a>
+              <a href="#{{ question.add_another_container.id }}-answers" class="govuk-link govuk-link--no-visited-state">Answers for “{{ question.add_another_container.name }}”</a>
             </p>
           {% endset %}
 
@@ -254,16 +255,16 @@
       "rows": summary_list_rows,
       "card": {
         "title": {
-          "text": summary_title if summary_title else "Answer " ~ ((add_another_index + 1) if add_another_index is not none else "")
+          "text": summary_title if summary_title else "Answer " ~ ((add_another_index + 1) if is_add_another_group else "")
         }
-      } if add_another_index is not none else none
+      } if is_add_another_group else none
     })
   }}
 
   {% for context in add_another_contexts %}
     {% if context.count and context.all_answered %}
-      <div class="govuk-!-margin-bottom-6">
-        <h2 class="govuk-heading-m" id="{{ context.container.id }}-answers">Answers for {{ context.container.name | lower }}</h2>
+      <div class="govuk-!-margin-bottom-9">
+        <h2 class="govuk-heading-m" id="{{ context.container.id }}-answers">Answers for “{{ context.container.name }}”</h2>
 
         {% for i in range(context.count) %}
           {{ summary_list_for_answers(context.container, runner, add_another_index=i, summary_title=context.summaries[i].summary_text_line) }}

--- a/tests/integration/deliver_grant_funding/routes/test_runner.py
+++ b/tests/integration/deliver_grant_funding/routes/test_runner.py
@@ -738,7 +738,7 @@ class TestCheckYourAnswers:
         assert response.status_code == 200
         soup = BeautifulSoup(response.data, "html.parser")
         assert "Check your answers" in soup.text
-        assert "Answers for favourite colour details" in soup.text
+        assert "Answers for “Favourite colour details”" in soup.text
         assert soup.find_all("h2", {"class": "govuk-summary-card__title"})[0].text.strip() == "First reason"
         assert soup.find_all("h2", {"class": "govuk-summary-card__title"})[1].text.strip() == "Second reason"
         assert (


### PR DESCRIPTION
GitHub closed/ auto merged into the stacked parent the original while it was still WIP https://github.com/communitiesuk/funding-service/pull/930

This commit updates the check your answers page to:
- show a single row for the whole container if a question is in an add another
  context
- for each add another context it comes across, show a summary list card
  which splits out all of the answers for a final overview

This pattern still needs to go through design thinking and user
feedback, especially on where a user would expect to go back and make
changes and its relation to the add another summary page.

For now this aims to show everything and let you change everything with
the idea that we can refine from there.

<img width="2834" height="2756" alt="funding communities gov localhost_8080_deliver_grant_caf0ce3f-5175-f69c-66a9-41e2c2245845_submissions_fc6f3dad-bafc-4b99-9328-ead1afa9e3c0_check-yours-answers_7255305d-b780-4cbc-9160-4c1d0d419003" src="https://github.com/user-attachments/assets/41fa929b-1fb2-42c6-837d-bf08c855398f" />
