### PR TITLE
BAU Tweak report page title

### DIFF
--- a/app/access_grant_funding/templates/access_grant_funding/view_locked_report.html
+++ b/app/access_grant_funding/templates/access_grant_funding/view_locked_report.html
@@ -3,7 +3,7 @@
 {% from "common/macros/submissions.html" import answers_summary_list with context %}
 {% from "common/macros/status.html" import submissionStatusTag with context %}
 
-{% set page_title = "Review report: " + submission.name %}
+{% set page_title = submission.name if submission.is_submitted else ("Review report: " ~ submission.name) %}
 
 {% set mainClasses = "app-full-screen-with-section-nav" %}
 

--- a/tests/integration/access_grant_funding/routes/test_reports.py
+++ b/tests/integration/access_grant_funding/routes/test_reports.py
@@ -112,6 +112,8 @@ class TestViewLockedReport:
 
         soup = BeautifulSoup(response.data, "html.parser")
 
+        assert get_h1_text(soup) == submission_submitted.collection.name
+
         # now that its submitted we don't have certifier actions even though we have permissions
         # to do that
         assert page_has_button(soup, button_text="Sign off and submit report") is None


### PR DESCRIPTION
Only add the call to action "Review report:" when the report is awaiting sign off, once its completed just show the name of the collection.