### PR TITLE
Add flag for certifying reports

### DIFF
--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -62,7 +62,14 @@ if TYPE_CHECKING:
 
 @flush_and_rollback_on_exceptions(coerce_exceptions=[(IntegrityError, DuplicateValueError)])
 def create_collection(*, name: str, user: User, grant: Grant, type_: CollectionType) -> Collection:
-    collection = Collection(name=name, created_by=user, grant=grant, slug=slugify(name), type=type_)
+    collection = Collection(
+        name=name,
+        created_by=user,
+        grant=grant,
+        slug=slugify(name),
+        type=type_,
+        requires_certification=True,  # note: this'll need to change when we have more than just monitoring reports
+    )
     db.session.add(collection)
     return collection
 

--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-026_require_member_permission
+027_requires_certification_flag

--- a/app/common/data/migrations/versions/027_requires_certification_flag.py
+++ b/app/common/data/migrations/versions/027_requires_certification_flag.py
@@ -1,0 +1,33 @@
+"""add requires certification flag
+
+Revision ID: 027_requires_certification_flag
+Revises: 026_require_member_permission
+Create Date: 2025-11-19 13:56:21.544903
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "027_requires_certification_flag"
+down_revision = "026_require_member_permission"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("collection", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("requires_certification", sa.Boolean(), nullable=True))
+
+    op.execute("UPDATE collection SET requires_certification = true WHERE type = 'MONITORING_REPORT'")
+
+    with op.batch_alter_table("collection", schema=None) as batch_op:
+        batch_op.create_check_constraint(
+            op.f("ck_monitoring_certification_not_null"),
+            "requires_certification IS NOT NULL OR type != 'MONITORING_REPORT'",
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("collection", schema=None) as batch_op:
+        batch_op.drop_column("requires_certification")

--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -157,10 +157,11 @@ class Collection(BaseModel):
         SqlEnum(CollectionStatusEnum, name="collection_status", validate_strings=True),
         default=CollectionStatusEnum.DRAFT,
     )
-    reporting_period_start_date: Mapped[datetime.date | None] = mapped_column(nullable=True)
-    reporting_period_end_date: Mapped[datetime.date | None] = mapped_column(nullable=True)
-    submission_period_start_date: Mapped[datetime.date | None] = mapped_column(nullable=True)
-    submission_period_end_date: Mapped[datetime.date | None] = mapped_column(nullable=True)
+    reporting_period_start_date: Mapped[datetime.date | None]
+    reporting_period_end_date: Mapped[datetime.date | None]
+    submission_period_start_date: Mapped[datetime.date | None]
+    submission_period_end_date: Mapped[datetime.date | None]
+    requires_certification: Mapped[bool | None]
 
     # NOTE: Don't use this relationship directly; use either `test_submissions` or `live_submissions`.
     _submissions: Mapped[list["Submission"]] = relationship(
@@ -180,7 +181,13 @@ class Collection(BaseModel):
         cascade="all",
     )
 
-    __table_args__ = (UniqueConstraint("name", "grant_id", name="uq_collection_name_grant_id"),)
+    __table_args__ = (
+        UniqueConstraint("name", "grant_id", name="uq_collection_name_grant_id"),
+        CheckConstraint(
+            "requires_certification IS NOT NULL OR type != 'MONITORING_REPORT'",
+            name="ck_monitoring_certification_not_null",
+        ),
+    )
 
     @property
     def test_submissions(self) -> list["Submission"]:

--- a/app/deliver_grant_funding/admin/entities.py
+++ b/app/deliver_grant_funding/admin/entities.py
@@ -144,7 +144,7 @@ class PlatformAdminCollectionView(PlatformAdminModelView):
         "type.value": "Type",
     }
 
-    form_columns = ["name", "slug", "type", "status"]
+    form_columns = ["name", "slug", "type", "status", "requires_certification"]
 
 
 class PlatformAdminUserRoleView(PlatformAdminModelView):

--- a/app/developers/data/grants.json
+++ b/app/developers/data/grants.json
@@ -7,6 +7,7 @@
           "grant_id": "caf0ce3f-5175-f69c-66a9-41e2c2245845",
           "id": "4e8f04f8-57c2-0399-464b-e62ff96b684a",
           "name": "Report on cheeseboards in parks",
+          "requires_certification": true,
           "slug": "report-on-cheeseboards-in-parks",
           "status": "Draft",
           "type": "monitoring report"
@@ -18,6 +19,7 @@
           "name": "Cheeseboards in Parks: Q1 2025",
           "reporting_period_end_date": "Mon, 31 Mar 2025 00:00:00 GMT",
           "reporting_period_start_date": "Wed, 01 Jan 2025 00:00:00 GMT",
+          "requires_certification": true,
           "slug": "cheeseboards-in-parks-q1-2025",
           "status": "Closed",
           "submission_period_end_date": "Mon, 30 Jun 2025 00:00:00 GMT",
@@ -31,6 +33,7 @@
           "name": "Cheeseboards in Parks: Q2 2025",
           "reporting_period_end_date": "Mon, 30 Jun 2025 00:00:00 GMT",
           "reporting_period_start_date": "Tue, 01 Apr 2025 00:00:00 GMT",
+          "requires_certification": true,
           "slug": "cheeseboards-in-parks-q2-2025",
           "status": "Open",
           "submission_period_end_date": "Wed, 30 Jun 2027 00:00:00 GMT",
@@ -1949,6 +1952,7 @@
           "grant_id": "df51f309-718c-4dd4-bd76-0bd6df032e4b",
           "id": "09e8d677-5fce-4081-9434-eefac1348e12",
           "name": "Communities for Afghans Phase 2",
+          "requires_certification": true,
           "slug": "communities-for-afghans-phase-2",
           "status": "Draft",
           "type": "monitoring report"
@@ -14256,7 +14260,7 @@
       "user_id": "62ee98f5-cf10-4848-95a4-5b6280529046"
     },
     {
-      "id": "0b455ab7-fba0-4139-86e0-29d86cccf5a4",
+      "id": "99029c90-6bd5-4761-b009-dad45934b73e",
       "permissions": [
         "admin",
         "member"

--- a/tests/models.py
+++ b/tests/models.py
@@ -211,6 +211,7 @@ class _CollectionFactory(SQLAlchemyModelFactory):
     name = factory.Sequence(lambda n: "Collection %d" % n)
     slug = factory.Sequence(lambda n: "collection-%d" % n)
     type = CollectionType.MONITORING_REPORT
+    requires_certification = True  # note: this'll need to change when we have more than just monitoring reports
 
     created_by_id = factory.LazyAttribute(lambda o: o.created_by.id)
     created_by = factory.SubFactory(_UserFactory)


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-1003

## 📝 Description
Adds a flag to the collection model to record whether or not a monitoring report should go through the certification flow.

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [-] I need the reviewer(s) to pull and run this change locally
- [-] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are testederations for reviewers -->
