### PR TITLE
Prevent users inserting references to same-page questions

### DIFF
--- a/app/common/forms/helpers.py
+++ b/app/common/forms/helpers.py
@@ -1,10 +1,10 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
-    from app.common.data.models import Component, Form, Question
+    from app.common.data.models import Component, Form, Group, Question
 
 
-def questions_in_same_page_group(c1: "Component", c2: "Component") -> bool:
+def questions_in_same_page_group(c1: "Question", c2: "Component") -> bool:
     """
     Check if two components are in the same group and that group shows on the same page.
     If they are then they shouldn't reference each other.
@@ -12,7 +12,9 @@ def questions_in_same_page_group(c1: "Component", c2: "Component") -> bool:
     Note: this relies on a current tech/product constraint that the "same page" setting can only be turned on for the
     leaf group in a set of nested groups (so we don't have to check parent groups for the same-page setting).
     """
-    return True if c1.parent and c2.parent and c1.parent == c2.parent and c1.parent.same_page else False
+    c2_parent: "Group | None" = cast("Group", c2) if c2.is_group else cast("Group | None", c2.parent)
+
+    return True if c1.parent and c2_parent and c1.parent == c2_parent and c2_parent.same_page else False
 
 
 def questions_in_same_add_another_container(q1: "Component", q2: "Component") -> bool:
@@ -26,26 +28,47 @@ def questions_in_same_add_another_container(q1: "Component", q2: "Component") ->
     )
 
 
-def get_referenceable_questions(form: "Form", current_component: "Component | None" = None) -> list["Question"]:
+def get_referenceable_questions(
+    form: "Form", current_component: "Component | None" = None, parent_component: "Group | None" = None
+) -> list["Question"]:
     """
     Return a list of questions from the current form that could be referenced from the current component, determined by:
     - Question comes before the current component in the form
     - Question is not in the same 'same page' page group as the current component
     - Question is not in an add another group, or if it is it's in the same add another group as the current component
 
-    If current component is None then return all cached questions in the form.
+    If current component is None then return all cached questions in the form. Current component will be none when the
+    user is trying to reference questions while in the *add question* flow, ie that question hasn't yet been persisted
+    to the DB at all.
+
+    If parent component is None then we're adding a question to the top-level of the section, which will add it to the
+    end and therefore all questions are initially in-scope. If parent component is not None, then it's being added to a
+    group and only questions before that in the global order should be available).
     """
     questions = form.cached_questions
+    limit_to_components_before = current_component
 
-    if current_component is None:
+    # Adding a question directly within a section
+    if current_component is None and parent_component is None:
         return questions
-    else:
-        return [
-            q
-            for q in questions
-            if (
-                form.global_component_index(q) < form.global_component_index(current_component)
-                and not questions_in_same_page_group(q, current_component)
-                and (questions_in_same_add_another_container(q, current_component) or not q.add_another_container)
-            )
-        ]
+
+    # Adding a question within a group
+    elif current_component is None and parent_component is not None:
+        limit_to_components_before = (
+            parent_component
+            if parent_component.same_page or len(parent_component.cached_questions) == 0
+            else parent_component.cached_questions[-1]
+        )
+
+    assert limit_to_components_before is not None
+    questions = [
+        q
+        for q in questions
+        if (
+            (not current_component or q != limit_to_components_before)
+            and form.global_component_index(q) <= form.global_component_index(limit_to_components_before)
+            and not questions_in_same_page_group(q, limit_to_components_before)
+            and (questions_in_same_add_another_container(q, limit_to_components_before) or not q.add_another_container)
+        )
+    ]
+    return questions

--- a/app/deliver_grant_funding/routes/reports.py
+++ b/app/deliver_grant_funding/routes/reports.py
@@ -895,6 +895,7 @@ def _store_question_state_and_redirect_to_add_context(
             add_context_data = AddContextToComponentGuidanceSessionModel(
                 component_form_data=cast(dict[str, Any], form_data),
                 component_id=question_id,
+                parent_id=parent_id,
                 is_add_another_guidance=is_add_another_guidance,
             )
         case _ManagedExpressionForm():
@@ -903,6 +904,7 @@ def _store_question_state_and_redirect_to_add_context(
                 managed_expression_name=managed_expression_name,  # type: ignore[arg-type]
                 expression_form_data=form_data,  # type: ignore[arg-type]
                 component_id=question_id,  # type: ignore[arg-type]
+                parent_id=parent_id,
                 expression_id=expression_id,
                 depends_on_question_id=depends_on_question_id,
             )
@@ -1050,6 +1052,7 @@ def select_context_source(grant_id: UUID, form_id: UUID) -> ResponseReturnValue:
     wtform = AddContextSelectSourceForm(
         form=db_form,
         current_component=get_component_by_id(add_context_data.component_id) if add_context_data.component_id else None,
+        parent_component=get_group_by_id(add_context_data.parent_id) if add_context_data.parent_id else None,
     )
     if wtform.validate_on_submit():
         add_context_data.data_source = ExpressionContext.ContextSources[wtform.data_source.data]
@@ -1097,6 +1100,7 @@ def select_context_source_question(grant_id: UUID, form_id: UUID) -> ResponseRet
         form=db_form,
         interpolate=SubmissionHelper.get_interpolator(collection=db_form.collection),
         current_component=current_component,
+        parent_component=get_group_by_id(add_context_data.parent_id) if add_context_data.parent_id else None,
         expression=isinstance(add_context_data, AddContextToExpressionsModel),
     )
 
@@ -1214,7 +1218,12 @@ def edit_question(grant_id: UUID, question_id: UUID) -> ResponseReturnValue:  # 
     if wt_form.is_submitted_to_add_context():
         form_data = wt_form.get_component_form_data()
         return _store_question_state_and_redirect_to_add_context(
-            wt_form, grant_id=grant_id, form_id=question.form_id, question_id=question.id, form_data=form_data
+            wt_form,
+            grant_id=grant_id,
+            form_id=question.form_id,
+            question_id=question.id,
+            parent_id=question.parent_id,
+            form_data=form_data,
         )
 
     confirm_deletion_form = GenericConfirmDeletionForm()
@@ -1340,6 +1349,7 @@ def manage_add_another_guidance(grant_id: UUID, group_id: UUID) -> ResponseRetur
             grant_id=grant_id,
             form_id=group.form_id,
             question_id=group_id,
+            parent_id=group.parent_id,
             form_data=form_data,
             is_add_another_guidance=True,
         )
@@ -1408,6 +1418,7 @@ def manage_guidance(grant_id: UUID, question_id: UUID) -> ResponseReturnValue:
             grant_id=grant_id,
             form_id=question.form_id,
             question_id=question_id,
+            parent_id=question.parent_id,
             form_data=form_data,
         )
 
@@ -1530,6 +1541,7 @@ def add_question_condition(grant_id: UUID, component_id: UUID, depends_on_questi
             grant_id=grant_id,
             form_id=component.form.id,
             question_id=component.id,
+            parent_id=component.parent_id,
             form_data=form_data,
             expression_type=ExpressionType.CONDITION,
             managed_expression_name=ManagedExpressionsEnum(form.type.data),
@@ -1634,6 +1646,7 @@ def edit_question_condition(grant_id: UUID, expression_id: UUID) -> ResponseRetu
             grant_id=grant_id,
             form_id=component.form.id,
             question_id=component.id,
+            parent_id=component.parent_id,
             form_data=form_data,
             expression_type=ExpressionType.CONDITION,
             managed_expression_name=ManagedExpressionsEnum(form.type.data),
@@ -1711,6 +1724,7 @@ def add_question_validation(grant_id: UUID, question_id: UUID) -> ResponseReturn
             grant_id=grant_id,
             form_id=question.form.id,
             question_id=question.id,
+            parent_id=question.parent_id,
             form_data=form_data,
             expression_type=ExpressionType.VALIDATION,
             managed_expression_name=ManagedExpressionsEnum(form.type.data),
@@ -1803,6 +1817,7 @@ def edit_question_validation(grant_id: UUID, expression_id: UUID) -> ResponseRet
             grant_id=grant_id,
             form_id=question.form.id,
             question_id=question.id,
+            parent_id=question.parent_id,
             form_data=form_data,
             expression_type=ExpressionType.VALIDATION,
             managed_expression_name=ManagedExpressionsEnum(form.type.data),

--- a/app/deliver_grant_funding/session_models.py
+++ b/app/deliver_grant_funding/session_models.py
@@ -45,6 +45,7 @@ class AddContextToComponentGuidanceSessionModel(BaseModel):
     component_form_data: dict[str, Any]
 
     component_id: UUID | None = None
+    parent_id: UUID | None = None
 
     is_add_another_guidance: bool | None = False
 
@@ -60,6 +61,7 @@ class AddContextToExpressionsModel(BaseModel):
     managed_expression_name: ManagedExpressionsEnum
     expression_form_data: dict[str, Any]
     component_id: UUID
+    parent_id: UUID | None = None
 
     data_source: ExpressionContext.ContextSources | None = None
     depends_on_question_id: UUID | None = None

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/select_context_source_question.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/select_context_source_question.html
@@ -23,18 +23,26 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-l">Question {{ heading_caption }}</span>
+      {% if form.question.choices | length > 0 %}
+        <span class="govuk-caption-l">Question {{ heading_caption }}</span>
 
-      <form method="post" novalidate>
-        {{ form.csrf_token }}
-        {{ form.question(params={"label": {"text": form.question.label.text, "isPageHeading": true, "classes": "govuk-fieldset__legend--l"} }) }}
+        <form method="post" novalidate>
+          {{ form.csrf_token }}
+          {{ form.question(params={"label": {"text": form.question.label.text, "isPageHeading": true, "classes": "govuk-fieldset__legend--l"} }) }}
 
-        <span class="govuk-button-group">
-          {{ form.submit(params={"text": "Reference data"}) }}
+          <span class="govuk-button-group">
+            {{ form.submit(params={"text": "Reference data"}) }}
 
-          <a class="govuk-link govuk-link--no-visited-state" href="{{ cancel_url }}">Cancel</a>
-        </span>
-      </form>
+            <a class="govuk-link govuk-link--no-visited-state" href="{{ cancel_url }}">Cancel</a>
+          </span>
+        </form>
+      {% else %}
+        <h1 class="govuk-heading-l">
+          <span class="govuk-caption-l">Question {{ heading_caption }}</span>
+          {{ form.question.label.text }}
+        </h1>
+        <p class="govuk-body">There are no questions available to reference.</p>
+      {% endif %}
     </div>
   </div>
 {% endblock content %}

--- a/tests/unit/common/forms/test_helpers.py
+++ b/tests/unit/common/forms/test_helpers.py
@@ -129,6 +129,30 @@ class TestGetReferenceableQuestions:
 
         assert referenceable_questions == [q1]
 
+    def test_includes_questions_in_group_if_not_same_page_when_creating_questions(self, factories):
+        form = factories.form.build()
+        q1 = factories.question.build(form=form)
+        group = factories.group.build(
+            form=form, presentation_options=QuestionPresentationOptions(show_questions_on_the_same_page=False)
+        )
+        q2 = factories.question.build(form=form, parent=group)
+
+        referenceable_questions = get_referenceable_questions(form, current_component=None, parent_component=group)
+
+        assert referenceable_questions == [q1, q2]
+
+    def test_filters_out_same_page_question_when_creating_questions(self, factories):
+        form = factories.form.build()
+        q1 = factories.question.build(form=form)
+        group = factories.group.build(
+            form=form, presentation_options=QuestionPresentationOptions(show_questions_on_the_same_page=True)
+        )
+        factories.question.build(form=form, parent=group)
+
+        referenceable_questions = get_referenceable_questions(form, current_component=None, parent_component=group)
+
+        assert referenceable_questions == [q1]
+
     def test_filters_out_add_another_question(self, factories):
         form = factories.form.build()
         factories.question.build(form=form, add_another=True)

--- a/tests/unit/deliver_grant_funding/test_forms.py
+++ b/tests/unit/deliver_grant_funding/test_forms.py
@@ -272,8 +272,8 @@ class TestSelectDataSourceQuestionForm:
             current_component=questions[2],
         )
 
-        assert len(form.question.choices) == 1
-        assert {q[0] for q in form.question.choices} == {""}
+        assert len(form.question.choices) == 0
+        assert form.question.choices == []
 
     def test_show_all_question_datatypes_if_no_expression(self, app, factories, mocker):
         text_question = factories.question.build(data_type=QuestionDataType.TEXT_SINGLE_LINE)


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
When a user is creating a question within a same-page group, we were showing them all of the questions in that same-page group in the 'reference data from a previous question in this section' dropdown.

These references are invalid: you cannot reference data from a question that shows on the same page, because that question hasn't been answered yet.

We should exclude these questions from the dropdown.

## 📸 Show the thing (screenshots, gifs)
<!-- Include screenshots for UI changes, new features, or visual modifications -->
<!-- Use "Before" and "After" sections if showing changes to existing functionality -->

### Before
![2025-10-30 12 43 01](https://github.com/user-attachments/assets/cb023e33-baed-42ae-8399-e68b5fae1b25)


### After
![2025-10-30 12 42 07](https://github.com/user-attachments/assets/476c9d48-cf06-40fa-bfc1-a920716d8580)


## 🧪 Testing
<!-- Describe how you've tested this change, and how a reviewer can test it -->

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [ ] Commits are logical, self-contained, and have clear descriptions

### Testing
- [ ] I have tested this change and it meets the acceptance criteria for the ticket
- [ ] I need the reviewer(s) to pull and run this change locally
- [ ] New (non-developer) functionality has appropriate unit and integration tests
- [ ] End-to-end tests have been updated (if applicable)
- [ ] Edge cases and error conditions are tested