### PR TITLE
BAU Tidy up form builder nav and titles

### DIFF
--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/add_section.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/add_section.html
@@ -1,7 +1,7 @@
 {% extends "deliver_grant_funding/grant_base.html" %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
-{% set page_title = "Reports" %}
+{% set page_title = "Add section" %}
 {% set active_item_identifier = "reports" %}
 
 {% block beforeContent %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/change_form_name.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/change_form_name.html
@@ -1,7 +1,7 @@
 {% extends "deliver_grant_funding/grant_base.html" %}
 {% from "deliver_grant_funding/macros/deliver_grant_funding_reports_breadcrumb.html" import deliver_grant_funding_reports_breadcrumb %}
 
-{% set page_title = "Sections" %}
+{% set page_title = "Change section name" %}
 {% set active_item_identifier = "reports" %}
 
 {% block beforeContent %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_section_questions.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_section_questions.html
@@ -4,7 +4,7 @@
 {% from "deliver_grant_funding/macros/dependency_banner.html" import dependency_banner %}
 {% from "deliver_grant_funding/macros/question_table.html" import question_table %}
 
-{% set page_title = "Reports" %}
+{% set page_title = db_form.title %}
 {% set active_item_identifier = "reports" %}
 {% set can_edit = authorisation_helper.can_edit_collection(current_user, db_form.collection_id) %}
 

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/manage_add_another_guidance.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/manage_add_another_guidance.html
@@ -5,6 +5,7 @@
 
 {% set page_title = "Add another summary page guidance" if not question.add_another_guidance_body else "Edit add another summary page guidance" %}
 {% set submit_label = "Add guidance" if not question.add_another_guidance_body else "Update guidance" %}
+{% set active_item_identifier = "reports" %}
 
 {% block beforeContent %}
   {% set back_link = url_for("deliver_grant_funding.list_group_questions", grant_id=grant.id, group_id=question.id) %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/manage_guidance.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/manage_guidance.html
@@ -5,6 +5,7 @@
 
 {% set page_title = "Add guidance" if not question.guidance_body else "Edit guidance" %}
 {% set submit_label = "Add guidance" if not question.guidance_body else "Update guidance" %}
+{% set active_item_identifier = "reports" %}
 
 {% block beforeContent %}
   {% set back_link = url_for("deliver_grant_funding.edit_question", grant_id=grant.id, question_id=question.id) if not question.is_group else url_for("deliver_grant_funding.list_group_questions", grant_id=grant.id, group_id=question.id) %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/view_submission.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/view_submission.html
@@ -12,7 +12,7 @@
     {{ mhclgTestBanner("Test submission") }}
   {% endif %}
 
-  {{ deliver_grant_funding_reports_breadcrumb(grant=grant, report=helper.submission.collection, immediate_parent_breadcrumb_item={"text": "Submissions", "href": url_for("deliver_grant_funding.list_submissions", grant_id=grant.id, report_id=helper.submission.collection.id, submission_mode=helper.submission.mode)}, this_page_breadcrumb_item={"text": helper.submission.created_by.email}) }}
+  {{ deliver_grant_funding_reports_breadcrumb(grant=grant, immediate_parent_breadcrumb_item={"text": "Submissions", "href": url_for("deliver_grant_funding.list_submissions", grant_id=grant.id, report_id=helper.submission.collection.id, submission_mode=helper.submission.mode)}, this_page_breadcrumb_item={"text": helper.submission.created_by.email}) }}
 {% endblock beforeContent %}
 
 {# todo: this can probably be combined with the macro in the form runner, there are quite a few subtle differences #}


### PR DESCRIPTION
Some form builder pages don't correctly set their sub navigation context and are missing titles, we can audit all of that before we're done but it can be visually distracting in the meantime.