### PR TITLE
BAU Use the functioning tasklist page until certifier screens are done

### DIFF
--- a/app/access_grant_funding/routes/runner.py
+++ b/app/access_grant_funding/routes/runner.py
@@ -34,9 +34,18 @@ def route_to_submission(organisation_id: UUID, grant_id: UUID, collection_id: UU
 
     submission_helper = SubmissionHelper(submission)
     if submission_helper.is_locked_state:
+        # todo: point to the completed version of a submission when the page is fully built out
+        # return redirect(
+        #     url_for(
+        #         "access_grant_funding.view_locked_report",
+        #         organisation_id=organisation_id,
+        #         grant_id=grant_id,
+        #         submission_id=submission.id,
+        #     )
+        # )
         return redirect(
             url_for(
-                "access_grant_funding.view_locked_report",
+                "access_grant_funding.tasklist",
                 organisation_id=organisation_id,
                 grant_id=grant_id,
                 submission_id=submission.id,

--- a/tests/integration/access_grant_funding/routes/test_runner.py
+++ b/tests/integration/access_grant_funding/routes/test_runner.py
@@ -97,7 +97,7 @@ class TestRouteToSubmission:
         assert response.status_code == 302
         expected_location = (
             f"/access/organisation/{grant_recipient.organisation.id}/grants/{grant_recipient.grant.id}"
-            f"/reports/{submission_awaiting_sign_off.id}/view"
+            f"/reports/{submission_awaiting_sign_off.id}/tasklist"
         )
         assert response.location == expected_location
 


### PR DESCRIPTION
We prematurely updated the routing logic in AGF to a work-in-progress flow while the test environment is being used for UR and demos. This feels like a clear need for us to round out an initial pass at feature flags to let us safely merge code as its put together.

For now revert routing to this page so that everything continues to work as expected for test environment users.