### PR TITLE
Remove Collection versioning

### DIFF
--- a/app/common/data/interfaces/exceptions.py
+++ b/app/common/data/interfaces/exceptions.py
@@ -17,6 +17,7 @@ class DuplicateValueError(Exception):
     constraint_name_map: dict[str, str] = {
         "uq_grant_name": "name",
         "uq_collection_name_version_grant_id": "name",
+        "uq_collection_name_grant_id": "name",
         "uq_form_title_collection": "title",
         "uq_form_slug_collection": "title",
         "uq_collection_slug_grant_id": "name",

--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-015_add_collection_status
+016_remove_collection_versioning

--- a/app/common/data/migrations/versions/015_add_collection_status.py
+++ b/app/common/data/migrations/versions/015_add_collection_status.py
@@ -1,6 +1,6 @@
 """add collection status
 
-Revision ID: 014_add_collection_status
+Revision ID: 015_add_collection_status
 Revises: 014_add_collection_dates
 Create Date: 2025-11-02 10:17:37.041932
 

--- a/app/common/data/migrations/versions/016_remove_collection_versioning.py
+++ b/app/common/data/migrations/versions/016_remove_collection_versioning.py
@@ -1,0 +1,114 @@
+"""remove collection versioning
+
+Revision ID: 016_remove_collection_versioning
+Revises: 015_add_collection_status
+Create Date: 2025-10-31
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "016_remove_collection_versioning"
+down_revision = "015_add_collection_status"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # 1. Drop foreign keys that reference composite (collection_id, collection_version)
+    op.drop_constraint(op.f("fk_submission_collection_id_collection"), "submission", type_="foreignkey")
+    op.drop_constraint(op.f("fk_form_collection_id_collection"), "form", type_="foreignkey")
+
+    # 2. Drop unique constraints on Form that include collection_version
+    op.drop_constraint("uq_form_order_collection", "form", type_="unique")
+    op.drop_constraint("uq_form_title_collection", "form", type_="unique")
+    op.drop_constraint("uq_form_slug_collection", "form", type_="unique")
+
+    # 3. Drop collection_version columns from submission and form
+    op.drop_column("submission", "collection_version")
+    op.drop_column("form", "collection_version")
+
+    # 4. Drop unique constraint on Collection that includes version
+    op.drop_constraint("uq_collection_name_version_grant_id", "collection", type_="unique")
+
+    # 5. Drop composite primary key and version column from collection
+    op.drop_constraint(op.f("pk_collection"), "collection", type_="primary")
+    op.drop_column("collection", "version")
+
+    # 6. Create new simple primary key on collection.id
+    op.create_primary_key(op.f("pk_collection"), "collection", ["id"])
+
+    # 7. Create new unique constraint on Collection without version
+    op.create_unique_constraint("uq_collection_name_grant_id", "collection", ["name", "grant_id"])
+
+    # 8. Recreate Form unique constraints without collection_version
+    op.create_unique_constraint("uq_form_order_collection", "form", ["order", "collection_id"], deferrable=True)
+    op.create_unique_constraint("uq_form_title_collection", "form", ["title", "collection_id"])
+    op.create_unique_constraint("uq_form_slug_collection", "form", ["slug", "collection_id"])
+
+    # 9. Create new simple foreign keys
+    op.create_foreign_key(
+        op.f("fk_submission_collection_id_collection"), "submission", "collection", ["collection_id"], ["id"]
+    )
+    op.create_foreign_key(op.f("fk_form_collection_id_collection"), "form", "collection", ["collection_id"], ["id"])
+
+
+def downgrade():
+    # 1. Drop simple foreign keys
+    op.drop_constraint(op.f("fk_submission_collection_id_collection"), "submission", type_="foreignkey")
+    op.drop_constraint(op.f("fk_form_collection_id_collection"), "form", type_="foreignkey")
+
+    # 2. Drop Form unique constraints without version
+    op.drop_constraint("uq_form_order_collection", "form", type_="unique")
+    op.drop_constraint("uq_form_title_collection", "form", type_="unique")
+    op.drop_constraint("uq_form_slug_collection", "form", type_="unique")
+
+    # 3. Drop Collection unique constraint without version
+    op.drop_constraint("uq_collection_name_grant_id", "collection", type_="unique")
+
+    # 4. Drop simple primary key
+    op.drop_constraint(op.f("pk_collection"), "collection", type_="primary")
+
+    # 5. Add version column back to collection
+    op.add_column("collection", sa.Column("version", sa.Integer(), nullable=False, server_default="1"))
+
+    # 6. Create composite primary key
+    op.create_primary_key(op.f("pk_collection"), "collection", ["id", "version"])
+
+    # 7. Remove server_default from version column
+    op.alter_column("collection", "version", server_default=False)
+
+    # 8. Create unique constraint with version
+    op.create_unique_constraint("uq_collection_name_version_grant_id", "collection", ["name", "grant_id", "version"])
+
+    # 9. Add collection_version columns back to form and submission
+    op.add_column("form", sa.Column("collection_version", sa.Integer(), nullable=False, server_default="1"))
+    op.add_column("submission", sa.Column("collection_version", sa.Integer(), nullable=False, server_default="1"))
+
+    # 10. Remove server_defaults
+    op.alter_column("form", "collection_version", server_default=False)
+    op.alter_column("submission", "collection_version", server_default=False)
+
+    # 11. Recreate Form unique constraints with collection_version
+    op.create_unique_constraint(
+        "uq_form_order_collection", "form", ["order", "collection_id", "collection_version"], deferrable=True
+    )
+    op.create_unique_constraint("uq_form_title_collection", "form", ["title", "collection_id", "collection_version"])
+    op.create_unique_constraint("uq_form_slug_collection", "form", ["slug", "collection_id", "collection_version"])
+
+    # 12. Recreate composite foreign keys
+    op.create_foreign_key(
+        op.f("fk_submission_collection_id_collection"),
+        "submission",
+        "collection",
+        ["collection_id", "collection_version"],
+        ["id", "version"],
+    )
+    op.create_foreign_key(
+        op.f("fk_form_collection_id_collection"),
+        "form",
+        "collection",
+        ["collection_id", "collection_version"],
+        ["id", "version"],
+    )

--- a/app/deliver_grant_funding/routes/reports.py
+++ b/app/deliver_grant_funding/routes/reports.py
@@ -161,7 +161,6 @@ def set_up_report(grant_id: UUID) -> ResponseReturnValue:
 @has_deliver_grant_role(RoleEnum.ADMIN)
 @auto_commit_after_request
 def change_report_name(grant_id: UUID, report_id: UUID) -> ResponseReturnValue:
-    # NOTE: this fetches the _latest version_ of the collection with this ID
     report = get_collection(report_id, grant_id=grant_id, type_=CollectionType.MONITORING_REPORT)
 
     form = SetUpReportForm(obj=report)
@@ -270,7 +269,6 @@ def add_section(grant_id: UUID, report_id: UUID) -> ResponseReturnValue:
 @has_deliver_grant_role(RoleEnum.ADMIN)
 @auto_commit_after_request
 def change_form_name(grant_id: UUID, form_id: UUID) -> ResponseReturnValue:
-    # NOTE: this fetches the _latest version_ of the collection with this ID
     db_form = get_form_by_id(form_id, grant_id=grant_id)
 
     if db_form.collection.live_submissions:

--- a/app/developers/data/grants.json
+++ b/app/developers/data/grants.json
@@ -8,9 +8,8 @@
           "id": "4e8f04f8-57c2-0399-464b-e62ff96b684a",
           "name": "Report on cheeseboards in parks",
           "slug": "report-on-cheeseboards-in-parks",
-          "status": "draft",
-          "type": "monitoring report",
-          "version": 1
+          "status": "closed",
+          "type": "monitoring report"
         }
       ],
       "component_references": [
@@ -1038,7 +1037,6 @@
       "forms": [
         {
           "collection_id": "4e8f04f8-57c2-0399-464b-e62ff96b684a",
-          "collection_version": 1,
           "id": "615f5183-f056-42c4-acd1-23d25db5f9a3",
           "order": 0,
           "slug": "contact-information",
@@ -1046,7 +1044,6 @@
         },
         {
           "collection_id": "4e8f04f8-57c2-0399-464b-e62ff96b684a",
-          "collection_version": 1,
           "id": "9cf64797-461d-467c-8834-470051899da7",
           "order": 1,
           "slug": "programme-progress",
@@ -1054,7 +1051,6 @@
         },
         {
           "collection_id": "4e8f04f8-57c2-0399-464b-e62ff96b684a",
-          "collection_version": 1,
           "id": "1482f2ef-9cbe-4e75-b8f0-4362f65822de",
           "order": 2,
           "slug": "outputs-and-outcomes",
@@ -1062,7 +1058,6 @@
         },
         {
           "collection_id": "4e8f04f8-57c2-0399-464b-e62ff96b684a",
-          "collection_version": 1,
           "id": "e34e4d79-6b02-4b08-b719-412c026a7c20",
           "order": 3,
           "slug": "main-risk-to-delivery",
@@ -1070,7 +1065,6 @@
         },
         {
           "collection_id": "4e8f04f8-57c2-0399-464b-e62ff96b684a",
-          "collection_version": 1,
           "id": "8506d7ef-2421-40d5-b120-daf870e09968",
           "order": 4,
           "slug": "spend-in-the-last-reporting-period",
@@ -1078,7 +1072,6 @@
         },
         {
           "collection_id": "4e8f04f8-57c2-0399-464b-e62ff96b684a",
-          "collection_version": 1,
           "id": "e2546f96-3655-483b-8531-0bbfd49a2631",
           "order": 5,
           "slug": "estimated-future-spend",
@@ -1758,8 +1751,7 @@
           "name": "Communities for Afghans Phase 2",
           "slug": "communities-for-afghans-phase-2",
           "status": "draft",
-          "type": "monitoring report",
-          "version": 1
+          "type": "monitoring report"
         }
       ],
       "component_references": [
@@ -7188,17 +7180,6 @@
         },
         {
           "context": {
-            "question_id": "0faf4b7b-bed2-4c29-b4f9-90fe3a9d2768"
-          },
-          "created_by_id": "acc47c80-8620-49d9-aa40-df1703286d43",
-          "id": "e149ff25-77bd-4bc6-9531-d88445fe7d08",
-          "managed_name": "Yes",
-          "question_id": "6745d6af-76fd-4c5c-a847-f55e00108cec",
-          "statement": "q_0faf4b7bbed24c29b4f990fe3a9d2768 is True",
-          "type_": "CONDITION"
-        },
-        {
-          "context": {
             "inclusive": true,
             "minimum_value": 3,
             "question_id": "14f1872c-c092-4680-a3fa-60b09d9cced9"
@@ -7208,6 +7189,17 @@
           "managed_name": "Greater than",
           "question_id": "6745d6af-76fd-4c5c-a847-f55e00108cec",
           "statement": "q_14f1872cc0924680a3fa60b09d9cced9 >= 3",
+          "type_": "CONDITION"
+        },
+        {
+          "context": {
+            "question_id": "0faf4b7b-bed2-4c29-b4f9-90fe3a9d2768"
+          },
+          "created_by_id": "acc47c80-8620-49d9-aa40-df1703286d43",
+          "id": "e149ff25-77bd-4bc6-9531-d88445fe7d08",
+          "managed_name": "Yes",
+          "question_id": "6745d6af-76fd-4c5c-a847-f55e00108cec",
+          "statement": "q_0faf4b7bbed24c29b4f990fe3a9d2768 is True",
           "type_": "CONDITION"
         },
         {
@@ -9870,7 +9862,6 @@
       "forms": [
         {
           "collection_id": "09e8d677-5fce-4081-9434-eefac1348e12",
-          "collection_version": 1,
           "id": "0f6c5ce4-0903-42c3-89b5-da19b011e3e0",
           "order": 0,
           "slug": "report-on-phase-2",
@@ -14024,9 +14015,8 @@
           "id": "157b21fd-4d7e-0dfe-0e4a-0b8d0d35353b",
           "name": "Report on picnic areas in parks",
           "slug": "report-on-picnic-areas-in-parks",
-          "status": "draft",
-          "type": "monitoring report",
-          "version": 1
+          "status": "scheduled",
+          "type": "monitoring report"
         }
       ],
       "component_references": [
@@ -14059,7 +14049,6 @@
       "forms": [
         {
           "collection_id": "157b21fd-4d7e-0dfe-0e4a-0b8d0d35353b",
-          "collection_version": 1,
           "id": "145189e8-f1da-149b-95e1-4afb893c856f",
           "order": 0,
           "slug": "form-3",
@@ -14067,7 +14056,6 @@
         },
         {
           "collection_id": "157b21fd-4d7e-0dfe-0e4a-0b8d0d35353b",
-          "collection_version": 1,
           "id": "79332ef5-531b-720f-bad1-15f46863bc9b",
           "order": 1,
           "slug": "form-4",
@@ -14075,7 +14063,6 @@
         },
         {
           "collection_id": "157b21fd-4d7e-0dfe-0e4a-0b8d0d35353b",
-          "collection_version": 1,
           "id": "6ba3aac0-b30b-0b4d-06a6-84ed632f4f84",
           "order": 2,
           "slug": "public-feedback-on-picnic-areas",
@@ -14179,9 +14166,8 @@
           "id": "920d3faf-c082-b34a-1cec-6d8db9a72dea",
           "name": "Report on playgrounds in parks",
           "slug": "report-on-playgrounds-in-parks",
-          "status": "draft",
-          "type": "monitoring report",
-          "version": 1
+          "status": "open",
+          "type": "monitoring report"
         }
       ],
       "component_references": [],
@@ -14191,7 +14177,6 @@
       "forms": [
         {
           "collection_id": "920d3faf-c082-b34a-1cec-6d8db9a72dea",
-          "collection_version": 1,
           "id": "5036b7da-0a66-75bb-04ca-4b7d97345fe5",
           "order": 0,
           "slug": "form-6",
@@ -14199,7 +14184,6 @@
         },
         {
           "collection_id": "920d3faf-c082-b34a-1cec-6d8db9a72dea",
-          "collection_version": 1,
           "id": "7ebb5886-bbc3-14b7-38fa-e16a09e053f7",
           "order": 1,
           "slug": "usage-statistics",
@@ -14207,7 +14191,6 @@
         },
         {
           "collection_id": "920d3faf-c082-b34a-1cec-6d8db9a72dea",
-          "collection_version": 1,
           "id": "08b95b3e-2ac8-234a-4c1d-666a9694e549",
           "order": 2,
           "slug": "maintenance-notes",
@@ -14363,7 +14346,7 @@
       "azure_ad_subject_id": "40e16bf9d02fa7f67c6bb767b197e544",
       "email": "sclark@test.communities.gov.uk",
       "id": "9ab212ee-6716-4921-b6a2-61a684bf2fe3",
-      "last_logged_in_at_utc": "Thu, 23 Oct 2025 20:04:48 GMT",
+      "last_logged_in_at_utc": "Tue, 04 Nov 2025 09:15:51 GMT",
       "name": "Willie Brown"
     },
     {

--- a/tests/integration/common/data/test_models.py
+++ b/tests/integration/common/data/test_models.py
@@ -37,7 +37,6 @@ class TestSubmissionModel:
 
         submission = Submission(
             collection_id=collection.id,
-            collection_version=collection.version,
             mode=SubmissionModeEnum.LIVE,
             created_by_id=user.id,
             grant_recipient_id=None,

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -179,7 +179,7 @@ class TestListReports:
         assert response.status_code == 302
         assert response.location == AnyStringMatching("^/deliver/grant/[a-z0-9-]{36}/reports$")
 
-        deleted_report = db_session.get(Collection, (report.id, report.version))
+        deleted_report = db_session.get(Collection, report.id)
         assert (deleted_report is None) == can_delete
 
 
@@ -324,7 +324,7 @@ class TestChangeReportName:
             assert response.status_code == 302
             assert response.location == AnyStringMatching("^/deliver/grant/[a-z0-9-]{36}/reports$")
 
-            updated_report = db_session.get(Collection, (report.id, report.version))
+            updated_report = db_session.get(Collection, report.id)
             assert updated_report.name == "Updated Name"
 
     def test_post_update_name_duplicate(self, authenticated_grant_admin_client, factories):
@@ -365,7 +365,7 @@ class TestChangeReportName:
         assert response.status_code == 302
         assert response.location == AnyStringMatching("^/deliver/grant/[a-z0-9-]{36}/reports$")
 
-        updated_report = db_session.get(Collection, (report.id, report.version))
+        updated_report = db_session.get(Collection, report.id)
         assert updated_report is not None
         assert updated_report.name == "Updated Name"
 

--- a/tests/integration/test_fixtures.py
+++ b/tests/integration/test_fixtures.py
@@ -121,7 +121,7 @@ def test_collection_factory_completed_submissions(db_session, factories):
         create_completed_submissions_each_question_type__live=2,
     )
 
-    collection_from_db = db_session.get(Collection, (collection.id, 1))
+    collection_from_db = db_session.get(Collection, collection.id)
     assert len(collection_from_db._submissions) == 5
     assert len(collection_from_db.test_submissions) == 3
     assert len(collection_from_db.live_submissions) == 2

--- a/tests/models.py
+++ b/tests/models.py
@@ -643,7 +643,6 @@ class _SubmissionFactory(SQLAlchemyModelFactory):
 
     collection = factory.SubFactory(_CollectionFactory)
     collection_id = factory.LazyAttribute(lambda o: o.collection.id)
-    collection_version = factory.LazyAttribute(lambda o: o.collection.version)
 
     grant_recipient = factory.LazyAttribute(
         lambda o: _GrantRecipientFactory.create() if o.mode == SubmissionModeEnum.LIVE else None


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
Collection versioning has been something we expected to bring in for a while, but we didn't ever get it over the line. At this point the code is adding complexity that provides no functional benefit, so this patch removes it. This will simplify the implementation of the Reports entity, which otherwise might need to understand versions on the backend despite nothing on the frontend alluding to or using them.

As/when we get versioninig prioritised properly we can bring this all back in, intentionally, with appropriate design considerations.

## 📸 Show the thing (screenshots, gifs)
<!-- Include screenshots for UI changes, new features, or visual modifications -->
<!-- Use "Before" and "After" sections if showing changes to existing functionality -->

### Before
<!-- Screenshot or description of previous state -->

### After
<!-- Screenshot or description of new state -->

## 🧪 Testing
<!-- Describe how you've tested this change, and how a reviewer can test it -->

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [ ] PR title and description provide sufficient context for reviewers
- [ ] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- [ ] No N+1 query problems introduced
- [ ] Any new DB queries include appropriate where clauses based on the user's permissions

### Testing
- [ ] I have tested this change and it meets the acceptance criteria for the ticket
- [ ] I need the reviewer(s) to pull and run this change locally
- [ ] New (non-developer) functionality has appropriate unit and integration tests
- [ ] End-to-end tests have been updated (if applicable)
- [ ] Edge cases and error conditions are tested

## 📚 Additional Notes
<!-- Any additional context, concerns, or considerations for reviewers -->
