### PR TITLE
Start emitting custom sentry metrics

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -199,7 +199,7 @@ def create_app() -> Flask:  # noqa: C901
     def load_user(user_id: str) -> Optional["User"]:
         user = interfaces.user.get_user(user_id)
         if user:
-            sentry_sdk.set_user({"email": user.email, "name": user.name})
+            sentry_sdk.set_user({"email": user.email, "name": user.name, "id": user_id})
         return user
 
     # This section is needed for url_for("foo", _external=True) to

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -1,0 +1,112 @@
+from enum import StrEnum
+from typing import TYPE_CHECKING, Mapping, Optional
+from uuid import UUID
+
+from sentry_sdk import metrics
+
+from app.common.expressions.managed import ManagedExpression
+
+if TYPE_CHECKING:
+    from app.common.data.models import Collection, Grant, GrantRecipient, Submission
+
+
+class MetricAttributeName(StrEnum):
+    GRANT_RECIPIENT = "grant-recipient"
+    GRANT_RECIPIENT_ID = "grant-recipient-id"
+    GRANT = "grant"
+    GRANT_ID = "grant-id"
+    COLLECTION = "collection"
+    COLLECTION_ID = "collection-id"
+    COLLECTION_TYPE = "collection-type"
+    SUBMISSION = "submission"
+    SUBMISSION_ID = "submission-id"
+    SUBMISSION_MODE = "submission-mode"
+    USER_ID = "user-id"
+
+    MANAGED_EXPRESSION_NAME = "managed-expression-name"
+
+
+class MetricEventName(StrEnum):
+    SUBMISSION_CREATED = "submission-created"
+    SECTION_MARKED_COMPLETE = "section-marked-as-complete"
+    SECTION_MARKED_INCOMPLETE = "section-marked_as_incomplete"
+    SUBMISSION_SENT_FOR_CERTIFICATION = "submission-sent-for-certification"
+    SUBMISSION_CERTIFIED = "submission-certified"
+    SUBMISSION_CERTIFICATION_DECLINED = "submission-certification-declined"
+    SUBMISSION_SUBMITTED = "submission-submitted"
+
+    SUBMISSION_MANAGED_VALIDATION_ERROR = "submission-managed-validation-error"
+    SUBMISSION_MANAGED_VALIDATION_SUCCESS = "submission-managed-validation-success"
+
+
+def _get_event_attributes(
+    grant_recipient: Optional["GrantRecipient"] = None,
+    submission: Optional["Submission"] = None,
+    collection: Optional["Collection"] = None,
+    grant: Optional["Grant"] = None,
+    managed_expression: Optional["ManagedExpression"] = None,
+    custom_attributes: Mapping[MetricAttributeName, str | int | UUID] | None = None,
+) -> dict[str, str | int | UUID]:
+    attributes: dict[str, str | int | UUID] = (
+        {str(k): v for k, v in custom_attributes.items()} if custom_attributes else {}
+    )
+
+    if submission:
+        attributes[str(MetricAttributeName.SUBMISSION_ID)] = submission.id
+        attributes[str(MetricAttributeName.SUBMISSION_MODE)] = str(submission.mode)
+
+        if not collection:
+            collection = submission.collection
+
+        if not grant_recipient:
+            grant_recipient = submission.grant_recipient
+
+    if collection:
+        attributes[str(MetricAttributeName.COLLECTION)] = collection.name
+        attributes[str(MetricAttributeName.COLLECTION_ID)] = str(collection.id)
+        attributes[str(MetricAttributeName.COLLECTION_TYPE)] = str(collection.type)
+
+        if not grant:
+            grant = collection.grant
+
+    if grant_recipient:
+        attributes[str(MetricAttributeName.GRANT_RECIPIENT)] = grant_recipient.organisation.name
+        attributes[str(MetricAttributeName.GRANT_RECIPIENT_ID)] = str(grant_recipient.id)
+
+        if not grant:
+            grant = grant_recipient.grant
+
+    if grant:
+        attributes[str(MetricAttributeName.GRANT)] = grant.name
+        attributes[str(MetricAttributeName.GRANT_ID)] = str(grant.id)
+
+    if managed_expression:
+        attributes[str(MetricAttributeName.MANAGED_EXPRESSION_NAME)] = managed_expression.name
+
+    return attributes
+
+
+def emit_metric_count(
+    event: MetricEventName,
+    count: int = 1,
+    grant_recipient: Optional["GrantRecipient"] = None,
+    submission: Optional["Submission"] = None,
+    collection: Optional["Collection"] = None,
+    grant: Optional["Grant"] = None,
+    managed_expression: Optional["ManagedExpression"] = None,
+    custom_attributes: Mapping[MetricAttributeName, str | int | UUID] | None = None,
+) -> None:
+    # TODO: emit as structured log for longer retention
+
+    metrics.count(
+        event,
+        count,
+        attributes=_get_event_attributes(
+            grant_recipient=grant_recipient,
+            submission=submission,
+            collection=collection,
+            grant=grant,
+            managed_expression=managed_expression,
+            custom_attributes=custom_attributes,
+        ),
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ exhaustive = true
 containers = ["app"]
 layers = [
     "developers",
-    " common : deliver_grant_funding : access_grant_funding : extensions : healthcheck : services : config : constants : logging : monkeypatch : sentry : types"
+    "common : deliver_grant_funding : access_grant_funding : extensions : healthcheck : services : config : constants : logging : metrics : monkeypatch : sentry : types"
 ]
 
 [[tool.importlinter.contracts]]

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -1,0 +1,190 @@
+from unittest.mock import Mock, patch
+from uuid import uuid4
+
+from app.metrics import MetricAttributeName, MetricEventName, emit_metric_count
+
+
+class TestEmitMetricCount:
+    @patch("app.metrics.metrics.count")
+    def test_basic_emission_with_no_attributes(self, mock_count):
+        emit_metric_count(MetricEventName.SUBMISSION_CREATED)
+
+        mock_count.assert_called_once_with(
+            MetricEventName.SUBMISSION_CREATED,
+            1,
+            attributes={},
+        )
+
+    @patch("app.metrics.metrics.count")
+    def test_emission_with_custom_count(self, mock_count):
+        emit_metric_count(MetricEventName.SUBMISSION_MANAGED_VALIDATION_ERROR, count=5)
+
+        mock_count.assert_called_once_with(
+            MetricEventName.SUBMISSION_MANAGED_VALIDATION_ERROR,
+            5,
+            attributes={},
+        )
+
+    @patch("app.metrics.metrics.count")
+    def test_emission_with_custom_attributes(self, mock_count):
+        user_id = uuid4()
+        custom_attrs = {
+            MetricAttributeName.USER_ID: str(user_id),
+        }
+
+        emit_metric_count(
+            MetricEventName.SECTION_MARKED_COMPLETE,
+            custom_attributes=custom_attrs,
+        )
+
+        mock_count.assert_called_once_with(
+            MetricEventName.SECTION_MARKED_COMPLETE,
+            1,
+            attributes={
+                "user-id": str(user_id),
+            },
+        )
+
+    @patch("app.metrics.metrics.count")
+    def test_emission_with_grant(self, mock_count, factories):
+        grant = factories.grant.build(name="Test Grant")
+
+        emit_metric_count(MetricEventName.SUBMISSION_CREATED, grant=grant)
+
+        mock_count.assert_called_once_with(
+            MetricEventName.SUBMISSION_CREATED,
+            1,
+            attributes={
+                "grant": "Test Grant",
+                "grant-id": str(grant.id),
+            },
+        )
+
+    @patch("app.metrics.metrics.count")
+    def test_emission_with_collection(self, mock_count, factories):
+        collection = factories.collection.build(name="Monthly Report", grant__name="Parent Grant")
+
+        emit_metric_count(MetricEventName.SUBMISSION_CREATED, collection=collection)
+
+        mock_count.assert_called_once_with(
+            MetricEventName.SUBMISSION_CREATED,
+            1,
+            attributes={
+                "collection": "Monthly Report",
+                "collection-id": str(collection.id),
+                "collection-type": "monitoring report",
+                "grant": "Parent Grant",
+                "grant-id": str(collection.grant.id),
+            },
+        )
+
+    @patch("app.metrics.metrics.count")
+    def test_emission_with_grant_recipient(self, mock_count, factories):
+        grant_recipient = factories.grant_recipient.build(
+            organisation__name="Test Organisation", grant__name="Test Grant"
+        )
+
+        emit_metric_count(MetricEventName.SUBMISSION_CREATED, grant_recipient=grant_recipient)
+
+        mock_count.assert_called_once_with(
+            MetricEventName.SUBMISSION_CREATED,
+            1,
+            attributes={
+                "grant-recipient": "Test Organisation",
+                "grant-recipient-id": str(grant_recipient.id),
+                "grant": "Test Grant",
+                "grant-id": str(grant_recipient.grant.id),
+            },
+        )
+
+    @patch("app.metrics.metrics.count")
+    def test_emission_with_submission(self, mock_count, factories):
+        grant_recipient = factories.grant_recipient.build(
+            organisation__name="Test Organisation", grant__name="Test Grant"
+        )
+        submission = factories.submission.build(
+            collection__name="Monthly Report", collection__grant=grant_recipient.grant, grant_recipient=grant_recipient
+        )
+
+        emit_metric_count(MetricEventName.SUBMISSION_SUBMITTED, submission=submission)
+
+        mock_count.assert_called_once_with(
+            MetricEventName.SUBMISSION_SUBMITTED,
+            1,
+            attributes={
+                "submission-id": submission.id,
+                "submission-mode": "test",
+                "collection": "Monthly Report",
+                "collection-id": str(submission.collection.id),
+                "collection-type": "monitoring report",
+                "grant": "Test Grant",
+                "grant-id": str(submission.collection.grant.id),
+                "grant-recipient": "Test Organisation",
+                "grant-recipient-id": str(submission.grant_recipient.id),
+            },
+        )
+
+    @patch("app.metrics.metrics.count")
+    def test_emission_with_managed_expression(self, mock_count):
+        managed_expression = Mock()
+        managed_expression.name = "TestExpression"
+
+        emit_metric_count(
+            MetricEventName.SUBMISSION_MANAGED_VALIDATION_ERROR,
+            managed_expression=managed_expression,
+        )
+
+        mock_count.assert_called_once_with(
+            MetricEventName.SUBMISSION_MANAGED_VALIDATION_ERROR,
+            1,
+            attributes={
+                "managed-expression-name": "TestExpression",
+            },
+        )
+
+    @patch("app.metrics.metrics.count")
+    def test_explicit_grant_overrides_collection_grant(self, mock_count, factories):
+        grant = factories.grant.build(name="Explicit Grant")
+        collection = factories.collection.build(name="Monthly Report", grant__name="Parent Grant")
+
+        emit_metric_count(
+            MetricEventName.SUBMISSION_CREATED,
+            collection=collection,
+            grant=grant,
+        )
+
+        mock_count.assert_called_once_with(
+            MetricEventName.SUBMISSION_CREATED,
+            1,
+            attributes={
+                "collection": "Monthly Report",
+                "collection-id": str(collection.id),
+                "collection-type": "monitoring report",
+                "grant": "Explicit Grant",
+                "grant-id": str(grant.id),
+            },
+        )
+
+    @patch("app.metrics.metrics.count")
+    def test_custom_attributes_combined_with_model_attributes(self, mock_count, factories):
+        grant = factories.grant.build(name="Test Grant")
+
+        custom_attrs = {
+            MetricAttributeName.USER_ID: "user-123",
+        }
+
+        emit_metric_count(
+            MetricEventName.SUBMISSION_CREATED,
+            grant=grant,
+            custom_attributes=custom_attrs,
+        )
+
+        mock_count.assert_called_once_with(
+            MetricEventName.SUBMISSION_CREATED,
+            1,
+            attributes={
+                "user-id": "user-123",
+                "grant": "Test Grant",
+                "grant-id": str(grant.id),
+            },
+        )


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
Sentry now has support for custom application-level metrics. Let's start emitting a few metrics we care about as a way of testing this functionality.

We should do a proper pass of sentry metrics if we think we want to use this for first-class metrics tracking