### PR TITLE
Set grant code during setup

### DIFF
--- a/app/common/data/interfaces/grants.py
+++ b/app/common/data/interfaces/grants.py
@@ -1,4 +1,3 @@
-import re
 from typing import Sequence
 from uuid import UUID
 
@@ -45,6 +44,13 @@ def grant_name_exists(name: str, exclude_grant_id: UUID | None = None) -> bool:
     return grant is not None
 
 
+def grant_code_exists(code: str, exclude_grant_id: UUID | None = None) -> Grant | None:
+    statement = select(Grant).where(Grant.code == code)
+    if exclude_grant_id:
+        statement = statement.where(Grant.id != exclude_grant_id)
+    return db.session.scalar(statement)
+
+
 def get_all_deliver_grants_by_user(user: User) -> Sequence[Grant]:
     from app.common.auth.authorisation_helper import AuthorisationHelper
 
@@ -70,6 +76,7 @@ def create_grant(
     *,
     ggis_number: str,
     name: str,
+    code: str,
     description: str,
     primary_contact_name: str,
     primary_contact_email: str,
@@ -81,8 +88,7 @@ def create_grant(
     grant: Grant = Grant(
         ggis_number=ggis_number,
         name=name,
-        # TODO: set this explicitly through a UI flow; next PR
-        code="".join(word[0].upper() for word in re.split(r"[\s-]+", name)),
+        code=code,
         description=description,
         primary_contact_name=primary_contact_name,
         primary_contact_email=primary_contact_email,

--- a/app/common/data/utils.py
+++ b/app/common/data/utils.py
@@ -1,8 +1,13 @@
 import random
+import re
 from typing import Sequence
 
 from app.common.data.models import Collection
 from app.common.data.types import CollectionType
+
+
+def generate_grant_code(name: str) -> str:
+    return "".join(word[0].upper() for word in re.split(r"\s+", (name or "")))
 
 
 def generate_submission_reference(collection: Collection, avoid_references: Sequence[str] | None = None) -> str:

--- a/app/deliver_grant_funding/session_models.py
+++ b/app/deliver_grant_funding/session_models.py
@@ -11,6 +11,7 @@ class GrantSetupSession(BaseModel):
     has_ggis: Literal["yes", "no"] | None = None
     ggis_number: str = ""
     name: str = ""
+    code: str = ""
     description: str = ""
     primary_contact_name: str = ""
     primary_contact_email: str = ""

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_details.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_details.html
@@ -45,6 +45,10 @@
               } if authorisation_helper.has_deliver_grant_role(grant.id, roles_enum.ADMIN, current_user) else {}
             },
             {
+              "key": {"text": "Grant code"},
+              "value": {"text": grant.code}
+            },
+            {
               "key": {"text": "Main purpose"},
               "value": {"text": grant.description},
               "actions": {

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_setup/grant_code.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_setup/grant_code.html
@@ -1,0 +1,55 @@
+{% if grant %}
+  {% extends "deliver_grant_funding/grant_base.html" %}
+  {% set active_item_identifier = "details" %}
+{% else %}
+  {% extends "deliver_grant_funding/base.html" %}
+  {% set active_item_identifier = "grants" %}
+{% endif %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+
+{% set page_title = grant.name %}
+
+{% block beforeContent %}
+  {% if not grant.id %}
+    {{
+      govukBackLink({
+          "text": "Back",
+          "href": back_link_href
+      })
+    }}
+  {% endif %}
+{% endblock beforeContent %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l">{% if grant.id %}{{ grant.name }}{% else %}Set up the grant{% endif %}</span>
+      <h1 class="govuk-heading-l">What is the unique code for this grant?</h1>
+
+      <p class="govuk-body">This should clearly identify the grant and will usually be an initialism of the grant name. The code must be unique for every grant in Deliver grant funding.</p>
+
+      <form method="post" novalidate>
+        {{ form.csrf_token }}
+
+        {{
+          form.code(params={
+            "label": {
+              "isPageHeading": false,
+              "classes": "govuk-visually-hidden"
+            },
+            "classes": "govuk-!-width-two-thirds",
+          })
+        }}
+
+        <div class="govuk-button-group">
+          {% set submit_label = 'Update grant code' if grant.id else 'Save and continue' %}
+          {{ form.submit(params={"text": submit_label}) }}
+
+          {% if grant %}
+            <a class="govuk-link govuk-link--no-visited-state" href="{{ back_link_href }}">Cancel</a>
+          {% endif %}
+        </div>
+      </form>
+    </div>
+  </div>
+{% endblock content %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_setup/initial_flow/check_your_answers.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_setup/initial_flow/check_your_answers.html
@@ -37,6 +37,18 @@
             }
           },
           {
+            "key": {"text": "Grant code"},
+            "value": {"text": grant_session.code},
+            "actions": {
+              "items": [{
+                "href": url_for("deliver_grant_funding.grant_setup_code", source=check_your_answers_source),
+                "classes": "govuk-link--no-visited-state",
+                "text": "Change",
+                "visuallyHiddenText": "grant code"
+              }]
+            }
+          },
+          {
             "key": {"text": "Main purpose"},
             "value": {"text": grant_session.description},
             "actions": {

--- a/tests/e2e/pages.py
+++ b/tests/e2e/pages.py
@@ -213,6 +213,23 @@ class GrantSetupNamePage(TopNavMixin, BasePage):
     def fill_name(self, name: str) -> None:
         self.name_input.fill(name)
 
+    def click_save_and_continue(self) -> GrantSetupCodePage:
+        self.save_continue_button.click()
+        grant_setup_code_page = GrantSetupCodePage(self.page, self.domain)
+        expect(grant_setup_code_page.title).to_be_visible()
+        return grant_setup_code_page
+
+
+class GrantSetupCodePage(TopNavMixin, BasePage):
+    def __init__(self, page: Page, domain: str) -> None:
+        super().__init__(page, domain)
+        self.title = self.page.get_by_role("heading", name="What is the unique code for this grant?")
+        self.code_input = self.page.get_by_role("textbox", name="Enter the grant code")
+        self.save_continue_button = self.page.get_by_role("button", name="Save and continue")
+
+    def fill_code(self, code: str) -> None:
+        self.code_input.fill(code)
+
     def click_save_and_continue(self) -> GrantSetupDescriptionPage:
         self.save_continue_button.click()
         grant_setup_description_page = GrantSetupDescriptionPage(self.page, self.domain)

--- a/tests/e2e/test_create_preview_collection.py
+++ b/tests/e2e/test_create_preview_collection.py
@@ -444,15 +444,18 @@ questions_with_groups_to_test: dict[str, TQuestionToTest] = {
 }
 
 
-def create_grant(new_grant_name: str, all_grants_page: AllGrantsPage) -> GrantDashboardPage:
+def create_grant(new_grant_name: str, grant_name_uuid: str, all_grants_page: AllGrantsPage) -> GrantDashboardPage:
     grant_intro_page = all_grants_page.click_set_up_a_grant()
     grant_ggis_page = grant_intro_page.click_continue()
     grant_ggis_page.select_yes()
     grant_ggis_page.fill_ggis_number()
     grant_name_page = grant_ggis_page.click_save_and_continue()
     grant_name_page.fill_name(new_grant_name)
-    grant_description_page = grant_name_page.click_save_and_continue()
-    grant_description_page.fill_description()
+    grant_code_page = grant_name_page.click_save_and_continue()
+    grant_code_page.fill_code(f"E2E-{grant_name_uuid[:8].upper()}")
+    grant_description_page = grant_code_page.click_save_and_continue()
+    new_grant_description = f"Description for {new_grant_name}"
+    grant_description_page.fill_description(new_grant_description)
     grant_contact_page = grant_description_page.click_save_and_continue()
     grant_contact_page.fill_contact_name()
     grant_contact_page.fill_contact_email()
@@ -857,7 +860,7 @@ def test_create_and_preview_report(
         all_grants_page.navigate()
 
         # Set up new grant
-        grant_dashboard_page = create_grant(new_grant_name, all_grants_page)
+        grant_dashboard_page = create_grant(new_grant_name, grant_name_uuid, all_grants_page)
 
         # Go to Reports tab
         grant_reports_page = grant_dashboard_page.click_reports(new_grant_name)

--- a/tests/e2e/test_create_view_edit_grant.py
+++ b/tests/e2e/test_create_view_edit_grant.py
@@ -27,7 +27,9 @@ def test_create_view_edit_grant_success(
         grant_name_page = grant_ggis_page.click_save_and_continue()
         new_grant_name = f"E2E {grant_name_uuid}"
         grant_name_page.fill_name(new_grant_name)
-        grant_description_page = grant_name_page.click_save_and_continue()
+        grant_code_page = grant_name_page.click_save_and_continue()
+        grant_code_page.fill_code(f"E2E-{grant_name_uuid[:8].upper()}")
+        grant_description_page = grant_code_page.click_save_and_continue()
         new_grant_description = f"Description for {new_grant_name}"
         grant_description_page.fill_description(new_grant_description)
         grant_contact_page = grant_description_page.click_save_and_continue()

--- a/tests/integration/common/data/interfaces/test_grants.py
+++ b/tests/integration/common/data/interfaces/test_grants.py
@@ -77,6 +77,7 @@ def test_create_grant(app, db_session) -> None:
     result = create_grant(
         ggis_number="GGIS-12345",
         name="Test Grant",
+        code="TG",
         description="This is a test grant.",
         primary_contact_name="John Doe",
         primary_contact_email="johndoe@example.com",
@@ -87,6 +88,7 @@ def test_create_grant(app, db_session) -> None:
     from_db = db_session.get(Grant, result.id)
     assert from_db is not None
     assert from_db.organisation.name == app.config["PLATFORM_DEPARTMENT_ORGANISATION_CONFIG"]["name"]
+    assert from_db.code == "TG"
 
 
 def test_create_duplicate_grant(factories) -> None:
@@ -95,6 +97,7 @@ def test_create_duplicate_grant(factories) -> None:
         create_grant(
             ggis_number="GGIS-12345",
             name="Duplicate Grant",
+            code="DG",
             description="This is a duplicate grant.",
             primary_contact_name="Jane Doe",
             primary_contact_email="janedoe@example.com",

--- a/tests/unit/test_all_routes_access.py
+++ b/tests/unit/test_all_routes_access.py
@@ -29,6 +29,7 @@ routes_with_expected_deliver_org_member_only_access = [
     "deliver_grant_funding.grant_setup_ggis",
     "deliver_grant_funding.grant_setup_ggis_required_info",
     "deliver_grant_funding.grant_setup_name",
+    "deliver_grant_funding.grant_setup_code",
     "deliver_grant_funding.grant_setup_description",
     "deliver_grant_funding.grant_setup_contact",
     "deliver_grant_funding.grant_setup_check_your_answers",


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-1054

## 📝 Description
Set grant code during setup

Allows users creating grants in Deliver grant funding to set its unique code during the grant setup flow.

This is not easily changeable after the fact, as it's used to generate submission references and that could lead to old references looking/feeling disconnected.

If the grant code needs to change this will be a manual developer action.

## 📸 Show the thing (screenshots, gifs)

![2025-12-10 12 38 40](https://github.com/user-attachments/assets/c60c7393-0df7-4f8b-9a75-ab21f0d55c94)

<img width="1002" height="684" alt="image" src="https://github.com/user-attachments/assets/47b517e2-3796-49c2-9de1-6ca13cc9b421" />

## 🧪 Testing
<!-- Describe how you've tested this change, and how a reviewer can test it -->

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [x] End-to-end tests have been updated (if applicable)
- [x] Edge cases and error conditions are tested