### PR TITLE
FSPT-1018 Submission events v2

### DIFF
--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-028_add_conditions_operator
+029_submission_events_v2

--- a/app/common/data/migrations/versions/029_submission_events_v2.py
+++ b/app/common/data/migrations/versions/029_submission_events_v2.py
@@ -1,0 +1,102 @@
+"""Submission events v2
+
+Revision ID: 029_submission_events_v2
+Revises: 028_add_conditions_operator
+Create Date: 2025-11-25 12:39:45.888152
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "029_submission_events_v2"
+down_revision = "028_add_conditions_operator"
+branch_labels = None
+depends_on = None
+
+submission_event_type_enum = sa.Enum(
+    "FORM_RUNNER_FORM_COMPLETED",
+    "FORM_RUNNER_FORM_RESET_TO_IN_PROGRESS",
+    "SUBMISSION_SENT_FOR_CERTIFICATION",
+    "SUBMISSION_SUBMITTED",
+    name="submission_event_type_enum",
+)
+
+submission_event_key_enum = sa.Enum(
+    "FORM_RUNNER_FORM_COMPLETED",
+    "SUBMISSION_SENT_FOR_CERTIFICATION",
+    "SUBMISSION_SUBMITTED",
+    name="submission_event_key_enum",
+)
+
+
+def upgrade() -> None:
+    submission_event_type_enum.create(op.get_bind())
+
+    with op.batch_alter_table("submission_event", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "event_type",
+                submission_event_type_enum,
+                nullable=True,
+            )
+        )
+        batch_op.add_column(sa.Column("related_entity_id", sa.Uuid(), nullable=True))
+
+        batch_op.add_column(
+            sa.Column("data", postgresql.JSONB(astext_type=sa.Text()), server_default="{}", nullable=False)
+        )
+
+    op.execute(
+        sa.text("""
+        UPDATE submission_event SET
+                related_entity_id = coalesce(submission_event.form_id, submission_event.submission_id),
+                event_type = submission_event.key::TEXT::submission_event_type_enum
+        """)
+    )
+
+    with op.batch_alter_table("submission_event", schema=None) as batch_op:
+        batch_op.alter_column("related_entity_id", nullable=False)
+        batch_op.alter_column("event_type", nullable=False)
+        batch_op.drop_constraint("fk_submission_event_form_id_form", type_="foreignkey")
+        batch_op.drop_column("key")
+        batch_op.drop_column("form_id")
+
+    submission_event_key_enum.drop(op.get_bind())
+
+
+def downgrade() -> None:
+    submission_event_key_enum.create(op.get_bind())
+
+    with op.batch_alter_table("submission_event", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("form_id", sa.UUID(), autoincrement=False, nullable=True))
+        batch_op.add_column(
+            sa.Column(
+                "key",
+                submission_event_key_enum,
+                autoincrement=False,
+                nullable=True,
+            )
+        )
+        batch_op.create_foreign_key("fk_submission_event_form_id_form", "form", ["form_id"], ["id"])
+        batch_op.drop_column("data")
+
+    op.execute(
+        sa.text("""
+        UPDATE submission_event SET form_id = submission_event.related_entity_id
+        WHERE submission_event.event_type = 'FORM_RUNNER_FORM_COMPLETED'
+        """)
+    )
+    op.execute(
+        sa.text("""
+        UPDATE submission_event SET key = submission_event.event_type::TEXT::submission_event_key_enum
+        """)
+    )
+
+    with op.batch_alter_table("submission_event", schema=None) as batch_op:
+        batch_op.alter_column("key", nullable=False)
+        batch_op.drop_column("related_entity_id")
+        batch_op.drop_column("event_type")
+
+    submission_event_type_enum.drop(op.get_bind())

--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -26,7 +26,7 @@ from app.common.data.types import (
     QuestionDataType,
     QuestionPresentationOptions,
     RoleEnum,
-    SubmissionEventKey,
+    SubmissionEventType,
     SubmissionModeEnum,
     json_flat_scalars,
     json_scalars,
@@ -596,15 +596,17 @@ class Group(Component):
 class SubmissionEvent(BaseModel):
     __tablename__ = "submission_event"
 
-    key: Mapped[SubmissionEventKey] = mapped_column(
-        SqlEnum(SubmissionEventKey, name="submission_event_key_enum", validate_strings=True)
+    event_type: Mapped[SubmissionEventType] = mapped_column(
+        SqlEnum(SubmissionEventType, name="submission_event_type_enum", validate_strings=True)
     )
+
+    related_entity_id: Mapped[uuid.UUID]
+
+    # properties are immutable and will be mapped to known pydantic models next
+    data: Mapped[json_flat_scalars] = mapped_column(server_default="{}")
 
     submission_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("submission.id"))
     submission: Mapped[Submission] = relationship("Submission", back_populates="events")
-
-    form_id: Mapped[Optional[uuid.UUID]] = mapped_column(ForeignKey("form.id"))
-    form: Mapped[Optional[Form]] = relationship("Form")
 
     created_by_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("user.id"))
     created_by: Mapped[User] = relationship("User")

--- a/app/common/data/types.py
+++ b/app/common/data/types.py
@@ -109,8 +109,9 @@ class TasklistSectionStatusEnum(enum.StrEnum):
     NO_QUESTIONS = "No questions"
 
 
-class SubmissionEventKey(enum.StrEnum):
+class SubmissionEventType(enum.StrEnum):
     FORM_RUNNER_FORM_COMPLETED = "Form completed"
+    FORM_RUNNER_FORM_RESET_TO_IN_PROGRESS = "Form reset to in progress"
     SUBMISSION_SENT_FOR_CERTIFICATION = "Submission sent for certification"
     SUBMISSION_SUBMITTED = "Submission submitted"
 

--- a/tests/integration/access_grant_funding/routes/test_runner.py
+++ b/tests/integration/access_grant_funding/routes/test_runner.py
@@ -12,7 +12,7 @@ from app.common.data.types import (
     QuestionDataType,
     QuestionPresentationOptions,
     RoleEnum,
-    SubmissionEventKey,
+    SubmissionEventType,
     SubmissionModeEnum,
 )
 from tests.utils import AnyStringMatching, get_h1_text, page_has_button, page_has_h2, page_has_link
@@ -188,8 +188,8 @@ class TestTasklist:
         factories.submission_event.create(
             created_by=client.user,
             submission=submission,
-            form=question.form,
-            key=SubmissionEventKey.FORM_RUNNER_FORM_COMPLETED,
+            related_entity_id=question.form.id,
+            event_type=SubmissionEventType.FORM_RUNNER_FORM_COMPLETED,
             created_at_utc=datetime(2025, 1, 1, 12, 0, 0),
         )
 
@@ -990,9 +990,9 @@ class TestConfirmSentForCertification:
             data={str(question.id): "Blue"},
             events=[
                 factories.submission_event.create(
-                    key=SubmissionEventKey.FORM_RUNNER_FORM_COMPLETED, form=question.form
+                    event_type=SubmissionEventType.FORM_RUNNER_FORM_COMPLETED, related_entity_id=question.form.id
                 ),
-                factories.submission_event.create(key=SubmissionEventKey.SUBMISSION_SENT_FOR_CERTIFICATION),
+                factories.submission_event.create(event_type=SubmissionEventType.SUBMISSION_SENT_FOR_CERTIFICATION),
             ],
         )
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -33,7 +33,7 @@ from app import create_app
 from app.common.data.interfaces.system import seed_system_data
 from app.common.data.models import GrantRecipient, Submission
 from app.common.data.models_user import User
-from app.common.data.types import AuthMethodEnum, GrantStatusEnum, RoleEnum, SubmissionEventKey, SubmissionModeEnum
+from app.common.data.types import AuthMethodEnum, GrantStatusEnum, RoleEnum, SubmissionEventType, SubmissionModeEnum
 from app.extensions.record_sqlalchemy_queries import QueryInfo, get_recorded_queries
 from app.services.notify import Notification
 from tests.conftest import FundingServiceTestClient, _Factories, _precompile_templates
@@ -463,12 +463,12 @@ def submission_awaiting_sign_off(factories: _Factories, grant_recipient: GrantRe
         data={str(question.id): "Question answer"},
         events=[
             factories.submission_event.create(
-                form=question.form,
-                key=SubmissionEventKey.FORM_RUNNER_FORM_COMPLETED,
+                related_entity_id=question.form.id,
+                event_type=SubmissionEventType.FORM_RUNNER_FORM_COMPLETED,
                 created_by=user,
             ),
             factories.submission_event.create(
-                key=SubmissionEventKey.SUBMISSION_SENT_FOR_CERTIFICATION,
+                event_type=SubmissionEventType.SUBMISSION_SENT_FOR_CERTIFICATION,
                 created_by=user,
             ),
         ],

--- a/tests/integration/deliver_grant_funding/routes/test_runner.py
+++ b/tests/integration/deliver_grant_funding/routes/test_runner.py
@@ -91,7 +91,9 @@ class TestSubmissionTasklist:
         submission = factories.submission.create(
             collection=question.form.collection, created_by=client.user, data=submission_data
         )
-        factories.submission_event.create(created_by=client.user, submission=submission, form=question.form)
+        factories.submission_event.create(
+            created_by=client.user, submission=submission, related_entity_id=question.form.id
+        )
 
         with client.session_transaction() as session:
             session["test_submission_form_id"] = question.form.id
@@ -138,7 +140,9 @@ class TestSubmissionTasklist:
             created_by=client.user,
             data=submission_data,
         )
-        factories.submission_event.create(created_by=client.user, submission=submission, form=question.form)
+        factories.submission_event.create(
+            created_by=client.user, submission=submission, related_entity_id=question.form.id
+        )
 
         response = client.post(
             url_for(

--- a/tests/models.py
+++ b/tests/models.py
@@ -52,7 +52,7 @@ from app.common.data.types import (
     QuestionDataType,
     QuestionPresentationOptions,
     RoleEnum,
-    SubmissionEventKey,
+    SubmissionEventType,
     SubmissionModeEnum,
 )
 from app.common.expressions import ExpressionContext
@@ -855,9 +855,9 @@ class _SubmissionEventFactory(SQLAlchemyModelFactory):
         sqlalchemy_session_persistence = "commit"
 
     id = factory.LazyFunction(uuid4)
-    key = SubmissionEventKey.FORM_RUNNER_FORM_COMPLETED
+    event_type = SubmissionEventType.FORM_RUNNER_FORM_COMPLETED
     submission = factory.SubFactory(_SubmissionFactory)
-    form = factory.SubFactory(_FormFactory)
+    related_entity_id = factory.LazyAttribute(lambda o: o.submission.id if o.submission else None)
     created_by = factory.SubFactory(_UserFactory)
     created_at_utc = factory.LazyFunction(lambda: datetime.datetime.now())
 

--- a/tests/unit/common/helpers/test_collections.py
+++ b/tests/unit/common/helpers/test_collections.py
@@ -8,7 +8,7 @@ from app.common.data.types import (
     ExpressionType,
     QuestionDataType,
     QuestionPresentationOptions,
-    SubmissionEventKey,
+    SubmissionEventType,
     SubmissionModeEnum,
 )
 from app.common.helpers.collections import SubmissionHelper
@@ -473,7 +473,9 @@ class TestSubmissionHelper:
             helper.cached_get_all_questions_are_answered_for_form.cache_clear()
             submission.events = [
                 factories.submission_event.build(
-                    submission=submission, form=form_one, key=SubmissionEventKey.FORM_RUNNER_FORM_COMPLETED
+                    submission=submission,
+                    related_entity_id=form_one.id,
+                    event_type=SubmissionEventType.FORM_RUNNER_FORM_COMPLETED,
                 )
             ]
 
@@ -491,7 +493,9 @@ class TestSubmissionHelper:
 
             submission.events.append(
                 factories.submission_event.build(
-                    submission=submission, form=form_two, key=SubmissionEventKey.FORM_RUNNER_FORM_COMPLETED
+                    submission=submission,
+                    related_entity_id=form_two.id,
+                    event_type=SubmissionEventType.FORM_RUNNER_FORM_COMPLETED,
                 )
             )
 
@@ -750,17 +754,17 @@ class TestSubmissionHelper:
             submission = factories.submission.build(mode=SubmissionModeEnum.LIVE)
             event_1 = factories.submission_event.build(
                 submission=submission,
-                key=SubmissionEventKey.SUBMISSION_SENT_FOR_CERTIFICATION,
+                event_type=SubmissionEventType.SUBMISSION_SENT_FOR_CERTIFICATION,
                 created_at_utc=datetime(2020, 1, 1, 13, 30, 0),
             )
             event_2 = factories.submission_event.build(
                 submission=submission,
-                key=SubmissionEventKey.FORM_RUNNER_FORM_COMPLETED,
+                event_type=SubmissionEventType.FORM_RUNNER_FORM_COMPLETED,
                 created_at_utc=datetime(2025, 12, 1, 13, 30, 0),
             )
             event_3 = factories.submission_event.build(
                 submission=submission,
-                key=SubmissionEventKey.SUBMISSION_SUBMITTED,
+                event_type=SubmissionEventType.SUBMISSION_SUBMITTED,
                 created_at_utc=datetime(2022, 6, 1, 13, 30, 0),
             )
 
@@ -773,7 +777,7 @@ class TestSubmissionHelper:
             user = factories.user.build()
             submission = factories.submission.build(mode=SubmissionModeEnum.LIVE)
             factories.submission_event.build(
-                submission=submission, key=SubmissionEventKey.SUBMISSION_SENT_FOR_CERTIFICATION, created_by=user
+                submission=submission, event_type=SubmissionEventType.SUBMISSION_SENT_FOR_CERTIFICATION, created_by=user
             )
             helper = SubmissionHelper(submission)
 
@@ -791,19 +795,19 @@ class TestSubmissionHelper:
             submission = factories.submission.build(mode=SubmissionModeEnum.LIVE)
             factories.submission_event.build(
                 submission=submission,
-                key=SubmissionEventKey.SUBMISSION_SENT_FOR_CERTIFICATION,
+                event_type=SubmissionEventType.SUBMISSION_SENT_FOR_CERTIFICATION,
                 created_by=user2,
                 created_at_utc=datetime(2020, 1, 1, 13, 30, 0),
             )
             factories.submission_event.build(
                 submission=submission,
-                key=SubmissionEventKey.SUBMISSION_SENT_FOR_CERTIFICATION,
+                event_type=SubmissionEventType.SUBMISSION_SENT_FOR_CERTIFICATION,
                 created_by=user,
                 created_at_utc=datetime(2025, 12, 1, 13, 30, 0),
             )
             factories.submission_event.build(
                 submission=submission,
-                key=SubmissionEventKey.SUBMISSION_SENT_FOR_CERTIFICATION,
+                event_type=SubmissionEventType.SUBMISSION_SENT_FOR_CERTIFICATION,
                 created_by=user2,
                 created_at_utc=datetime(2022, 6, 1, 13, 30, 0),
             )


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-1018

## 📝 Description
Updates the submission events table to prepare for "reducing" streams of submission events to allow workflows and state to go both backwards and forwards.

This will allow us to model submissions being signed off, declined, submitted and marked as overdue.

We'll also be able to streamline how individual forms/ sections are tracked with events so we're no longer deleting events when a user goes back and changes if its completed or not but can use the properties enabled by this change.

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
~- [ ] I need the reviewer(s) to pull and run this change locally~
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [x] End-to-end tests have been updated (if applicable)
- [x] Edge cases and error conditions are tested
