### PR TITLE
Move grant details tab to end

### DIFF
--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_base.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_base.html
@@ -5,22 +5,22 @@
 {%
   set nav_items = [
       {
-          "text": "Grant details",
-          "key": "grant_details",
-          "href": url_for("deliver_grant_funding.grant_details", grant_id=grant.id),
-          "current": active_item_identifier == "details"
-      },
-      {
           "text": "Reports",
           "key": "reports",
           "href": url_for("deliver_grant_funding.list_reports", grant_id=grant.id),
           "current": active_item_identifier == "reports"
       },
       {
-          "text": "Grant team",
+          "text": "Team",
           "key": "grant_users",
           "href": url_for("deliver_grant_funding.list_users_for_grant", grant_id=grant.id),
           "current": active_item_identifier == "grant_team"
+      },
+      {
+          "text": "Grant details",
+          "key": "grant_details",
+          "href": url_for("deliver_grant_funding.grant_details", grant_id=grant.id),
+          "current": active_item_identifier == "details"
       },
   ]
 %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_list.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_list.html
@@ -50,12 +50,12 @@
 {% macro grant_table(grants, id_override=none) %}
   {% set table_rows = namespace(items=[]) %}
   {% for grant in grants %}
-    {% set grant_detail_link %}
-      <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.grant_details', grant_id=grant.id) }}">{{ grant.name }}</a>
+    {% set grant_homepage_link %}
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.grant_homepage', grant_id=grant.id) }}">{{ grant.name }}</a>
     {% endset %}
     {%
       set table_rows.items = table_rows.items + [
-          [{"html": grant_detail_link},
+          [{"html": grant_homepage_link},
             {"text": grant.ggis_number},
             {"text": grantStatusTag(grant.status)}]
       ]

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_team/grant_user_list.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_team/grant_user_list.html
@@ -26,7 +26,7 @@
       {% endwith %}
       <h1 class="govuk-heading-l">
         <span class="govuk-caption-l">{{ grant.name }}</span>
-        Grant team
+        Team
       </h1>
 
       {% if not grant.grant_team_users %}

--- a/app/developers/deliver_routes.py
+++ b/app/developers/deliver_routes.py
@@ -43,7 +43,7 @@ def grant_developers(grant_id: UUID) -> ResponseReturnValue:
     if become_grant_team_member_form.validate_on_submit():
         interfaces.user.remove_platform_admin_role_from_user(interfaces.user.get_current_user())
         interfaces.user.set_grant_team_role_for_user(interfaces.user.get_current_user(), grant, [RoleEnum.MEMBER])
-        return redirect(url_for("deliver_grant_funding.grant_details", grant_id=grant.id))
+        return redirect(url_for("deliver_grant_funding.grant_homepage", grant_id=grant.id))
 
     return render_template(
         "developers/deliver/grant_developers.html",

--- a/tests/integration/common/auth/test_auth.py
+++ b/tests/integration/common/auth/test_auth.py
@@ -262,7 +262,7 @@ class TestSSOGetTokenView:
         dummy_grant = factories.grant.create()
         factories.user.create(email="test@test.communities.gov.uk", azure_ad_subject_id="subject_id")
         with anonymous_client.session_transaction() as session:
-            session["next"] = url_for("deliver_grant_funding.grant_details", grant_id=dummy_grant.id)
+            session["next"] = url_for("deliver_grant_funding.grant_homepage", grant_id=dummy_grant.id)
 
         with patch("app.common.auth.build_msal_app") as mock_build_msap_app:
             # Partially mock the expected return value; just enough for the test.

--- a/tests/integration/deliver_grant_funding/routes/test_misc.py
+++ b/tests/integration/deliver_grant_funding/routes/test_misc.py
@@ -3,7 +3,7 @@ from bs4 import BeautifulSoup
 
 from app.common.data.interfaces.user import get_current_user
 from app.common.data.types import RoleEnum
-from tests.utils import get_h1_text
+from tests.utils import AnyStringMatching, get_h1_text
 
 
 class TestListGrants:
@@ -28,13 +28,12 @@ class TestListGrants:
         self, app, authenticated_grant_member_client, factories, templates_rendered, track_sql_queries
     ):
         with track_sql_queries() as queries:
-            result = authenticated_grant_member_client.get("/deliver/grants", follow_redirects=True)
-        assert result.status_code == 200
-        soup = BeautifulSoup(result.data, "html.parser")
+            result = authenticated_grant_member_client.get("/deliver/grants", follow_redirects=False)
+        assert result.status_code == 302
+        BeautifulSoup(result.data, "html.parser")
 
-        nav_items = [item.text.strip() for item in soup.select(".govuk-service-navigation__item")]
-        assert nav_items == ["Grant details", "Reports", "Grant team"]
         assert len(queries) == 4  # 1) select user, 2) select user_role, 3) select org, 4) select grants
+        assert result.location == AnyStringMatching(r"/deliver/.+/index")
 
     def test_list_grants_as_member_with_multiple_grants(
         self, app, authenticated_grant_member_client, factories, templates_rendered, track_sql_queries

--- a/tests/unit/test_all_routes_access.py
+++ b/tests/unit/test_all_routes_access.py
@@ -93,6 +93,7 @@ routes_with_expected_collection_is_editable_decorator = [
     "deliver_grant_funding.edit_question_validation",
 ]
 routes_with_expected_member_only_access = [
+    "deliver_grant_funding.grant_homepage",
     "deliver_grant_funding.list_users_for_grant",
     "deliver_grant_funding.grant_details",
     "deliver_grant_funding.list_reports",


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
In user research we've often seen the 'Grand details' tab as a landing/home page causing confusion. There isn't a strong drive to do anything on this page, and it's often not hugely relevant to the person's task.

We move grant details to the end of the service navigation here, and make the 'list reports' page the default landing page for a grant now.

## 📸 Show the thing (screenshots, gifs)
<!-- Include screenshots for UI changes, new features, or visual modifications -->
<!-- Use "Before" and "After" sections if showing changes to existing functionality -->

### Before
![2025-11-11 12 33 47](https://github.com/user-attachments/assets/e540b4ac-b5f0-4a44-b0f0-ed5994ace47c)


### After
![2025-11-11 12 30 40](https://github.com/user-attachments/assets/799930e7-6d51-4462-a50d-a88852f4a750)


### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested