### PR TITLE
FSPT-1013 Properly separate tasklist section and submission statuses

### DIFF
--- a/app/common/collections/runner.py
+++ b/app/common/collections/runner.py
@@ -6,7 +6,7 @@ from flask import abort, current_app, url_for
 
 from app.common.collections.forms import AddAnotherSummaryForm, CheckYourAnswersForm, build_question_form
 from app.common.data import interfaces
-from app.common.data.types import FormRunnerState, SubmissionStatusEnum, TRunnerUrlMap
+from app.common.data.types import FormRunnerState, TasklistSectionStatusEnum, TRunnerUrlMap
 from app.common.exceptions import RedirectException
 from app.common.expressions import interpolate
 from app.common.forms import GenericSubmitForm
@@ -110,7 +110,9 @@ class FormRunner:
             ).all_answered
             self._check_your_answers_form = CheckYourAnswersForm(
                 section_completed=(
-                    "yes" if self.submission.get_status_for_form(self.form) == SubmissionStatusEnum.COMPLETED else None
+                    "yes"
+                    if self.submission.get_status_for_form(self.form) == TasklistSectionStatusEnum.COMPLETED
+                    else None
                 ),
                 all_questions_answered=all_questions_answered,
             )

--- a/app/common/data/types.py
+++ b/app/common/data/types.py
@@ -98,17 +98,14 @@ class SubmissionStatusEnum(enum.StrEnum):
     IN_PROGRESS = "In progress"
     READY_TO_SUBMIT = "Ready to submit"
     AWAITING_SIGN_OFF = "Awaiting sign off"
-
-    # todo: change to "Submitted"
-    COMPLETED = "Completed"
+    SUBMITTED = "Submitted"
     OVERDUE = "Overdue"
 
 
 class TasklistSectionStatusEnum(enum.StrEnum):
-    NOT_STARTED = SubmissionStatusEnum.NOT_STARTED.value
-    IN_PROGRESS = SubmissionStatusEnum.IN_PROGRESS.value
-    COMPLETED = SubmissionStatusEnum.COMPLETED.value
-
+    NOT_STARTED = "Not started"
+    IN_PROGRESS = "In progress"
+    COMPLETED = "Completed"
     NO_QUESTIONS = "No questions"
 
 

--- a/app/common/templates/common/macros/collections.html
+++ b/app/common/templates/common/macros/collections.html
@@ -1,7 +1,7 @@
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "govuk_frontend_jinja/components/task-list/macro.html" import govukTaskList %}
 {% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
-{% from "common/macros/status.html" import status with context %}
+{% from "common/macros/status.html" import tasklistSectionStatusTag with context %}
 {% from "common/partials/mhclg-test-banner.html" import mhclgStopTestingBanner %}
 
 {% macro collection_before(runner, override_back_link=None) %}
@@ -347,7 +347,7 @@
                 "text": form.title,
               },
               "status": {
-                "html": status(submission.get_tasklist_status_for_form(form)) ,
+                "html": tasklistSectionStatusTag(submission.get_tasklist_status_for_form(form)) ,
               },
               "href": link_href,
             })

--- a/app/common/templates/common/macros/status.html
+++ b/app/common/templates/common/macros/status.html
@@ -1,6 +1,6 @@
 {% from "govuk_frontend_jinja/components/tag/macro.html" import govukTag %}
 
-{% macro status(status) %}
+{% macro tasklistSectionStatusTag(status) %}
   {% set show_without_tag = [ enum.tasklist_section_status.COMPLETED ] %}
   {%
     set classMap = {

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/runner/collection_tasklist.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/runner/collection_tasklist.html
@@ -1,6 +1,6 @@
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "common/partials/mhclg-test-banner.html" import mhclgStopTestingBanner %}
-{% from "common/macros/status.html" import status with context %}
+{% from "common/macros/status.html" import submissionStatusTag with context %}
 {% from "common/macros/collections.html" import collection_tasklist with context %}
 {% extends "developers/deliver/access_grant_funding_base.html" %}
 
@@ -26,10 +26,9 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">{{ runner.submission.name }}</h1>
 
-      {# NOTE: Should we have this as a custom component or macro-ize it? #}
       <dl class="app-metadata govuk-!-margin-bottom-7">
         <dt class="app-metadata__key">Status:</dt>
-        <dd class="app-metadata__value" data-testid="submission-status">{{ status(runner.submission.status) }}</dd>
+        <dd class="app-metadata__value" data-testid="submission-status">{{ submissionStatusTag(runner.submission.status) }}</dd>
       </dl>
     </div>
   </div>

--- a/app/developers/templates/developers/access/collection_tasklist.html
+++ b/app/developers/templates/developers/access/collection_tasklist.html
@@ -1,6 +1,6 @@
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "common/partials/mhclg-test-banner.html" import mhclgTestBanner %}
-{% from "common/macros/status.html" import status with context %}
+{% from "common/macros/status.html" import submissionStatusTag with context %}
 {% from "common/macros/collections.html" import collection_tasklist with context %}
 {% extends "developers/access/base.html" %}
 
@@ -28,7 +28,7 @@
       {# NOTE: Should we have this as a custom component or macro-ize it? #}
       <dl class="app-metadata govuk-!-margin-bottom-7">
         <dt class="app-metadata__key">Status:</dt>
-        <dd class="app-metadata__value" data-testid="submission-status">{{ status(runner.submission.status) }}</dd>
+        <dd class="app-metadata__value" data-testid="submission-status">{{ submissionStatusTag(runner.submission.status) }}</dd>
       </dl>
     </div>
   </div>

--- a/app/developers/templates/developers/access/grant_details.html
+++ b/app/developers/templates/developers/access/grant_details.html
@@ -1,7 +1,7 @@
 {% extends "developers/access/base.html" %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "govuk_frontend_jinja/components/task-list/macro.html" import govukTaskList %}
-{% from "common/macros/status.html" import status with context %}
+{% from "common/macros/status.html" import submissionStatusTag with context %}
 
 {% set page_title = "Grants" %}
 
@@ -41,7 +41,7 @@
                   "text": collection.name,
                 },
                 "status": {
-                  "html": status(submission_helper.status if submission_helper else enum.submission_status.NOT_STARTED)
+                  "html": submissionStatusTag(submission_helper.status if submission_helper else enum.submission_status.NOT_STARTED)
                 },
                 "href": link_href,
               })

--- a/tests/integration/common/helpers/test_collections.py
+++ b/tests/integration/common/helpers/test_collections.py
@@ -369,7 +369,7 @@ class TestSubmissionHelper:
             submission = factories.submission.create(collection=form.collection)
             helper = SubmissionHelper(submission)
 
-            assert helper.get_status_for_form(form) == SubmissionStatusEnum.NOT_STARTED
+            assert helper.get_status_for_form(form) == TasklistSectionStatusEnum.NOT_STARTED
             assert helper.get_tasklist_status_for_form(form) == TasklistSectionStatusEnum.NOT_STARTED
 
             helper.submit_answer_for_question(
@@ -379,7 +379,7 @@ class TestSubmissionHelper:
                 ),
             )
 
-            assert helper.get_status_for_form(form) == SubmissionStatusEnum.IN_PROGRESS
+            assert helper.get_status_for_form(form) == TasklistSectionStatusEnum.IN_PROGRESS
             assert helper.get_tasklist_status_for_form(form) == TasklistSectionStatusEnum.IN_PROGRESS
 
             helper.submit_answer_for_question(
@@ -389,12 +389,12 @@ class TestSubmissionHelper:
                 ),
             )
 
-            assert helper.get_status_for_form(form) == SubmissionStatusEnum.IN_PROGRESS
+            assert helper.get_status_for_form(form) == TasklistSectionStatusEnum.IN_PROGRESS
             assert helper.get_tasklist_status_for_form(form) == TasklistSectionStatusEnum.IN_PROGRESS
 
             helper.toggle_form_completed(form, submission.created_by, True)
 
-            assert helper.get_status_for_form(form) == SubmissionStatusEnum.COMPLETED
+            assert helper.get_status_for_form(form) == TasklistSectionStatusEnum.COMPLETED
             assert helper.get_tasklist_status_for_form(form) == TasklistSectionStatusEnum.COMPLETED
 
             # make sure the second form is unaffected by the first forms status
@@ -404,14 +404,14 @@ class TestSubmissionHelper:
                     q_d696aebc49d24170a92fb6ef42994296="User submitted data"
                 ),
             )
-            assert helper.get_status_for_form(form_two) == SubmissionStatusEnum.IN_PROGRESS
+            assert helper.get_status_for_form(form_two) == TasklistSectionStatusEnum.IN_PROGRESS
             assert helper.get_tasklist_status_for_form(form_two) == TasklistSectionStatusEnum.IN_PROGRESS
 
         def test_form_status_with_no_questions(self, db_session, factories):
             form = factories.form.create()
             submission = factories.submission.create(collection=form.collection)
             helper = SubmissionHelper(submission)
-            assert helper.get_status_for_form(form) == SubmissionStatusEnum.NOT_STARTED
+            assert helper.get_status_for_form(form) == TasklistSectionStatusEnum.NOT_STARTED
             assert helper.get_tasklist_status_for_form(form) == TasklistSectionStatusEnum.NO_QUESTIONS
 
         def test_submission_status_based_on_forms(self, db_session, factories):
@@ -434,7 +434,7 @@ class TestSubmissionHelper:
             )
             helper.toggle_form_completed(question.form, submission.created_by, True)
 
-            assert helper.get_status_for_form(question.form) == SubmissionStatusEnum.COMPLETED
+            assert helper.get_status_for_form(question.form) == TasklistSectionStatusEnum.COMPLETED
             assert helper.get_tasklist_status_for_form(question.form) == TasklistSectionStatusEnum.COMPLETED
             assert helper.status == SubmissionStatusEnum.IN_PROGRESS
 
@@ -446,14 +446,14 @@ class TestSubmissionHelper:
             )
             helper.toggle_form_completed(question_two.form, submission.created_by, True)
 
-            assert helper.get_status_for_form(question_two.form) == SubmissionStatusEnum.COMPLETED
+            assert helper.get_status_for_form(question_two.form) == TasklistSectionStatusEnum.COMPLETED
             assert helper.get_tasklist_status_for_form(question_two.form) == TasklistSectionStatusEnum.COMPLETED
 
             assert helper.status == SubmissionStatusEnum.READY_TO_SUBMIT
 
             helper.submit(submission.created_by)
 
-            assert helper.status == SubmissionStatusEnum.COMPLETED
+            assert helper.status == SubmissionStatusEnum.SUBMITTED
 
         @pytest.mark.freeze_time("2025-01-10 12:00:00")
         @pytest.mark.parametrize("is_overdue", [True, False])
@@ -504,7 +504,7 @@ class TestSubmissionHelper:
             # outside of overdue scope
             helper.submit(submission.created_by)
 
-            assert helper.status == SubmissionStatusEnum.COMPLETED
+            assert helper.status == SubmissionStatusEnum.SUBMITTED
 
         def test_toggle_form_status(self, db_session, factories):
             question = factories.question.create(id=uuid.UUID("d696aebc-49d2-4170-a92f-b6ef42994294"))
@@ -527,7 +527,7 @@ class TestSubmissionHelper:
             )
             helper.toggle_form_completed(form, submission.created_by, True)
 
-            assert helper.get_status_for_form(form) == SubmissionStatusEnum.COMPLETED
+            assert helper.get_status_for_form(form) == TasklistSectionStatusEnum.COMPLETED
             assert helper.get_tasklist_status_for_form(form) == TasklistSectionStatusEnum.COMPLETED
 
         def test_toggle_form_status_doesnt_change_status_if_already_completed(self, db_session, factories):
@@ -551,11 +551,11 @@ class TestSubmissionHelper:
             )
             helper.toggle_form_completed(question.form, submission.created_by, True)
 
-            assert helper.get_status_for_form(question.form) == SubmissionStatusEnum.COMPLETED
+            assert helper.get_status_for_form(question.form) == TasklistSectionStatusEnum.COMPLETED
             assert helper.get_tasklist_status_for_form(question.form) == TasklistSectionStatusEnum.COMPLETED
 
             helper.toggle_form_completed(question.form, submission.created_by, True)
-            assert helper.get_status_for_form(question.form) == SubmissionStatusEnum.COMPLETED
+            assert helper.get_status_for_form(question.form) == TasklistSectionStatusEnum.COMPLETED
             assert helper.get_tasklist_status_for_form(question.form) == TasklistSectionStatusEnum.COMPLETED
             assert len(submission.events) == 1
 


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-1013

## 📝 Description
Initially submission statuses directly reflected the status for each section in the tasklist, not started, in progress and completed.

Now that the submission workflow involves more steps we've started to separate the two enums but they continue to half depend on each other.

Separate these out and update type signatures to make it clear in the code which is calculated the status of a section and whats part of the submission workflow status.
