### PR TITLE
Add grant codes and submission references

### DIFF
--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -49,6 +49,7 @@ from app.common.data.types import (
     SubmissionEventType,
     SubmissionModeEnum,
 )
+from app.common.data.utils import generate_submission_reference
 from app.common.expressions import ALLOWED_INTERPOLATION_REGEX, INTERPOLATE_REGEX, ExpressionContext
 from app.common.expressions.managed import BaseDataSourceManagedExpression
 from app.common.forms.helpers import questions_in_same_add_another_container
@@ -397,8 +398,22 @@ def get_submission(
 def create_submission(
     *, collection: Collection, created_by: User, mode: SubmissionModeEnum, grant_recipient: GrantRecipient | None = None
 ) -> Submission:
+    existing_grant_submission_references = (
+        db.session.execute(
+            select(Submission.reference).join(Submission.collection).where(Collection.grant_id == collection.grant_id)
+        )
+        .scalars()
+        .all()
+    )
+    new_reference = generate_submission_reference(collection, existing_grant_submission_references)
+
     submission = Submission(
-        collection=collection, created_by=created_by, mode=mode, data={}, grant_recipient=grant_recipient
+        reference=new_reference,
+        collection=collection,
+        created_by=created_by,
+        mode=mode,
+        data={},
+        grant_recipient=grant_recipient,
     )
     db.session.add(submission)
     emit_metric_count(MetricEventName.SUBMISSION_CREATED, submission=submission)

--- a/app/common/data/interfaces/grants.py
+++ b/app/common/data/interfaces/grants.py
@@ -1,3 +1,4 @@
+import re
 from typing import Sequence
 from uuid import UUID
 
@@ -80,6 +81,8 @@ def create_grant(
     grant: Grant = Grant(
         ggis_number=ggis_number,
         name=name,
+        # TODO: set this explicitly through a UI flow; next PR
+        code="".join(word[0].upper() for word in re.split(r"[\s-]+", name)),
         description=description,
         primary_contact_name=primary_contact_name,
         primary_contact_email=primary_contact_email,

--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-030_submission_workflow
+031_submission_references

--- a/app/common/data/migrations/versions/031_submission_references.py
+++ b/app/common/data/migrations/versions/031_submission_references.py
@@ -1,0 +1,79 @@
+"""add grant codes and submission references
+
+Revision ID: 031_submission_references
+Revises: 030_submission_workflow
+Create Date: 2025-12-10 09:17:07.234536
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "031_submission_references"
+down_revision = "030_submission_workflow"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("grant", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("code", postgresql.CITEXT(), nullable=True))
+
+    with op.batch_alter_table("submission", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("reference", postgresql.CITEXT(), nullable=True))
+
+    op.execute(
+        """
+        UPDATE "grant"
+        SET code = UPPER(
+                         REGEXP_REPLACE(
+                             REGEXP_REPLACE("grant".name, '(\\w)\\w*\\s*', '\\1', 'g'),
+                             '[^A-Za-z]', '', 'g'
+                         )
+                   )
+        WHERE code IS NULL
+        """
+    )
+
+    with op.batch_alter_table("grant", schema=None) as batch_op:
+        batch_op.alter_column("code", existing_nullable=True, nullable=False)
+        batch_op.create_unique_constraint(batch_op.f("uq_grant_code"), ["code"])
+
+    # tiny risk of non-unique reference generation, but so small as to be ignorable for us
+    op.execute(
+        """
+        UPDATE submission s
+        SET reference = subq.new_reference
+        FROM (
+            SELECT
+                s.id,
+                g.code || '-R' ||
+                STRING_AGG(
+                    SUBSTRING('234679CDFGHJKLMNPQRTVWXYZ' FROM floor(random() * 25)::int + 1 FOR 1),
+                    ''
+                ) AS new_reference
+            FROM
+                submission s
+                INNER JOIN collection c ON s.collection_id = c.id
+                INNER JOIN "grant" g ON c.grant_id = g.id
+            CROSS JOIN generate_series(1, 6) -- Generate 6 random characters
+            GROUP BY s.id, g.code
+        ) subq
+        WHERE s.id = subq.id;
+        """
+    )
+
+    with op.batch_alter_table("submission", schema=None) as batch_op:
+        batch_op.alter_column("reference", existing_nullable=True, nullable=False)
+        batch_op.create_unique_constraint(batch_op.f("uq_submission_reference"), ["reference"])
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("submission", schema=None) as batch_op:
+        batch_op.drop_constraint(batch_op.f("uq_submission_reference"), type_="unique")
+        batch_op.drop_column("reference")
+
+    with op.batch_alter_table("grant", schema=None) as batch_op:
+        batch_op.drop_constraint(batch_op.f("uq_grant_code"), type_="unique")
+        batch_op.drop_column("code")

--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -43,6 +43,7 @@ class Grant(BaseModel):
 
     ggis_number: Mapped[str]
     name: Mapped[CIStr] = mapped_column(unique=True)
+    code: Mapped[CIStr] = mapped_column(unique=True)
     status: Mapped[GrantStatusEnum] = mapped_column(default=GrantStatusEnum.DRAFT)
     description: Mapped[str]
     primary_contact_name: Mapped[str]
@@ -206,16 +207,12 @@ class Collection(BaseModel):
 class Submission(BaseModel):
     __tablename__ = "submission"
 
+    reference: Mapped[CIStr] = mapped_column(unique=True)
+
     data: Mapped[json_scalars] = mapped_column(mutable_json_type(dbtype=JSONB, nested=True))  # type: ignore[no-untyped-call]
     mode: Mapped[SubmissionModeEnum] = mapped_column(
         SqlEnum(SubmissionModeEnum, name="submission_mode_enum", validate_strings=True)
     )
-
-    # TODO: generated and persisted human readable references for submissions
-    #       these will likely want to fit the domain need
-    @property
-    def reference(self) -> str:
-        return str(self.id)[:8]
 
     created_by_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("user.id"))
     grant_recipient_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("grant_recipient.id"))

--- a/app/common/data/utils.py
+++ b/app/common/data/utils.py
@@ -1,0 +1,32 @@
+import random
+from typing import Sequence
+
+from app.common.data.models import Collection
+from app.common.data.types import CollectionType
+
+
+def generate_submission_reference(collection: Collection, avoid_references: Sequence[str] | None = None) -> str:
+    # Removed letters and numbers where there could be confusion (eg 0 and O, B and 8, etc)
+    # Removed all vowels to reduce the chance of forming real possibly-offensive words
+    alphabet = "234679CDFGHJKLMNPQRTVWXYZ"
+
+    grant_code = collection.grant.code
+
+    limit = 100
+    while limit:
+        submission_code = "".join(random.choices(alphabet, k=6))
+
+        match collection.type:
+            case CollectionType.MONITORING_REPORT:
+                fmt = "{grant_code}-R{submission_code}"
+
+            case _:
+                raise RuntimeError(f"Cannot generate reference for unknown submission type {collection.type}")
+
+        reference = fmt.format(grant_code=grant_code, submission_code=submission_code)
+        if not avoid_references or reference not in avoid_references:
+            return reference
+
+        limit -= 1
+
+    raise RuntimeError("Could not generate a unique submission reference")

--- a/app/developers/data/grants.json
+++ b/app/developers/data/grants.json
@@ -1214,6 +1214,7 @@
         }
       ],
       "grant": {
+        "code": "CIP",
         "description": "Funding to help local cheesemongers provide samples to park visitors, with the intention to increase the local community's satisfaction with the variety and quality of local cheeses.",
         "ggis_number": "GGIS-000000",
         "id": "caf0ce3f-5175-f69c-66a9-41e2c2245845",
@@ -2983,8 +2984,9 @@
         }
       ],
       "grant": {
+        "code": "CFA",
         "description": "Fill me in later",
-        "ggis_number": "fill-me-in-later",
+        "ggis_number": "G2-SCH-2025-123456",
         "id": "df51f309-718c-4dd4-bd76-0bd6df032e4b",
         "name": "Communities for Afghans",
         "primary_contact_email": "someone@communities.gov.uk",

--- a/tests/integration/common/data/test_models.py
+++ b/tests/integration/common/data/test_models.py
@@ -38,6 +38,7 @@ class TestSubmissionModel:
         submission = Submission(
             collection_id=collection.id,
             mode=SubmissionModeEnum.LIVE,
+            reference="TEST-R123456",
             created_by_id=user.id,
             grant_recipient_id=None,
             data={},

--- a/tests/models.py
+++ b/tests/models.py
@@ -55,6 +55,7 @@ from app.common.data.types import (
     SubmissionEventType,
     SubmissionModeEnum,
 )
+from app.common.data.utils import generate_submission_reference
 from app.common.expressions import ExpressionContext
 from app.common.expressions.managed import AnyOf, GreaterThan, Specifically
 from app.common.helpers.submission_events import SubmissionEventHelper
@@ -104,6 +105,7 @@ class _GrantFactory(SQLAlchemyModelFactory):
     id = factory.LazyFunction(uuid4)
     ggis_number = factory.Sequence(lambda n: f"GGIS-{n:06d}")
     name = factory.Sequence(lambda n: "Grant %d" % n)
+    code = factory.Sequence(lambda n: f"GRANT-{n}")
     status = GrantStatusEnum.DRAFT
     description = factory.Faker("text", max_nb_chars=200)
     primary_contact_name = factory.Faker("name")
@@ -655,6 +657,8 @@ class _SubmissionFactory(SQLAlchemyModelFactory):
 
     collection = factory.SubFactory(_CollectionFactory)
     collection_id = factory.LazyAttribute(lambda o: o.collection.id)
+
+    reference = factory.LazyAttribute(lambda o: generate_submission_reference(o.collection))
 
     grant_recipient = factory.LazyAttribute(
         lambda o: _GrantRecipientFactory.build(grant=o.collection.grant if o.collection else None)

--- a/tests/unit/common/data/test_utils.py
+++ b/tests/unit/common/data/test_utils.py
@@ -1,0 +1,33 @@
+import pytest
+
+from app.common.data.utils import generate_submission_reference
+
+
+class TestGenerateSubmissionReference:
+    def test_generate_code(self, factories, mocker):
+        mocker.patch("random.choices", return_value=["1", "2", "3", "4", "5", "6"])
+
+        collection = factories.collection.build(grant__code="TEST")
+
+        assert generate_submission_reference(collection) == "TEST-R123456"
+
+    def test_avoid_reference(self, factories, mocker):
+        mocker.patch(
+            "random.choices",
+            side_effect=[
+                ["1", "2", "3", "4", "5", "6"],
+                ["1", "2", "3", "4", "5", "7"],
+            ],
+        )
+
+        collection = factories.collection.build(grant__code="TEST")
+
+        assert generate_submission_reference(collection, avoid_references=["TEST-R123456"]) == "TEST-R123457"
+
+    def test_max_100_attempts(self, factories, mocker):
+        mocker.patch("random.choices", return_value=["1", "2", "3", "4", "5", "6"])
+
+        collection = factories.collection.build(grant__code="TEST")
+
+        with pytest.raises(RuntimeError, match="Could not generate a unique submission reference"):
+            generate_submission_reference(collection, avoid_references=["TEST-R123456"])


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-1054

## 📝 Description
Up until now we've just been using part of the submission UUID as its 'reference', but this was only ever a holding pattern.

We'd like to convey some useful information in the reference and have settled on:

- grant name 
- type of submission (eg monitoring report)

With some added randomness to keep references short and unique.

A subsequent PR will (/may) add a step to the Deliver grant setup flow and/or admin pages for setting grant codes.

## 🧪 Testing
<!-- Describe how you've tested this change, and how a reviewer can test it -->

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [x] Edge cases and error conditions are tested