### PR TITLE
Add new access grant funding user roles

### DIFF
--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-019_case_insensitive_component
+020_add_access_roles

--- a/app/common/data/migrations/versions/020_add_access_roles.py
+++ b/app/common/data/migrations/versions/020_add_access_roles.py
@@ -1,0 +1,51 @@
+"""add access roles
+
+Revision ID: 020_add_access_roles
+Revises: 019_case_insensitive_component
+Create Date: 2025-11-07 19:15:40.026361
+
+"""
+
+from alembic import op
+from alembic_postgresql_enum import TableReference
+
+revision = "020_add_access_roles"
+down_revision = "019_case_insensitive_component"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.sync_enum_values(  # ty: ignore[unresolved-attribute]
+        enum_schema="public",
+        enum_name="role_enum",
+        new_values=["ADMIN", "MEMBER", "DATA_PROVIDER", "CERTIFIER"],
+        affected_columns=[
+            TableReference(table_schema="public", table_name="invitation", column_name="role"),
+            TableReference(table_schema="public", table_name="user_role", column_name="role"),
+        ],
+        enum_values_to_rename=[],
+    )
+    op.create_check_constraint(
+        op.f("ck_user_role_member_role_not_platform"),
+        "user_role",
+        "role != 'MEMBER' OR NOT (organisation_id IS NULL AND grant_id IS NULL)",
+    )
+
+
+def downgrade() -> None:
+    op.sync_enum_values(  # ty: ignore[unresolved-attribute]
+        enum_schema="public",
+        enum_name="role_enum",
+        new_values=["ADMIN", "MEMBER"],
+        affected_columns=[
+            TableReference(table_schema="public", table_name="invitation", column_name="role"),
+            TableReference(table_schema="public", table_name="user_role", column_name="role"),
+        ],
+        enum_values_to_rename=[],
+    )
+    op.create_check_constraint(
+        op.f("ck_user_role_member_role_not_platform"),
+        "user_role",
+        "role != 'MEMBER' OR NOT (organisation_id IS NULL AND grant_id IS NULL)",
+    )

--- a/app/common/data/types.py
+++ b/app/common/data/types.py
@@ -51,10 +51,14 @@ class OrganisationType(enum.StrEnum):
 
 
 class RoleEnum(enum.StrEnum):
+    # TODO: new 'PLATFORM_ADMIN' role that specifically only grants access to our admin panel?
     ADMIN = (
         "admin"  # Admin level permissions, combines with null columns in UserRole table to denote level of admin access
     )
+    # TODO: rename to 'read/view' to better reflect what access it gives?
     MEMBER = "member"  # Basic read level permissions
+    DATA_PROVIDER = "data-provider"
+    CERTIFIER = "certifier"
 
 
 # If a user roles implies they get other (lower) roles as well, list the role here with the roles they should get.


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-938

## Stacked PR 1/5

1. https://github.com/communitiesuk/funding-service/pull/1001
    * Updates RoleEnum to add new roles and help unlock Access grant funding work.
2. https://github.com/communitiesuk/funding-service/pull/1004
    * Add new `permissions` column, backfilled from existing `role` column, and start populating it (but not using it)
3. https://github.com/communitiesuk/funding-service/pull/1005
    * Start using the new `permissions` column everywhere, leaving `role` unused
4. https://github.com/communitiesuk/funding-service/pull/1006
    * Make the old `role` columns nullable and stop writing data to them
5. https://github.com/communitiesuk/funding-service/pull/1007
    * Drop the old `role` columns


## 📝 Description
These permissions will be overlaid on the `member` role to provide appropriate controls / checkpoints for grant recipients.

This change does not allow a user to have multiple roles in the same org+grant context; that will come shortly.

This will support both of the platform admin 'set up certifiers' work and the general access grant funding buildout.