### PR TITLE
Link new grant team members to the reports page

### DIFF
--- a/app/services/notify.py
+++ b/app/services/notify.py
@@ -109,7 +109,7 @@ class NotificationService:
             current_app.config["GOVUK_NOTIFY_MEMBER_CONFIRMATION_TEMPLATE_ID"],
             personalisation={
                 "grant_name": grant.name,
-                "sign_in_url": url_for("deliver_grant_funding.grant_details", grant_id=grant.id, _external=True),
+                "sign_in_url": url_for("deliver_grant_funding.list_reports", grant_id=grant.id, _external=True),
             },
         )
 

--- a/tests/unit/services/test_notify.py
+++ b/tests/unit/services/test_notify.py
@@ -90,7 +90,7 @@ class TestNotificationService:
                         "template_id": "49ba98c5-0573-4c77-8cb0-3baebe70ee86",
                         "personalisation": {
                             "grant_name": grant.name,
-                            "sign_in_url": f"http://funding.communities.gov.localhost:8080/deliver/grant/{grant.id}/details",
+                            "sign_in_url": f"http://funding.communities.gov.localhost:8080/deliver/grant/{grant.id}/reports",
                         },
                     }
                 )


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
Discussed and agreed at a huddle this afternoon. When we invite grant team members, let's link them to the reports tab rather than the grant details page.