### PR TITLE
BAU Redirect appropriately for logged out users on the admin pages

### DIFF
--- a/app/deliver_grant_funding/admin/mixins.py
+++ b/app/deliver_grant_funding/admin/mixins.py
@@ -1,7 +1,17 @@
+from typing import Any
+
+from flask import abort
+from flask.typing import ResponseReturnValue
+
 from app.common.auth.authorisation_helper import AuthorisationHelper
+from app.common.auth.decorators import deliver_grant_funding_login_required
 from app.common.data.interfaces.user import get_current_user
 
 
 class FlaskAdminPlatformAdminAccessibleMixin:
     def is_accessible(self) -> bool:
         return AuthorisationHelper.is_platform_admin(get_current_user())
+
+    @deliver_grant_funding_login_required
+    def inaccessible_callback(self, *args: Any, **kwargs: Any) -> ResponseReturnValue:
+        return abort(403)

--- a/tests/integration/deliver_grant_funding/admin/test_views.py
+++ b/tests/integration/deliver_grant_funding/admin/test_views.py
@@ -17,7 +17,7 @@ class TestFlaskAdminAccess:
             ("authenticated_grant_admin_client", 403),
             ("authenticated_grant_member_client", 403),
             ("authenticated_no_role_client", 403),
-            ("anonymous_client", 403),
+            ("anonymous_client", 302),
         ],
     )
     def test_admin_index_denied_for_non_platform_admin(self, client_fixture, expected_code, request):
@@ -32,7 +32,7 @@ class TestFlaskAdminAccess:
             ("authenticated_grant_admin_client", 403),
             ("authenticated_grant_member_client", 403),
             ("authenticated_no_role_client", 403),
-            ("anonymous_client", 403),
+            ("anonymous_client", 302),
         ],
     )
     def test_admin_user_list_denied_for_non_platform_admin(self, client_fixture, expected_code, request):
@@ -47,7 +47,7 @@ class TestFlaskAdminAccess:
             ("authenticated_grant_admin_client", 403),
             ("authenticated_grant_member_client", 403),
             ("authenticated_no_role_client", 403),
-            ("anonymous_client", 403),
+            ("anonymous_client", 302),
         ],
     )
     def test_admin_user_detail_denied_for_non_platform_admin(
@@ -56,7 +56,7 @@ class TestFlaskAdminAccess:
         client = request.getfixturevalue(client_fixture)
         user = factories.user.create()
 
-        response = client.get(f"/deliver/admin/user/details/?id={user.id}", follow_redirects=True)
+        response = client.get(f"/deliver/admin/user/details/?id={user.id}", follow_redirects=False)
         assert response.status_code == expected_code
 
 
@@ -68,7 +68,7 @@ class TestReportingLifecycleSelectGrant:
             ("authenticated_grant_admin_client", 403),
             ("authenticated_grant_member_client", 403),
             ("authenticated_no_role_client", 403),
-            ("anonymous_client", 403),
+            ("anonymous_client", 302),
         ],
     )
     def test_select_grant_permissions(self, client_fixture, expected_code, request):
@@ -152,7 +152,7 @@ class TestReportingLifecycleSelectReport:
             ("authenticated_grant_admin_client", 403),
             ("authenticated_grant_member_client", 403),
             ("authenticated_no_role_client", 403),
-            ("anonymous_client", 403),
+            ("anonymous_client", 302),
         ],
     )
     def test_select_report_permissions(self, client_fixture, expected_code, request, factories, db_session):
@@ -210,7 +210,7 @@ class TestReportingLifecycleTasklist:
             ("authenticated_grant_admin_client", 403),
             ("authenticated_grant_member_client", 403),
             ("authenticated_no_role_client", 403),
-            ("anonymous_client", 403),
+            ("anonymous_client", 302),
         ],
     )
     def test_tasklist_permissions(self, client_fixture, expected_code, request, factories, db_session):
@@ -466,7 +466,7 @@ class TestReportingLifecycleMakeGrantLive:
             ("authenticated_grant_admin_client", 403),
             ("authenticated_grant_member_client", 403),
             ("authenticated_no_role_client", 403),
-            ("anonymous_client", 403),
+            ("anonymous_client", 302),
         ],
     )
     def test_confirm_page_permissions(self, client_fixture, expected_code, request, factories, db_session):
@@ -552,7 +552,7 @@ class TestReportingLifecycleMarkGrantAsOnboarding:
             ("authenticated_grant_admin_client", 403),
             ("authenticated_grant_member_client", 403),
             ("authenticated_no_role_client", 403),
-            ("anonymous_client", 403),
+            ("anonymous_client", 302),
         ],
     )
     def test_confirm_page_permissions(self, client_fixture, expected_code, request, factories, db_session):
@@ -619,7 +619,7 @@ class TestManageOrganisations:
             ("authenticated_grant_admin_client", 403),
             ("authenticated_grant_member_client", 403),
             ("authenticated_no_role_client", 403),
-            ("anonymous_client", 403),
+            ("anonymous_client", 302),
         ],
     )
     def test_manage_organisations_permissions(self, client_fixture, expected_code, request, factories, db_session):
@@ -804,7 +804,7 @@ class TestManageGrantRecipients:
             ("authenticated_grant_admin_client", 403),
             ("authenticated_grant_member_client", 403),
             ("authenticated_no_role_client", 403),
-            ("anonymous_client", 403),
+            ("anonymous_client", 302),
         ],
     )
     def test_manage_grant_recipients_permissions(self, client_fixture, expected_code, request, factories, db_session):
@@ -967,7 +967,7 @@ class TestSetUpGrantRecipientUsers:
             ("authenticated_grant_admin_client", 403),
             ("authenticated_grant_member_client", 403),
             ("authenticated_no_role_client", 403),
-            ("anonymous_client", 403),
+            ("anonymous_client", 302),
         ],
     )
     def test_set_up_grant_recipient_users_permissions(
@@ -1217,7 +1217,7 @@ class TestRevokeGrantRecipientUsers:
             ("authenticated_grant_admin_client", 403),
             ("authenticated_grant_member_client", 403),
             ("authenticated_no_role_client", 403),
-            ("anonymous_client", 403),
+            ("anonymous_client", 302),
         ],
     )
     def test_revoke_grant_recipient_users_permissions(
@@ -1332,7 +1332,7 @@ class TestScheduleReport:
             ("authenticated_grant_admin_client", 403),
             ("authenticated_grant_member_client", 403),
             ("authenticated_no_role_client", 403),
-            ("anonymous_client", 403),
+            ("anonymous_client", 302),
         ],
     )
     def test_schedule_report_permissions(self, client_fixture, expected_code, request, factories, db_session):


### PR DESCRIPTION
This wraps the flask admin unauthenticated flow with our existing decorator which manages session state and "is logged in" behaviour.

This should mean that:
- if you are signed in but don't have admin permissions `is_accessible` will reject you and the dectorator will run the code in the overrided `inaccessible_callback` which will by default `abort(403)`
- if you are signed in and do have admin permissions none of this code will run
- if you are not signed in the decorator will perform that same redirect/ state management as it does in the app

This commit puts the `inaccessible_callback` on the `FlaskAdminPlatformAdminAccessibleMixin` which means that it can't guarantee which base class it will be used alongside and results in a bit of a dodgy cast to make mypy happy.

To guarantee you would have access to the `innaccessible_callback` method on your superclass you could instead implement this on the `PlatformAdminBaseView` (but then you wouldnt always get this behaviour when you use this mixin - didn't have conviction in which was better).

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I need the reviewer(s) to pull and run this change locally
