### PR TITLE
FSPT-980 Adding google analytics to Deliver Grant Funding

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -210,6 +210,12 @@ def create_app() -> Flask:  # noqa: C901
     app.jinja_env.add_extension("jinja2.ext.i18n")
     app.jinja_env.add_extension("jinja2.ext.do")
 
+    def get_google_tag_manager_id() -> str:
+        return str(current_app.config["GOOGLE_TAG_MANAGER_ID"])
+
+    def get_current_env_name() -> str:
+        return str(current_app.config["FLASK_ENV"].value)
+
     @app.context_processor
     def _jinja_template_context() -> dict[str, Any]:
         return dict(
@@ -222,6 +228,8 @@ def create_app() -> Flask:  # noqa: C901
             format_datetime_range=format_datetime_range,
             format_thousands=format_thousands,
             to_ordinal=to_ordinal,
+            get_google_tag_manager_id=get_google_tag_manager_id,
+            get_current_env_name=get_current_env_name,
             enum=dict(
                 submission_mode=SubmissionModeEnum,
                 flash_message_type=FlashMessageType,

--- a/app/config.py
+++ b/app/config.py
@@ -28,16 +28,22 @@ class DatabaseSecret(BaseModel):
 
 FS_CONTENT_SECURITY_POLICY = {
     "default-src": ["'self'"],
-    "script-src": ["'self'"],
+    "content_security_policy_nonce_in": ["script-src"],
+    "script-src": [
+        "'self'",
+        "https://www.googletagmanager.com",
+    ],
     "img-src": [
         "'self'",
         "data:",  # Flask-Admin's select-with-search "x" icon for deleting selections
+        "www.googletagmanager.com",
     ],
     "style-src": [
         "'self'",
         "'unsafe-hashes'",
         "'sha256-9/aFFbAwf+Mwl6MrBQzrJ/7ZK5vo7HdOUR7iKlBk78U='",  # MHCLG Crest
     ],
+    "connect-src": ["'self'", "www.googletagmanager.com", "www.google.com", "https://*.google-analytics.com"],
 }
 
 
@@ -281,6 +287,9 @@ class _SharedConfig(_BaseConfig):
     }
     SEED_SYSTEM_DATA: bool = True
     GRANT_TEAM_RECIPIENT_LIST_SPREADSHEET: str = "https://mhclg.sharepoint.com/:x:/s/FundingServiceOnboarding/EVu_B9_W6OJKvjS8j-Xd_dABBQ0sPGB6vWLNLkoHfrHyHg?e=cG79Bd&nav=MTVfezAwMDAwMDAwLTAwMDEtMDAwMC0wMDAwLTAwMDAwMDAwMDAwMH0"
+
+    # Google Analytics
+    GOOGLE_TAG_MANAGER_ID: str = "GTM-T8XPM3NL"
 
     @property
     def IS_PRODUCTION(self) -> bool:

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/base.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/base.html
@@ -7,7 +7,26 @@
 {% set right_nav_items = right_nav_items or [] %}
 
 {% block pageTitle %}{{ page_title }} - {{ super() }}{% endblock pageTitle %}
+{% block head %}
+  <!-- Google Tag Manager -->
+  <script nonce="{{csp_nonce()}}">
+    (function (w, d, s, l, i) {
+      w[l] = w[l] || [];
+      w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js", env: "{{get_current_env_name()}}" });
+      var f = d.getElementsByTagName(s)[0],
+        j = d.createElement(s),
+        dl = l != "dataLayer" ? "&l=" + l : "";
+      j.async = true;
+      j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
+      var n = d.querySelector("[nonce]");
+      n && j.setAttribute("nonce", n.nonce || n.getAttribute("nonce"));
+      f.parentNode.insertBefore(j, f);
+    })(window, document, "script", "dataLayer", "{{ get_google_tag_manager_id() }}");
+  </script>
 
+  <!-- End Google Tag Manager -->
+  {{ super() }}
+{% endblock %}
 {% block header %}
   {{
     mhclgHeader(
@@ -22,6 +41,9 @@
 {% endblock header %}
 
 {% block main %}
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T8XPM3NL" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
   <div {% if show_watermark %}class="app-watermark-container"{% endif %}>
     <div class="govuk-width-container {% if containerClasses %}{{ containerClasses }}{% endif %}">
       {% block beforeContent %}{% endblock %}


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-980

## 📝 Description
This PR adds the google tag manager code snippet for our new Funding Service Google Tag Manager container. The google tag manager then loads scripts directly from google so the content security policy is also updated to allow this to happen.

As we want to send our current environment name in the data layer for the tag, this PR also makes a new function, `get_current_env_name`, available to the jinja template context which just returns the current environment name.

## 📸 Show the thing (screenshots, gifs)
### Tags being loaded
This shows a page view in dev, as viewed in the Google Tag Assistant
<img width="1087" height="812" alt="Screenshot 2025-11-06 at 09 03 21" src="https://github.com/user-attachments/assets/71bd2929-4f7c-47e5-89f8-ab5ba9f0aadf" />
### Data fed through into analytics
This shows a breakdown of users by hostname (dev vs localhost)
<img width="1343" height="165" alt="Screenshot 2025-11-06 at 09 04 38" src="https://github.com/user-attachments/assets/534ab7e7-0243-441a-9dcc-fed8353dfc45" />


## 🧪 Testing
- Pull this branch
- Install the google tag assistant chrome extension
- Load any deliver grant funding page with the extension enabled
- Click 'Troubleshoot tag'. This opens a new tab showing the tag assistant debug view
- Reload the deliver grant funding page
- See the values passed to the tag in the debug view

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions


### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [ ] New (non-developer) functionality has appropriate unit and integration tests
- [ ] End-to-end tests have been updated (if applicable)
- [ ] Edge cases and error conditions are tested

## 📚 Additional Notes
This is now sending data to Google Analytics for all environments where this change is deployed. In order to filter out non-prod traffic, all our reports will need to use a Comparison that matches on host name.

This change sends a custom variable called `env_name` with the value of the current environment name (local, dev etc) and although this can be seen in the tag assistant so is being set correctly, we haven't yet worked out how to surface this in Google Analytics.
