### PR TITLE
Redirect unauthorised test previews to report

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -29,6 +29,7 @@ from app.common.data.types import (
     SubmissionStatusEnum,
     TasklistSectionStatusEnum,
 )
+from app.common.exceptions import RedirectException
 from app.common.filters import (
     format_date,
     format_date_approximate,
@@ -96,6 +97,10 @@ def _register_global_error_handlers(app: Flask) -> None:
         return render_template(
             "common/errors/500.html", service_desk_url=_determine_service_desk_url_based_on_request_url(request.url)
         ), 500
+
+    @app.errorhandler(RedirectException)
+    def handle_redirect(error: RedirectException) -> ResponseReturnValue:
+        return redirect(error.url)
 
 
 def _register_custom_converters(app: Flask) -> None:

--- a/app/common/exceptions.py
+++ b/app/common/exceptions.py
@@ -1,0 +1,3 @@
+class RedirectException(Exception):
+    def __init__(self, url: str) -> None:
+        self.url = url

--- a/tests/integration/deliver_grant_funding/routes/test_runner.py
+++ b/tests/integration/deliver_grant_funding/routes/test_runner.py
@@ -44,20 +44,27 @@ class TestSubmissionTasklist:
             assert "Not started" in soup.text
 
     @pytest.mark.parametrize(
-        "client_fixture",
+        "client_fixture, submission_mode, expected_status_code",
         (
-            ("authenticated_no_role_client"),
-            ("authenticated_grant_member_client"),
-            ("authenticated_grant_admin_client"),
+            ("authenticated_no_role_client", SubmissionModeEnum.TEST, 403),
+            ("authenticated_grant_member_client", SubmissionModeEnum.TEST, 302),
+            ("authenticated_grant_admin_client", SubmissionModeEnum.TEST, 302),
+            ("authenticated_no_role_client", SubmissionModeEnum.LIVE, 403),
+            ("authenticated_grant_member_client", SubmissionModeEnum.LIVE, 403),
+            ("authenticated_grant_admin_client", SubmissionModeEnum.LIVE, 403),
         ),
     )
-    def test_get_other_users_submission_tasklist_403s(self, request: FixtureRequest, client_fixture: str, factories):
+    def test_get_other_users_submission_tasklist_403s(
+        self, request: FixtureRequest, client_fixture: str, factories, submission_mode, expected_status_code
+    ):
         client = request.getfixturevalue(client_fixture)
         grant = getattr(client, "grant", None) or factories.grant.create()
         question = factories.question.create(form__title="Colour information", form__collection__grant=grant)
 
         generic_user = factories.user.create()
-        generic_submission = factories.submission.create(collection=question.form.collection, created_by=generic_user)
+        generic_submission = factories.submission.create(
+            collection=question.form.collection, created_by=generic_user, mode=submission_mode
+        )
 
         response = client.get(
             url_for(
@@ -66,7 +73,7 @@ class TestSubmissionTasklist:
                 submission_id=generic_submission.id,
             )
         )
-        assert response.status_code == 403
+        assert response.status_code == expected_status_code
 
     @pytest.mark.parametrize(
         "client_fixture, can_preview",
@@ -301,14 +308,19 @@ class TestAskAQuestion:
         )
 
     @pytest.mark.parametrize(
-        "client_fixture",
+        "client_fixture, submission_mode, expected_status_code",
         (
-            ("authenticated_no_role_client"),
-            ("authenticated_grant_member_client"),
-            ("authenticated_grant_admin_client"),
+            ("authenticated_no_role_client", SubmissionModeEnum.TEST, 403),
+            ("authenticated_grant_member_client", SubmissionModeEnum.TEST, 302),
+            ("authenticated_grant_admin_client", SubmissionModeEnum.TEST, 302),
+            ("authenticated_no_role_client", SubmissionModeEnum.LIVE, 403),
+            ("authenticated_grant_member_client", SubmissionModeEnum.LIVE, 403),
+            ("authenticated_grant_admin_client", SubmissionModeEnum.LIVE, 403),
         ),
     )
-    def test_get_other_users_ask_a_question_403s(self, request: FixtureRequest, client_fixture: str, factories):
+    def test_get_other_users_ask_a_question_403s(
+        self, request: FixtureRequest, client_fixture: str, factories, submission_mode, expected_status_code
+    ):
         client = request.getfixturevalue(client_fixture)
         grant = getattr(client, "grant", None) or factories.grant.create()
         question = factories.question.create(
@@ -318,7 +330,9 @@ class TestAskAQuestion:
         )
 
         generic_user = factories.user.create()
-        generic_submission = factories.submission.create(collection=question.form.collection, created_by=generic_user)
+        generic_submission = factories.submission.create(
+            collection=question.form.collection, created_by=generic_user, mode=submission_mode
+        )
 
         response = client.get(
             url_for(
@@ -328,7 +342,7 @@ class TestAskAQuestion:
                 question_id=question.id,
             )
         )
-        assert response.status_code == 403
+        assert response.status_code == expected_status_code
 
     def test_get_ask_a_question_with_failing_condition_redirects(self, authenticated_grant_admin_client, factories):
         grant = authenticated_grant_admin_client.grant
@@ -753,14 +767,19 @@ class TestCheckYourAnswers:
         )
 
     @pytest.mark.parametrize(
-        "client_fixture",
+        "client_fixture, submission_mode, expected_status_code",
         (
-            ("authenticated_no_role_client"),
-            ("authenticated_grant_member_client"),
-            ("authenticated_grant_admin_client"),
+            ("authenticated_no_role_client", SubmissionModeEnum.TEST, 403),
+            ("authenticated_grant_member_client", SubmissionModeEnum.TEST, 302),
+            ("authenticated_grant_admin_client", SubmissionModeEnum.TEST, 302),
+            ("authenticated_no_role_client", SubmissionModeEnum.LIVE, 403),
+            ("authenticated_grant_member_client", SubmissionModeEnum.LIVE, 403),
+            ("authenticated_grant_admin_client", SubmissionModeEnum.LIVE, 403),
         ),
     )
-    def test_get_other_users_check_your_answers_403s(self, request: FixtureRequest, client_fixture: str, factories):
+    def test_get_other_users_check_your_answers_403s(
+        self, request: FixtureRequest, client_fixture: str, factories, submission_mode, expected_status_code
+    ):
         client = request.getfixturevalue(client_fixture)
         grant = getattr(client, "grant", None) or factories.grant.create()
         question = factories.question.create(
@@ -770,7 +789,9 @@ class TestCheckYourAnswers:
         )
 
         generic_user = factories.user.create()
-        generic_submission = factories.submission.create(collection=question.form.collection, created_by=generic_user)
+        generic_submission = factories.submission.create(
+            collection=question.form.collection, created_by=generic_user, mode=submission_mode
+        )
 
         response = client.get(
             url_for(
@@ -780,7 +801,7 @@ class TestCheckYourAnswers:
                 form_id=question.form.id,
             )
         )
-        assert response.status_code == 403
+        assert response.status_code == expected_status_code
 
     @pytest.mark.parametrize(
         "client_fixture, can_preview",


### PR DESCRIPTION
We've seen form designers sharing URLs for links to their own test submission's form runner instance. For test submissions, these are tied to a specific user and can only be completed by that user. If another user tries to access it we are 403ing, and this has caused confusion.

These users were trying to share links to the report/submission; it feels more helpful here for us to at least redirect other users to the report definition where they can start their own preview.

If someone without deliver access tries to do this, they'll still get a 403 from Deliver itself.