### PR TITLE
BAU Raise warnings if a non-explicit GET request can change state

### DIFF
--- a/app/deliver_grant_funding/admin/views.py
+++ b/app/deliver_grant_funding/admin/views.py
@@ -490,7 +490,6 @@ class PlatformAdminReportingLifecycleView(PlatformAdminBaseView):
         )
 
     @expose("/<uuid:grant_id>/<uuid:collection_id>/send-emails-to-data-providers", methods=["GET"])  # type: ignore[misc]
-    @auto_commit_after_request
     def send_emails_to_recipients(self, grant_id: UUID, collection_id: UUID) -> Any:
         grant = get_grant(grant_id)
         collection = get_collection(collection_id, grant_id=grant_id, type_=CollectionType.MONITORING_REPORT)
@@ -509,7 +508,6 @@ class PlatformAdminReportingLifecycleView(PlatformAdminBaseView):
         )
 
     @expose("/<uuid:grant_id>/<uuid:collection_id>/send-emails-to-data-providers/download-csv", methods=["GET"])  # type: ignore[misc]
-    @auto_commit_after_request
     def download_data_providers_csv(self, grant_id: UUID, collection_id: UUID) -> Any:
         grant = get_grant(grant_id)
         collection = get_collection(collection_id, grant_id=grant_id, type_=CollectionType.MONITORING_REPORT)


### PR DESCRIPTION
As we're leaning heavily on the SQLAlchemy ORM models throughout our code we should try and avoid situations where properties are unknowingly committed.

This shouldn't be on developers making changes and shouldn't be on reviewers, require endpoints that should change state with `GET` to be added to an explicit list.