### PR TITLE
BAU Use submission status tag for deliver grant funding

### DIFF
--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_submissions.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_submissions.html
@@ -1,7 +1,7 @@
 {% from "deliver_grant_funding/macros/deliver_grant_funding_reports_breadcrumb.html" import deliver_grant_funding_reports_breadcrumb %}
 {% from "govuk_frontend_jinja/components/table/macro.html" import govukTable %}
 {% from "common/partials/mhclg-test-banner.html" import mhclgTestBanner %}
-{% from "common/macros/status.html" import status with context %}
+{% from "common/macros/status.html" import submissionStatusTag with context %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% extends "deliver_grant_funding/grant_base.html" %}
 
@@ -54,7 +54,7 @@
               {
                 "html": link_to_submission,
               }, {
-                "html": status(submission_helper.status)
+                "html": submissionStatusTag(submission_helper.status)
               }, {
                 "text": format_date_short(submission_helper.submission.updated_at_utc)
               }
@@ -90,7 +90,7 @@
               {
                 "html": link_to_submission,
               }, {
-                "html": status(grant_recipient_submission_helper.status if grant_recipient_submission_helper else enum.submission_status.NOT_STARTED)
+                "html": submissionStatusTag(grant_recipient_submission_helper.status if grant_recipient_submission_helper else enum.submission_status.NOT_STARTED)
               }, {
                 "text": format_date_short(grant_recipient_submission_helper.submission.updated_at_utc) if grant_recipient_submission_helper else ''
               }

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/view_submission.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/view_submission.html
@@ -1,7 +1,7 @@
 {% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
 {% from "deliver_grant_funding/macros/deliver_grant_funding_reports_breadcrumb.html" import deliver_grant_funding_reports_breadcrumb %}
 {% from "common/partials/mhclg-test-banner.html" import mhclgTestBanner %}
-{% from "common/macros/status.html" import status with context %}
+{% from "common/macros/status.html" import submissionStatusTag with context %}
 {% extends "deliver_grant_funding/grant_base.html" %}
 
 {% set page_title = "Submission - " ~ helper.submission.collection.name %}
@@ -126,14 +126,20 @@
 {% endmacro %}
 
 {% block content %}
-  <span class="govuk-caption-l">{{ helper.submission.created_by.email }}</span>
+  <span class="govuk-caption-l">{{ helper.submission.grant_recipient.organisation.name if helper.submission.grant_recipient else helper.submission.created_by.email }}</span>
   <div class="app-aligned-header-tag govuk-!-margin-bottom-6">
     <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Submission</h1>
-    {{ status(helper.status) }}
+    {{ submissionStatusTag(helper.status) }}
   </div>
 
   {% for form in helper.get_ordered_visible_forms() %}
     <h2 class="govuk-heading-m govuk-!-margin-top-4">{{ form.title }}</h2>
     {{ answers_summary_list(form) }}
   {% endfor %}
+
+  <p class="govuk-body">
+    <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.list_submissions', grant_id=grant.id, report_id=helper.submission.collection.id, submission_mode=helper.submission.mode) }}">
+      Back to submissions
+    </a>
+  </p>
 {% endblock content %}


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
Uses the submission status tag for deliver grant funding (introduced in access grant funding).

Also tweaks:
- uses the grant recipient name for the caption if it exists
- adds a link in case that page is long


## 📸 Show the thing (screenshots, gifs)
<!-- Include screenshots for UI changes, new features, or visual modifications -->
<!-- Use "Before" and "After" sections if showing changes to existing functionality -->

### Before
<img width="1232" height="933" alt="funding communities gov localhost_8080_deliver_grant_a594a4f6-6229-4664-bfd8-10c1ff0ff76b_report_e236f74e-26aa-48fd-a658-8e43eb8c3049_submissions_live (1)" src="https://github.com/user-attachments/assets/938ad13b-4e50-425c-9201-644c52ddda2c" />

<img width="1232" height="933" alt="funding communities gov localhost_8080_deliver_grant_a594a4f6-6229-4664-bfd8-10c1ff0ff76b_submission_97afc9c9-e4e5-4f39-9e75-bdbd3ee33bc0" src="https://github.com/user-attachments/assets/096128c3-5128-441e-b942-01f2d826aa07" />

### After
<!-- Screenshot or description of new state -->
<img width="1232" height="933" alt="funding communities gov localhost_8080_deliver_grant_a594a4f6-6229-4664-bfd8-10c1ff0ff76b_report_e236f74e-26aa-48fd-a658-8e43eb8c3049_submissions_live" src="https://github.com/user-attachments/assets/4b7694e5-cc17-4dd7-8932-22692781e2f2" />

<img width="1232" height="933" alt="funding communities gov localhost_8080_deliver_grant_a594a4f6-6229-4664-bfd8-10c1ff0ff76b_submission_97afc9c9-e4e5-4f39-9e75-bdbd3ee33bc0 (1)" src="https://github.com/user-attachments/assets/2fce91a3-bf25-42fb-b0bd-9ecb6be71a43" />