### PR TITLE
Add a UK postcode validator

### DIFF
--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-023_remove_role_columns
+024_sync_managed_expression_enum

--- a/app/common/data/migrations/versions/024_sync_managed_expression_enum.py
+++ b/app/common/data/migrations/versions/024_sync_managed_expression_enum.py
@@ -1,0 +1,58 @@
+"""add UK postcode validator
+
+Revision ID: 024_sync_managed_expression_enum
+Revises: 023_remove_role_columns
+Create Date: 2025-11-17 14:52:54.201569
+
+"""
+
+from alembic import op
+from alembic_postgresql_enum import TableReference
+
+revision = "024_sync_managed_expression_enum"
+down_revision = "023_remove_role_columns"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.sync_enum_values(  # ty: ignore[unresolved-attribute]
+        enum_schema="public",
+        enum_name="managed_expression_enum",
+        new_values=[
+            "GREATER_THAN",
+            "LESS_THAN",
+            "BETWEEN",
+            "IS_YES",
+            "IS_NO",
+            "ANY_OF",
+            "SPECIFICALLY",
+            "IS_BEFORE",
+            "IS_AFTER",
+            "BETWEEN_DATES",
+            "UK_POSTCODE",
+        ],
+        affected_columns=[TableReference(table_schema="public", table_name="expression", column_name="managed_name")],
+        enum_values_to_rename=[],
+    )
+
+
+def downgrade() -> None:
+    op.sync_enum_values(  # ty: ignore[unresolved-attribute]
+        enum_schema="public",
+        enum_name="managed_expression_enum",
+        new_values=[
+            "GREATER_THAN",
+            "LESS_THAN",
+            "BETWEEN",
+            "IS_YES",
+            "IS_NO",
+            "ANY_OF",
+            "SPECIFICALLY",
+            "IS_BEFORE",
+            "IS_AFTER",
+            "BETWEEN_DATES",
+        ],
+        affected_columns=[TableReference(table_schema="public", table_name="expression", column_name="managed_name")],
+        enum_values_to_rename=[],
+    )

--- a/app/common/data/types.py
+++ b/app/common/data/types.py
@@ -154,6 +154,7 @@ class ManagedExpressionsEnum(enum.StrEnum):
     IS_BEFORE = "Is before"
     IS_AFTER = "Is after"
     BETWEEN_DATES = "Between dates"
+    UK_POSTCODE = "UK postcode"
 
 
 class FormRunnerState(enum.StrEnum):

--- a/tests/e2e/test_create_preview_collection.py
+++ b/tests/e2e/test_create_preview_collection.py
@@ -26,6 +26,7 @@ from app.common.expressions.managed import (
     LessThan,
     ManagedExpression,
     Specifically,
+    UKPostcode,
 )
 from app.common.filters import format_thousands
 from tests.e2e.config import EndToEndTestSecrets
@@ -287,11 +288,19 @@ questions_to_test: dict[str, TQuestionToTest] = {
             managed_expression=Specifically(question_id=uuid.uuid4(), item={"key": "option-2", "label": "option 2"}),
         ),
     },
-    "text-single-line": {
+    "postcode": {
         "type": QuestionDataType.TEXT_SINGLE_LINE,
-        "text": "Enter a single line of text",
-        "display_text": "Enter a single line of text",
-        "answers": [_QuestionResponse("E2E question text single line")],
+        "text": "Enter a postcode",
+        "display_text": "Enter a postcode",
+        "answers": [
+            _QuestionResponse("E2E question text single line", "The answer must be a UK postcode"),
+            _QuestionResponse("SW1A 1AA"),
+        ],
+        "validation": E2EManagedExpression(
+            managed_expression=UKPostcode(
+                question_id=uuid.uuid4(),
+            )
+        ),  # question_id does not matter here
         "guidance": GuidanceText(
             heading="This is a guidance page heading",
             body_heading="Guidance subheading",
@@ -835,7 +844,7 @@ def test_create_and_preview_report(
         # Sense check that the test includes all question types
         new_question_type_error = None
         try:
-            assert len(QuestionDataType) == 9 and len(questions_to_test) == 14 and len(ManagedExpressionsEnum) == 10, (
+            assert len(QuestionDataType) == 9 and len(questions_to_test) == 14 and len(ManagedExpressionsEnum) == 11, (
                 "If you have added a new question type or managed expression, update this test to include the "
                 "new question type or managed expression in `questions_to_test`."
             )

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -2809,7 +2809,7 @@ class TestAddQuestionConditionSelectQuestion:
             text="My question",
             name="Question name",
             hint="Question hint",
-            data_type=QuestionDataType.TEXT_SINGLE_LINE,
+            data_type=QuestionDataType.TEXT_MULTI_LINE,
         )
         group = factories.group.create(form=form, name="Test group")
 
@@ -3962,7 +3962,7 @@ class TestAddQuestionValidation:
             form=db_form,
             text="What is your name?",
             name="applicant name",
-            data_type=QuestionDataType.TEXT_SINGLE_LINE,
+            data_type=QuestionDataType.TEXT_MULTI_LINE,
         )
 
         response = authenticated_grant_admin_client.get(

--- a/tests/unit/common/expressions/test_registry.py
+++ b/tests/unit/common/expressions/test_registry.py
@@ -10,7 +10,7 @@ from app.common.expressions.registry import (
 
 class TestManagedExpressions:
     def test_get_registered_data_types(self, factories):
-        unsupported_question_type = QuestionDataType.TEXT_SINGLE_LINE
+        unsupported_question_type = QuestionDataType.TEXT_MULTI_LINE
 
         # because we're using a defaultdict we should make sure reading empty values can't change the logic
         assert get_managed_conditions_by_data_type(unsupported_question_type) == []
@@ -19,7 +19,7 @@ class TestManagedExpressions:
 
     def test_get_supported_form_questions_filters_question_types(self, factories):
         form = factories.form.build()
-        factories.question.build_batch(3, data_type=QuestionDataType.TEXT_SINGLE_LINE, form=form)
+        factories.question.build_batch(3, data_type=QuestionDataType.TEXT_MULTI_LINE, form=form)
         only_supported_target = factories.question.build(data_type=QuestionDataType.INTEGER, form=form)
         question = factories.question.build(data_type=QuestionDataType.INTEGER, form=form)
         supported_questions = get_supported_form_questions(question)
@@ -54,7 +54,7 @@ class TestManagedExpressions:
         assert get_supported_form_questions(group_integer_questions[2]) == [valid_question]
 
     def test_new_managed_expressions_added(self):
-        assert len(_registry_by_expression_enum) == 10, (
+        assert len(_registry_by_expression_enum) == 11, (
             "If you've added a new managed expression, update this test and add"
             "suitable tests in `tests/integration/common/expressions/test_managed.py`"
         )


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-999

## 📝 Description
Adds a naive managed validation rule to check that a single line of text answers conforms to, roughly, the UK postcode format.

This will allow invalid UK postcodes through (ie ones that don't resolve to a real location), because we only match on the pattern. We don't do any lookups to validate it's a real postcode.

Product are happy with this scope limitation at the moment.

## 📸 Show the thing (screenshots, gifs)
![2025-11-17 15 02 55](https://github.com/user-attachments/assets/0d272e32-7310-4a27-bd2a-ee3d92320e9e)


### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested