### PR TITLE
BAU Don't show report link in submission breadcrumb

### DIFF
--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_submissions.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_submissions.html
@@ -12,7 +12,7 @@
   {% if helper.is_test_mode %}
     {{ mhclgTestBanner("Test submissions") }}
   {% endif %}
-  {{ deliver_grant_funding_reports_breadcrumb(grant=grant, report=report, this_page_breadcrumb_item={"text":"Submissions"}) }}
+  {{ deliver_grant_funding_reports_breadcrumb(grant=grant, this_page_breadcrumb_item={"text":"Submissions"}) }}
 {% endblock beforeContent %}
 
 {% block content %}


### PR DESCRIPTION
Currently the "Report" link in the breadcrumb heirarchy is re-used between the submission list and the form builder - because of this it takes you back to the form builder for the given report.

This is confusing on submissions as you haven't come from there.

Remove it for submissions for now, these pages may be tweaked as we think about service nav, testing forms and building out the access grant funding pages.

## 📸 Show the thing (screenshots, gifs)

### Before
<img width="990" height="636" alt="Screenshot 2025-11-03 at 15 18 43" src="https://github.com/user-attachments/assets/9aa5132d-ec68-4b30-b2af-148295709a59" />


### After
<img width="1003" height="625" alt="Screenshot 2025-11-03 at 15 18 52" src="https://github.com/user-attachments/assets/563e741a-a16e-4262-91e9-cd07ab72678e" />
