### PR TITLE
BAU Disable flask debug toolbar for integration tests

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -99,6 +99,7 @@ def build_db_config(setup_db_container: PostgresContainer | None) -> Dict[str, A
             "DATABASE_NAME": "db-access-not-available-for-unit-tests",
             # pragma: allowlist nextline secret
             "DATABASE_SECRET": json.dumps({"username": "invalid", "password": "invalid"}),
+            "DEBUG_TB_ENABLED": "false",
         }
     return {
         "DATABASE_HOST": setup_db_container.get_container_host_ip(),
@@ -107,6 +108,7 @@ def build_db_config(setup_db_container: PostgresContainer | None) -> Dict[str, A
         "DATABASE_SECRET": json.dumps(
             {"username": setup_db_container.username, "password": setup_db_container.password}
         ),
+        "DEBUG_TB_ENABLED": "false",
     }
 
 


### PR DESCRIPTION
This is very likely negligible in terms of performance but it does mean that the responses we're asserting on are currently different than the ones in production. Things like the all of the env context and the queries used to generate the page will be "in" the response and could maybe cause false positives for very broad assertions (which we'll likely avoid anyway!)

For some reason setting app debug to false or using `app.config.update()` was happening after flask debug toolbar had already set up and didn't stop the HTML being injected on every response, happy to dig into that more if this doesn't feel like the appropriate place. 