### PR TITLE
Always include a link to live submissions

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -29,7 +29,10 @@ class DatabaseSecret(BaseModel):
 FS_CONTENT_SECURITY_POLICY = {
     "default-src": ["'self'"],
     "script-src": ["'self'"],
-    "img-src": ["'self'"],
+    "img-src": [
+        "'self'",
+        "data:",  # Flask-Admin's select-with-search "x" icon for deleting selections
+    ],
     "style-src": [
         "'self'",
         "'unsafe-hashes'",
@@ -57,7 +60,6 @@ def make_development_csp() -> dict[str, list[str]]:
         [
             "http://localhost:5173",  # Vite assets
             "ws://localhost:5173",  # Vite assets
-            "data:",  # Flask-Admin's select-with-search "x" icon for deleting selections
         ]
     )
     csp["style-src"].extend(

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_reports.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_reports.html
@@ -59,23 +59,27 @@
           {% endset %}
 
 
-          {% set submissionsText %}
-            {# TODO: Once reports have a draft/live status, this should also take that into account (ie if live, only show live submissions) #}
-            {% if report.live_submissions %}
-              {% trans count=report.live_submissions | length %}{{ count }} submission{% pluralize %}{{ count }} submissions{% endtrans %}
-            {% else %}
-              {% trans count=report.test_submissions | length %}{{ count }} test submission{% pluralize %}{{ count }} test submissions{% endtrans %}
-            {% endif %}
-            <span class="govuk-visually-hidden">for {{ report.name }}</span>
+          {% set liveSubmissionsText %}
+            {% trans count=report.live_submissions | length %}{{ count }} live submission{% pluralize %}{{ count }} live submissions{% endtrans %} <span class="govuk-visually-hidden">for {{ report.name }}</span>
+          {% endset %}
+          {% set testSubmissionsText %}
+            {% trans count=report.test_submissions | length %}{{ count }} test submission{% pluralize %}{{ count }} test submissions{% endtrans %} <span class="govuk-visually-hidden">for {{ report.name }}</span>
           {% endset %}
 
 
           {% set submissionsHtml %}
-            <a
-              class="govuk-link govuk-link--no-visited-state"
-              href="{{ url_for('deliver_grant_funding.list_submissions', grant_id=grant.id, report_id=report.id, submission_mode=enum.submission_mode.LIVE if report.live_submissions else enum.submission_mode.TEST) }}">
-              {{ submissionsText }}
-            </a>
+            <p class="govuk-body">
+              <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.list_submissions', grant_id=grant.id, report_id=report.id, submission_mode=enum.submission_mode.LIVE) }}">
+                {{ liveSubmissionsText }}
+              </a>
+            </p>
+
+            {# TODO: hide test submissions link when the reporting round status is live #}
+            <p class="govuk-body">
+              <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.list_submissions', grant_id=grant.id, report_id=report.id, submission_mode=enum.submission_mode.TEST) }}">
+                {{ testSubmissionsText }}
+              </a>
+            </p>
           {% endset %}
 
           {% set actions = [] %}

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -102,10 +102,16 @@ class TestListReports:
         soup = BeautifulSoup(response.data, "html.parser")
         assert grant.name in soup.text
 
-        review_submissions_links = page_has_link(soup, "0 test submissions")
-        assert review_submissions_links is not None
-        assert review_submissions_links.get("href") == AnyStringMatching(
+        test_submission_links = page_has_link(soup, "0 test submissions")
+        assert test_submission_links is not None
+        assert test_submission_links.get("href") == AnyStringMatching(
             r"/deliver/grant/[a-z0-9-]{36}/report/[a-z0-9-]{36}/submissions/test"
+        )
+
+        live_submissions_links = page_has_link(soup, "0 live submissions")
+        assert live_submissions_links is not None
+        assert live_submissions_links.get("href") == AnyStringMatching(
+            r"/deliver/grant/[a-z0-9-]{36}/report/[a-z0-9-]{36}/submissions/live"
         )
 
         expected_links = [


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-939

## 📝 Description
During sign-off of the above, Christian flagged that it would be good if grant teams could see the grant recipients we've set up for this.

This patch will allow the grant team to see a list of all of the grant recipients we have set up for their grant, which allows us to pass that QA check to them and should help catch a situation where they might have forgotten to tell us about one or more recipients.

We'll hide the link to view test submissions when the reporting round is live.

## 📸 Show the thing (screenshots, gifs)
<img width="1020" height="931" alt="image" src="https://github.com/user-attachments/assets/11667c67-315a-438c-bb7f-760887adff3f" />

## 🧪 Testing
<!-- Describe how you've tested this change, and how a reviewer can test it -->

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [-] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested