### PR TITLE
Drop submissions when seeding grants

### DIFF
--- a/app/developers/commands.py
+++ b/app/developers/commands.py
@@ -27,6 +27,7 @@ from app.common.data.models import (
     Group,
     Organisation,
     Question,
+    Submission,
 )
 from app.common.data.models_user import User, UserRole
 from app.common.data.types import ComponentType, QuestionPresentationOptions
@@ -281,6 +282,13 @@ def seed_grants() -> None:  # noqa: C901
         grant_data["grant"]["id"] = uuid.UUID(grant_data["grant"]["id"])
 
         try:
+            db.session.execute(
+                delete(Submission).where(
+                    Submission.collection_id.in_(
+                        select(Collection.id).where(Collection.grant_id == grant_data["grant"]["id"])
+                    )
+                )
+            )
             db.session.execute(delete(GrantRecipient).where(GrantRecipient.grant_id == grant_data["grant"]["id"]))
             delete_grant(grant_data["grant"]["id"])
             db.session.flush()


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
https://funding-service-design-team-dl.sentry.io/issues/7049692233

We've seen our test environment fail to re-seed grants overnight because some submissions were holding FK references still. Let's drop submissions first when refreshing grants. If we need or want some submissions to be saved each time, we'll need to set up as part of the export.

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [-] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested