### PR TITLE
BAU Add moving grants to onboarding to reporting lifecycle

### DIFF
--- a/app/common/data/interfaces/grants.py
+++ b/app/common/data/interfaces/grants.py
@@ -112,6 +112,8 @@ def update_grant(
             case (GrantStatusEnum.DRAFT, GrantStatusEnum.LIVE) | (GrantStatusEnum.ONBOARDING, GrantStatusEnum.LIVE):
                 if len(grant.grant_team_users) < 2:
                     raise NotEnoughGrantTeamUsersError()
+            case GrantStatusEnum.DRAFT, GrantStatusEnum.ONBOARDING:
+                pass
             case GrantStatusEnum.LIVE, GrantStatusEnum.DRAFT:
                 pass
             case _:

--- a/app/deliver_grant_funding/admin/forms.py
+++ b/app/deliver_grant_funding/admin/forms.py
@@ -53,6 +53,10 @@ class PlatformAdminMakeGrantLiveForm(FlaskForm):
     submit = SubmitField("Make grant live", widget=GovSubmitInput())
 
 
+class PlatformAdminMarkAsOnboardingForm(FlaskForm):
+    submit = SubmitField("Mark as onboarding", widget=GovSubmitInput())
+
+
 class PlatformAdminBulkCreateOrganisationsForm(FlaskForm):
     # The default structure of this data is set so that it should be easy to copy+paste from Delta's organisation export
     # when opened in Excel. Hide the irrelevant columns in Excel, then select the table contents and paste it into

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/admin/confirm-make-grant-active-onboarding.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/admin/confirm-make-grant-active-onboarding.html
@@ -1,0 +1,61 @@
+{% extends "admin/base.html" %}
+{% import 'admin/layout.html' as layout with context %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% from 'govuk_frontend_jinja/components/error-summary/macro.html' import govukErrorSummary %}
+{% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
+
+{% block beforeContent %}
+  {{ govukBackLink({"text": "Back", "href": url_for('reporting_lifecycle.tasklist', grant_id=grant.id, collection_id=collection.id) }) }}
+{% endblock %}
+
+{% block action_panel %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-half">
+      {{ layout.messages() }}
+
+      {% if form.errors %}
+        {{ govukErrorSummary(wtforms_errors(form)) }}
+      {% endif %}
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l">{{ grant.name }}</span>
+        Mark grant as onboarding with Funding Service
+      </h1>
+      <p class="govuk-body">Onboarding grants are shown as active on the grants list dashboard.</p>
+      <p class="govuk-body">A grant should have a valid GGIS number before it is marked as onboarding.</p>
+
+      {% set grant_team_users %}
+        <ul class="govuk-list govuk-list--bullet">
+          {% for user in grant.grant_team_users %}
+            <li>{{ user.email }}</li>
+          {% endfor %}
+        </ul>
+      {% endset %}
+
+      {{
+        govukSummaryList({
+          "rows": [{
+            "key": { "text": "Grant name" },
+            "value": { "text": grant.name },
+          }, {
+            "key": { "text": "Grant description" },
+            "value": { "text": grant.description },
+          }, {
+            "key": { "text": "GGIS number" },
+            "value": { "text": grant.ggis_number },
+          }, {
+            "key": { "text": "Grant team users" },
+            "value": { "html": grant_team_users },
+          }
+          ],
+          "classes": "app-!-border-top-line govuk-!-margin-bottom-8"
+        })
+      }}
+      <form method="post" novalidate>
+        {{ form.csrf_token }}
+        {{ form.grant_id }}
+        {{ form.submit }}
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/admin/reporting-lifecycle-tasklist.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/admin/reporting-lifecycle-tasklist.html
@@ -40,6 +40,21 @@
 
       {% if grant.status == enum.grant_status.DRAFT %}
         {% set status_tag = govukTag({"text": "To do", "classes": "govuk-tag--grey"}) %}
+        {% set link_href = url_for('reporting_lifecycle.mark_as_onboarding', grant_id=grant.id, collection_id=collection.id) %}
+      {% else %}
+        {% set status_tag = govukTag({"text": "Completed", "classes": "govuk-tag--green"}) %}
+        {% set link_href = "" %}
+      {% endif %}
+      {%
+        do rows.append({
+          "title": {"text": "Mark as onboarding with Funding Service", "classes": "govuk-link--no-visited-state"},
+          "status": {"html": status_tag},
+          "href": link_href,
+        })
+      %}
+
+      {% if grant.status in [ enum.grant_status.DRAFT, enum.grant_status.ONBOARDING ] %}
+        {% set status_tag = govukTag({"text": "To do", "classes": "govuk-tag--grey"}) %}
         {% set link_href = url_for('reporting_lifecycle.make_live', grant_id=grant.id, collection_id=collection.id) %}
       {% else %}
         {% set status_tag = govukTag({"text": "Completed", "classes": "govuk-tag--green"}) %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_list.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_list.html
@@ -25,15 +25,19 @@
     </div>
   </div>
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
+    <div class="govuk-grid-column-full govuk-!-margin-top-4">
       {% if onboarding_grants %}
-        <h2 class="govuk-heading-m govuk-!-margin-top-4">Active grants</h2>
-        {{ grant_table(onboarding_grants, id_override="active-grants") }}
+        <div class="govuk-!-margin-bottom-8">
+          <h2 class="govuk-heading-m">Active grants</h2>
+          {{ grant_table(onboarding_grants, id_override="active-grants") }}
+        </div>
       {% endif %}
 
       {% if draft_grants %}
-        <h2 class="govuk-heading-m govuk-!-margin-top-8">Draft grants</h2>
-        {{ grant_table(draft_grants, id_override="draft-grants") }}
+        <div class="govuk-!-margin-bottom-8">
+          <h2 class="govuk-heading-m">Draft grants</h2>
+          {{ grant_table(draft_grants, id_override="draft-grants") }}
+        </div>
       {% endif %}
 
       {% if not onboarding_grants and not draft_grants %}

--- a/tests/unit/test_all_routes_access.py
+++ b/tests/unit/test_all_routes_access.py
@@ -177,6 +177,7 @@ routes_with_access_controlled_by_flask_admin = [
     "reporting_lifecycle.index",
     "reporting_lifecycle.select_report",
     "reporting_lifecycle.tasklist",
+    "reporting_lifecycle.mark_as_onboarding",
     "reporting_lifecycle.make_live",
     "reporting_lifecycle.set_up_organisations",
     "reporting_lifecycle.set_up_grant_recipients",


### PR DESCRIPTION
This commit adds the ability to mark a grant as "onboarding" in the reporting lifecycle.

Its the first grant step and doesn't have any requirements.

This allows our team to work on "Active" grants which are always prioritised at the top of their dashboard while allowing others in the team and the wider org to setup grants that are either coming far in the future or just to get familiar with the tools.

We've added no hard state transition requirements to move to this status after "Draft" and before "Live" because it doesn't feel like it should be a hard requirement and does no checks of its own.

Before running this lifecycle step (note some bonus minor visual tweaks on this page)

<img width="2594" height="2058" alt="funding communities gov localhost_8080_deliver_grants (3)" src="https://github.com/user-attachments/assets/8ff1d78e-94bf-4c29-9059-839dc0f5300a" />

Tasklist straight after the grant is set up

<img width="2542" height="2616" alt="funding communities gov localhost_8080_deliver_admin_reporting-lifecycle_9229f1c4-d5f2-4a8b-9443-134f4a229d39_84a8792e-13cd-417e-b203-3b4bf675f1d4" src="https://github.com/user-attachments/assets/a62501aa-d555-450b-9ae2-37b9e038dbc1" />

Clicking into the new step

<img width="2542" height="2202" alt="funding communities gov localhost_8080_deliver_admin_reporting-lifecycle_9229f1c4-d5f2-4a8b-9443-134f4a229d39_84a8792e-13cd-417e-b203-3b4bf675f1d4_mark-as-onboarding" src="https://github.com/user-attachments/assets/3c9e6393-facf-46a3-9b54-3d4ed880287a" />

Submitting the new step

<img width="2542" height="2932" alt="funding communities gov localhost_8080_deliver_admin_reporting-lifecycle_9229f1c4-d5f2-4a8b-9443-134f4a229d39_84a8792e-13cd-417e-b203-3b4bf675f1d4 (1)" src="https://github.com/user-attachments/assets/a36976a6-47f9-4e06-afb9-dc97925c32ec" />

List grants now appropriately organises the grant 

<img width="2542" height="2058" alt="funding communities gov localhost_8080_deliver_grants (2)" src="https://github.com/user-attachments/assets/31debbbb-5e0f-4ef6-9db9-3cd9fa0fe877" />
