### PR TITLE
Use permissions column

### DIFF
--- a/app/common/auth/authorisation_helper.py
+++ b/app/common/auth/authorisation_helper.py
@@ -24,7 +24,7 @@ class AuthorisationHelper:
         if isinstance(user, AnonymousUserMixin):
             return False
         return any(
-            role.role == RoleEnum.ADMIN and role.organisation_id is None and role.grant_id is None
+            RoleEnum.ADMIN in role.permissions and role.organisation_id is None and role.grant_id is None
             for role in user.roles
         )
 
@@ -35,7 +35,7 @@ class AuthorisationHelper:
         if AuthorisationHelper.is_platform_admin(user=user):
             return True
         return any(
-            role.role == RoleEnum.ADMIN
+            RoleEnum.ADMIN in role.permissions
             and role.organisation_id
             and role.grant_id is None
             and role.organisation.can_manage_grants
@@ -49,7 +49,7 @@ class AuthorisationHelper:
         if AuthorisationHelper.is_platform_admin(user=user):
             return True
         return any(
-            (role.role == RoleEnum.MEMBER or role.role == RoleEnum.ADMIN)
+            (RoleEnum.MEMBER in role.permissions or RoleEnum.ADMIN in role.permissions)
             and role.organisation_id
             and role.grant_id is None
             and role.organisation.can_manage_grants
@@ -66,7 +66,7 @@ class AuthorisationHelper:
         grant = get_grant(grant_id)
 
         for role in user.roles:
-            if role.role == RoleEnum.ADMIN:
+            if RoleEnum.ADMIN in role.permissions:
                 # entire org admin
                 if role.organisation_id == grant.organisation_id and role.grant_id is None:
                     return True
@@ -86,7 +86,7 @@ class AuthorisationHelper:
         grant = get_grant(grant_id)
 
         for role in user.roles:
-            if role.role == RoleEnum.MEMBER or role.role == RoleEnum.ADMIN:
+            if RoleEnum.MEMBER in role.permissions or RoleEnum.ADMIN in role.permissions:
                 # entire org member
                 if role.organisation_id == grant.organisation_id and role.grant_id is None:
                     return True

--- a/app/common/data/interfaces/grant_recipients.py
+++ b/app/common/data/interfaces/grant_recipients.py
@@ -44,7 +44,9 @@ def all_grant_recipients_have_users(grant: "Grant") -> bool:
                 UserRole.grant_id == grant.id,
                 UserRole.organisation_id == grant_recipient.organisation_id,
                 Organisation.can_manage_grants.is_(False),
-                UserRole.role == RoleEnum.MEMBER,  # TODO: might become a 'DATA_PROVIDER' permission with Access work
+                UserRole.permissions.contains(
+                    [RoleEnum.MEMBER]
+                ),  # TODO: might become a 'DATA_PROVIDER' permission with Access work
             )
         )
         if not user_count or user_count == 0:
@@ -61,7 +63,9 @@ def get_grant_recipient_users_count(grant: Grant) -> int:
         .where(
             Organisation.can_manage_grants.is_(False),
             UserRole.grant_id == grant.id,
-            UserRole.role == RoleEnum.MEMBER,  # TODO: might become a 'DATA_PROVIDER' permission with Access work
+            UserRole.permissions.contains(
+                [RoleEnum.MEMBER]
+            ),  # TODO: might become a 'DATA_PROVIDER' permission with Access work
         )
     )
     return db.session.scalar(statement) or 0
@@ -80,7 +84,9 @@ def get_grant_recipient_users_by_organisation(grant: Grant) -> dict[GrantRecipie
                 Organisation.can_manage_grants.is_(False),
                 UserRole.organisation_id == grant_recipient.organisation_id,
                 UserRole.grant_id == grant.id,
-                UserRole.role == RoleEnum.MEMBER,  # TODO: might become a 'DATA_PROVIDER' permission with Access work
+                UserRole.permissions.contains(
+                    [RoleEnum.MEMBER]
+                ),  # TODO: might become a 'DATA_PROVIDER' permission with Access work
             )
         )
         users = db.session.scalars(statement).all()
@@ -100,7 +106,9 @@ def get_grant_recipient_user_roles(grant: Grant) -> Sequence[UserRole]:
         .join(Organisation, Organisation.id == UserRole.organisation_id)
         .where(
             UserRole.grant_id == grant.id,
-            UserRole.role == RoleEnum.MEMBER,  # TODO: might become a 'DATA_PROVIDER' permission with Access work
+            UserRole.permissions.contains(
+                [RoleEnum.MEMBER]
+            ),  # TODO: might become a 'DATA_PROVIDER' permission with Access work
         )
     )
 
@@ -118,7 +126,9 @@ def revoke_grant_recipient_user_role(user_id: uuid.UUID, organisation_id: uuid.U
                 UserRole.organisation_id == organisation_id,
                 Organisation.can_manage_grants.is_(False),
                 UserRole.grant_id == grant_id,
-                UserRole.role == RoleEnum.MEMBER,  # TODO: might become a 'DATA_PROVIDER' permission with Access work
+                UserRole.permissions.contains(
+                    [RoleEnum.MEMBER]
+                ),  # TODO: might become a 'DATA_PROVIDER' permission with Access work
             )
         )
     )

--- a/app/common/data/types.py
+++ b/app/common/data/types.py
@@ -50,6 +50,7 @@ class OrganisationType(enum.StrEnum):
     WELSH_UNITARY_AUTHORITY = "Welsh Unitary Authority"
 
 
+# TODO: Rename PermissionEnum
 class RoleEnum(enum.StrEnum):
     # TODO: new 'PLATFORM_ADMIN' role that specifically only grants access to our admin panel?
     ADMIN = (

--- a/app/deliver_grant_funding/admin/views.py
+++ b/app/deliver_grant_funding/admin/views.py
@@ -222,7 +222,7 @@ class PlatformAdminReportingLifecycleView(PlatformAdminBaseView):
             for org_name, full_name, email_address in users_data:
                 org_id = grant_recipient_names_to_ids[org_name]
                 user = upsert_user_by_email(email_address=email_address, name=full_name)
-                upsert_user_role(user=user, role=RoleEnum.MEMBER, organisation_id=org_id, grant_id=grant.id)
+                upsert_user_role(user=user, permissions=[RoleEnum.MEMBER], organisation_id=org_id, grant_id=grant.id)
 
             flash(
                 f"Successfully set up {len(users_data)} grant recipient {'user' if len(users_data) == 1 else 'users'}.",

--- a/app/deliver_grant_funding/routes/grant_setup.py
+++ b/app/deliver_grant_funding/routes/grant_setup.py
@@ -180,7 +180,7 @@ def grant_setup_check_your_answers() -> ResponseReturnValue:
         if not AuthorisationHelper.is_deliver_org_admin(get_current_user()):
             upsert_user_role(
                 get_current_user(),
-                role=RoleEnum.ADMIN,
+                permissions=[RoleEnum.ADMIN],
                 organisation_id=grant.organisation_id,
                 grant_id=grant.id,
             )

--- a/app/developers/commands.py
+++ b/app/developers/commands.py
@@ -350,10 +350,10 @@ def seed_grants() -> None:  # noqa: C901
             )
         )
         if db_role:
-            db_role.role = role["role"]
-            db_role.permissions = [role["role"]]
+            db_role.role = role["permissions"][0]
+            db_role.permissions = role["permissions"]
         else:
-            role_data = {**role, "permissions": [role["role"]]}
+            role_data = {**role, "role": role["permissions"][0], "permissions": role["permissions"]}
             db_role = UserRole(**role_data)
             db.session.add(db_role)
 

--- a/app/developers/deliver_routes.py
+++ b/app/developers/deliver_routes.py
@@ -42,7 +42,7 @@ def grant_developers(grant_id: UUID) -> ResponseReturnValue:
 
     if become_grant_team_member_form.validate_on_submit():
         interfaces.user.remove_platform_admin_role_from_user(interfaces.user.get_current_user())
-        interfaces.user.set_grant_team_role_for_user(interfaces.user.get_current_user(), grant, RoleEnum.MEMBER)
+        interfaces.user.set_grant_team_role_for_user(interfaces.user.get_current_user(), grant, [RoleEnum.MEMBER])
         return redirect(url_for("deliver_grant_funding.grant_details", grant_id=grant.id))
 
     return render_template(

--- a/tests/integration/common/auth/test_decorators.py
+++ b/tests/integration/common/auth/test_decorators.py
@@ -129,7 +129,7 @@ class TestMHCLGLoginRequired:
             return "OK"
 
         user = factories.user.create(email="test@communities.gov.uk")
-        factories.user_role.create(user_id=user.id, user=user, role=RoleEnum.ADMIN)
+        factories.user_role.create(user_id=user.id, user=user, permissions=[RoleEnum.ADMIN])
 
         login_user(user)
         session["auth"] = AuthMethodEnum.MAGIC_LINK
@@ -158,7 +158,7 @@ class TestPlatformAdminRoleRequired:
             return "OK"
 
         user = factories.user.create(email="test@communities.gov.uk")
-        factories.user_role.create(user_id=user.id, user=user, role=RoleEnum.ADMIN)
+        factories.user_role.create(user_id=user.id, user=user, permissions=[RoleEnum.ADMIN])
 
         login_user(user)
         session["auth"] = AuthMethodEnum.SSO
@@ -195,7 +195,9 @@ class TestDeliverOrgAdminRoleRequired:
 
         user = factories.user.create(email="test@communities.gov.uk")
         grant = factories.grant.create()
-        factories.user_role.create(user_id=user.id, user=user, role=RoleEnum.ADMIN, organisation=grant.organisation)
+        factories.user_role.create(
+            user_id=user.id, user=user, permissions=[RoleEnum.ADMIN], organisation=grant.organisation
+        )
 
         login_user(user)
         session["auth"] = AuthMethodEnum.SSO
@@ -209,7 +211,7 @@ class TestDeliverOrgAdminRoleRequired:
             return "OK"
 
         user = factories.user.create(email="test@communities.gov.uk")
-        factories.user_role.create(user_id=user.id, user=user, role=RoleEnum.ADMIN)
+        factories.user_role.create(user_id=user.id, user=user, permissions=[RoleEnum.ADMIN])
 
         login_user(user)
         session["auth"] = AuthMethodEnum.SSO
@@ -236,7 +238,7 @@ class TestDeliverOrgAdminRoleRequired:
 
         user = factories.user.create(email="test@communities.gov.uk")
         organisation = factories.organisation.create(can_manage_grants=False)
-        factories.user_role.create(user_id=user.id, user=user, role=RoleEnum.ADMIN, organisation=organisation)
+        factories.user_role.create(user_id=user.id, user=user, permissions=[RoleEnum.ADMIN], organisation=organisation)
 
         with pytest.raises(Forbidden):
             login_user(user)
@@ -250,7 +252,7 @@ class TestDeliverOrgAdminRoleRequired:
 
         user = factories.user.create(email="test@communities.gov.uk")
         grant = factories.grant.create()
-        factories.user_role.create(user_id=user.id, user=user, role=RoleEnum.ADMIN, grant=grant)
+        factories.user_role.create(user_id=user.id, user=user, permissions=[RoleEnum.ADMIN], grant=grant)
 
         with pytest.raises(Forbidden):
             login_user(user)
@@ -264,7 +266,9 @@ class TestDeliverOrgAdminRoleRequired:
 
         user = factories.user.create(email="test@communities.gov.uk")
         grant = factories.grant.create()
-        factories.user_role.create(user_id=user.id, user=user, role=RoleEnum.MEMBER, organisation=grant.organisation)
+        factories.user_role.create(
+            user_id=user.id, user=user, permissions=[RoleEnum.MEMBER], organisation=grant.organisation
+        )
 
         with pytest.raises(Forbidden):
             login_user(user)
@@ -286,7 +290,9 @@ class TestDeliverOrgAdminRoleRequired:
 
         user = factories.user.create(email="test@communities.gov.uk")
         grant = factories.grant.create()
-        factories.user_role.create(user_id=user.id, user=user, role=RoleEnum.ADMIN, organisation=grant.organisation)
+        factories.user_role.create(
+            user_id=user.id, user=user, permissions=[RoleEnum.ADMIN], organisation=grant.organisation
+        )
 
         login_user(user)
         session["auth"] = AuthMethodEnum.MAGIC_LINK
@@ -316,7 +322,9 @@ class TestDeliverOrgMemberRoleRequired:
 
         user = factories.user.create(email="test@communities.gov.uk")
         grant = factories.grant.create()
-        factories.user_role.create(user_id=user.id, user=user, role=RoleEnum.MEMBER, organisation=grant.organisation)
+        factories.user_role.create(
+            user_id=user.id, user=user, permissions=[RoleEnum.MEMBER], organisation=grant.organisation
+        )
 
         login_user(user)
         session["auth"] = AuthMethodEnum.SSO
@@ -330,7 +338,7 @@ class TestDeliverOrgMemberRoleRequired:
             return "OK"
 
         user = factories.user.create(email="test@communities.gov.uk")
-        factories.user_role.create(user_id=user.id, user=user, role=RoleEnum.ADMIN)
+        factories.user_role.create(user_id=user.id, user=user, permissions=[RoleEnum.ADMIN])
 
         login_user(user)
         session["auth"] = AuthMethodEnum.SSO
@@ -357,7 +365,7 @@ class TestDeliverOrgMemberRoleRequired:
 
         user = factories.user.create(email="test@communities.gov.uk")
         organisation = factories.organisation.create(can_manage_grants=False)
-        factories.user_role.create(user_id=user.id, user=user, role=RoleEnum.MEMBER, organisation=organisation)
+        factories.user_role.create(user_id=user.id, user=user, permissions=[RoleEnum.MEMBER], organisation=organisation)
 
         with pytest.raises(Forbidden):
             login_user(user)
@@ -371,7 +379,7 @@ class TestDeliverOrgMemberRoleRequired:
 
         user = factories.user.create(email="test@communities.gov.uk")
         grant = factories.grant.create()
-        factories.user_role.create(user_id=user.id, user=user, role=RoleEnum.MEMBER, grant=grant)
+        factories.user_role.create(user_id=user.id, user=user, permissions=[RoleEnum.MEMBER], grant=grant)
 
         with pytest.raises(Forbidden):
             login_user(user)
@@ -393,7 +401,9 @@ class TestDeliverOrgMemberRoleRequired:
 
         user = factories.user.create(email="test@communities.gov.uk")
         grant = factories.grant.create()
-        factories.user_role.create(user_id=user.id, user=user, role=RoleEnum.MEMBER, organisation=grant.organisation)
+        factories.user_role.create(
+            user_id=user.id, user=user, permissions=[RoleEnum.MEMBER], organisation=grant.organisation
+        )
 
         login_user(user)
         session["auth"] = AuthMethodEnum.MAGIC_LINK
@@ -470,7 +480,7 @@ class TestHasDeliverGrantRole:
 
     def test_admin_user_has_access(self, factories):
         user = factories.user.create(email="test.admin@communities.gov.uk")
-        factories.user_role.create(user=user, role=RoleEnum.ADMIN)
+        factories.user_role.create(user=user, permissions=[RoleEnum.ADMIN])
 
         @has_deliver_grant_role(role=RoleEnum.ADMIN)
         def view_func(grant_id: UUID):
@@ -498,7 +508,7 @@ class TestHasDeliverGrantRole:
     def test_without_grant_id(self, factories):
         user = factories.user.create(email="test.member2@communities.gov.uk")
         grant = factories.grant.create()
-        factories.user_role.create(user=user, role=RoleEnum.MEMBER, grant=grant)
+        factories.user_role.create(user=user, permissions=[RoleEnum.MEMBER], grant=grant)
 
         @has_deliver_grant_role(role=RoleEnum.ADMIN)
         def view_func(grant_id: UUID):
@@ -512,7 +522,7 @@ class TestHasDeliverGrantRole:
     def test_member_user_has_access(self, factories):
         user = factories.user.create(email="test.member@communities.gov.uk")
         grant = factories.grant.create()
-        factories.user_role.create(user=user, role=RoleEnum.MEMBER, grant=grant)
+        factories.user_role.create(user=user, permissions=[RoleEnum.MEMBER], grant=grant)
 
         @has_deliver_grant_role(role=RoleEnum.MEMBER)
         def view_func(grant_id: UUID):
@@ -527,7 +537,7 @@ class TestHasDeliverGrantRole:
     def test_member_user_denied_for_admin_role(self, factories):
         user = factories.user.create(email="test.member2@communities.gov.uk")
         grant = factories.grant.create()
-        factories.user_role.create(user=user, role=RoleEnum.MEMBER, grant=grant)
+        factories.user_role.create(user=user, permissions=[RoleEnum.MEMBER], grant=grant)
 
         @has_deliver_grant_role(role=RoleEnum.ADMIN)
         def view_func(grant_id: UUID):
@@ -546,7 +556,7 @@ class TestCollectionIsEditable:
         user = factories.user.create(email="test.admin@communities.gov.uk")
         grant = factories.grant.create()
         collection = factories.collection.create(grant=grant, status=CollectionStatusEnum.DRAFT)
-        factories.user_role.create(user=user, role=RoleEnum.ADMIN, grant=grant)
+        factories.user_role.create(user=user, permissions=[RoleEnum.ADMIN], grant=grant)
 
         @collection_is_editable()
         def view_func(collection_id: UUID):
@@ -566,7 +576,7 @@ class TestCollectionIsEditable:
         user = factories.user.create(email="test.admin@communities.gov.uk")
         grant = factories.grant.create()
         collection = factories.collection.create(grant=grant, status=collection_status)
-        factories.user_role.create(user=user, role=RoleEnum.ADMIN, grant=grant)
+        factories.user_role.create(user=user, permissions=[RoleEnum.ADMIN], grant=grant)
 
         @collection_is_editable()
         def view_func(collection_id: UUID):
@@ -583,7 +593,7 @@ class TestCollectionIsEditable:
         user = factories.user.create(email="test.admin@communities.gov.uk")
         grant = factories.grant.create()
         collection = factories.collection.create(grant=grant, status=CollectionStatusEnum.DRAFT)
-        factories.user_role.create(user=user, role=RoleEnum.ADMIN, grant=None)
+        factories.user_role.create(user=user, permissions=[RoleEnum.ADMIN], grant=None)
 
         @collection_is_editable()
         def view_func(collection_id: UUID):
@@ -599,7 +609,7 @@ class TestCollectionIsEditable:
         user = factories.user.create(email="test.admin@communities.gov.uk")
         grant = factories.grant.create()
         collection = factories.collection.create(grant=grant, status=CollectionStatusEnum.OPEN)
-        factories.user_role.create(user=user, role=RoleEnum.ADMIN, grant=None)
+        factories.user_role.create(user=user, permissions=[RoleEnum.ADMIN], grant=None)
 
         @collection_is_editable()
         def view_func(collection_id: UUID):
@@ -616,7 +626,7 @@ class TestCollectionIsEditable:
         user = factories.user.create(email="test.member@communities.gov.uk")
         grant = factories.grant.create()
         collection = factories.collection.create(grant=grant, status=CollectionStatusEnum.DRAFT)
-        factories.user_role.create(user=user, role=RoleEnum.MEMBER, grant=grant)
+        factories.user_role.create(user=user, permissions=[RoleEnum.MEMBER], grant=grant)
 
         @collection_is_editable()
         def view_func(collection_id: UUID):
@@ -643,7 +653,7 @@ class TestCollectionIsEditable:
         user = factories.user.create(email="test.admin@communities.gov.uk")
         grant = factories.grant.create()
         collection = factories.collection.create(grant=grant, status=CollectionStatusEnum.DRAFT)
-        factories.user_role.create(user=user, role=RoleEnum.ADMIN, grant=grant)
+        factories.user_role.create(user=user, permissions=[RoleEnum.ADMIN], grant=grant)
 
         @collection_is_editable()
         def view_func(collection_id: UUID):
@@ -660,7 +670,7 @@ class TestCollectionIsEditable:
         user = factories.user.create(email="test.admin@communities.gov.uk")
         grant = factories.grant.create()
         collection = factories.collection.create(grant=grant, status=CollectionStatusEnum.OPEN)
-        factories.user_role.create(user=user, role=RoleEnum.ADMIN, grant=grant)
+        factories.user_role.create(user=user, permissions=[RoleEnum.ADMIN], grant=grant)
 
         @collection_is_editable()
         def view_func(collection_id: UUID):
@@ -678,7 +688,7 @@ class TestCollectionIsEditable:
         grant = factories.grant.create()
         collection = factories.collection.create(grant=grant, status=CollectionStatusEnum.DRAFT)
         form = factories.form.create(collection=collection)
-        factories.user_role.create(user=user, role=RoleEnum.ADMIN, grant=grant)
+        factories.user_role.create(user=user, permissions=[RoleEnum.ADMIN], grant=grant)
 
         @collection_is_editable()
         def view_func(form_id: UUID):
@@ -696,7 +706,7 @@ class TestCollectionIsEditable:
         collection = factories.collection.create(grant=grant, status=CollectionStatusEnum.DRAFT)
         form = factories.form.create(collection=collection)
         question = factories.question.create(form=form)
-        factories.user_role.create(user=user, role=RoleEnum.ADMIN, grant=grant)
+        factories.user_role.create(user=user, permissions=[RoleEnum.ADMIN], grant=grant)
 
         @collection_is_editable()
         def view_func(component_id: UUID):

--- a/tests/integration/common/data/db/test_constraints.py
+++ b/tests/integration/common/data/db/test_constraints.py
@@ -7,21 +7,23 @@ from app.common.data.types import ExpressionType, ManagedExpressionsEnum, RoleEn
 class TestUserRoleConstraints:
     def test_member_role_not_platform(self, factories):
         with pytest.raises(IntegrityError) as error:
-            factories.user_role.create(has_grant=False, has_organisation=False, role=RoleEnum.MEMBER)
+            factories.user_role.create(has_grant=False, has_organisation=False, permissions=[RoleEnum.MEMBER])
         assert (
             'new row for relation "user_role" violates check constraint "ck_user_role_member_role_not_platform"'
         ) in error.value.args[0]
 
     def test_unique_constraint_with_nulls(self, factories):
-        user_role = factories.user_role.create(role=RoleEnum.ADMIN)
+        user_role = factories.user_role.create(permissions=[RoleEnum.ADMIN])
         with pytest.raises(IntegrityError) as error:
-            factories.user_role.create(user_id=user_role.user_id, user=user_role.user, role=RoleEnum.ADMIN)
+            factories.user_role.create(user_id=user_role.user_id, user=user_role.user, permissions=[RoleEnum.ADMIN])
         assert 'duplicate key value violates unique constraint "uq_user_org_grant"' in error.value.args[0]
 
     def test_grant_id_required_if_organisation_id(self, factories):
         grant = factories.grant.create()
         with pytest.raises(IntegrityError) as error:
-            factories.user_role.create(role=RoleEnum.ADMIN, organisation=None, organisation_id=None, grant=grant)
+            factories.user_role.create(
+                permissions=[RoleEnum.ADMIN], organisation=None, organisation_id=None, grant=grant
+            )
         assert (
             'new row for relation "user_role" violates check constraint "ck_user_role_org_required_if_grant"'
             in error.value.args[0]

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -483,7 +483,7 @@ class TestUpdateCollection:
             user=user,
             organisation=grant_recipient.organisation,
             grant=grant,
-            role=RoleEnum.MEMBER,
+            permissions=[RoleEnum.MEMBER],
         )
 
         updated_collection = update_collection(collection, status=to_status)

--- a/tests/integration/common/data/interfaces/test_grant_recipients.py
+++ b/tests/integration/common/data/interfaces/test_grant_recipients.py
@@ -153,7 +153,7 @@ class TestGetGrantRecipientUsersCount:
         grant_recipient = factories.grant_recipient.create(grant=grant)
         user = factories.user.create()
         factories.user_role.create(
-            user=user, organisation=grant_recipient.organisation, grant=grant, role=RoleEnum.MEMBER
+            user=user, organisation=grant_recipient.organisation, grant=grant, permissions=[RoleEnum.MEMBER]
         )
 
         count = get_grant_recipient_users_count(grant)
@@ -166,7 +166,7 @@ class TestGetGrantRecipientUsersCount:
         users = factories.user.create_batch(3)
         for user in users:
             factories.user_role.create(
-                user=user, organisation=grant_recipient.organisation, grant=grant, role=RoleEnum.MEMBER
+                user=user, organisation=grant_recipient.organisation, grant=grant, permissions=[RoleEnum.MEMBER]
             )
 
         count = get_grant_recipient_users_count(grant)
@@ -179,12 +179,12 @@ class TestGetGrantRecipientUsersCount:
 
         user1 = factories.user.create()
         factories.user_role.create(
-            user=user1, organisation=grant_recipients[0].organisation, grant=grant, role=RoleEnum.MEMBER
+            user=user1, organisation=grant_recipients[0].organisation, grant=grant, permissions=[RoleEnum.MEMBER]
         )
 
         user2 = factories.user.create()
         factories.user_role.create(
-            user=user2, organisation=grant_recipients[1].organisation, grant=grant, role=RoleEnum.MEMBER
+            user=user2, organisation=grant_recipients[1].organisation, grant=grant, permissions=[RoleEnum.MEMBER]
         )
 
         count = get_grant_recipient_users_count(grant)
@@ -197,7 +197,7 @@ class TestGetGrantRecipientUsersCount:
 
         grant_team_user = factories.user.create()
         factories.user_role.create(
-            user=grant_team_user, organisation=grant.organisation, grant=grant, role=RoleEnum.MEMBER
+            user=grant_team_user, organisation=grant.organisation, grant=grant, permissions=[RoleEnum.MEMBER]
         )
 
         count = get_grant_recipient_users_count(grant)
@@ -208,7 +208,7 @@ class TestGetGrantRecipientUsersCount:
         grant = factories.grant.create()
         factories.grant_recipient.create(grant=grant)
         user = factories.user.create()
-        factories.user_role.create(user=user, role=RoleEnum.ADMIN)
+        factories.user_role.create(user=user, permissions=[RoleEnum.ADMIN])
 
         count = get_grant_recipient_users_count(grant)
 
@@ -220,7 +220,7 @@ class TestGetGrantRecipientUsersCount:
         grant_recipient = factories.grant_recipient.create(grant=grant1)
         user = factories.user.create()
         factories.user_role.create(
-            user=user, organisation=grant_recipient.organisation, grant=grant2, role=RoleEnum.MEMBER
+            user=user, organisation=grant_recipient.organisation, grant=grant2, permissions=[RoleEnum.MEMBER]
         )
 
         count = get_grant_recipient_users_count(grant1)
@@ -249,7 +249,7 @@ class TestAllGrantRecipientsHaveUsers:
         grant_recipient = factories.grant_recipient.create(grant=grant)
         user = factories.user.create()
         factories.user_role.create(
-            user=user, organisation=grant_recipient.organisation, grant=grant, role=RoleEnum.MEMBER
+            user=user, organisation=grant_recipient.organisation, grant=grant, permissions=[RoleEnum.MEMBER]
         )
 
         result = all_grant_recipients_have_users(grant)
@@ -263,7 +263,7 @@ class TestAllGrantRecipientsHaveUsers:
         for grant_recipient in grant_recipients:
             user = factories.user.create()
             factories.user_role.create(
-                user=user, organisation=grant_recipient.organisation, grant=grant, role=RoleEnum.MEMBER
+                user=user, organisation=grant_recipient.organisation, grant=grant, permissions=[RoleEnum.MEMBER]
             )
 
         result = all_grant_recipients_have_users(grant)
@@ -276,7 +276,7 @@ class TestAllGrantRecipientsHaveUsers:
 
         user = factories.user.create()
         factories.user_role.create(
-            user=user, organisation=grant_recipients[0].organisation, grant=grant, role=RoleEnum.MEMBER
+            user=user, organisation=grant_recipients[0].organisation, grant=grant, permissions=[RoleEnum.MEMBER]
         )
 
         result = all_grant_recipients_have_users(grant)
@@ -290,7 +290,7 @@ class TestAllGrantRecipientsHaveUsers:
 
         for user in users:
             factories.user_role.create(
-                user=user, organisation=grant_recipient.organisation, grant=grant, role=RoleEnum.MEMBER
+                user=user, organisation=grant_recipient.organisation, grant=grant, permissions=[RoleEnum.MEMBER]
             )
 
         result = all_grant_recipients_have_users(grant)
@@ -301,7 +301,7 @@ class TestAllGrantRecipientsHaveUsers:
         grant = factories.grant.create()
         factories.grant_recipient.create(grant=grant)
         user = factories.user.create()
-        factories.user_role.create(user=user, role=RoleEnum.ADMIN)
+        factories.user_role.create(user=user, permissions=[RoleEnum.ADMIN])
 
         result = all_grant_recipients_have_users(grant)
 
@@ -313,7 +313,7 @@ class TestAllGrantRecipientsHaveUsers:
         grant_recipient = factories.grant_recipient.create(grant=grant1)
         user = factories.user.create()
         factories.user_role.create(
-            user=user, organisation=grant_recipient.organisation, grant=grant2, role=RoleEnum.MEMBER
+            user=user, organisation=grant_recipient.organisation, grant=grant2, permissions=[RoleEnum.MEMBER]
         )
 
         result = all_grant_recipients_have_users(grant1)
@@ -325,7 +325,7 @@ class TestAllGrantRecipientsHaveUsers:
         factories.grant_recipient.create(grant=grant)
         grant_team_user = factories.user.create()
         factories.user_role.create(
-            user=grant_team_user, organisation=grant.organisation, grant=grant, role=RoleEnum.MEMBER
+            user=grant_team_user, organisation=grant.organisation, grant=grant, permissions=[RoleEnum.MEMBER]
         )
 
         result = all_grant_recipients_have_users(grant)
@@ -356,7 +356,7 @@ class TestGetGrantRecipientUsersByOrganisation:
         grant_recipient = factories.grant_recipient.create(grant=grant)
         user = factories.user.create()
         factories.user_role.create(
-            user=user, organisation=grant_recipient.organisation, grant=grant, role=RoleEnum.MEMBER
+            user=user, organisation=grant_recipient.organisation, grant=grant, permissions=[RoleEnum.MEMBER]
         )
 
         result = get_grant_recipient_users_by_organisation(grant)
@@ -372,7 +372,7 @@ class TestGetGrantRecipientUsersByOrganisation:
         users = factories.user.create_batch(3)
         for user in users:
             factories.user_role.create(
-                user=user, organisation=grant_recipient.organisation, grant=grant, role=RoleEnum.MEMBER
+                user=user, organisation=grant_recipient.organisation, grant=grant, permissions=[RoleEnum.MEMBER]
             )
 
         result = get_grant_recipient_users_by_organisation(grant)
@@ -392,7 +392,7 @@ class TestGetGrantRecipientUsersByOrganisation:
             users_per_recipient[grant_recipient.id] = users
             for user in users:
                 factories.user_role.create(
-                    user=user, organisation=grant_recipient.organisation, grant=grant, role=RoleEnum.MEMBER
+                    user=user, organisation=grant_recipient.organisation, grant=grant, permissions=[RoleEnum.MEMBER]
                 )
 
         result = get_grant_recipient_users_by_organisation(grant)
@@ -411,10 +411,10 @@ class TestGetGrantRecipientUsersByOrganisation:
         user1 = factories.user.create()
         user2 = factories.user.create()
         factories.user_role.create(
-            user=user1, organisation=grant_recipient.organisation, grant=grant1, role=RoleEnum.MEMBER
+            user=user1, organisation=grant_recipient.organisation, grant=grant1, permissions=[RoleEnum.MEMBER]
         )
         factories.user_role.create(
-            user=user2, organisation=grant_recipient.organisation, grant=grant2, role=RoleEnum.MEMBER
+            user=user2, organisation=grant_recipient.organisation, grant=grant2, permissions=[RoleEnum.MEMBER]
         )
 
         result = get_grant_recipient_users_by_organisation(grant1)
@@ -430,9 +430,9 @@ class TestGetGrantRecipientUsersByOrganisation:
         member_user = factories.user.create()
         admin_user = factories.user.create()
         factories.user_role.create(
-            user=member_user, organisation=grant_recipient.organisation, grant=grant, role=RoleEnum.MEMBER
+            user=member_user, organisation=grant_recipient.organisation, grant=grant, permissions=[RoleEnum.MEMBER]
         )
-        factories.user_role.create(user=admin_user, role=RoleEnum.ADMIN)
+        factories.user_role.create(user=admin_user, permissions=[RoleEnum.ADMIN])
 
         result = get_grant_recipient_users_by_organisation(grant)
 
@@ -455,7 +455,7 @@ class TestGetGrantRecipientUserRoles:
         grant_recipient = factories.grant_recipient.create(grant=grant)
         user = factories.user.create(name="Test User", email="test@example.com")
         factories.user_role.create(
-            user=user, organisation=grant_recipient.organisation, grant=grant, role=RoleEnum.MEMBER
+            user=user, organisation=grant_recipient.organisation, grant=grant, permissions=[RoleEnum.MEMBER]
         )
 
         result = get_grant_recipient_user_roles(grant)
@@ -473,7 +473,7 @@ class TestGetGrantRecipientUserRoles:
         users = factories.user.create_batch(3)
         for user in users:
             factories.user_role.create(
-                user=user, organisation=grant_recipient.organisation, grant=grant, role=RoleEnum.MEMBER
+                user=user, organisation=grant_recipient.organisation, grant=grant, permissions=[RoleEnum.MEMBER]
             )
 
         result = get_grant_recipient_user_roles(grant)
@@ -492,10 +492,10 @@ class TestGetGrantRecipientUserRoles:
         user2 = factories.user.create(name="User 2")
 
         factories.user_role.create(
-            user=user1, organisation=grant_recipients[0].organisation, grant=grant, role=RoleEnum.MEMBER
+            user=user1, organisation=grant_recipients[0].organisation, grant=grant, permissions=[RoleEnum.MEMBER]
         )
         factories.user_role.create(
-            user=user2, organisation=grant_recipients[1].organisation, grant=grant, role=RoleEnum.MEMBER
+            user=user2, organisation=grant_recipients[1].organisation, grant=grant, permissions=[RoleEnum.MEMBER]
         )
 
         result = get_grant_recipient_user_roles(grant)
@@ -512,10 +512,10 @@ class TestGetGrantRecipientUserRoles:
         user1 = factories.user.create()
         user2 = factories.user.create()
         factories.user_role.create(
-            user=user1, organisation=grant_recipient.organisation, grant=grant1, role=RoleEnum.MEMBER
+            user=user1, organisation=grant_recipient.organisation, grant=grant1, permissions=[RoleEnum.MEMBER]
         )
         factories.user_role.create(
-            user=user2, organisation=grant_recipient.organisation, grant=grant2, role=RoleEnum.MEMBER
+            user=user2, organisation=grant_recipient.organisation, grant=grant2, permissions=[RoleEnum.MEMBER]
         )
 
         result = get_grant_recipient_user_roles(grant1)
@@ -529,9 +529,9 @@ class TestGetGrantRecipientUserRoles:
         member_user = factories.user.create()
         admin_user = factories.user.create()
         factories.user_role.create(
-            user=member_user, organisation=grant_recipient.organisation, grant=grant, role=RoleEnum.MEMBER
+            user=member_user, organisation=grant_recipient.organisation, grant=grant, permissions=[RoleEnum.MEMBER]
         )
-        factories.user_role.create(user=admin_user, role=RoleEnum.ADMIN)
+        factories.user_role.create(user=admin_user, permissions=[RoleEnum.ADMIN])
 
         result = get_grant_recipient_user_roles(grant)
 
@@ -545,7 +545,7 @@ class TestRevokeGrantRecipientUserRole:
         grant_recipient = factories.grant_recipient.create(grant=grant)
         user = factories.user.create()
         factories.user_role.create(
-            user=user, organisation=grant_recipient.organisation, grant=grant, role=RoleEnum.MEMBER
+            user=user, organisation=grant_recipient.organisation, grant=grant, permissions=[RoleEnum.MEMBER]
         )
 
         result = revoke_grant_recipient_user_role(user.id, grant_recipient.organisation_id, grant.id)
@@ -570,10 +570,10 @@ class TestRevokeGrantRecipientUserRole:
         user1 = factories.user.create()
         user2 = factories.user.create()
         factories.user_role.create(
-            user=user1, organisation=grant_recipient.organisation, grant=grant, role=RoleEnum.MEMBER
+            user=user1, organisation=grant_recipient.organisation, grant=grant, permissions=[RoleEnum.MEMBER]
         )
         factories.user_role.create(
-            user=user2, organisation=grant_recipient.organisation, grant=grant, role=RoleEnum.MEMBER
+            user=user2, organisation=grant_recipient.organisation, grant=grant, permissions=[RoleEnum.MEMBER]
         )
 
         result = revoke_grant_recipient_user_role(user1.id, grant_recipient.organisation_id, grant.id)
@@ -590,7 +590,7 @@ class TestRevokeGrantRecipientUserRole:
         grant_recipient = factories.grant_recipient.create(grant=grant1)
         user = factories.user.create()
         factories.user_role.create(
-            user=user, organisation=grant_recipient.organisation, grant=grant1, role=RoleEnum.MEMBER
+            user=user, organisation=grant_recipient.organisation, grant=grant1, permissions=[RoleEnum.MEMBER]
         )
 
         result = revoke_grant_recipient_user_role(user.id, grant_recipient.organisation_id, grant2.id)
@@ -606,7 +606,7 @@ class TestRevokeGrantRecipientUserRole:
         grant_recipient2 = factories.grant_recipient.create(grant=grant)
         user = factories.user.create()
         factories.user_role.create(
-            user=user, organisation=grant_recipient1.organisation, grant=grant, role=RoleEnum.MEMBER
+            user=user, organisation=grant_recipient1.organisation, grant=grant, permissions=[RoleEnum.MEMBER]
         )
 
         result = revoke_grant_recipient_user_role(user.id, grant_recipient2.organisation_id, grant.id)
@@ -619,7 +619,7 @@ class TestRevokeGrantRecipientUserRole:
     def test_does_not_revoke_non_member_roles(self, db_session, factories):
         grant = factories.grant.create()
         user = factories.user.create()
-        admin_role = factories.user_role.create(user=user, role=RoleEnum.ADMIN)
+        admin_role = factories.user_role.create(user=user, permissions=[RoleEnum.ADMIN])
 
         result = revoke_grant_recipient_user_role(user.id, admin_role.organisation_id, grant.id)
 
@@ -630,7 +630,7 @@ class TestRevokeGrantRecipientUserRole:
         grant_recipient = factories.grant_recipient.create(grant=grant)
         user = factories.user.create()
         factories.user_role.create(
-            user=user, organisation=grant_recipient.organisation, grant=grant, role=RoleEnum.MEMBER
+            user=user, organisation=grant_recipient.organisation, grant=grant, permissions=[RoleEnum.MEMBER]
         )
 
         initial_roles_count = len(user.roles)
@@ -644,6 +644,8 @@ class TestRevokeGrantRecipientUserRole:
 
     def test_will_not_revoke_grant_managing_org_role(self, db_session, factories):
         grant = factories.grant.create()
-        user_role = factories.user_role.create(grant=grant, organisation=grant.organisation, role=RoleEnum.MEMBER)
+        user_role = factories.user_role.create(
+            grant=grant, organisation=grant.organisation, permissions=[RoleEnum.MEMBER]
+        )
 
         assert revoke_grant_recipient_user_role(user_role.user_id, grant.organisation_id, grant.id) == 0

--- a/tests/integration/common/data/interfaces/test_grants.py
+++ b/tests/integration/common/data/interfaces/test_grants.py
@@ -146,12 +146,12 @@ class TestUpdateGrant:
 
     def test_update_group_status_not_enough_grant_team_users(self, factories):
         grant = factories.grant.create(name="test_grant")
-        factories.user_role.create(grant=grant, role=RoleEnum.MEMBER)
+        factories.user_role.create(grant=grant, permissions=[RoleEnum.MEMBER])
 
         with pytest.raises(NotEnoughGrantTeamUsersError):
             update_grant(grant=grant, status=GrantStatusEnum.LIVE)
 
-        factories.user_role.create(grant=grant, role=RoleEnum.MEMBER)
+        factories.user_role.create(grant=grant, permissions=[RoleEnum.MEMBER])
         updated_grant = update_grant(grant=grant, status=GrantStatusEnum.LIVE)
 
         assert updated_grant.status == GrantStatusEnum.LIVE

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -299,7 +299,7 @@ def authenticated_grant_member_client(
     grant = factories.grant.create()
     factories.user_role.create(
         user=user,
-        role=RoleEnum.MEMBER,
+        permissions=[RoleEnum.MEMBER],
         organisation=grant.organisation,
         grant=grant,
     )
@@ -330,7 +330,7 @@ def authenticated_grant_admin_client(
     grant = factories.grant.create()
     factories.user_role.create(
         user=user,
-        role=RoleEnum.ADMIN,
+        permissions=[RoleEnum.ADMIN],
         organisation=grant.organisation,
         grant=grant,
     )
@@ -354,7 +354,7 @@ def authenticated_platform_admin_client(
     email = email_mark.args[0] if email_mark else "test@communities.gov.uk"
 
     user = factories.user.create(email=email)
-    factories.user_role.create(user_id=user.id, user=user, role=RoleEnum.ADMIN)
+    factories.user_role.create(user_id=user.id, user=user, permissions=[RoleEnum.ADMIN])
 
     login_user(user)
     with anonymous_client.session_transaction() as session:
@@ -376,7 +376,7 @@ def authenticated_org_admin_client(
     organisation = _get_grant_managing_organisation()
     factories.user_role.create(
         user=user,
-        role=RoleEnum.ADMIN,
+        permissions=[RoleEnum.ADMIN],
         organisation=organisation,
         grant=None,
     )
@@ -402,7 +402,7 @@ def authenticated_org_member_client(
     organisation = _get_grant_managing_organisation()
     factories.user_role.create(
         user=user,
-        role=RoleEnum.MEMBER,
+        permissions=[RoleEnum.MEMBER],
         organisation=organisation,
         grant=None,
     )

--- a/tests/integration/deliver_grant_funding/admin/test_views.py
+++ b/tests/integration/deliver_grant_funding/admin/test_views.py
@@ -508,8 +508,8 @@ class TestReportingLifecycleMakeGrantLive:
     ):
         grant = factories.grant.create(name="Test Grant", status=GrantStatusEnum.DRAFT)
         collection = factories.collection.create(grant=grant)
-        factories.user_role.create(grant=grant, role=RoleEnum.MEMBER)
-        factories.user_role.create(grant=grant, role=RoleEnum.ADMIN)
+        factories.user_role.create(grant=grant, permissions=[RoleEnum.MEMBER])
+        factories.user_role.create(grant=grant, permissions=[RoleEnum.ADMIN])
 
         response = authenticated_platform_admin_client.post(
             f"/deliver/admin/reporting-lifecycle/{grant.id}/{collection.id}/make-live",
@@ -528,7 +528,7 @@ class TestReportingLifecycleMakeGrantLive:
     def test_post_fails_without_enough_team_members(self, authenticated_platform_admin_client, factories, db_session):
         grant = factories.grant.create(name="Test Grant", status=GrantStatusEnum.DRAFT)
         collection = factories.collection.create(grant=grant)
-        factories.user_role.create(grant=grant, role=RoleEnum.MEMBER)
+        factories.user_role.create(grant=grant, permissions=[RoleEnum.MEMBER])
 
         response = authenticated_platform_admin_client.post(
             f"/deliver/admin/reporting-lifecycle/{grant.id}/{collection.id}/make-live",
@@ -1025,7 +1025,7 @@ class TestSetUpGrantRecipientUsers:
         assert user is not None
         assert user.name == "John Doe"
         assert len(user.roles) == 1
-        assert user.roles[0].role == RoleEnum.MEMBER
+        assert RoleEnum.MEMBER in user.roles[0].permissions
         assert user.roles[0].organisation_id == org.id
         assert user.roles[0].grant_id == grant.id
 
@@ -1058,7 +1058,7 @@ class TestSetUpGrantRecipientUsers:
         assert user.id == existing_user.id
         assert user.name == "New Name"
         assert any(
-            role.role == RoleEnum.MEMBER and role.organisation_id == org.id and role.grant_id == grant.id
+            RoleEnum.MEMBER in role.permissions and role.organisation_id == org.id and role.grant_id == grant.id
             for role in user.roles
         )
 
@@ -1238,7 +1238,7 @@ class TestRevokeGrantRecipientUsers:
         org = factories.organisation.create(name="Org 1", can_manage_grants=False)
         factories.grant_recipient.create(grant=grant, organisation=org)
         user = factories.user.create(name="John Doe", email="john@example.com")
-        factories.user_role.create(user=user, organisation=org, grant=grant, role=RoleEnum.MEMBER)
+        factories.user_role.create(user=user, organisation=org, grant=grant, permissions=[RoleEnum.MEMBER])
 
         response = authenticated_platform_admin_client.get(
             f"/deliver/admin/reporting-lifecycle/{grant.id}/{collection.id}/revoke-grant-recipient-users"
@@ -1256,7 +1256,7 @@ class TestRevokeGrantRecipientUsers:
         org = factories.organisation.create(name="Test Organisation", can_manage_grants=False)
         factories.grant_recipient.create(grant=grant, organisation=org)
         user = factories.user.create(name="John Doe", email="john@example.com")
-        user_role = factories.user_role.create(user=user, organisation=org, grant=grant, role=RoleEnum.MEMBER)
+        user_role = factories.user_role.create(user=user, organisation=org, grant=grant, permissions=[RoleEnum.MEMBER])
 
         from app.common.data.models_user import UserRole
 
@@ -1283,8 +1283,12 @@ class TestRevokeGrantRecipientUsers:
         factories.grant_recipient.create(grant=grant, organisation=org2)
         user1 = factories.user.create(name="John Doe", email="john@example.com")
         user2 = factories.user.create(name="Jane Smith", email="jane@example.com")
-        user_role1 = factories.user_role.create(user=user1, organisation=org1, grant=grant, role=RoleEnum.MEMBER)
-        user_role2 = factories.user_role.create(user=user2, organisation=org2, grant=grant, role=RoleEnum.MEMBER)
+        user_role1 = factories.user_role.create(
+            user=user1, organisation=org1, grant=grant, permissions=[RoleEnum.MEMBER]
+        )
+        user_role2 = factories.user_role.create(
+            user=user2, organisation=org2, grant=grant, permissions=[RoleEnum.MEMBER]
+        )
 
         from app.common.data.models_user import UserRole
 
@@ -1310,7 +1314,7 @@ class TestRevokeGrantRecipientUsers:
         org = factories.organisation.create(name="Test Organisation", can_manage_grants=False)
         factories.grant_recipient.create(grant=grant, organisation=org)
         user = factories.user.create(name="John Doe", email="john@example.com")
-        factories.user_role.create(user=user, organisation=org, grant=grant, role=RoleEnum.MEMBER)
+        factories.user_role.create(user=user, organisation=org, grant=grant, permissions=[RoleEnum.MEMBER])
 
         response = authenticated_platform_admin_client.post(
             f"/deliver/admin/reporting-lifecycle/{grant.id}/{collection.id}/revoke-grant-recipient-users",
@@ -1347,7 +1351,7 @@ class TestScheduleReport:
         grant_recipient = factories.grant_recipient.create(grant=grant)
         user = factories.user.create()
         factories.user_role.create(
-            user=user, organisation=grant_recipient.organisation, grant=grant, role=RoleEnum.MEMBER
+            user=user, organisation=grant_recipient.organisation, grant=grant, permissions=[RoleEnum.MEMBER]
         )
 
         client = request.getfixturevalue(client_fixture)
@@ -1367,7 +1371,7 @@ class TestScheduleReport:
         grant_recipient = factories.grant_recipient.create(grant=grant)
         user = factories.user.create()
         factories.user_role.create(
-            user=user, organisation=grant_recipient.organisation, grant=grant, role=RoleEnum.MEMBER
+            user=user, organisation=grant_recipient.organisation, grant=grant, permissions=[RoleEnum.MEMBER]
         )
 
         response = authenticated_platform_admin_client.get(
@@ -1392,7 +1396,7 @@ class TestScheduleReport:
         grant_recipient = factories.grant_recipient.create(grant=grant)
         user = factories.user.create()
         factories.user_role.create(
-            user=user, organisation=grant_recipient.organisation, grant=grant, role=RoleEnum.MEMBER
+            user=user, organisation=grant_recipient.organisation, grant=grant, permissions=[RoleEnum.MEMBER]
         )
 
         response = authenticated_platform_admin_client.post(

--- a/tests/integration/deliver_grant_funding/routes/test_misc.py
+++ b/tests/integration/deliver_grant_funding/routes/test_misc.py
@@ -42,7 +42,7 @@ class TestListGrants:
         grants = factories.grant.create_batch(5)
         user = get_current_user()
         for grant in grants:
-            factories.user_role.create(user_id=user.id, user=user, role=RoleEnum.MEMBER, grant=grant)
+            factories.user_role.create(user_id=user.id, user=user, permissions=[RoleEnum.MEMBER], grant=grant)
 
         result = authenticated_grant_member_client.get("/deliver/grants")
         assert result.status_code == 200
@@ -77,7 +77,7 @@ class TestListGrants:
         if "grant_admin" in client_fixture or "grant_member" in client_fixture:
             role = RoleEnum.ADMIN if "admin" in client_fixture else RoleEnum.MEMBER
             for grant in grants:
-                factories.user_role.create(user=client.user, role=role, grant=grant)
+                factories.user_role.create(user=client.user, permissions=[role], grant=grant)
 
         response = client.get("/deliver/grants")
         assert response.status_code == 200

--- a/tests/models.py
+++ b/tests/models.py
@@ -161,8 +161,8 @@ class _UserRoleFactory(SQLAlchemyModelFactory):
     organisation = factory.LazyAttribute(lambda o: o.grant.organisation if o.grant else None)
     grant_id = factory.LazyAttribute(lambda o: o.grant.id if o.grant else None)
     grant = None
-    role = None  # This needs to be overridden when initialising the factory
-    permissions = factory.LazyAttribute(lambda o: [o.role] if o.role else None)
+    role = factory.LazyAttribute(lambda o: o.permissions[0] if o.permissions else None)
+    permissions = None  # This needs to be overridden when initialising the factory
 
     class Params:
         has_organisation = factory.Trait(
@@ -880,8 +880,8 @@ class _InvitationFactory(SQLAlchemyModelFactory):
     organisation = None
     grant_id = None
     grant = None
-    role = None
-    permissions = factory.LazyAttribute(lambda o: [o.role] if o.role else None)
+    role = factory.LazyAttribute(lambda o: o.permissions[0] if o.permissions else None)
+    permissions = None
     expires_at_utc = factory.LazyFunction(lambda: datetime.datetime.now() + datetime.timedelta(days=7))
     claimed_at_utc = None
 

--- a/tests/unit/deliver_grant_funding/test_forms.py
+++ b/tests/unit/deliver_grant_funding/test_forms.py
@@ -85,7 +85,7 @@ def test_grant_ggis_form_fails_when_yes_selected_and_empty(app: Flask):
 def test_user_already_in_grant_users(app: Flask, factories, mocker):
     grant = factories.grant.build(name="Test Grant")
     user = factories.user.build(email="test.user@communities.gov.uk")
-    factories.user_role.build(user=user, role=RoleEnum.MEMBER, organisation=grant.organisation, grant=grant)
+    factories.user_role.build(user=user, permissions=[RoleEnum.MEMBER], organisation=grant.organisation, grant=grant)
     mocker.patch("app.common.auth.authorisation_helper.get_grant", return_value=grant)
 
     form = GrantAddUserForm(grant=grant)
@@ -101,7 +101,7 @@ def test_user_already_in_grant_users(app: Flask, factories, mocker):
 def test_user_already_platform_admin(app: Flask, factories):
     grant = factories.grant.build(name="Test")
     user = factories.user.build(email="test.user@communities.gov.uk")
-    factories.user_role.build(user=user, role=RoleEnum.ADMIN)
+    factories.user_role.build(user=user, permissions=[RoleEnum.ADMIN])
 
     form = GrantAddUserForm(grant=grant)
     form.user_email.data = "test.admin@communities.gov.uk"


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-938

## Stacked PR 3/5

1. https://github.com/communitiesuk/funding-service/pull/1001
    * Updates RoleEnum to add new roles and help unlock Access grant funding work.
2. https://github.com/communitiesuk/funding-service/pull/1004
    * Add new `permissions` column, backfilled from existing `role` column, and start populating it (but not using it)
3. https://github.com/communitiesuk/funding-service/pull/1005
    * Start using the new `permissions` column everywhere, leaving `role` unused
4. https://github.com/communitiesuk/funding-service/pull/1006
    * Make the old `role` columns nullable and stop writing data to them
5. https://github.com/communitiesuk/funding-service/pull/1007
    * Drop the old `role` columns

## 📝 Description
Start using the `permissions` column instead of the `role` columns.

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested