### PR TITLE
BAU: Send certify confirmation/decline emails to all users

### DIFF
--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -875,6 +875,10 @@ class GrantRecipient(BaseModel):
         return preferred_certifiers or self._all_certifiers
 
     @property
+    def unique_data_providers_and_certifiers(self) -> set[User]:
+        return set(self.data_providers + list(self.certifiers))
+
+    @property
     def certifier_names(self) -> str:
         names = [certifier.name for certifier in self.certifiers]
         if names and len(names) == 1:

--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -286,6 +286,10 @@ class SubmissionHelper:
         return self.events.submission_state.certified_at_utc
 
     @property
+    def declined_by(self) -> User | None:
+        return self.events.submission_state.declined_by
+
+    @property
     def created_at_utc(self) -> datetime:
         return self.submission.created_at_utc
 

--- a/tests/unit/services/test_notify.py
+++ b/tests/unit/services/test_notify.py
@@ -306,7 +306,7 @@ class TestNotificationService:
             "grant_report_url": f"http://funding.communities.gov.localhost:8080/access/organisation/{submission_awaiting_sign_off.grant_recipient.organisation.id}/grants/{submission_awaiting_sign_off.grant_recipient.grant.id}/collection/{submission_awaiting_sign_off.collection.id}",
         }
         notification_service.send_access_certifier_confirm_submission_declined(
-            certifier_user=certifier,
+            user=certifier,
             submission_helper=helper,
         )
         assert len(mock_notification_service_calls) == 1
@@ -339,7 +339,7 @@ class TestNotificationService:
 
         notification_service.send_access_submitter_submission_declined(
             submission_helper=helper,
-            certifier_user=certifier,
+            user=helper.sent_for_certification_by,
         )
         assert len(mock_notification_service_calls) == 1
         assert mock_notification_service_calls[0].kwargs["personalisation"] == expected_personalisation


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
We previously sent the decline certification and certification/submit success email notifications only to those users who had sent the report for certification and had declined or certified it. In discussion with product it was decided that we should default to sending these emails to all grant recipient data provider and certifier users, rather than just the individuals who had triggered those submission events. This is something we will monitor and can roll back if it gets too spammy.

## 🧪 Testing
Decline or certify a report locally for a grant recipient where you have multiple data providers and certifiers. In the Notify API tab you should now see emails to all these users, not just those who sent the report for certification and declined or certified it.

## 📋 Developer Checklist

### Review Readiness
- [X] PR title and description provide sufficient context for reviewers
- [X] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- [X] No N+1 query problems introduced
- ~[ ] Any new DB queries include appropriate where clauses based on the user's permissions~

### Testing
- [X] I have tested this change and it meets the acceptance criteria for the ticket
- ~[ ] I need the reviewer(s) to pull and run this change locally~
- [X] New (non-developer) functionality has appropriate unit and integration tests
- ~[ ] End-to-end tests have been updated (if applicable)~
- [X] Edge cases and error conditions are tested
