### PR TITLE
Set up Cache-Control headers

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -122,6 +122,7 @@ class _SharedConfig(_BaseConfig):
     PROXY_FIX_PROTO: int = 1  # CloudFront for AWS environments; Caddy for PullPreview
     PROXY_FIX_HOST: int = 1  # We inject X-Forwarded-For using Cloudfront custom headings
     SERVER_NAME: str
+    SEND_FILE_MAX_AGE_DEFAULT: int = 31536000
 
     # Basic auth
     BASIC_AUTH_ENABLED: bool = False

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -11,7 +11,7 @@ from unittest.mock import _Call, patch
 
 import pytest
 from _pytest.fixtures import FixtureRequest
-from flask import Flask, abort, template_rendered
+from flask import Flask, Response, abort, template_rendered
 from flask.sessions import SessionMixin
 from flask.typing import ResponseReturnValue
 from flask_login import login_user
@@ -123,6 +123,12 @@ def app(setup_db_container: PostgresContainer) -> Generator[Flask, None, None]:
                 return abort(500)
             raise e
         raise RuntimeError("query expected no results and an error, but didn't")
+
+    @app.route("/custom-cache-control")
+    def custom_cache_control() -> ResponseReturnValue:
+        response = Response(mimetype="text/plain")
+        response.headers["Cache-Control"] = "max-age=30"
+        return response
 
     app.config.update({"TESTING": True})
     _precompile_templates(app)

--- a/tests/integration/test_cache_control.py
+++ b/tests/integration/test_cache_control.py
@@ -1,0 +1,50 @@
+import tempfile
+from pathlib import Path
+
+from flask import url_for
+
+from tests.conftest import FundingServiceTestClient
+
+
+class TestCacheControl:
+    def test_healthcheck_cache_headers(self, anonymous_client: FundingServiceTestClient) -> None:
+        response = anonymous_client.get("/healthcheck")
+        assert response.status_code == 200
+
+        assert response.headers["Cache-Control"] == "no-store, no-cache, must-revalidate, private, max-age=0"
+
+    def test_redirect_cache_headers(self, anonymous_client: FundingServiceTestClient) -> None:
+        response = anonymous_client.get("/", follow_redirects=False)
+        assert response.status_code == 302
+
+        assert response.headers["Cache-Control"] == "no-store, no-cache, must-revalidate, private, max-age=0"
+        assert response.headers["Pragma"] == "no-cache"
+        assert response.headers["Expires"] == "0"
+
+    def test_404_page_cache_headers(self, anonymous_client: FundingServiceTestClient) -> None:
+        response = anonymous_client.get("/nonexistent-page")
+        assert response.status_code == 404
+
+        assert response.headers["Cache-Control"] == "no-store, no-cache, must-revalidate, private, max-age=0"
+        assert response.headers["Pragma"] == "no-cache"
+        assert response.headers["Expires"] == "0"
+
+    def test_static_file_cache_headers(self, anonymous_client: FundingServiceTestClient, monkeypatch) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_content = b"test file content"
+            test_file_path = Path(tmpdir) / "test.txt"
+            test_file_path.write_bytes(test_content)
+
+            monkeypatch.setattr(anonymous_client.application, "static_folder", tmpdir)
+
+            response = anonymous_client.get(url_for("static", filename="test.txt"))
+
+            _ = response.get_data()
+            response.close()
+
+            assert response.headers["Cache-Control"] == "public, max-age=31536000"
+
+    def test_custom_cache_control(self, anonymous_client: FundingServiceTestClient) -> None:
+        response = anonymous_client.get("/custom-cache-control")
+        assert response.status_code == 200
+        assert response.headers["Cache-Control"] == "max-age=30"


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
We're not currently doing a good job of caching our assets, for two reasons:

1) We set a default cache duration of 31536000 (1 year) seconds for any 'sent files' (assets) 2) We haven't enabled caching on CloudFront.

This PR deals with the first part of that, setting up much longer cache durations for all of our static assets (1 year), and explicitly disabling caching on everything else. I'll follow up by enabling caching on CloudFront.