### PR TITLE
FSPT-985: Error handlers understand app context

### DIFF
--- a/app/common/templates/common/errors/403.html
+++ b/app/common/templates/common/errors/403.html
@@ -1,4 +1,4 @@
-{% extends "common/base.html" %}
+{% extends base_template %}
 
 {% block pageTitle %}You do not have permission to access this page - {{ super() }}{% endblock pageTitle %}
 

--- a/app/common/templates/common/errors/404.html
+++ b/app/common/templates/common/errors/404.html
@@ -1,4 +1,4 @@
-{% extends "common/base.html" %}
+{% extends base_template %}
 
 {% block pageTitle %}Page not found - {{ super() }}{% endblock pageTitle %}
 

--- a/app/common/templates/common/errors/500.html
+++ b/app/common/templates/common/errors/500.html
@@ -1,4 +1,4 @@
-{% extends "common/base.html" %}
+{% extends base_template %}
 
 {% block pageTitle %}Sorry, there is a problem with the service - {{ super() }}{% endblock pageTitle %}
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -91,8 +91,24 @@ def app(setup_db_container: PostgresContainer) -> Generator[Flask, None, None]:
     def raise_403() -> ResponseReturnValue:
         return abort(403)
 
+    @app.route("/access/_testing/403")
+    def raise_access_403() -> ResponseReturnValue:
+        return abort(403)
+
+    @app.route("/deliver/_testing/403")
+    def raise_deliver_403() -> ResponseReturnValue:
+        return abort(403)
+
     @app.route("/_testing/500")
     def raise_500() -> ResponseReturnValue:
+        return abort(500)
+
+    @app.route("/access/_testing/500")
+    def raise_access_500() -> ResponseReturnValue:
+        return abort(500)
+
+    @app.route("/deliver/_testing/500")
+    def raise_deliver_500() -> ResponseReturnValue:
         return abort(500)
 
     @app.route("/_testing/sqlalchemy-not-found")

--- a/tests/integration/test_app.py
+++ b/tests/integration/test_app.py
@@ -3,12 +3,13 @@ from typing import Generator
 from unittest.mock import patch
 
 import pytest
+from bs4 import BeautifulSoup
 from flask import Flask, url_for
 from flask_sqlalchemy_lite import SQLAlchemy
 from testcontainers.postgres import PostgresContainer
 
 from app import create_app
-from tests.utils import build_db_config
+from tests.utils import build_db_config, get_link_hrefs, get_service_name_text
 
 
 @pytest.fixture(scope="session")
@@ -64,20 +65,70 @@ class TestBasicAuth:
 
 
 class TestAppErrorHandlers:
-    def test_app_404_on_unknown_url(self, app, client):
-        response = client.get("/route/to/nowhere")
+    @pytest.mark.parametrize(
+        "service_url, service_desk_url, service_name",
+        [
+            ("/access", "ACCESS_SERVICE_DESK_URL", "MHCLG Access grant funding"),
+            ("/deliver", "DELIVER_SERVICE_DESK_URL", "MHCLG Funding Service"),
+            ("", "SERVICE_DESK_URL", "MHCLG Funding Service"),
+        ],
+    )
+    def test_app_404_on_unknown_url(self, app, client, service_url, service_desk_url, service_name):
+        response = client.get(f"{service_url}/route/to/nowhere")
         assert response.status_code == 404
-        assert "Page not found" in response.text
-        assert app.config["SERVICE_DESK_URL"] in response.text
 
-    def test_app_404_on_sqlalchemy_not_found(self, app, client):
-        response = client.get("/_testing/sqlalchemy-not-found")
+        soup = BeautifulSoup(response.data, "html.parser")
+        assert "Page not found" in soup.text
+        assert app.config[service_desk_url] in get_link_hrefs(soup)
+        assert service_name == get_service_name_text(soup)
+
+    @pytest.mark.parametrize(
+        "service_url, service_desk_url, service_name",
+        [
+            ("/access", "ACCESS_SERVICE_DESK_URL", "MHCLG Access grant funding"),
+            ("/deliver", "DELIVER_SERVICE_DESK_URL", "MHCLG Funding Service"),
+            ("", "SERVICE_DESK_URL", "MHCLG Funding Service"),
+        ],
+    )
+    def test_app_404_on_sqlalchemy_not_found(self, app, client, service_url, service_desk_url, service_name):
+        response = client.get(f"{service_url}/_testing/sqlalchemy-not-found")
         assert response.status_code == 404
