### PR TITLE
Remove old role columns

### DIFF
--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-022_make_role_nullable
+023_remove_role_columns

--- a/app/common/data/migrations/versions/023_remove_role_columns.py
+++ b/app/common/data/migrations/versions/023_remove_role_columns.py
@@ -1,0 +1,46 @@
+"""remove role columns
+
+Revision ID: 023_remove_role_columns
+Revises: 022_make_role_nullable
+Create Date: 2025-11-09 11:55:41.338973
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "023_remove_role_columns"
+down_revision = "022_make_role_nullable"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("invitation", schema=None) as batch_op:
+        batch_op.drop_column("role")
+
+    with op.batch_alter_table("user_role", schema=None) as batch_op:
+        batch_op.drop_column("role")
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("user_role", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "role",
+                postgresql.ENUM("ADMIN", "MEMBER", "DATA_PROVIDER", "CERTIFIER", name="role_enum", create_type=False),
+                autoincrement=False,
+                nullable=True,
+            )
+        )
+
+    with op.batch_alter_table("invitation", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "role",
+                postgresql.ENUM("ADMIN", "MEMBER", "DATA_PROVIDER", "CERTIFIER", name="role_enum", create_type=False),
+                autoincrement=False,
+                nullable=True,
+            )
+        )


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-938

## Stacked PR 5/5

1. https://github.com/communitiesuk/funding-service/pull/1001
    * Updates RoleEnum to add new roles and help unlock Access grant funding work.
2. https://github.com/communitiesuk/funding-service/pull/1004
    * Add new `permissions` column, backfilled from existing `role` column, and start populating it (but not using it)
3. https://github.com/communitiesuk/funding-service/pull/1005
    * Start using the new `permissions` column everywhere, leaving `role` unused
4. https://github.com/communitiesuk/funding-service/pull/1006
    * Make the old `role` columns nullable and stop writing data to them
5. https://github.com/communitiesuk/funding-service/pull/1007
    * Drop the old `role` columns

## 📝 Description
Finally we drop the now-defunct `role` columns from `UserRole` and `Invitation`.

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested