### PR TITLE
BAU: Pluralise `section` correctly in reports list

### DIFF
--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_reports.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_reports.html
@@ -62,12 +62,12 @@
                 Sections are groups of questions with a common theme
               {% else %}
                 <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.list_report_sections', grant_id=grant.id, report_id=report.id) }}">
-                  {{ report.forms | length }} sections<span class="govuk-visually-hidden"> in report for {{ report.name }}</span>
+                  {% trans count=report.forms | length %}{{ count }} section{% pluralize %}{{ count }} sections{% endtrans %}<span class="govuk-visually-hidden"> in report for {{ report.name }}</span>
                 </a>
               {% endif %}
             {% else %}
               <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.list_report_sections', grant_id=grant.id, report_id=report.id) }}">
-                {{ report.forms | length }} sections<span class="govuk-visually-hidden"> in report for {{ report.name }}</span>
+                {% trans count=report.forms | length %}{{ count }} section{% pluralize %}{{ count }} sections{% endtrans %}<span class="govuk-visually-hidden"> in report for {{ report.name }}</span>
               </a>
             {% endif %}
           {% endset %}

--- a/tests/e2e/reports_pages.py
+++ b/tests/e2e/reports_pages.py
@@ -213,7 +213,7 @@ class GrantReportsPage(ReportsBasePage):
         return add_section_page
 
     def click_manage_sections(self, report_name: str, grant_name: str) -> ReportSectionsPage:
-        self.page.get_by_role("link", name=re.compile(r"\d+ sections")).click()
+        self.page.get_by_role("link", name=re.compile(r"\d+ section")).click()
         report_sections_page = ReportSectionsPage(
             self.page, self.domain, grant_name=grant_name, report_name=report_name
         )


### PR DESCRIPTION
We weren't correctly pluralising `section` in the report summary card, with the word always being plural. This correctly counts the number of sections to use the singular if there's only 1 section.

| Before    | After |
| -------- | ------- |
| <img width="824" height="1225" alt="image" src="https://github.com/user-attachments/assets/dd75d85c-6c7e-470b-8e2a-ea606d74acc2" />  | <img width="838" height="1242" alt="image" src="https://github.com/user-attachments/assets/9c601e6e-bc3b-4d44-ac58-7c368eb19c35" />  |