-        assert "Page not found" in response.text
-        assert app.config["SERVICE_DESK_URL"] in response.text
 
-    def test_app_500_on_internal_server_error(self, app, client):
-        response = client.get("/_testing/500")
+        soup = BeautifulSoup(response.data, "html.parser")
+        assert "Page not found" in soup.text
+        assert app.config[service_desk_url] in get_link_hrefs(soup)
+        assert service_name == get_service_name_text(soup)
+
+    @pytest.mark.parametrize(
+        "service_url, service_desk_url, service_name",
+        [
+            ("/access", "ACCESS_SERVICE_DESK_URL", "MHCLG Access grant funding"),
+            ("/deliver", "DELIVER_SERVICE_DESK_URL", "MHCLG Funding Service"),
+            ("", "SERVICE_DESK_URL", "MHCLG Funding Service"),
+        ],
+    )
+    def test_app_500_on_internal_server_error(self, app, client, service_url, service_desk_url, service_name):
+        response = client.get(f"{service_url}/_testing/500")
         assert response.status_code == 500
-        assert "Sorry, there is a problem with the service" in response.text
-        assert app.config["SERVICE_DESK_URL"] in response.text
+
+        soup = BeautifulSoup(response.data, "html.parser")
+        assert "Sorry, there is a problem with the service" in soup.text
+        assert app.config[service_desk_url] in get_link_hrefs(soup)
+        assert service_name == get_service_name_text(soup)
+
+    @pytest.mark.parametrize(
+        "service_url, service_desk_url, service_name",
+        [
+            ("/access", "ACCESS_SERVICE_DESK_URL", "MHCLG Access grant funding"),
+            ("/deliver", "DELIVER_SERVICE_DESK_URL", "MHCLG Funding Service"),
+            ("", "SERVICE_DESK_URL", "MHCLG Funding Service"),
+        ],
+    )
+    def test_app_403_on_forbidden_url(self, app, client, service_url, service_desk_url, service_name):
+        response = client.get(f"{service_url}/_testing/403")
+        assert response.status_code == 403
+
+        soup = BeautifulSoup(response.data, "html.parser")
+        assert "You do not have permission to access this page" in soup.text
+        assert app.config[service_desk_url] in get_link_hrefs(soup)
+        assert service_name == get_service_name_text(soup)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -126,6 +126,21 @@ def get_h2_text(soup: BeautifulSoup) -> str:
     return get_soup_text(soup, "h2")
 
 
+def get_link_hrefs(soup: BeautifulSoup) -> list[str]:
+    links = soup.find_all("a")
+    link_hrefs = []
+    for link in links:
+        href = link.get("href")
+        if href is not None and isinstance(href, str):
+            link_hrefs.append(href)
+    return link_hrefs
+
+
+def get_service_name_text(soup: BeautifulSoup) -> str | None:
+    service_name_element = soup.find("span", class_="govuk-header__product-name")
+    return service_name_element.text if service_name_element else None
+
+
 def page_has_link(soup: BeautifulSoup, link_text: str) -> Tag | None:
     links = soup.select("a")
 


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-985

## 📝 Description
Now our concept of two distinct services is coming together, our error handlers and templates should understand the correct service context and at least show the right service name in the header to avoid user confusion.

This change extends the helper function which decides which service desk URL to pass to the templates to also decide which base templates the error template should extend, which would show the correct service name and can be extended in the future to show more service context.

## 📸 Show the thing (screenshots, gifs)

### Example 403:
![2025-11-21 14 36 03](https://github.com/user-attachments/assets/3525c70d-0054-4dea-8751-142e325f7228)


### Example 404:
![2025-11-21 14 40 48](https://github.com/user-attachments/assets/e3f41dde-251d-4f34-b37c-7bf80fce5c85)



## 🧪 Testing
Pull the branch and try to 1. hit some URLs that you shouldn't have access to with the authed user, 2. 

## 📋 Developer Checklist

### Review Readiness
- [X] PR title and description provide sufficient context for reviewers
- [X] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- ~[ ] No N+1 query problems introduced~
- ~[ ] Any new DB queries include appropriate where clauses based on the user's permissions~

### Testing
- [X] I have tested this change and it meets the acceptance criteria for the ticket
- ~[ ] I need the reviewer(s) to pull and run this change locally~
- [X] New (non-developer) functionality has appropriate unit and integration tests
- ~[ ] End-to-end tests have been updated (if applicable)~
- ~[ ] Edge cases and error conditions are tested~