### PR TITLE
Show grant recipient organisation name for submissions

### DIFF
--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-011_set_up_grant_recipients
+012_grant_recipient_relationship

--- a/app/common/data/migrations/versions/012_grant_recipient_relationship.py
+++ b/app/common/data/migrations/versions/012_grant_recipient_relationship.py
@@ -1,0 +1,37 @@
+"""set up grant recipient to submissions relationship
+
+Revision ID: 012_grant_recipient_relationship
+Revises: 011_set_up_grant_recipients
+Create Date: 2025-10-29 08:57:24.396260
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "012_grant_recipient_relationship"
+down_revision = "011_set_up_grant_recipients"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("submission", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("grant_recipient_id", sa.Uuid(), nullable=True))
+        batch_op.create_foreign_key(
+            batch_op.f("fk_submission_grant_recipient_id_grant_recipient"),
+            "grant_recipient",
+            ["grant_recipient_id"],
+            ["id"],
+        )
+        batch_op.create_check_constraint(
+            "ck_grant_recipient_if_live",
+            "mode = 'TEST' OR grant_recipient_id IS NOT NULL",
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("submission", schema=None) as batch_op:
+        batch_op.drop_constraint("ck_grant_recipient_if_live", type_="check")
+        batch_op.drop_constraint(batch_op.f("fk_submission_grant_recipient_id_grant_recipient"), type_="foreignkey")
+        batch_op.drop_column("grant_recipient_id")

--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -531,6 +531,16 @@ class CollectionHelper:
         ]
         self.submission_helpers = {s.id: SubmissionHelper(s) for s in self.submissions}
 
+        self.grant_recipients = self.collection.grant.grant_recipients
+        self.grant_recipients_submission_helpers: dict[UUID, SubmissionHelper | None] = {
+            gr.id: None for gr in self.grant_recipients
+        }
+        self.grant_recipients_submission_helpers.update(
+            {s.grant_recipient.id: self.submission_helpers[s.id] for s in self.submissions}
+            if not self.is_test_mode
+            else {}
+        )
+
     @property
     def is_test_mode(self) -> bool:
         return self.submission_mode == SubmissionModeEnum.TEST

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_submissions.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_submissions.html
@@ -42,43 +42,80 @@
     </div>
     <div class="govuk-grid-column-full">
       {% set rows=[] %}
-      {% for submission_helper in helper.submission_helpers.values() %}
-        {# TODO: We should show the organisation/recipient name instead of the user's email address #}
-        {% set link_to_submission %}
-          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.view_submission', grant_id=grant.id, submission_id=submission_helper.submission.id) }}" data-submission-link>
-            {{ submission_helper.submission.created_by.email }}
-          </a>
-        {% endset %}
-        {%
-          do rows.append([
-            {
-              "html": link_to_submission,
-            }, {
-              "html": status(submission_helper.status)
-            }, {
-              "text": format_date_short(submission_helper.submission.updated_at_utc)
-            }
-          ])
-        %}
+      {% if helper.is_test_mode %}
+        {% for submission_helper in helper.submission_helpers.values() %}
+          {% set link_to_submission %}
+            <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.view_submission', grant_id=grant.id, submission_id=submission_helper.submission.id) }}" data-submission-link>
+              {{ submission_helper.submission.created_by.email }}
+            </a>
+          {% endset %}
+          {%
+            do rows.append([
+              {
+                "html": link_to_submission,
+              }, {
+                "html": status(submission_helper.status)
+              }, {
+                "text": format_date_short(submission_helper.submission.updated_at_utc)
+              }
+            ])
+          %}
+        {% else %}
+          {% set no_collections_text %}
+            <span><i>No submissions found for this monitoring report</i></span>
+          {% endset %}
+          {%
+            do rows.append([
+              {
+                "html": no_collections_text,
+                "colspan": 3
+              }
+            ])
+          %}
+        {% endfor %}
       {% else %}
-        {% set no_collections_text %}
-          <span><i>No submissions found for this monitoring report</i></span>
-        {% endset %}
-        {%
-          do rows.append([
-            {
-              "html": no_collections_text,
-              "colspan": 3
-            }
-          ])
-        %}
-      {% endfor %}
+        {% for grant_recipient in helper.grant_recipients %}
+          {% set grant_recipient_submission_helper = helper.grant_recipients_submission_helpers[grant_recipient.id] %}
+          {% set link_to_submission %}
+            {% if grant_recipient_submission_helper %}
+              <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.view_submission', grant_id=grant.id, submission_id=grant_recipient_submission_helper.submission.id) }}" data-submission-link>
+                {{ grant_recipient.organisation.name }}
+              </a>
+            {% else %}
+              {{ grant_recipient.organisation.name }}
+            {% endif %}
+          {% endset %}
+          {%
+            do rows.append([
+              {
+                "html": link_to_submission,
+              }, {
+                "html": status(grant_recipient_submission_helper.status if grant_recipient_submission_helper else enum.submission_status.NOT_STARTED)
+              }, {
+                "text": format_date_short(grant_recipient_submission_helper.submission.updated_at_utc) if grant_recipient_submission_helper else ''
+              }
+            ])
+          %}
+        {% else %}
+          {% set no_collections_text %}
+            <span><i>No submissions found for this monitoring report</i></span>
+          {% endset %}
+          {%
+            do rows.append([
+              {
+                "html": no_collections_text,
+                "colspan": 3
+              }
+            ])
+          %}
+        {% endfor %}
+      {% endif %}
 
       {{
         govukTable({
           "captionClasses": "govuk-table__caption--m",
           "head": [
-            { "text": "Recipient", "classes": "govuk-!-width-one-half" },
+            { "text": "User" if helper.is_test_mode else "Grant recipient", "classes": "govuk-!-width-one-half" },
             { "text": "Status" },
             { "text": "Last updated" }
           ],

--- a/tests/models.py
+++ b/tests/models.py
@@ -645,6 +645,11 @@ class _SubmissionFactory(SQLAlchemyModelFactory):
     collection_id = factory.LazyAttribute(lambda o: o.collection.id)
     collection_version = factory.LazyAttribute(lambda o: o.collection.version)
 
+    grant_recipient = factory.LazyAttribute(
+        lambda o: _GrantRecipientFactory.create() if o.mode == SubmissionModeEnum.LIVE else None
+    )
+    grant_recipient_id = factory.LazyAttribute(lambda o: o.grant_recipient.id if o.grant_recipient else None)
+
 
 class _FormFactory(SQLAlchemyModelFactory):
     class Meta:


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-939

## 📝 Description
Now that we have a GrantRecipient model, we can update the 'list submissions' page to show the recipient's organisation name instead of the user who created the submission when we're looking at live submissions.

## 📸 Show the thing (screenshots, gifs)
<!-- Include screenshots for UI changes, new features, or visual modifications -->
<!-- Use "Before" and "After" sections if showing changes to existing functionality -->

### Test submissions
<img width="1023" height="865" alt="image" src="https://github.com/user-attachments/assets/49becc7f-096c-41f0-b0bb-e2e7ca52f09f" />

### Live submissions
<img width="999" height="850" alt="image" src="https://github.com/user-attachments/assets/90d9d379-5c4d-48b5-8aa2-ad1bce705bc3" />

## 🧪 Testing
<!-- Describe how you've tested this change, and how a reviewer can test it -->

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested