### PR TITLE
Track when grants and collections change state

### DIFF
--- a/app/common/data/interfaces/grants.py
+++ b/app/common/data/interfaces/grants.py
@@ -15,6 +15,7 @@ from app.common.data.models import Collection, Grant, Organisation
 from app.common.data.models_user import User
 from app.common.data.types import GrantStatusEnum
 from app.extensions import db
+from app.metrics import MetricAttributeName, MetricEventName, emit_metric_count
 from app.types import NOT_PROVIDED, TNotProvided
 
 
@@ -118,6 +119,15 @@ def update_grant(
                 pass
             case _:
                 raise StateTransitionError(model="grant", from_state=grant.status, to_state=status)
+
+        emit_metric_count(
+            MetricEventName.GRANT_STATUS_CHANGED,
+            grant=grant,
+            custom_attributes={
+                MetricAttributeName.FROM_STATUS: str(grant.status),
+                MetricAttributeName.TO_STATUS: str(status),
+            },
+        )
         grant.status = status
 
     if description is not NOT_PROVIDED:

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -23,6 +23,9 @@ class MetricAttributeName(StrEnum):
     SUBMISSION_MODE = "submission-mode"
     USER_ID = "user-id"
 
+    FROM_STATUS = "from-status"
+    TO_STATUS = "to-status"
+
     MANAGED_EXPRESSION_NAME = "managed-expression-name"
 
 
@@ -41,6 +44,9 @@ class MetricEventName(StrEnum):
     SUBMISSION_MANAGED_VALIDATION_SUCCESS = "submission-managed-validation-success"
 
     SECTION_RESET_TO_IN_PROGRESS_BY_CERTIFIER = "section-reset-to-in-progress-by-certifier"
+
+    GRANT_STATUS_CHANGED = "grant-status-changed"
+    COLLECTION_STATUS_CHANGED = "collection-status-changed"
 
 
 def _get_event_attributes(


### PR DESCRIPTION
This might be useful for tracking how long the funding service and form designers need to prepare a grant, and a report, collectively to go live. Shorter times should be 'better'.