### PR TITLE
FSPT-850 View submission works for add another

### DIFF
--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/view_submission.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/view_submission.html
@@ -15,6 +15,116 @@
   {{ deliver_grant_funding_reports_breadcrumb(grant=grant, report=helper.submission.collection, immediate_parent_breadcrumb_item={"text": "Submissions", "href": url_for("deliver_grant_funding.list_submissions", grant_id=grant.id, report_id=helper.submission.collection.id, submission_mode=helper.submission.mode)}, this_page_breadcrumb_item={"text": helper.submission.created_by.email}) }}
 {% endblock beforeContent %}
 
+{# todo: this can probably be combined with the macro in the form runner, there are quite a few subtle differences #}
+{#       so should be well covered if done #}
+{% macro answers_summary_list(container, add_another_index=none, summary_title=none) %}
+  {# each container context will have its own summary list which we'll populate at the end of this macro #}
+  {% set add_another_contexts = [] %}
+  {% set rows = [] %}
+
+  {% set is_add_another_group = add_another_index is not none %}
+  {% set context = helper.cached_evaluation_context if not is_add_another_group else helper.cached_evaluation_context.with_add_another_context(container, helper, add_another_index=add_another_index) %}
+
+  {% for question in helper.cached_get_ordered_visible_questions(container, override_context=context if is_add_another_group else none) %}
+
+    {% if question.add_another_container and not is_add_another_group %}
+      {# for the add another context we'll just include one row with a link to the full answers below #}
+      {% if question.add_another_container not in (add_another_contexts | map(attribute="container")) %}
+        {% set count = helper.get_count_for_add_another(question.add_another_container) %}
+        {% set summaries = [] %}
+        {% set status = namespace(all_answered = true) %}
+        {% for i in range(count) %}
+          {% set (summary, is_answered) = helper.get_answer_summary_for_add_another(question.add_another_container, add_another_index=i) %}
+          {%
+            do summaries.append({
+              "summary_text_line": summary,
+              "is_answered": is_answered
+            })
+          %}
+          {% if not is_answered %}{% set status.all_answered = false %}{% endif %}
+        {% endfor %}
+        {%
+          do add_another_contexts.append({
+            "container": question.add_another_container,
+            "count": count,
+            "summaries": summaries,
+            "all_answered": status.all_answered
+          })
+        %}
+
+        {% set key_text = interpolate(question.add_another_container.name) %}
+
+
+        {% set value_html %}
+          <p class="govuk-body">There {% trans count=count %}is {{ count }} answer{% pluralize %}are {{ count }} answers{% endtrans %}</p>
+          {% if count %}
+            <p class="govuk-body">
+              <a href="#{{ question.add_another_container.id }}-answers" class="govuk-link govuk-link--no-visited-state">Answers for “{{ question.add_another_container.name }}”</a>
+            </p>
+          {% endif %}
+        {% endset %}
+        {%
+          do rows.append({
+              "key": {"text": key_text, "classes": "govuk-!-font-weight-regular" },
+              "value": {"html": value_html },
+          })
+        %}
+      {% endif %}
+    {% else %}
+      {% set answer = helper.cached_get_answer_for_question(question.id, add_another_index=add_another_index) %}
+      {% set value_html %}
+        {% if answer %}
+          {% include answer._render_answer_template %}
+        {% else %}
+          (Not answered)
+        {% endif %}
+      {% endset %}
+
+      {% if is_add_another_group %}
+        {% set context = helper.cached_interpolation_context.with_add_another_context(container, helper, add_another_index=add_another_index) %}
+        {% set key_text = interpolate(question.text, context=context) %}
+      {% else %}
+        {% set key_text = interpolate(question.text) %}
+      {% endif %}
+      {%
+        do rows.append({
+          "key": {
+            "text": key_text,
+            "classes": "govuk-!-font-weight-regular",
+          },
+          "value": {
+            "text": value_html
+          }
+        })
+      %}
+    {% endif %}
+  {% endfor %}
+
+  {{
+    govukSummaryList({
+      "rows": rows,
+      "attributes":{"data-testid":container.title if container.title else container.form.title},
+      "card": {
+        "title": {
+          "text": summary_title if summary_title else "Answer " ~ ((add_another_index + 1) if is_add_another_group else "")
+        }
+      } if is_add_another_group else none
+    })
+  }}
+
+  {% for add_another_context in add_another_contexts %}
+    {% if add_another_context.count %}
+      <div class="govuk-!-margin-bottom-9">
+        <h3 class="govuk-heading-s" id="{{ add_another_context.container.id }}-answers">{{ add_another_context.container.name }}</h3>
+
+        {% for i in range(add_another_context.count) %}
+          {{ answers_summary_list(add_another_context.container, add_another_index=i, summary_title=add_another_context.summaries[i].summary_text_line) }}
+        {% endfor %}
+      </div>
+    {% endif %}
+  {% endfor %}
+{% endmacro %}
+
 {% block content %}
   <span class="govuk-caption-l">{{ helper.submission.created_by.email }}</span>
   <div class="app-aligned-header-tag govuk-!-margin-bottom-6">
@@ -24,35 +134,6 @@
 
   {% for form in helper.get_ordered_visible_forms() %}
     <h2 class="govuk-heading-m govuk-!-margin-top-4">{{ form.title }}</h2>
-    {% set rows = [] %}
-    {% for question in helper.cached_get_ordered_visible_questions(form) %}
-
-      {% set answer = helper.cached_get_answer_for_question(question.id) %}
-      {% set value_html %}
-        {% if answer %}
-          {% include answer._render_answer_template %}
-        {% else %}
-          (Not answered)
-        {% endif %}
-      {% endset %}
-      {%
-        do rows.append({
-          "key": {
-            "text": interpolate(question.text),
-            "classes": "govuk-!-font-weight-regular",
-          },
-          "value": {
-            "text": value_html
-          }
-        })
-      %}
-    {% endfor %}
-
-    {{
-      govukSummaryList({
-        "rows": rows,
-        "attributes":{"data-testid":form.title}
-      })
-    }}
+    {{ answers_summary_list(form) }}
   {% endfor %}
 {% endblock content %}

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -5203,3 +5203,43 @@ class TestViewSubmission:
 
         assert "When did you last buy some cheese" in soup.text
         assert "1 January 2025" in soup.text
+
+    def test_get_view_submission_displays_questions_with_add_another(self, authenticated_grant_admin_client, factories):
+        collection = factories.collection.create(
+            grant=authenticated_grant_admin_client.grant,
+            create_completed_submissions_add_another_nested_group__test=1,
+            create_completed_submissions_add_another_nested_group__use_random_data=False,
+        )
+        response = authenticated_grant_admin_client.get(
+            url_for(
+                "deliver_grant_funding.view_submission",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                submission_id=collection.test_submissions[0].id,
+            )
+        )
+
+        assert response.status_code == 200
+        soup = BeautifulSoup(response.data, "html.parser")
+
+        assert "There are 5 answers" in soup.text
+
+        assert (
+            len(
+                [
+                    key
+                    for key in soup.find_all("dt", {"class": "govuk-summary-list__key"})
+                    if key.text.strip() == "What is the name of this person?"
+                ]
+            )
+            == 5
+        )
+        assert (
+            len(
+                [
+                    key
+                    for key in soup.find_all("dt", {"class": "govuk-summary-list__key"})
+                    if key.text.strip() == "What is this person's email address?"
+                ]
+            )
+            == 5
+        )


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-850

## 📝 Description
Main goal for now is to stop the view submission page from failing if you're configured for add another. 

This commit needs to decide if we'll go for one summary list component that knows how to do this between check your answers and the form runner or if we're OK with two.

I think its likely you'd want to "step in" to see the grouped answers as an assessor/ reviewer so the pattern might be different in the future anyway.

For now we're using a separate macro with a similar strategy, the headings, keys and actions for the view submission page are all different too.

## 📸 Show the thing (screenshots, gifs)

<img width="2060" height="2855" alt="funding communities gov localhost_8080_deliver_grant_caf0ce3f-5175-f69c-66a9-41e2c2245845_submission_596396af-3adc-483b-b0fd-7e3e24693037" src="https://github.com/user-attachments/assets/82c4f13e-59ab-4b21-a3a2-0e32ec5c3fef" />

