### PR TITLE
Clean up adding/removing permissions

### DIFF
--- a/app/common/auth/__init__.py
+++ b/app/common/auth/__init__.py
@@ -11,7 +11,7 @@ from app.common.auth.decorators import redirect_if_authenticated
 from app.common.auth.forms import SignInForm
 from app.common.auth.sso import MSAL_ERROR_AUTHORIZATION_CODE_WAS_ALREADY_REDEEMED, build_auth_code_flow, build_msal_app
 from app.common.data import interfaces
-from app.common.data.types import AuthMethodEnum
+from app.common.data.types import AuthMethodEnum, RoleEnum
 from app.common.forms import GenericSubmitForm
 from app.common.security.utils import sanitise_redirect_url
 from app.extensions import auto_commit_after_request, notification_service
@@ -171,7 +171,9 @@ def sso_get_token() -> ResponseReturnValue:
             name=sso_user["name"],
         )
         if AuthorisationHelper.is_platform_admin(user):
-            interfaces.user.remove_platform_admin_role_from_user(user)
+            interfaces.user.remove_permissions_from_user(
+                user, permissions=[RoleEnum.MEMBER, RoleEnum.ADMIN], organisation_id=None, grant_id=None
+            )
             if not user.roles:
                 return redirect(
                     url_for("auth.signed_in_but_no_permissions", invite_expired=False),

--- a/app/deliver_grant_funding/routes/grant_setup.py
+++ b/app/deliver_grant_funding/routes/grant_setup.py
@@ -4,7 +4,7 @@ from flask.typing import ResponseReturnValue
 from app.common.auth.authorisation_helper import AuthorisationHelper
 from app.common.auth.decorators import is_deliver_org_member
 from app.common.data import interfaces
-from app.common.data.interfaces.user import get_current_user, upsert_user_role
+from app.common.data.interfaces.user import add_permissions_to_user, get_current_user
 from app.common.data.types import RoleEnum
 from app.common.forms import GenericSubmitForm
 from app.constants import CHECK_YOUR_ANSWERS
@@ -178,7 +178,7 @@ def grant_setup_check_your_answers() -> ResponseReturnValue:
         session.pop("grant_setup", None)
 
         if not AuthorisationHelper.is_deliver_org_admin(get_current_user()):
-            upsert_user_role(
+            add_permissions_to_user(
                 get_current_user(),
                 permissions=[RoleEnum.ADMIN],
                 organisation_id=grant.organisation_id,

--- a/app/developers/deliver_routes.py
+++ b/app/developers/deliver_routes.py
@@ -9,6 +9,7 @@ from app.common.data import interfaces
 from app.common.data.interfaces.temporary import (
     delete_grant,
 )
+from app.common.data.interfaces.user import add_permissions_to_user, get_current_user, remove_permissions_from_user
 from app.common.data.types import (
     RoleEnum,
 )
@@ -41,8 +42,11 @@ def grant_developers(grant_id: UUID) -> ResponseReturnValue:
         return redirect(url_for("deliver_grant_funding.list_grants"))
 
     if become_grant_team_member_form.validate_on_submit():
-        interfaces.user.remove_platform_admin_role_from_user(interfaces.user.get_current_user())
-        interfaces.user.set_grant_team_role_for_user(interfaces.user.get_current_user(), grant, [RoleEnum.MEMBER])
+        user = get_current_user()
+        remove_permissions_from_user(user=user, permissions=[RoleEnum.ADMIN, RoleEnum.MEMBER])
+        add_permissions_to_user(
+            user, permissions=[RoleEnum.MEMBER], organisation_id=grant.organisation_id, grant_id=grant.id
+        )
         return redirect(url_for("deliver_grant_funding.grant_homepage", grant_id=grant.id))
 
     return render_template(


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
Remove some of our custom interfaces for adding functions for specific role types, instead using the core `add_permissions_to_user` and `remove_permissions_from_user` interfaces.

We move `upsert_user_role` to an internal helper function for those+similar interfaces