### PR TITLE
Change e2e user to a deliverable email address

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -35,7 +35,7 @@ e2e_user_configs: dict[DeliverGrantFundingUserType, E2ETestUserConfig] = {
     ),
     DeliverGrantFundingUserType.GRANT_TEAM_MEMBER: E2ETestUserConfig(
         user_id="SSO_GRANT_TEAM_MEMBER_USER_ID",
-        email="svc-Preaward-Funds@communities.gov.uk",
+        email="fsd-post-award@communities.gov.uk",
         expected_login_url_pattern="^{domain}/deliver/grant/[a-f0-9-]{{36}}/reports$",
     ),
 }


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
We're currently seeing delivery failures when sending invite emails to the svc account, because it doesn't receive emails.

We can re-use our post-award DL, which is deliverable and doesn't bother/spam anyone. This'll remove a bunch of delivery failures from our Notify dashboards.

When deploying this, I'll manually update the user in each of the environments to match the new email.