### PR TITLE
Don't show grant recipients on grant team members page

### DIFF
--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -54,19 +54,14 @@ class Grant(BaseModel):
     organisation: Mapped["Organisation"] = relationship("Organisation", back_populates="grants")
     grant_recipients: Mapped[list["GrantRecipient"]] = relationship("GrantRecipient", back_populates="grant")
 
-    users: Mapped[list["User"]] = relationship(
-        "User",
-        secondary="user_role",
-        primaryjoin="Grant.id==UserRole.grant_id",
-        secondaryjoin="User.id==UserRole.user_id",
-        viewonly=True,
-    )
     invitations: Mapped[list["Invitation"]] = relationship(
         "Invitation",
         back_populates="grant",
         viewonly=True,
     )
 
+    # This is specifically people granted *explicit* access to this specific grant, not just anyone with more
+    # generalised access to the grant (eg org and platform admins)
     grant_team_users: Mapped[list["User"]] = relationship(
         "User",
         secondary="user_role",

--- a/app/deliver_grant_funding/routes/grant_team.py
+++ b/app/deliver_grant_funding/routes/grant_team.py
@@ -36,7 +36,7 @@ def add_user_to_grant(grant_id: UUID) -> ResponseReturnValue:
         if form.user_email.data:
             # are they already in this grant - if so, redirect to the list of users
             grant_user = next(
-                (user for user in grant.users if user.email.lower() == form.user_email.data.lower()), None
+                (user for user in grant.grant_team_users if user.email.lower() == form.user_email.data.lower()), None
             )
             if grant_user:
                 return redirect(url_for("deliver_grant_funding.list_users_for_grant", grant_id=grant_id))

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_team/grant_user_list.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_team/grant_user_list.html
@@ -29,7 +29,7 @@
         Grant team
       </h1>
 
-      {% if not grant.users %}
+      {% if not grant.grant_team_users %}
         <p class="govuk-body">No grant team members have been added to this grant yet.</p>
       {% endif %}
 
@@ -74,7 +74,7 @@
 
   {% set table_rows = namespace(items=[]) %}
 
-  {% for user in grant.users if authorisation_helper.has_logged_in(user) %}
+  {% for user in grant.grant_team_users if authorisation_helper.has_logged_in(user) %}
     {%
       set table_rows.items = table_rows.items + [[
         {"text": user.name},


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
The Deliver grant funding page was incorrectly showing grant recipient users as grant team members. This is wrong.

## 📸 Show the thing (screenshots, gifs)

<img width="1286" height="535" alt="image" src="https://github.com/user-attachments/assets/d43c5d9d-9a30-4fc6-9911-b9c6d26b2b84" />


### Before
<img width="1015" height="935" alt="image" src="https://github.com/user-attachments/assets/e33d3562-e43d-44e6-9292-0335ecc6f440" />


### After
<img width="1031" height="866" alt="image" src="https://github.com/user-attachments/assets/016c2ac3-6c7d-4aa1-aa42-a8b9ce389fdb" />

## 🧪 Testing
<!-- Describe how you've tested this change, and how a reviewer can test it -->

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [-] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested