### PR TITLE
More missed e2e fixes

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -36,7 +36,7 @@ e2e_user_configs: dict[DeliverGrantFundingUserType, E2ETestUserConfig] = {
     DeliverGrantFundingUserType.GRANT_TEAM_MEMBER: E2ETestUserConfig(
         user_id="SSO_GRANT_TEAM_MEMBER_USER_ID",
         email="svc-Preaward-Funds@communities.gov.uk",
-        expected_login_url_pattern="^{domain}/deliver/grant/[a-f0-9-]{{36}}/details$",
+        expected_login_url_pattern="^{domain}/deliver/grant/[a-f0-9-]{{36}}/reports$",
     ),
 }
 

--- a/tests/e2e/pages.py
+++ b/tests/e2e/pages.py
@@ -62,7 +62,7 @@ class SSOSignInPage(BasePage):
         # If already logged in, this will redirect to /grants
         expect(
             self.title.or_(self.page.get_by_role("heading", name="Grants", exact=True)).or_(
-                self.page.get_by_role("heading", name="Grant details")
+                self.page.get_by_role("heading", name="Reports")
             )
         ).to_be_visible()
 


### PR DESCRIPTION
The last PR fixed e2e in docker, but not in the test env.

This fixes it in the test env.

<img width="986" height="263" alt="image" src="https://github.com/user-attachments/assets/4e422094-bc19-4b1c-bcba-bce686415391" />