### PR TITLE
FSPT-960: App index redirects to Access index

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -306,7 +306,7 @@ def create_app() -> Flask:  # noqa: C901
 
     @app.route("/", methods=["GET"])
     def index() -> ResponseReturnValue:
-        return redirect(url_for("deliver_grant_funding.list_grants"))
+        return redirect(url_for("access_grant_funding.index"))
 
     # when developing we want the toolbar assets to not cause the page to flicker
     # otherwise we don't want the server to continually 304 on assets the browser has

--- a/app/common/auth/__init__.py
+++ b/app/common/auth/__init__.py
@@ -184,7 +184,7 @@ def sso_get_token() -> ResponseReturnValue:
         )
 
     # For all other valid users with roles after the above, finish the flow and redirect
-    redirect_to_path = sanitise_redirect_url(session.pop("next", url_for("index")))
+    redirect_to_path = sanitise_redirect_url(session.pop("next", url_for("deliver_grant_funding.list_grants")))
     session.pop("flow", None)
 
     if not login_user(user):

--- a/tests/integration/common/auth/test_auth.py
+++ b/tests/integration/common/auth/test_auth.py
@@ -339,8 +339,40 @@ class TestSSOGetTokenView:
                 follow_redirects=True,
             )
         assert response.status_code == 200
+        # This isn't the exact URL in the session `next` but that's because the grant_homepage redirects to list_reports
+        assert response.request.path == url_for("deliver_grant_funding.list_reports", grant_id=dummy_grant.id)
+
         soup = BeautifulSoup(response.data, "html.parser")
         assert dummy_grant.name in get_h1_text(soup)
+
+        with anonymous_client.session_transaction() as session:
+            assert "next" not in session
+
+        new_user = db_session.scalar(select(User).where(User.email == "test@test.communities.gov.uk"))
+        assert new_user.name == "SSO User"
+
+    def test_get_valid_token_with_default_redirect(self, anonymous_client, factories, db_session):
+        factories.user.create(email="test@test.communities.gov.uk", azure_ad_subject_id="subject_id")
+
+        with patch("app.common.auth.build_msal_app") as mock_build_msap_app:
+            # Partially mock the expected return value; just enough for the test.
+            mock_build_msap_app.return_value.acquire_token_by_auth_code_flow.return_value = {
+                "id_token_claims": {
+                    "preferred_username": "test@test.communities.gov.uk",
+                    "name": "SSO User",
+                    "roles": ["FS_PLATFORM_ADMIN"],
+                    "sub": "subject_id",
+                }
+            }
+            response = anonymous_client.get(
+                url_for("auth.sso_get_token"),
+                follow_redirects=True,
+            )
+        assert response.status_code == 200
+        assert response.request.path == url_for("deliver_grant_funding.list_grants")
+
+        soup = BeautifulSoup(response.data, "html.parser")
+        assert "Grants" in get_h1_text(soup)
 
         with anonymous_client.session_transaction() as session:
             assert "next" not in session

--- a/tests/integration/test_app.py
+++ b/tests/integration/test_app.py
@@ -81,3 +81,10 @@ class TestAppErrorHandlers:
         assert response.status_code == 500
         assert "Sorry, there is a problem with the service" in response.text
         assert app.config["SERVICE_DESK_URL"] in response.text
+
+
+class TestAppIndex:
+    def test_get_app_index_redirects_to_access_grant_funding(self, anonymous_client):
+        response = anonymous_client.get("/", follow_redirects=False)
+        assert response.status_code == 302
+        assert response.location == url_for("access_grant_funding.index")


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-960

## 📝 Description
Deliver grant funding and Access grant funding have two distinct and separate user groups, and most users will go directly to the relevant service. However, there's still a chance a user will try to access the root of the service, in which case we need to make a decision about where we redirect them or whether we show options for going through to Access or Deliver to the user.

In the short term, we decided to redirect to the Access grant funding index. The reasons for this are:
- Magic link login (which is what the Access grant funding index will in turn redirect to) is set up to deal with internal users who might have accidentally made their way there, and will send them on to the SSO login route
- We want to minimise friction for external grant recipient users
- These users are also less likely to be aware of the difference between Access and Deliver grant funding, so we should default to the service they need

This does have implications for internal (mainly Funding Service) users who might have bookmarked funding.communities.gov.uk and will then be redirected to Access rather than Deliver as expected, so we should discuss this.

Originally part of https://github.com/communitiesuk/funding-service/pull/1028 but pulled out into a separate PR so it can be considered in full.

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [X] PR title and description provide sufficient context for reviewers
- [X] Commits are logical, self-contained, and have clear descriptions

### Testing
- [X] I have tested this change and it meets the acceptance criteria for the ticket
- ~[ ] I need the reviewer(s) to pull and run this change locally~
- [X] New (non-developer) functionality has appropriate unit and integration tests
- ~[ ] End-to-end tests have been updated (if applicable)~
- [X] Edge cases and error conditions are tested
