### PR TITLE
FSPT-1012 Navigate directly to grant if you only have 1 in AGF

### DIFF
--- a/app/access_grant_funding/routes/__init__.py
+++ b/app/access_grant_funding/routes/__init__.py
@@ -4,5 +4,6 @@ access_grant_funding_blueprint = Blueprint(name="access_grant_funding", import_n
 
 from app.access_grant_funding.routes import (  # noqa: E402, F401
     misc,
+    reports,
     runner,
 )

--- a/app/access_grant_funding/routes/misc.py
+++ b/app/access_grant_funding/routes/misc.py
@@ -11,14 +11,9 @@ from app.common.auth.decorators import (
     is_access_org_member,
 )
 from app.common.data import interfaces
-from app.common.data.interfaces.collections import (
-    get_all_submissions_with_mode_for_collection_with_full_schema,
-)
 from app.common.data.interfaces.grant_recipients import get_grant_recipient
-from app.common.data.interfaces.grants import get_grant
 from app.common.data.interfaces.organisations import get_organisation
-from app.common.data.types import RoleEnum, SubmissionModeEnum
-from app.common.helpers.collections import SubmissionHelper
+from app.common.data.types import RoleEnum
 
 
 @access_grant_funding_blueprint.route("/", methods=["GET"])
@@ -81,40 +76,7 @@ def list_organisations() -> ResponseReturnValue:
 
 
 @access_grant_funding_blueprint.route(
-    "/organisation/<uuid:organisation_id>/grant/<uuid:grant_id>/reports", methods=["GET"]
-)
-@has_access_grant_role(RoleEnum.MEMBER)
-def list_reports(organisation_id: UUID, grant_id: UUID) -> ResponseReturnValue:
-    grant = get_grant(grant_id=grant_id)
-
-    grant_recipient = get_grant_recipient(grant_id, organisation_id)
-
-    # TODO refactor when we persist the collection status and/or implement multiple rounds
-    submissions = []
-    for report in grant.access_reports:
-        submissions.extend(
-            [
-                SubmissionHelper(submission=submission)
-                for submission in get_all_submissions_with_mode_for_collection_with_full_schema(
-                    collection_id=report.id,
-                    submission_mode=SubmissionModeEnum.LIVE,
-                    grant_recipient_id=grant_recipient.id,
-                )
-            ]
-        )
-
-    return render_template(
-        "access_grant_funding/report_list.html",
-        reports=grant.access_reports,
-        organisation_id=organisation_id,
-        grant=grant,
-        submissions=submissions,
-        grant_recipient=grant_recipient,
-    )
-
-
-@access_grant_funding_blueprint.route(
-    "/organisation/<uuid:organisation_id>/grant/<uuid:grant_id>/users", methods=["GET"]
+    "/organisation/<uuid:organisation_id>/grants/<uuid:grant_id>/users", methods=["GET"]
 )
 @has_access_grant_role(RoleEnum.MEMBER)
 def list_grant_team(organisation_id: UUID, grant_id: UUID) -> ResponseReturnValue:

--- a/app/access_grant_funding/routes/reports.py
+++ b/app/access_grant_funding/routes/reports.py
@@ -1,0 +1,42 @@
+from uuid import UUID
+
+from flask import render_template
+from flask.typing import ResponseReturnValue
+
+from app.access_grant_funding.routes import access_grant_funding_blueprint
+from app.common.auth.decorators import has_access_grant_role
+from app.common.data.interfaces.collections import get_all_submissions_with_mode_for_collection_with_full_schema
+from app.common.data.interfaces.grant_recipients import get_grant_recipient
+from app.common.data.types import RoleEnum, SubmissionModeEnum
+from app.common.helpers.collections import SubmissionHelper
+
+
+@access_grant_funding_blueprint.route(
+    "/organisation/<uuid:organisation_id>/grants/<uuid:grant_id>/reports", methods=["GET"]
+)
+@has_access_grant_role(RoleEnum.MEMBER)
+def list_reports(organisation_id: UUID, grant_id: UUID) -> ResponseReturnValue:
+    grant_recipient = get_grant_recipient(grant_id, organisation_id)
+
+    # TODO refactor when we persist the collection status and/or implement multiple rounds
+    submissions = []
+    for report in grant_recipient.grant.access_reports:
+        submissions.extend(
+            [
+                SubmissionHelper(submission=submission)
+                for submission in get_all_submissions_with_mode_for_collection_with_full_schema(
+                    collection_id=report.id,
+                    submission_mode=SubmissionModeEnum.LIVE,
+                    grant_recipient_id=grant_recipient.id,
+                )
+            ]
+        )
+
+    return render_template(
+        "access_grant_funding/report_list.html",
+        reports=grant_recipient.grant.access_reports,
+        organisation_id=organisation_id,
+        grant=grant_recipient.grant,
+        submissions=submissions,
+        grant_recipient=grant_recipient,
+    )

--- a/tests/integration/access_grant_funding/test_routes.py
+++ b/tests/integration/access_grant_funding/test_routes.py
@@ -16,7 +16,7 @@ class TestIndex:
         assert response.status_code == 302
         assert response.location == (
             f"/access/organisation/{authenticated_grant_recipient_member_client.organisation.id}"
-            f"/grant/{authenticated_grant_recipient_member_client.grant.id}/reports"
+            f"/grants/{authenticated_grant_recipient_member_client.grant.id}/reports"
         )
 
     def test_get_index_two_grant_recipients_same_org_redirects(


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-1012

## 📝 Description
Updates the AGF index route to point to a single grant if you only have one, you should never then see the select a grant page until your organisation is associated with multiple grants.

Note if you arrive anauthorised with a link to a specific resource you'll still be forwarded to that.

Also change `/grant` to `/grants` in the reports URL and also moves the
reports route handler into its own file as it could be considered a
separate part of the application.

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [x] End-to-end tests have been updated (if applicable)
- [x] Edge cases and error conditions are tested
