### PR TITLE
BAU: VS Code settings for formatting HTML on save

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,18 @@
 {
-    "plugins": ["prettier-plugin-jinja-template"]
+    "tabWidth": 4,
+    "overrides": [
+        {
+            "files": "**/*.html",
+            "options": {
+                "plugins": [
+                    "prettier-plugin-jinja-template"
+                ],
+                "parser": "jinja-template",
+                "tabWidth": 2,
+                "htmlWhitespaceSensitivity": "css",
+                "bracketSameLine": true,
+                "printWidth": 240
+            }
+        }
+    ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,9 @@
         "tests"
     ],
     "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+    "python.testing.pytestEnabled": true,
+    "[html][javascript][css][scss][sass]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "prettier.configPath": ".prettierrc"
 }

--- a/Makefile
+++ b/Makefile
@@ -22,15 +22,15 @@ vite:
 
 .PHONY: check-html
 check-html:
-	npx prettier --plugin=prettier-plugin-jinja-template --parser=jinja-template --tab-width=2 --html-whitespace-sensitivity css --bracket-same-line=true --print-width=240 --check **/*.html
+	npx prettier --check **/*.html
 
 .PHONY: format-html
 format-html:
-	npx prettier --plugin=prettier-plugin-jinja-template --parser=jinja-template --tab-width=2 --html-whitespace-sensitivity css --bracket-same-line=true --print-width=240 --write **/*.html
+	npx prettier --write **/*.html
 
 .PHONY: format-css-js
 format-css-js:
-	npx prettier --tab-width=4 --write "**/*.{js,css,sass,scss}"
+	npx prettier --write "**/*.{js,css,sass,scss}"
 
 .PHONY: format-frontend
 format-frontend: format-css-js format-html


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
VS Code's default HTML format on save does not follow our desired HTML formatting rules, which are applied with prettier through Make commands and used in our pre-commit hooks.

This change adds all the configurations passed to the make format/check-html commands to the prettierrc config file and updates the VS Code settings.json to use these settings as the formatter for HTML files.
