### PR TITLE
Override certifiers for specific grants

### DIFF
--- a/app/deliver_grant_funding/admin/forms.py
+++ b/app/deliver_grant_funding/admin/forms.py
@@ -8,7 +8,7 @@ from govuk_frontend_wtf.wtforms_widgets import GovCheckboxInput, GovDateInput, G
 from markupsafe import Markup, escape
 from wtforms import DateField, SubmitField
 from wtforms.fields.choices import SelectField, SelectMultipleField
-from wtforms.fields.simple import BooleanField, EmailField, TextAreaField
+from wtforms.fields.simple import BooleanField, EmailField, StringField, TextAreaField
 from wtforms.validators import DataRequired, Email, Optional
 from xgovuk_flask_admin import GovSelectWithSearch
 
@@ -390,3 +390,52 @@ class PlatformAdminScheduleReportForm(FlaskForm):
 
 class PlatformAdminMakeReportLiveForm(FlaskForm):
     submit = SubmitField("Open report for submissions", widget=GovSubmitInput())
+
+
+class PlatformAdminCreateGrantOverrideCertifiersForm(FlaskForm):
+    organisation_id = SelectField(
+        "Organisation name",
+        choices=[],
+        widget=GovSelectWithSearch(),
+        validators=[DataRequired("Select an organisation")],
+    )
+    full_name = StringField(
+        "Full name",
+        validators=[DataRequired("Enter the certifier's full name")],
+        widget=GovTextInput(),
+    )
+    email = EmailField(
+        "Email address",
+        validators=[DataRequired("Enter an email address"), Email("Enter a valid email address")],
+        widget=GovTextInput(),
+    )
+    submit = SubmitField("Add grant-specific certifier", widget=GovSubmitInput())
+
+    def __init__(self, grant_recipients: Sequence["GrantRecipient"]) -> None:
+        super().__init__()
+        self.organisation_id.choices = [
+            ("", ""),
+            *[(str(gr.organisation.id), gr.organisation.name) for gr in grant_recipients],
+        ]
+
+
+class PlatformAdminRevokeGrantOverrideCertifiersForm(FlaskForm):
+    organisation_id = SelectField(
+        "Organisation",
+        choices=[],
+        widget=GovSelectWithSearch(),
+        validators=[DataRequired("Select an organisation")],
+    )
+    email = EmailField(
+        "Email address",
+        validators=[DataRequired("Enter an email address"), Email("Enter a valid email address")],
+        widget=GovTextInput(),
+    )
+    submit = SubmitField("Revoke grant-specific certifier access", widget=GovSubmitInput())
+
+    def __init__(self, grant_recipients: Sequence["GrantRecipient"]) -> None:
+        super().__init__()
+        self.organisation_id.choices = [
+            ("", ""),
+            *[(str(gr.organisation.id), gr.organisation.name) for gr in grant_recipients],
+        ]

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/admin/override-grant-certifiers.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/admin/override-grant-certifiers.html
@@ -1,0 +1,76 @@
+{% extends "admin/master.html" %}
+{% import 'admin/layout.html' as layout with context %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% from 'govuk_frontend_jinja/components/error-summary/macro.html' import govukErrorSummary %}
+{% from 'govuk_frontend_jinja/components/inset-text/macro.html' import govukInsetText %}
+{% from 'govuk_frontend_jinja/components/details/macro.html' import govukDetails %}
+{% from 'deliver_grant_funding/partials/existing-certifiers.html' import existingCertifiersTable %}
+
+{% block beforeContent %}
+  {{ govukBackLink({"text": "Back", "href": url_for('reporting_lifecycle.tasklist', grant_id=grant.id, collection_id=collection.id) }) }}
+{% endblock %}
+
+{% block action_panel %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ layout.messages() }}
+
+      {% if form.errors %}
+        {{ govukErrorSummary(wtforms_errors(form)) }}
+      {% endif %}
+
+      <span class="govuk-caption-l">{{ grant.name }} - {{ collection.name }}</span>
+      <h1 class="govuk-heading-l">Override certifiers for this grant</h1>
+
+      <p class="govuk-body">Grant-specific certifier overrides allow you to set different certifiers for {{ grant.name }} that replace the organisation-level certifiers.</p>
+
+      {{
+        govukInsetText({
+          "html": "When any grant-specific certifiers exist for an organisation, only those certifiers (not the organisation-level ones) will be used for this grant."
+        })
+      }}
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      {% set existingCertifiersHtml %}
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-one-half">
+            <p class="govuk-body">
+              If any of these certifiers are incorrect, you can
+              <a href="{{ url_for('reporting_lifecycle.revoke_grant_override_certifiers', grant_id=grant.id, collection_id=collection.id) }}" class="govuk-link">revoke certifiers</a>.
+            </p>
+          </div>
+        </div>
+
+        {{ existingCertifiersTable(certifiers_by_org, overrides=True) }}
+      {% endset %}
+
+      {{
+        govukDetails({
+          "summaryText": "Existing grant-specific certifiers by organisation",
+          "html": existingCertifiersHtml,
+        })
+      }}
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h2 class="govuk-heading-m">Add grant-specific certifier</h2>
+
+      <form method="post" novalidate>
+        {{ form.csrf_token }}
+
+        {{ form.organisation_id }}
+
+        {{ form.full_name }}
+
+        {{ form.email }}
+
+        {{ form.submit }}
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/admin/reporting-lifecycle-tasklist.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/admin/reporting-lifecycle-tasklist.html
@@ -88,6 +88,13 @@
           "href": url_for('reporting_lifecycle.set_up_grant_recipient_data_providers', grant_id=grant.id, collection_id=collection.id),
         })
       %}
+      {%
+        do rows.append({
+          "title": {"text": "Override certifiers for this grant", "classes": "govuk-link--no-visited-state"},
+          "status": {"html": govukTag({"text": grant_override_certifiers_count ~ (" override" if grant_override_certifiers_count == 1 else " overrides"), "classes": "govuk-tag--blue"})},
+          "href": url_for('reporting_lifecycle.override_grant_certifiers', grant_id=grant.id, collection_id=collection.id),
+        })
+      %}
       {{ govukTaskList({ "idPrefix": "grant-tasks", "items": rows, "attributes": {"id": "grant-tasks"} }) }}
 
       <h2 class="govuk-heading-m">Report tasks</h2>

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/admin/revoke-grant-override-certifiers.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/admin/revoke-grant-override-certifiers.html
@@ -1,0 +1,54 @@
+{% extends "admin/master.html" %}
+{% import 'admin/layout.html' as layout with context %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% from 'govuk_frontend_jinja/components/error-summary/macro.html' import govukErrorSummary %}
+{% from 'deliver_grant_funding/partials/existing-certifiers.html' import existingCertifiersTable %}
+{% from 'govuk_frontend_jinja/components/details/macro.html' import govukDetails %}
+
+{% block beforeContent %}
+  {{ govukBackLink({"text": "Back", "href": url_for('reporting_lifecycle.override_grant_certifiers', grant_id=grant.id, collection_id=collection.id) }) }}
+{% endblock %}
+
+{% block action_panel %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-half">
+      {{ layout.messages() }}
+
+      {% if form.errors %}
+        {{ govukErrorSummary(wtforms_errors(form)) }}
+      {% endif %}
+
+      <span class="govuk-caption-l">{{ grant.name }} - {{ collection.name }}</span>
+      <h1 class="govuk-heading-l">Revoke grant-specific certifier</h1>
+
+      <p class="govuk-body">Enter the organisation and email address of the grant-specific certifier you want to revoke access for.</p>
+    </div>
+  </div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      {% set existingCertifiersHtml %}
+        {{ existingCertifiersTable(certifiers_by_org, overrides=True) }}
+      {% endset %}
+
+      {{
+        govukDetails({
+          "summaryText": "Existing grant-specific certifiers by organisation",
+          "html": existingCertifiersHtml,
+        })
+      }}
+    </div>
+  </div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-half">
+      <form method="post" novalidate>
+        {{ form.csrf_token }}
+
+        {{ form.organisation_id }}
+
+        {{ form.email }}
+
+        {{ form.submit }}
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/partials/existing-certifiers.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/partials/existing-certifiers.html
@@ -1,6 +1,6 @@
 {% from 'govuk_frontend_jinja/components/table/macro.html' import govukTable %}
 
-{% macro existingCertifiersTable(certifiers_by_org) %}
+{% macro existingCertifiersTable(certifiers_by_org, overrides=False) %}
   {% set tableRows = [] %}
   {% for organisation, users in certifiers_by_org.items() %}
     {% if users %}
@@ -12,7 +12,7 @@
         </ul>
       {% endset %}
     {% else %}
-      {% set userDetails = 'No certifier set up' %}
+      {% set userDetails = 'No certifier overrides set up' if overrides else 'No certifiers set up' %}
     {% endif %}
     {%
       do tableRows.append([

--- a/tests/unit/test_all_routes_access.py
+++ b/tests/unit/test_all_routes_access.py
@@ -231,6 +231,8 @@ routes_with_access_controlled_by_flask_admin = [
     "reporting_lifecycle.set_up_grant_recipients",
     "reporting_lifecycle.set_up_grant_recipient_data_providers",
     "reporting_lifecycle.revoke_grant_recipient_data_providers",
+    "reporting_lifecycle.override_grant_certifiers",
+    "reporting_lifecycle.revoke_grant_override_certifiers",
     "reporting_lifecycle.set_collection_dates",
     "reporting_lifecycle.schedule_report",
     "reporting_lifecycle.make_report_live",


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-988

## 📝 Description
We understand that some grant recipient organisations deputise or delegate
responsibility for certification of reports before submission to MHCLG. Delta's
system supports this so the need is fairly crystallised.

This patch adds the ability to easily set up and revoke override certifiers for
specific grants.

## 📸 Show the thing (screenshots, gifs)
<img width="1287" height="1242" alt="image" src="https://github.com/user-attachments/assets/062bc0a9-1b4b-4390-a092-c1a592a9b755" />

<img width="1284" height="1296" alt="image" src="https://github.com/user-attachments/assets/01d1163b-c989-46cd-9499-165a176b3650" />

<img width="1290" height="1022" alt="image" src="https://github.com/user-attachments/assets/f956cae4-0337-45a3-a78d-06693393734a" />


### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested