### PR TITLE
Make 'role' columns nullable

### DIFF
--- a/app/common/data/interfaces/exceptions.py
+++ b/app/common/data/interfaces/exceptions.py
@@ -48,7 +48,6 @@ class InvalidUserRoleError(Exception):
     message: str
 
     constraint_message_map: dict[str, str] = {
-        "ck_user_role_member_role_not_platform": "A 'member' role must be linked to an organisation or grant.",
         "ck_user_role_non_admin_permissions_require_org": (
             "Non-'admin' roles must be linked to an organisation or grant."
         ),

--- a/app/common/data/interfaces/user.py
+++ b/app/common/data/interfaces/user.py
@@ -119,13 +119,11 @@ def upsert_user_role(
             user_id=user.id,
             organisation_id=organisation_id,
             grant_id=grant_id,
-            role=permissions[0],
             permissions=permissions,
         )
         .on_conflict_do_update(
             index_elements=["user_id", "organisation_id", "grant_id"],
             set_={
-                "role": permissions[0],
                 "permissions": permissions,
             },
         )
@@ -211,7 +209,6 @@ def create_invitation(
         email=email,
         organisation_id=organisation.id if organisation else None,
         grant_id=grant.id if grant else None,
-        role=permissions[0],
         permissions=permissions,
         expires_at_utc=func.now() + datetime.timedelta(days=7),
     )

--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-021_add_permissions_array
+022_make_role_nullable

--- a/app/common/data/migrations/versions/022_make_role_nullable.py
+++ b/app/common/data/migrations/versions/022_make_role_nullable.py
@@ -1,0 +1,35 @@
+"""make role columns nullable
+
+Revision ID: 022_make_role_nullable
+Revises: 021_add_permissions_array
+Create Date: 2025-11-09 11:00:00.000000
+
+"""
+
+from alembic import op
+
+revision = "022_make_role_nullable"
+down_revision = "021_add_permissions_array"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("user_role", schema=None) as batch_op:
+        batch_op.drop_constraint(op.f("ck_user_role_member_role_not_platform"), type_="check")
+        batch_op.alter_column("role", existing_nullable=False, nullable=True)
+
+    with op.batch_alter_table("invitation", schema=None) as batch_op:
+        batch_op.alter_column("role", existing_nullable=False, nullable=True)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("invitation", schema=None) as batch_op:
+        batch_op.alter_column("role", existing_nullable=True, nullable=False)
+
+    with op.batch_alter_table("user_role", schema=None) as batch_op:
+        batch_op.alter_column("role", existing_nullable=True, nullable=False)
+        batch_op.create_check_constraint(
+            op.f("ck_user_role_member_role_not_platform"),
+            "role != 'MEMBER' OR organisation_id IS NOT NULL",
+        )

--- a/app/common/data/models_user.py
+++ b/app/common/data/models_user.py
@@ -111,14 +111,6 @@ class UserRole(BaseModel):
         ForeignKey("organisation.id", ondelete="CASCADE"), nullable=True
     )
     grant_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("grant.id", ondelete="CASCADE"), nullable=True)
-    role: Mapped["RoleEnum"] = mapped_column(
-        SqlEnum(
-            RoleEnum,
-            name="role_enum",
-            validate_strings=True,
-        ),
-        nullable=False,
-    )
     permissions: Mapped[list["RoleEnum"]] = mapped_column(
         postgresql.ARRAY(SqlEnum(RoleEnum, name="role_enum", validate_strings=True)),
         nullable=False,
@@ -142,10 +134,6 @@ class UserRole(BaseModel):
         Index("ix_user_roles_user_id_organisation_id", "user_id", "organisation_id"),
         Index("ix_user_roles_user_id_grant_id", "user_id", "grant_id"),
         Index("ix_user_roles_organisation_id_role_id_grant_id", "user_id", "organisation_id", "grant_id"),
-        CheckConstraint(
-            "role != 'MEMBER' OR organisation_id IS NOT NULL",
-            name="member_role_not_platform",
-        ),
         CheckConstraint(
             (
                 "('MEMBER' != ALL(permissions) AND 'CERTIFIER' != ALL(permissions) AND "
@@ -195,14 +183,6 @@ class Invitation(BaseModel):
         ForeignKey("organisation.id", ondelete="CASCADE"), nullable=True
     )
     grant_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("grant.id", ondelete="CASCADE"), nullable=True)
-    role: Mapped["RoleEnum"] = mapped_column(
-        SqlEnum(
-            RoleEnum,
-            name="role_enum",
-            validate_strings=True,
-        ),
-        nullable=False,
-    )
     permissions: Mapped[list["RoleEnum"]] = mapped_column(
         postgresql.ARRAY(SqlEnum(RoleEnum, name="role_enum", validate_strings=True)),
         nullable=False,

--- a/app/deliver_grant_funding/admin/entities.py
+++ b/app/deliver_grant_funding/admin/entities.py
@@ -225,8 +225,6 @@ class PlatformAdminInvitationView(PlatformAdminModelView):
     }
 
     def on_model_change(self, form: Form, model: Invitation, is_created: bool) -> None:
-        model.role = model.permissions[0]
-
         if is_created:
             # Make new invitations last 1 hour by default, since these invitations are very privileged.
             model.expires_at_utc = func.now() + datetime.timedelta(hours=1)

--- a/app/developers/commands.py
+++ b/app/developers/commands.py
@@ -79,7 +79,7 @@ ExportData = TypedDict(
 def _sort_export_data_in_place(export_data: ExportData) -> None:
     export_data["users"].sort(key=lambda u: u["email"])
     export_data["user_roles"].sort(
-        key=lambda ur: (ur["user_id"], ur.get("organisation_id"), ur.get("grant_id"), ur["role"])
+        key=lambda ur: (ur["user_id"], ur.get("organisation_id"), ur.get("grant_id"), ur["permissions"])
     )
 
     # Grant-managing orgs first, then by name
@@ -350,10 +350,9 @@ def seed_grants() -> None:  # noqa: C901
             )
         )
         if db_role:
-            db_role.role = role["permissions"][0]
             db_role.permissions = role["permissions"]
         else:
-            role_data = {**role, "role": role["permissions"][0], "permissions": role["permissions"]}
+            role_data = {**role, "permissions": role["permissions"]}
             db_role = UserRole(**role_data)
             db.session.add(db_role)
 

--- a/app/developers/data/grants.json
+++ b/app/developers/data/grants.json
@@ -14055,7 +14055,6 @@
       "permissions": [
         "member"
       ],
-      "role": "member",
       "user_id": "4f990e2b-690b-4c97-a47b-c9a073e92827"
     },
     {
@@ -14065,7 +14064,6 @@
       "permissions": [
         "member"
       ],
-      "role": "member",
       "user_id": "62ee98f5-cf10-4848-95a4-5b6280529046"
     },
     {
@@ -14073,7 +14071,6 @@
       "permissions": [
         "admin"
       ],
-      "role": "admin",
       "user_id": "9ab212ee-6716-4921-b6a2-61a684bf2fe3"
     },
     {
@@ -14083,7 +14080,6 @@
       "permissions": [
         "member"
       ],
-      "role": "member",
       "user_id": "a08a325c-645a-4a36-9787-c2acd75dd0f2"
     },
     {
@@ -14093,7 +14089,6 @@
       "permissions": [
         "member"
       ],
-      "role": "member",
       "user_id": "e8f81083-7d87-4c20-af0a-4ec4b3378cdb"
     }
   ],

--- a/tests/integration/common/data/db/test_constraints.py
+++ b/tests/integration/common/data/db/test_constraints.py
@@ -9,7 +9,8 @@ class TestUserRoleConstraints:
         with pytest.raises(IntegrityError) as error:
             factories.user_role.create(has_grant=False, has_organisation=False, permissions=[RoleEnum.MEMBER])
         assert (
-            'new row for relation "user_role" violates check constraint "ck_user_role_member_role_not_platform"'
+            'new row for relation "user_role" violates check constraint '
+            '"ck_user_role_non_admin_permissions_require_org"'
         ) in error.value.args[0]
 
     def test_unique_constraint_with_nulls(self, factories):

--- a/tests/integration/common/data/interfaces/test_user.py
+++ b/tests/integration/common/data/interfaces/test_user.py
@@ -291,7 +291,7 @@ class TestUpsertUserRole:
     @pytest.mark.parametrize(
         "organisation, grant, role, message",
         [
-            (False, False, RoleEnum.MEMBER, "A 'member' role must be linked to an organisation or grant."),
+            (False, False, RoleEnum.MEMBER, "Non-'admin' roles must be linked to an organisation or grant."),
         ],
     )
     def test_add_invalid_user_role(self, factories, organisation, grant, role, message) -> None:

--- a/tests/models.py
+++ b/tests/models.py
@@ -161,7 +161,6 @@ class _UserRoleFactory(SQLAlchemyModelFactory):
     organisation = factory.LazyAttribute(lambda o: o.grant.organisation if o.grant else None)
     grant_id = factory.LazyAttribute(lambda o: o.grant.id if o.grant else None)
     grant = None
-    role = factory.LazyAttribute(lambda o: o.permissions[0] if o.permissions else None)
     permissions = None  # This needs to be overridden when initialising the factory
 
     class Params:
@@ -880,7 +879,6 @@ class _InvitationFactory(SQLAlchemyModelFactory):
     organisation = None
     grant_id = None
     grant = None
-    role = factory.LazyAttribute(lambda o: o.permissions[0] if o.permissions else None)
     permissions = None
     expires_at_utc = factory.LazyFunction(lambda: datetime.datetime.now() + datetime.timedelta(days=7))
     claimed_at_utc = None


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-938

## Stacked PR 4/5

1. https://github.com/communitiesuk/funding-service/pull/1001
    * Updates RoleEnum to add new roles and help unlock Access grant funding work.
2. https://github.com/communitiesuk/funding-service/pull/1004
    * Add new `permissions` column, backfilled from existing `role` column, and start populating it (but not using it)
3. https://github.com/communitiesuk/funding-service/pull/1005
    * Start using the new `permissions` column everywhere, leaving `role` unused
4. https://github.com/communitiesuk/funding-service/pull/1006
    * Make the old `role` columns nullable and stop writing data to them
5. https://github.com/communitiesuk/funding-service/pull/1007
    * Drop the old `role` columns

## 📝 Description
Makes the `role` column on `UserRole` and `Invitation` tables nullable, and then stops writing any data to them, to prepare for dropping them. These have now been replaced by a `permissions[]` column.

The DB migrations CI check will fail because the migration dropping the columns has been split out to a separate PR for backwards-compatible deployment.

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested