### PR TITLE
Removing footer links on deliver grant funding base template

### DIFF
--- a/app/common/templates/common/base.html
+++ b/app/common/templates/common/base.html
@@ -61,12 +61,6 @@
 {% block footer %}
   {{
     govukFooter({
-        "meta": {
-            "items": [
-                { "href": "#", "text": ("Cookies") },
-                { "href": "#", "text": ("Accessibility statement") }
-            ]
-        }
     })
   }}
 {% endblock footer %}


### PR DESCRIPTION
Removing the footer links from deliver grant funding as we don't yet have a cookie policy or accessibility statement.