### PR TITLE
Require MEMBER role always

### DIFF
--- a/app/common/data/interfaces/exceptions.py
+++ b/app/common/data/interfaces/exceptions.py
@@ -54,6 +54,8 @@ class InvalidUserRoleError(Exception):
         "ck_invitation_non_admin_permissions_require_org": (
             "Non-'admin' roles must be linked to an organisation or grant."
         ),
+        "ck_user_role_member_permission_required": "The 'member' role must always be present",
+        "ck_invitation_member_permission_required": "The 'member' role must always be present",
     }
 
     def __init__(self, integrity_error: IntegrityError) -> None:

--- a/app/common/data/interfaces/user.py
+++ b/app/common/data/interfaces/user.py
@@ -180,9 +180,7 @@ def add_permissions_to_user(
     # We're make sure that the MEMBER role is always explicitly included (this is effectively the 'view' permission)
     # NOTE: we could infer view access from the presence of a UserRole at all, so MEMBER could be considered redundant
     #       and is up for removal in the future.
-    # NOTE: for now, we only add the MEMBER role in non-platform-wide contexts. Future cleanup may allow MEMBER
-    #       role for platform contexts.
-    if RoleEnum.MEMBER not in permissions and organisation_id:
+    if RoleEnum.MEMBER not in permissions:
         permissions.append(RoleEnum.MEMBER)
 
     user_role = get_user_role(user, organisation_id, grant_id)
@@ -229,6 +227,9 @@ def create_invitation(
 ) -> Invitation:
     if organisation is None and grant is not None:
         raise ValueError("If specifying grant, must also specify organisation")
+
+    if RoleEnum.MEMBER not in permissions:
+        permissions.append(RoleEnum.MEMBER)
 
     # Expire any existing invitations for the same email, organisation, and grant,
     # filtering on NULL if org/grant not passed

--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-025_awaiting_sign_off_status
+026_require_member_permission

--- a/app/common/data/migrations/versions/026_require_member_permission.py
+++ b/app/common/data/migrations/versions/026_require_member_permission.py
@@ -1,0 +1,100 @@
+"""require member permission
+
+Revision ID: 026_require_member_permission
+Revises: 025_awaiting_sign_off_status
+Create Date: 2025-11-20 00:00:00.000000
+
+"""
+
+from alembic import op
+
+revision = "026_require_member_permission"
+down_revision = "025_awaiting_sign_off_status"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("user_role", schema=None) as batch_op:
+        batch_op.drop_constraint(op.f("ck_user_role_non_admin_permissions_require_org"), type_="check")
+    with op.batch_alter_table("invitation", schema=None) as batch_op:
+        batch_op.drop_constraint(op.f("ck_invitation_non_admin_permissions_require_org"), type_="check")
+
+    op.execute(
+        """
+        UPDATE user_role
+        SET permissions = array_append(permissions, 'MEMBER')
+        WHERE NOT ('MEMBER' = ANY(permissions))
+        """
+    )
+    op.execute(
+        """
+        UPDATE invitation
+        SET permissions = array_append(permissions, 'MEMBER')
+        WHERE NOT ('MEMBER' = ANY(permissions))
+        """
+    )
+
+    with op.batch_alter_table("user_role", schema=None) as batch_op:
+        batch_op.create_check_constraint(
+            op.f("ck_user_role_non_admin_permissions_require_org"),
+            "('CERTIFIER' != ALL(permissions) AND 'DATA_PROVIDER' != ALL(permissions)) OR organisation_id IS NOT NULL",
+        )
+        batch_op.create_check_constraint(
+            op.f("ck_user_role_member_permission_required"),
+            "'MEMBER' = ANY(permissions)",
+        )
+
+    with op.batch_alter_table("invitation", schema=None) as batch_op:
+        batch_op.create_check_constraint(
+            op.f("ck_invitation_non_admin_permissions_require_org"),
+            "('CERTIFIER' != ALL(permissions) AND 'DATA_PROVIDER' != ALL(permissions)) OR organisation_id IS NOT NULL",
+        )
+        batch_op.create_check_constraint(
+            op.f("ck_invitation_member_permission_required"),
+            "'MEMBER' = ANY(permissions)",
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("invitation", schema=None) as batch_op:
+        batch_op.drop_constraint(op.f("ck_invitation_non_admin_permissions_require_org"), type_="check")
+        batch_op.drop_constraint(op.f("ck_invitation_member_permission_required"), type_="check")
+
+    op.execute(
+        """
+        UPDATE invitation
+        SET permissions = array_remove(permissions, 'MEMBER')
+        WHERE 'MEMBER' = ANY(permissions) AND organisation_id IS NULL
+        """
+    )
+
+    with op.batch_alter_table("invitation", schema=None) as batch_op:
+        batch_op.create_check_constraint(
+            op.f("ck_invitation_non_admin_permissions_require_org"),
+            (
+                "('MEMBER' != ALL(permissions) AND 'CERTIFIER' != ALL(permissions) AND "
+                "'DATA_PROVIDER' != ALL(permissions)) OR organisation_id IS NOT NULL"
+            ),
+        )
+
+    with op.batch_alter_table("user_role", schema=None) as batch_op:
+        batch_op.drop_constraint(op.f("ck_user_role_non_admin_permissions_require_org"), type_="check")
+        batch_op.drop_constraint(op.f("ck_user_role_member_permission_required"), type_="check")
+
+    op.execute(
+        """
+        UPDATE user_role
+        SET permissions = array_remove(permissions, 'MEMBER')
+        WHERE 'MEMBER' = ANY(permissions) AND organisation_id IS NULL
+        """
+    )
+
+    with op.batch_alter_table("user_role", schema=None) as batch_op:
+        batch_op.create_check_constraint(
+            op.f("ck_user_role_non_admin_permissions_require_org"),
+            (
+                "('MEMBER' != ALL(permissions) AND 'CERTIFIER' != ALL(permissions) AND "
+                "'DATA_PROVIDER' != ALL(permissions)) OR organisation_id IS NOT NULL"
+            ),
+        )

--- a/app/common/data/models_user.py
+++ b/app/common/data/models_user.py
@@ -167,12 +167,10 @@ class UserRole(BaseModel):
         Index("ix_user_roles_user_id_grant_id", "user_id", "grant_id"),
         Index("ix_user_roles_organisation_id_role_id_grant_id", "user_id", "organisation_id", "grant_id"),
         CheckConstraint(
-            (
-                "('MEMBER' != ALL(permissions) AND 'CERTIFIER' != ALL(permissions) AND "
-                "'DATA_PROVIDER' != ALL(permissions)) OR organisation_id IS NOT NULL"
-            ),
+            "('CERTIFIER' != ALL(permissions) AND 'DATA_PROVIDER' != ALL(permissions)) OR organisation_id IS NOT NULL",
             name="non_admin_permissions_require_org",
         ),
+        CheckConstraint("'MEMBER' = ANY(permissions)", name="member_permission_required"),
         CheckConstraint(
             "(organisation_id IS NULL AND grant_id IS NULL) or (organisation_id IS NOT NULL)",
             name="org_required_if_grant",
@@ -229,12 +227,10 @@ class Invitation(BaseModel):
 
     __table_args__ = (
         CheckConstraint(
-            (
-                "('MEMBER' != ALL(permissions) AND 'CERTIFIER' != ALL(permissions) AND "
-                "'DATA_PROVIDER' != ALL(permissions)) OR organisation_id IS NOT NULL"
-            ),
+            "('CERTIFIER' != ALL(permissions) AND 'DATA_PROVIDER' != ALL(permissions)) OR organisation_id IS NOT NULL",
             name="non_admin_permissions_require_org",
         ),
+        CheckConstraint("'MEMBER' = ANY(permissions)", name="member_permission_required"),
     )
 
     @hybrid_property

--- a/app/developers/data/grants.json
+++ b/app/developers/data/grants.json
@@ -14256,9 +14256,10 @@
       "user_id": "62ee98f5-cf10-4848-95a4-5b6280529046"
     },
     {
-      "id": "59754cdf-3c78-42ac-9e10-5025116403f2",
+      "id": "0b455ab7-fba0-4139-86e0-29d86cccf5a4",
       "permissions": [
-        "admin"
+        "admin",
+        "member"
       ],
       "user_id": "9ab212ee-6716-4921-b6a2-61a684bf2fe3"
     },
@@ -14275,7 +14276,8 @@
     {
       "id": "881e0740-d057-419b-832e-84aa32256e4d",
       "permissions": [
-        "admin"
+        "admin",
+        "member"
       ],
       "user_id": "b538317c-82d9-41ae-82e7-a0578bc7ea0c"
     },
@@ -14328,7 +14330,7 @@
       "azure_ad_subject_id": "40e16bf9d02fa7f67c6bb767b197e544",
       "email": "sclark@test.communities.gov.uk",
       "id": "9ab212ee-6716-4921-b6a2-61a684bf2fe3",
-      "last_logged_in_at_utc": "Wed, 05 Nov 2025 07:25:19 GMT",
+      "last_logged_in_at_utc": "Thu, 20 Nov 2025 09:49:40 GMT",
       "name": "Willie Brown"
     },
     {

--- a/tests/models.py
+++ b/tests/models.py
@@ -50,6 +50,7 @@ from app.common.data.types import (
     GrantStatusEnum,
     QuestionDataType,
     QuestionPresentationOptions,
+    RoleEnum,
     SubmissionEventKey,
     SubmissionModeEnum,
 )
@@ -174,6 +175,14 @@ class _UserRoleFactory(SQLAlchemyModelFactory):
             grant_id=factory.LazyAttribute(lambda o: o.grant.id),
             grant=factory.SubFactory(_GrantFactory),
         )
+
+    @classmethod
+    def _adjust_kwargs(cls, **kwargs: Any) -> Any:
+        if kwargs["permissions"] is None:
+            kwargs["permissions"] = []
+        if RoleEnum.MEMBER not in kwargs["permissions"]:
+            kwargs["permissions"].append(RoleEnum.MEMBER)
+        return kwargs
 
 
 class _MagicLinkFactory(SQLAlchemyModelFactory):
@@ -899,3 +908,11 @@ class _InvitationFactory(SQLAlchemyModelFactory):
             user=factory.SubFactory(_UserFactory),
             user_id=factory.LazyAttribute(lambda o: o.user.id if o.user else None),
         )
+
+    @classmethod
+    def _adjust_kwargs(cls, **kwargs: Any) -> Any:
+        if kwargs["permissions"] is None:
+            kwargs["permissions"] = []
+        if RoleEnum.MEMBER not in kwargs["permissions"]:
+            kwargs["permissions"].append(RoleEnum.MEMBER)
+        return kwargs


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
For now we're codifying that MEMBER is the minimum level of access available, and is essentially 'read' access in most cases. (Caveat: we might make 'member' at the platform level have access to reporting lifecycle and invitations, but no other DB tables - TBD).

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested