### PR TITLE
BAU: Fix 'view submission' styling & breadcrumb

### DIFF
--- a/app/common/templates/common/macros/status.html
+++ b/app/common/templates/common/macros/status.html
@@ -60,7 +60,7 @@
     }
   %}
   {% if status in show_without_tag %}
-    {{ status }}
+    <span class="govuk-body govuk-!-margin-bottom-0">{{ status }}</span>
   {% else %}
     {{ govukTag({"text": status, "classes": "app-status-tag " ~ classMap[status] }) }}
   {% endif %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/view_submission.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/view_submission.html
@@ -12,7 +12,7 @@
     {{ mhclgTestBanner("Test submission") }}
   {% endif %}
 
-  {{ deliver_grant_funding_reports_breadcrumb(grant=grant, immediate_parent_breadcrumb_item={"text": "Submissions", "href": url_for("deliver_grant_funding.list_submissions", grant_id=grant.id, report_id=helper.submission.collection.id, submission_mode=helper.submission.mode)}, this_page_breadcrumb_item={"text": helper.submission.created_by.email}) }}
+  {{ deliver_grant_funding_reports_breadcrumb(grant=grant, immediate_parent_breadcrumb_item={"text": "Submissions", "href": url_for("deliver_grant_funding.list_submissions", grant_id=grant.id, report_id=helper.submission.collection.id, submission_mode=helper.submission.mode)}, this_page_breadcrumb_item={"text": helper.submission.grant_recipient.organisation.name if helper.submission.grant_recipient else helper.submission.created_by.email }) }}
 {% endblock beforeContent %}
 
 {% block content %}


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
Fixes a couple of things noticed during a demo:
- live submissions were showing the submitted user's email in the breadcrumb (as it is for test submissions) instead of the grant recipient org
- 'Submitted' status doesn't have a tag and was showing as raw text on the the view submission page, as previously we only saw this status in the list reports table where it would be styled with govuk table cell styling. The fix here doesn't look _great_ but we've talked about updating the layout of this page to match the 'view_locked_report' page, in which case it would become redundant as that doesn't display the status when submitted (or would display it elsewhere).

## 📸 Show the thing (screenshots, gifs)

### Before
<img width="367" height="236" alt="image" src="https://github.com/user-attachments/assets/bffc7071-cdc4-4970-bc18-4d092f7209b3" />

No change to styling in a table:
<img width="903" height="135" alt="image" src="https://github.com/user-attachments/assets/8308064a-578c-468f-ae50-7f492826b000" />


### After
<img width="449" height="360" alt="image" src="https://github.com/user-attachments/assets/a5150a91-abf6-437f-8fc2-31564066a943" />

No change to styling in a table:
<img width="902" height="114" alt="image" src="https://github.com/user-attachments/assets/d13e2f52-3de3-4e33-962f-cd3287198dcd" />
