### PR TITLE
BAU Add a dependency cooldown to renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "github>communitiesuk/renovate-config"
   ],
+  "minimumReleaseAge": "7 days",
   "packageRules": [
     {
       "groupName": "Frontend asset dependencies",


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
Introduces the minimum release age config which should instruct renovate to wait for x days after a release is published before it becomes a candidate for an depenedency update on the project (either auto merging or waiting for review following our current policy).

This allows some time between releases and more thorough security audits and usage which should cover some % of supply chain failures.

Note that security updates bypass this rule and are suggested immediately.

Note that the only package manager this doesn't work for is docker but should apply to our pypi and npm dependencies.

Documentation here https://docs.renovatebot.com/key-concepts/minimum-release-age/
