### PR TITLE
Add links between Deliver and admin panel

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -140,14 +140,14 @@ def _setup_flask_admin(app: Flask, db_: SQLAlchemy) -> None:
 
     flask_admin = Admin(
         app,
-        name="Funding Service Admin",
+        name="Funding Service admin",
         endpoint="platform_admin",
         url="/deliver/admin",
         index_view=PlatformAdminIndexView(url="/deliver/admin", endpoint="platform_admin"),
-        theme=XGovukFrontendTheme(),
+        theme=XGovukFrontendTheme(base_template="deliver_grant_funding/admin/mhclg_base.html"),
         csp_nonce_generator=app.jinja_env.globals["csp_nonce"],
     )
-    XGovukFlaskAdmin(app, "Funding Service Admin")
+    XGovukFlaskAdmin(app)
     with app.app_context():
         register_admin_views(flask_admin, db_)
 

--- a/app/assets/admin.scss
+++ b/app/assets/admin.scss
@@ -1,0 +1,36 @@
+$govuk-brand-colour: #912b88;
+
+@import "../../node_modules/govuk-frontend/dist/govuk/base";
+
+.app-\!-align-vertically {
+    display: inline-flex !important;
+    align-items: center !important;
+}
+
+.app-header__content {
+    @include govuk-media-query($from: desktop) {
+        display: inline-flex !important;
+        flex-direction: row-reverse;
+        width: 50%;
+    }
+}
+
+.app-header__logo {
+    @include govuk-media-query($from: desktop) {
+        width: 50%;
+    }
+}
+
+.app-header__navigation {
+    @include govuk-media-query($from: desktop) {
+        padding-top: 18px !important;
+    }
+}
+
+.app-header__navigation-item {
+    border-bottom-color: darken($govuk-brand-colour, 15%) !important;
+
+    a {
+        font-weight: $govuk-font-weight-bold !important;
+    }
+}

--- a/app/common/templates/common/partials/mhclg-header.html
+++ b/app/common/templates/common/partials/mhclg-header.html
@@ -4,7 +4,16 @@
   {%- set menuButtonText = params.menuButtonText if params.menuButtonText else 'Menu' -%}
   {%- set _productName = params.productName if params.productName else 'MHCLG Funding Service' -%}
   {%- set _classes = params.classes if params.classes else 'govuk-header--full-width-border app-!-no-wrap' -%}
-  {%- set _navigation = params.navigation if params.navigation else [{ "text": ("Sign out"), "href": url_for('auth.sign_out') }] if currentUser and currentUser.is_authenticated else [] -%}
+  {%
+    set _navigation = (
+    params.navigation
+    if params.navigation else
+    [
+      {"text": "Admin panel", "href": url_for('platform_admin.index') } if authorisation_helper.is_platform_admin(currentUser) else {},
+      { "text": ("Sign out"), "href": url_for('auth.sign_out') }
+    ] if currentUser and currentUser.is_authenticated else []
+    )
+  %}
   {%- set _navigationClasses = params.navigationClasses if params.navigationClasses else 'govuk-header__navigation--end' -%}
 
 
@@ -14,7 +23,7 @@
 
   <header class="govuk-header {% if _classes %}{{ _classes }}{% endif %}" data-module="govuk-header" {{- govukAttributes(params.attributes) }}>
     <div class="govuk-header__container {{ params.containerClasses | default("govuk-width-container", true) }}">
-      <div class="govuk-header__logo govuk-!-margin-bottom-1">
+      <div class="govuk-header__logo">
         <a href="{{ params.homepageUrl | default("/", true) }}" class="govuk-header__link govuk-header__link--homepage">
           {#- The SVG needs `focusable="false"` so that Internet Explorer does
         not treat it as an interactive element - without this it will be

--- a/app/config.py
+++ b/app/config.py
@@ -28,7 +28,6 @@ class DatabaseSecret(BaseModel):
 
 FS_CONTENT_SECURITY_POLICY = {
     "default-src": ["'self'"],
-    "content_security_policy_nonce_in": ["script-src"],
     "script-src": [
         "'self'",
         "https://www.googletagmanager.com",

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/admin/confirm-make-grant-active-onboarding.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/admin/confirm-make-grant-active-onboarding.html
@@ -1,4 +1,4 @@
-{% extends "admin/base.html" %}
+{% extends "admin/master.html" %}
 {% import 'admin/layout.html' as layout with context %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from 'govuk_frontend_jinja/components/error-summary/macro.html' import govukErrorSummary %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/admin/confirm-make-grant-live.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/admin/confirm-make-grant-live.html
@@ -1,4 +1,4 @@
-{% extends "admin/base.html" %}
+{% extends "admin/master.html" %}
 {% import 'admin/layout.html' as layout with context %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from 'govuk_frontend_jinja/components/error-summary/macro.html' import govukErrorSummary %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/admin/confirm-make-report-live.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/admin/confirm-make-report-live.html
@@ -1,4 +1,4 @@
-{% extends "admin/base.html" %}
+{% extends "admin/master.html" %}
 {% import 'admin/layout.html' as layout with context %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from 'govuk_frontend_jinja/components/error-summary/macro.html' import govukErrorSummary %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/admin/confirm-schedule-report.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/admin/confirm-schedule-report.html
@@ -1,4 +1,4 @@
-{% extends "admin/base.html" %}
+{% extends "admin/master.html" %}
 {% import 'admin/layout.html' as layout with context %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from 'govuk_frontend_jinja/components/error-summary/macro.html' import govukErrorSummary %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/admin/mhclg_base.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/admin/mhclg_base.html
@@ -1,0 +1,36 @@
+{% extends "admin/base.html" %}
+
+{% block pageTitle %}Admin panel - MHCLG Funding Service{% endblock %}
+
+{% block head %}
+  {{ super() }}
+
+  <link rel="stylesheet" href="{{ vite_asset('app/assets/admin.scss') }}" type="text/css" />
+{% endblock %}
+
+{% block headerRow %}
+  <header class="govuk-header" data-module="govuk-header">
+    <div class="govuk-header__container govuk-width-container">
+      <div class="govuk-header__logo app-header__logo">
+        <a href="{{ url_for("deliver_grant_funding.list_grants") }}" class="govuk-header__link govuk-header__link--homepage app-!-align-vertically">
+          <img src="/static/assets/images/mhclg-crest.png" alt="MHCLG Crest" width="32" height="32" style="color: white; filter: brightness(0) invert(1);" nonce="{{ csp_nonce() }}" />
+          <span class="govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-!-margin-left-1">MHCLG Funding Service</span>
+        </a>
+      </div>
+
+      {# Bit of a hack - this is deprecated GOV.UK Header CSS; but it'll do for now ... (sorry future us) #}
+      <div class="govuk-header__content app-header__content">
+        <nav aria-label="Menu" class="govuk-header__navigation app-header__navigation">
+          <ul class="govuk-header__navigation-list">
+            <li class="govuk-header__navigation-item app-header__navigation-item">
+              <a class="govuk-header__link" href="{{ url_for('deliver_grant_funding.list_grants') }}">Deliver grant funding</a>
+            </li>
+            <li class="govuk-header__navigation-item app-header__navigation-item">
+              <a class="govuk-header__link" href="{{ url_for('auth.sign_out') }}">Sign out</a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </div>
+  </header>
+{% endblock %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/admin/reporting-lifecycle-tasklist.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/admin/reporting-lifecycle-tasklist.html
@@ -1,4 +1,4 @@
-{% extends "admin/base.html" %}
+{% extends "admin/master.html" %}
 {% import 'admin/layout.html' as layout with context %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "govuk_frontend_jinja/components/task-list/macro.html" import govukTaskList %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/admin/revoke-global-certifiers.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/admin/revoke-global-certifiers.html
@@ -1,4 +1,4 @@
-{% extends "admin/base.html" %}
+{% extends "admin/master.html" %}
 {% import 'admin/layout.html' as layout with context %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from 'govuk_frontend_jinja/components/error-summary/macro.html' import govukErrorSummary %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/admin/revoke-grant-recipient-data-providers.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/admin/revoke-grant-recipient-data-providers.html
@@ -1,4 +1,4 @@
-{% extends "admin/base.html" %}
+{% extends "admin/master.html" %}
 {% import 'admin/layout.html' as layout with context %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from 'govuk_frontend_jinja/components/error-summary/macro.html' import govukErrorSummary %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/admin/select-grant-for-reporting-lifecycle.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/admin/select-grant-for-reporting-lifecycle.html
@@ -1,4 +1,4 @@
-{% extends "admin/base.html" %}
+{% extends "admin/master.html" %}
 {% import 'admin/layout.html' as layout with context %}
 {% from 'govuk_frontend_jinja/components/error-summary/macro.html' import govukErrorSummary %}
 

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/admin/select-report-for-reporting-lifecycle.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/admin/select-report-for-reporting-lifecycle.html
@@ -1,4 +1,4 @@
-{% extends "admin/base.html" %}
+{% extends "admin/master.html" %}
 {% import 'admin/layout.html' as layout with context %}
 {% from 'govuk_frontend_jinja/components/error-summary/macro.html' import govukErrorSummary %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/admin/send-emails-to-data-providers.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/admin/send-emails-to-data-providers.html
@@ -1,4 +1,4 @@
-{% extends "admin/base.html" %}
+{% extends "admin/master.html" %}
 {% import 'admin/layout.html' as layout with context %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/admin/set-collection-dates.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/admin/set-collection-dates.html
@@ -1,4 +1,4 @@
-{% extends "admin/base.html" %}
+{% extends "admin/master.html" %}
 {% import 'admin/layout.html' as layout with context %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from 'govuk_frontend_jinja/components/error-summary/macro.html' import govukErrorSummary %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/admin/set-up-global-certifiers.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/admin/set-up-global-certifiers.html
@@ -1,4 +1,4 @@
-{% extends "admin/base.html" %}
+{% extends "admin/master.html" %}
 {% import 'admin/layout.html' as layout with context %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from 'govuk_frontend_jinja/components/error-summary/macro.html' import govukErrorSummary %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/admin/set-up-grant-recipient-data-providers.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/admin/set-up-grant-recipient-data-providers.html
@@ -1,4 +1,4 @@
-{% extends "admin/base.html" %}
+{% extends "admin/master.html" %}
 {% import 'admin/layout.html' as layout with context %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from 'govuk_frontend_jinja/components/error-summary/macro.html' import govukErrorSummary %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/admin/set-up-grant-recipients.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/admin/set-up-grant-recipients.html
@@ -1,4 +1,4 @@
-{% extends "admin/base.html" %}
+{% extends "admin/master.html" %}
 {% import 'admin/layout.html' as layout with context %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from 'govuk_frontend_jinja/components/error-summary/macro.html' import govukErrorSummary %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/admin/set-up-organisations.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/admin/set-up-organisations.html
@@ -1,4 +1,4 @@
-{% extends "admin/base.html" %}
+{% extends "admin/master.html" %}
 {% import 'admin/layout.html' as layout with context %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from 'govuk_frontend_jinja/components/error-summary/macro.html' import govukErrorSummary %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "num2words==0.5.14",
     "mistune==3.1.4",
     "faker==38.0.0",
-    "xgovuk-flask-admin==0.1.4",
+    "xgovuk-flask-admin==0.1.5",
     "flask-admin==2.0.2",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -644,7 +644,7 @@ requires-dist = [
     { name = "sqlalchemy", specifier = "==2.0.44" },
     { name = "sqlalchemy-json", specifier = "==0.7.0" },
     { name = "wtforms", extras = ["email"], specifier = "==3.2.1" },
-    { name = "xgovuk-flask-admin", specifier = "==0.1.4" },
+    { name = "xgovuk-flask-admin", specifier = "==0.1.5" },
 ]
 
 [package.metadata.requires-dev]
@@ -1887,7 +1887,7 @@ email = [
 
 [[package]]
 name = "xgovuk-flask-admin"
-version = "0.1.4"
+version = "0.1.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -1900,9 +1900,9 @@ dependencies = [
     { name = "sqlalchemy" },
     { name = "tox-uv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3e/2b/f208f1bf34448cb4769596cec9483d31aaef5b9342fbd76e1feb4f09e816/xgovuk_flask_admin-0.1.4.tar.gz", hash = "sha256:d44259e109b403ecdee11e02410d0a61d698094c6fe1a17910213b9eca2efdc4", size = 450514, upload-time = "2025-11-08T20:58:20.072Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/a5/8c587b0c641d41f2a3cb2771aa857cd73c68f39cea1377a35d57dccd9851/xgovuk_flask_admin-0.1.5.tar.gz", hash = "sha256:35ce4f7f11d1232158a7d2be5da77d1113880ef1707c0fc90c42b2d109e4f83f", size = 450536, upload-time = "2025-11-20T07:58:38.13Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/45/0a137bd44eb422b08edd630a2d97595ca5fa6b5df8f3415feac135ce307a/xgovuk_flask_admin-0.1.4-py3-none-any.whl", hash = "sha256:987fbd2dc344938dd7007fbcc745cdc17c883394f6d4f6e3516451e391a484e4", size = 458087, upload-time = "2025-11-08T20:58:17.79Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/7b/703dbf413ade0f95fa5665b6b92df66424add4739feb315175406c0959c6/xgovuk_flask_admin-0.1.5-py3-none-any.whl", hash = "sha256:55c7cba036c18d72f2b341de8c3b5cdc3960e84421f6340c42bab6f4077a3bed", size = 458107, upload-time = "2025-11-20T07:58:36.458Z" },
 ]
 
 [[package]]

--- a/vite.config.js
+++ b/vite.config.js
@@ -9,7 +9,11 @@ export default defineConfig({
         outDir: path.join(__dirname, "app/assets/dist"),
         manifest: "manifest.json",
         rollupOptions: {
-            input: ["app/assets/main.scss", "app/assets/main.js"],
+            input: [
+                "app/assets/main.scss",
+                "app/assets/main.js",
+                "app/assets/admin.scss",
+            ],
             external: [
                 /assets\/fonts\/.*\.(woff|woff2)$/,
                 /assets\/images\/.*\.svg$/,


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
We've had to manually URL hack to `/deliver/admin` to get to the platform admin panel so far; this patch adds links to the header to get back and forth between Deliver grant funding and the platform admin panel.

Also updates the admin panel header to show MHCLG Funding Service instead of GOV.UK

## 📸 Show the thing (screenshots, gifs)
<img width="1017" height="808" alt="image" src="https://github.com/user-attachments/assets/d4143559-04eb-40d1-99ca-8d7968782573" />
<img width="1342" height="766" alt="image" src="https://github.com/user-attachments/assets/8d79b948-1d10-4104-837d-3bfd50892631" />


### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [-] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested