### PR TITLE
Add task for making a report live

### DIFF
--- a/app/common/data/interfaces/exceptions.py
+++ b/app/common/data/interfaces/exceptions.py
@@ -150,9 +150,9 @@ class GrantRecipientsRequiredToScheduleReportError(Exception):
     pass
 
 
-class GrantRecipientUsersRequiredToScheduleReportError(Exception):
+class GrantRecipientUsersRequiredError(Exception):
     pass
 
 
-class GrantMustBeLiveToScheduleReportError(Exception):
+class GrantMustBeLiveError(Exception):
     pass

--- a/app/deliver_grant_funding/admin/forms.py
+++ b/app/deliver_grant_funding/admin/forms.py
@@ -380,3 +380,7 @@ class PlatformAdminSetCollectionDatesForm(FlaskForm):
 
 class PlatformAdminScheduleReportForm(FlaskForm):
     submit = SubmitField("Sign off and lock report", widget=GovSubmitInput())
+
+
+class PlatformAdminMakeReportLiveForm(FlaskForm):
+    submit = SubmitField("Open report for submissions", widget=GovSubmitInput())

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/admin/confirm-make-report-live.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/admin/confirm-make-report-live.html
@@ -1,0 +1,34 @@
+{% extends "admin/base.html" %}
+{% import 'admin/layout.html' as layout with context %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% from 'govuk_frontend_jinja/components/error-summary/macro.html' import govukErrorSummary %}
+{% from 'govuk_frontend_jinja/components/inset-text/macro.html' import govukInsetText %}
+
+{% block beforeContent %}
+  {{ govukBackLink({"text": "Back", "href": url_for('reporting_lifecycle.tasklist', grant_id=grant.id, collection_id=collection.id) }) }}
+{% endblock %}
+
+{% block action_panel %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-half">
+      {{ layout.messages() }}
+
+      {% if form.errors %}
+        {{ govukErrorSummary(wtforms_errors(form)) }}
+      {% endif %}
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l">{{ grant.name }}</span>
+        Open the report for submissions
+      </h1>
+      <p class="govuk-body">Opening the report will allow grant recipients to start making submissions.</p>
+
+      {{ govukInsetText({ "text": "Once the report is live, grant recipients will be able to access it and begin submitting their data." }) }}
+
+      <form method="post" novalidate>
+        {{ form.csrf_token }}
+        {{ form.submit }}
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/admin/reporting-lifecycle-tasklist.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/admin/reporting-lifecycle-tasklist.html
@@ -130,7 +130,7 @@
       {% set prerequisites_met = grant.status == enum.grant_status.LIVE and grant_recipients_count > 0 and dates_are_set and all_recipients_have_users %}
       {% set scheduledReportStatus = {"tag": {"text": "To do", "classes": "govuk-tag--grey"} } %}
 
-      {% if collection.status == enum.collection_status.SCHEDULED %}
+      {% if collection.status != enum.collection_status.DRAFT %}
         {% set scheduledReportStatus = {"tag": {"text": "Completed", "classes": "govuk-tag--green"} } %}
       {% elif not prerequisites_met %}
         {% set scheduledReportStatus = {"text": "Cannot start yet", "classes": "govuk-task-list__status--cannot-start-yet"} %}
@@ -139,7 +139,22 @@
         do rows.append({
           "title": {"text": "Sign off and lock report", "classes": "govuk-link--no-visited-state"},
           "status": scheduledReportStatus,
-          "href": url_for('reporting_lifecycle.schedule_report', grant_id=grant.id, collection_id=collection.id) if prerequisites_met and collection.status != enum.collection_status.SCHEDULED else "",
+          "href": url_for('reporting_lifecycle.schedule_report', grant_id=grant.id, collection_id=collection.id) if prerequisites_met and collection.status == enum.collection_status.DRAFT else "",
+        })
+      %}
+
+      {% set makeReportLiveStatus = {"tag": {"text": "To do", "classes": "govuk-tag--grey"} } %}
+
+      {% if collection.status == enum.collection_status.OPEN %}
+        {% set makeReportLiveStatus = {"tag": {"text": "Completed", "classes": "govuk-tag--green"} } %}
+      {% elif collection.status != enum.collection_status.SCHEDULED %}
+        {% set makeReportLiveStatus = {"text": "Cannot start yet", "classes": "govuk-task-list__status--cannot-start-yet"} %}
+      {% endif %}
+      {%
+        do rows.append({
+          "title": {"text": "Open the report for submissions", "classes": "govuk-link--no-visited-state"},
+          "status": makeReportLiveStatus,
+          "href": url_for('reporting_lifecycle.make_report_live', grant_id=grant.id, collection_id=collection.id) if collection.status == enum.collection_status.SCHEDULED else "",
         })
       %}
 

--- a/tests/unit/test_all_routes_access.py
+++ b/tests/unit/test_all_routes_access.py
@@ -221,6 +221,7 @@ routes_with_access_controlled_by_flask_admin = [
     "reporting_lifecycle.revoke_grant_recipient_data_providers",
     "reporting_lifecycle.set_collection_dates",
     "reporting_lifecycle.schedule_report",
+    "reporting_lifecycle.make_report_live",
 ]
 
 


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-942

## 📝 Description
Adds a task to open a report for submissions. This simply toggles the state from SCHEDULED to OPEN. The only real check added here is that we can't manually open a report before the `submission_period_start_date`.

## 📸 Show the thing (screenshots, gifs)
![2025-11-13 07 13 41](https://github.com/user-attachments/assets/9aa61606-21eb-4488-bcb5-c172f4f5dc3e)

## 🧪 Testing
<!-- Describe how you've tested this change, and how a reviewer can test it -->

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested