### PR TITLE
Log out metrics; add new grant recipient mode attribute

### DIFF
--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -92,6 +92,7 @@ class TestEmitMetricCount:
             attributes={
                 "grant-recipient": "Test Organisation",
                 "grant-recipient-id": str(grant_recipient.id),
+                "grant-recipient-mode": "live",
                 "grant": "Test Grant",
                 "grant-id": str(grant_recipient.grant.id),
             },
@@ -121,6 +122,7 @@ class TestEmitMetricCount:
                 "grant-id": str(submission.collection.grant.id),
                 "grant-recipient": "Test Organisation",
                 "grant-recipient-id": str(submission.grant_recipient.id),
+                "grant-recipient-mode": "live",
             },
         )
 


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
Start emitting logs for each metric we track, so that these go to Cloudwatch, which is stored for longer, and allows us to do reporting more easily.