### PR TITLE
BAU Align the grant tables on desktop

### DIFF
--- a/app/assets/main.scss
+++ b/app/assets/main.scss
@@ -267,3 +267,15 @@ $inset-nested-rows: 30px;
         margin-top: -50px - govuk-spacing(6);
     }
 }
+
+.app-grants-table--cell-width-200 {
+    @include govuk-media-query($from: desktop) {
+        width: 200px;
+    }
+}
+
+.app-grants-table--cell-width-300 {
+    @include govuk-media-query($from: desktop) {
+        width: 300px;
+    }
+}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_list.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_list.html
@@ -66,7 +66,7 @@
     govukTable({
         "captionClasses": "govuk-table__caption--m",
         "firstCellIsHeader": false,
-        "head": [{"text": "Grant"}, {"text": "GGIS number"}, {"text": "Status"}],
+        "head": [{"text": "Grant"}, {"text": "GGIS number", "classes": "app-grants-table--cell-width-300"}, {"text": "Status", "classes": "app-grants-table--cell-width-200"}],
         "rows": table_rows.items,
         "attributes": {"id": id_override},
     })


### PR DESCRIPTION
This will probably get redesigned when more thought is put into it or things like pagination are needed but this keeps the columns in line on desktop for the time being.

We don't fix the widths on mobile because the default behaviour of picking as much space as possible for longer columns should win instead of keeping a fixed width for the two RHS columns.

## 📸 Show the thing (screenshots, gifs)
<!-- Include screenshots for UI changes, new features, or visual modifications -->
<!-- Use "Before" and "After" sections if showing changes to existing functionality -->

### Before
<!-- Screenshot or description of previous state -->

<img width="2064" height="2150" alt="funding communities gov localhost_8080_deliver_grants (5)" src="https://github.com/user-attachments/assets/69b1a3ee-3627-46fa-89da-00b4c7ad7cc1" />


### After
<!-- Screenshot or description of new state -->

<img width="2064" height="2200" alt="funding communities gov localhost_8080_deliver_grants (4)" src="https://github.com/user-attachments/assets/ac551833-46f5-46f1-b7c4-ba9dc37b9106" />
