### PR TITLE
Re-validate submission on submit

### DIFF
--- a/app/common/collections/runner.py
+++ b/app/common/collections/runner.py
@@ -7,7 +7,7 @@ from flask import abort, current_app, url_for
 from app.common.collections.forms import AddAnotherSummaryForm, CheckYourAnswersForm, build_question_form
 from app.common.data import interfaces
 from app.common.data.types import FormRunnerState, TasklistSectionStatusEnum, TRunnerUrlMap
-from app.common.exceptions import RedirectException
+from app.common.exceptions import RedirectException, SubmissionValidationFailed
 from app.common.expressions import interpolate
 from app.common.forms import GenericSubmitForm
 from app.common.helpers.collections import SubmissionHelper
@@ -235,6 +235,9 @@ class FormRunner:
             else:
                 self.submission.submit(user)
             return True
+        except SubmissionValidationFailed as e:
+            self._tasklist_form.submit.errors.append(e.error_message)  # type:ignore[attr-defined]
+            return False
         except ValueError:
             current_app.logger.warning(
                 "ValueError when submitting id %(submission_id)s",

--- a/app/common/collections/validation.py
+++ b/app/common/collections/validation.py
@@ -1,0 +1,118 @@
+from typing import TYPE_CHECKING, cast
+
+from flask import current_app
+
+from app.common.collections.types import NOT_ANSWERED
+from app.common.exceptions import SubmissionValidationFailed, ValidationError
+from app.common.expressions import UndefinedVariableInExpression, evaluate, interpolate
+from app.metrics import MetricEventName, emit_metric_count
+
+if TYPE_CHECKING:
+    from app.common.data.models import Component, Form, Group, Question
+    from app.common.helpers.collections import SubmissionHelper
+
+
+class SubmissionValidator:
+    def __init__(self, submission_helper: "SubmissionHelper"):
+        self.helper = submission_helper
+
+    def validate_all_reachable_questions(self) -> None:
+        errors = []
+
+        for form in self.helper.get_ordered_visible_forms():
+            errors.extend(self._validate_form(form))
+
+        if errors:
+            emit_metric_count(
+                MetricEventName.SUBMISSION_BLOCKED_BY_INVALID_ANSWERS, 1, submission=self.helper.submission
+            )
+            raise SubmissionValidationFailed(
+                f"Could not submit submission id={self.helper.submission.id} because some answers are no longer valid.",
+                errors=errors,
+            )
+
+    def _validate_form(self, form: "Form") -> list[ValidationError]:
+        errors = []
+        processed_add_another_containers = []
+
+        for question in form.cached_questions:
+            if question.add_another_container:
+                if question.add_another_container.id in processed_add_another_containers:
+                    continue
+
+                errors.extend(self._validate_add_another_container(question.add_another_container, form))
+                processed_add_another_containers.append(question.add_another_container.id)
+
+            else:
+                if self.helper.is_component_visible(question, self.helper.cached_evaluation_context):
+                    answer = self.helper.cached_get_answer_for_question(question.id)
+                    if answer is not None and answer != NOT_ANSWERED:
+                        errors.extend(self._validate_question(question, form))
+
+        return errors
+
+    def _validate_question(
+        self, question: "Question", form: "Form", add_another_index: int | None = None
+    ) -> list[ValidationError]:
+        errors: list[ValidationError] = []
+
+        if not question.validations:
+            return errors
+
+        context = self.helper.cached_evaluation_context
+        if add_another_index is not None and question.add_another_container:
+            context = context.with_add_another_context(
+                question.add_another_container, submission_helper=self.helper, add_another_index=add_another_index
+            )
+
+        for validation_expr in question.validations:
+            if not validation_expr.managed:
+                raise RuntimeError(f"Unmanaged validation not supported: {validation_expr.id}")
+
+            try:
+                if not evaluate(expression=validation_expr, context=context):
+                    error_message = interpolate(
+                        validation_expr.managed.message, context=self.helper.cached_interpolation_context
+                    )
+                    errors.append(
+                        ValidationError(
+                            question_id=question.id,
+                            question_name=question.name,
+                            form_id=form.id,
+                            form_title=form.title,
+                            error_message=error_message,
+                            answer=self.helper.cached_get_answer_for_question(
+                                question.id, add_another_index=add_another_index
+                            ),
+                            add_another_index=add_another_index,
+                        )
+                    )
+            except UndefinedVariableInExpression:
+                current_app.logger.warning(
+                    "Undefined variable in validation for question %(qid)s (form %(fid)s)",
+                    dict(qid=question.id, fid=form.id),
+                )
+
+        return errors
+
+    def _validate_add_another_container(self, container: "Component", form: "Form") -> list[ValidationError]:
+        errors = []
+        container = cast("Group | Question", container)
+
+        count = self.helper.get_count_for_add_another(container)
+        for index in range(count):
+            context = self.helper.cached_evaluation_context.with_add_another_context(
+                container, submission_helper=self.helper, add_another_index=index
+            )
+
+            questions = (
+                cast("Group", container).cached_questions if container.is_group else [cast("Question", container)]
+            )
+
+            for q in questions:
+                if self.helper.is_component_visible(q, context):
+                    answer = self.helper.cached_get_answer_for_question(q.id, add_another_index=index)
+                    if answer is not None and answer != NOT_ANSWERED:
+                        errors.extend(self._validate_question(q, form, add_another_index=index))
+
+        return errors

--- a/app/common/exceptions.py
+++ b/app/common/exceptions.py
@@ -1,3 +1,40 @@
+from typing import Any, NamedTuple
+from uuid import UUID
+
+from flask import render_template
+from markupsafe import Markup
+
+
 class RedirectException(Exception):
     def __init__(self, url: str) -> None:
         self.url = url
+
+
+class ValidationError(NamedTuple):
+    question_id: UUID
+    question_name: str
+    form_id: UUID
+    form_title: str
+    error_message: str
+    answer: Any
+    add_another_index: int | None = None
+
+
+class SubmissionValidationFailed(ValueError):
+    def __init__(self, message: str, errors: list[ValidationError]) -> None:
+        self.message = message
+        self.errors = errors
+
+        super().__init__(self.message)
+
+    @property
+    def error_message(self) -> str:
+        # TODO: refine this error content
+        failed_questions_markup = render_template(
+            "common/partials/validation-error-on-submission.html", errors=self.errors
+        )
+        return Markup(
+            f"Unable to submit as some answers are invalid. Review your answers and try again:"
+            f"{failed_questions_markup}<br>"
+            f"Contact support if you need help."
+        )

--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -29,6 +29,7 @@ from app.common.collections.types import (
     UrlAnswer,
     YesNoAnswer,
 )
+from app.common.collections.validation import SubmissionValidator
 from app.common.data import interfaces
 from app.common.data.interfaces.collections import (
     get_all_submissions_with_mode_for_collection,
@@ -507,6 +508,8 @@ class SubmissionHelper:
                         RoleEnum.CERTIFIER,
                     )
 
+        SubmissionValidator(self).validate_all_reachable_questions()
+
         interfaces.collections.add_submission_event(
             self.submission,
             event_type=SubmissionEventType.SUBMISSION_SUBMITTED,
@@ -530,6 +533,8 @@ class SubmissionHelper:
                 f"Could not send submission id={self.id} for sign off because this report does not require "
                 f"certification."
             )
+
+        SubmissionValidator(self).validate_all_reachable_questions()
 
         if self.all_forms_are_completed:
             interfaces.collections.add_submission_event(

--- a/app/common/templates/common/partials/validation-error-on-submission.html
+++ b/app/common/templates/common/partials/validation-error-on-submission.html
@@ -1,0 +1,5 @@
+<ul class="govuk-list--bullet">
+  {% for error in errors %}
+    <li>{{ error.form_title }} - {{ error.question_name }}: {{ error.answer.get_value_for_text_export() }}</li>
+  {% endfor %}
+</ul>

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -43,6 +43,7 @@ class MetricEventName(StrEnum):
     SUBMISSION_CERTIFIED = "submission-certified"
     SUBMISSION_CERTIFICATION_DECLINED = "submission-certification-declined"
     SUBMISSION_SUBMITTED = "submission-submitted"
+    SUBMISSION_BLOCKED_BY_INVALID_ANSWERS = "submission-blocked-by-invalid-answers"
 
     SUBMISSION_MANAGED_VALIDATION_ERROR = "submission-managed-validation-error"
     SUBMISSION_MANAGED_VALIDATION_SUCCESS = "submission-managed-validation-success"

--- a/tests/unit/common/collections/test_validation.py
+++ b/tests/unit/common/collections/test_validation.py
@@ -1,0 +1,250 @@
+import uuid
+
+import pytest
+
+from app.common.collections.validation import SubmissionValidator
+from app.common.data.types import ExpressionType, ManagedExpressionsEnum, QuestionDataType
+from app.common.exceptions import SubmissionValidationFailed
+from app.common.helpers.collections import SubmissionHelper
+
+
+class TestSubmissionValidator:
+    def test_all_valid_answers_pass(self, factories):
+        form = factories.form.build()
+        q1 = factories.question.build(form=form, id=uuid.uuid4(), data_type=QuestionDataType.INTEGER, order=0)
+        q2 = factories.question.build(form=form, id=uuid.uuid4(), data_type=QuestionDataType.INTEGER, order=1)
+
+        factories.expression.build(
+            question=q2,
+            type_=ExpressionType.VALIDATION,
+            managed_name=ManagedExpressionsEnum.GREATER_THAN,
+            statement=f"(({q2.safe_qid})) > (({q1.safe_qid}))",
+            context={"question_id": str(q2.id), "minimum_value": None, "minimum_expression": f"(({q1.safe_qid}))"},
+        )
+
+        submission = factories.submission.build(collection=form.collection)
+        submission.data = {str(q1.id): {"value": 50}, str(q2.id): {"value": 100}}
+
+        helper = SubmissionHelper(submission)
+        validator = SubmissionValidator(helper)
+        assert validator.validate_all_reachable_questions() is None
+
+    def test_invalid_answer_caught(self, factories):
+        form = factories.form.build()
+        q1 = factories.question.build(form=form, id=uuid.uuid4(), data_type=QuestionDataType.INTEGER, order=0)
+        q2 = factories.question.build(form=form, id=uuid.uuid4(), data_type=QuestionDataType.INTEGER, order=1)
+
+        factories.expression.build(
+            question=q2,
+            type_=ExpressionType.VALIDATION,
+            managed_name=ManagedExpressionsEnum.GREATER_THAN,
+            statement=f"(({q2.safe_qid})) > (({q1.safe_qid}))",
+            context={"question_id": str(q2.id), "minimum_value": None, "minimum_expression": f"(({q1.safe_qid}))"},
+        )
+
+        submission = factories.submission.build(collection=form.collection)
+        submission.data = {str(q1.id): {"value": 100}, str(q2.id): {"value": 50}}
+
+        helper = SubmissionHelper(submission)
+        validator = SubmissionValidator(helper)
+        with pytest.raises(SubmissionValidationFailed) as e:
+            validator.validate_all_reachable_questions()
+
+        errors = e.value.errors
+        assert len(errors) == 1
+        assert errors[0].question_id == q2.id
+        assert errors[0].form_id == form.id
+
+    def test_multiple_validation_errors_collected(self, factories):
+        form = factories.form.build()
+        q1 = factories.question.build(form=form, id=uuid.uuid4(), data_type=QuestionDataType.INTEGER, order=0)
+        q2 = factories.question.build(form=form, id=uuid.uuid4(), data_type=QuestionDataType.INTEGER, order=1)
+        q3 = factories.question.build(form=form, id=uuid.uuid4(), data_type=QuestionDataType.INTEGER, order=2)
+
+        factories.expression.build(
+            question=q2,
+            type_=ExpressionType.VALIDATION,
+            managed_name=ManagedExpressionsEnum.GREATER_THAN,
+            statement=f"(({q2.safe_qid})) > (({q1.safe_qid}))",
+            context={"question_id": str(q2.id), "minimum_value": None, "minimum_expression": f"(({q1.safe_qid}))"},
+        )
+
+        factories.expression.build(
+            question=q3,
+            type_=ExpressionType.VALIDATION,
+            managed_name=ManagedExpressionsEnum.LESS_THAN,
+            statement=f"(({q3.safe_qid})) < (({q1.safe_qid}))",
+            context={"question_id": str(q3.id), "maximum_value": None, "maximum_expression": f"(({q1.safe_qid}))"},
+        )
+
+        submission = factories.submission.build(collection=form.collection)
+        submission.data = {str(q1.id): {"value": 50}, str(q2.id): {"value": 30}, str(q3.id): {"value": 70}}
+
+        helper = SubmissionHelper(submission)
+        validator = SubmissionValidator(helper)
+        with pytest.raises(SubmissionValidationFailed) as e:
+            validator.validate_all_reachable_questions()
+
+        errors = e.value.errors
+        assert len(errors) == 2
+        error_question_ids = {e.question_id for e in errors}
+        assert error_question_ids == {q2.id, q3.id}
+
+    def test_unreachable_questions_not_validated(self, factories):
+        form = factories.form.build()
+        q1 = factories.question.build(form=form, id=uuid.uuid4(), data_type=QuestionDataType.YES_NO, order=0)
+        q2 = factories.question.build(form=form, id=uuid.uuid4(), data_type=QuestionDataType.INTEGER, order=1)
+
+        factories.expression.build(
+            question=q2,
+            type_=ExpressionType.CONDITION,
+            managed_name=ManagedExpressionsEnum.IS_YES,
+            statement=f"{q1.safe_qid} is True",
+            context={"question_id": str(q1.id)},
+        )
+
+        factories.expression.build(
+            question=q2,
+            type_=ExpressionType.VALIDATION,
+            managed_name=ManagedExpressionsEnum.GREATER_THAN,
+            statement=f"(({q2.safe_qid})) > 100",
+            context={"question_id": str(q2.id), "minimum_value": 100, "minimum_expression": None},
+        )
+
+        submission = factories.submission.build(collection=form.collection)
+        submission.data = {str(q1.id): False, str(q2.id): {"value": 50}}
+
+        helper = SubmissionHelper(submission)
+        validator = SubmissionValidator(helper)
+        assert validator.validate_all_reachable_questions() is None
+
+    def test_changed_validation_rules(self, factories):
+        form = factories.form.build()
+        q1 = factories.question.build(form=form, id=uuid.uuid4(), data_type=QuestionDataType.INTEGER, order=0)
+        q2 = factories.question.build(form=form, id=uuid.uuid4(), data_type=QuestionDataType.INTEGER, order=1)
+
+        factories.expression.build(
+            question=q2,
+            type_=ExpressionType.VALIDATION,
+            managed_name=ManagedExpressionsEnum.GREATER_THAN,
+            statement=f"(({q2.safe_qid})) > (({q1.safe_qid}))",
+            context={"question_id": str(q2.id), "minimum_value": None, "minimum_expression": f"(({q1.safe_qid}))"},
+        )
+
+        submission = factories.submission.build(collection=form.collection)
+        submission.data = {str(q1.id): {"value": 50}, str(q2.id): {"value": 100}}
+
+        helper = SubmissionHelper(submission)
+        validator = SubmissionValidator(helper)
+        assert validator.validate_all_reachable_questions() is None
+
+        submission.data[str(q1.id)] = {"value": 150}
+        helper.cached_get_answer_for_question.cache_clear()
+        from app.common.expressions import ExpressionContext
+
+        helper.cached_evaluation_context = ExpressionContext.build_expression_context(
+            collection=submission.collection, submission_helper=helper, mode="evaluation"
+        )
+
+        with pytest.raises(SubmissionValidationFailed) as e:
+            validator.validate_all_reachable_questions()
+
+        errors = e.value.errors
+        assert len(errors) == 1
+        assert errors[0].question_id == q2.id
+
+    def test_questions_without_validations(self, factories):
+        form = factories.form.build()
+        q1 = factories.question.build(form=form, id=uuid.uuid4(), data_type=QuestionDataType.INTEGER, order=0)
+        q2 = factories.question.build(form=form, id=uuid.uuid4(), data_type=QuestionDataType.INTEGER, order=1)
+
+        submission = factories.submission.build(collection=form.collection)
+        submission.data = {str(q1.id): {"value": 50}, str(q2.id): {"value": 100}}
+
+        helper = SubmissionHelper(submission)
+        validator = SubmissionValidator(helper)
+        assert validator.validate_all_reachable_questions() is None
+
+    def test_unanswered_questions_skipped(self, factories):
+        form = factories.form.build()
+        q1 = factories.question.build(form=form, id=uuid.uuid4(), data_type=QuestionDataType.INTEGER, order=0)
+        q2 = factories.question.build(form=form, id=uuid.uuid4(), data_type=QuestionDataType.INTEGER, order=1)
+
+        factories.expression.build(
+            question=q2,
+            type_=ExpressionType.VALIDATION,
+            managed_name=ManagedExpressionsEnum.GREATER_THAN,
+            statement=f"(({q2.safe_qid})) > (({q1.safe_qid}))",
+            context={"question_id": str(q2.id), "minimum_value": None, "minimum_expression": f"(({q1.safe_qid}))"},
+        )
+
+        submission = factories.submission.build(collection=form.collection)
+        submission.data = {str(q1.id): {"value": 50}}
+
+        helper = SubmissionHelper(submission)
+        validator = SubmissionValidator(helper)
+
+        assert validator.validate_all_reachable_questions() is None
+
+    def test_add_another_all_entries_valid(self, factories):
+        form = factories.form.build()
+        group = factories.group.build(form=form, id=uuid.uuid4(), add_another=True, order=0)
+        q1 = factories.question.build(
+            form=form, parent=group, id=uuid.uuid4(), data_type=QuestionDataType.INTEGER, order=0
+        )
+
+        factories.expression.build(
+            question=q1,
+            type_=ExpressionType.VALIDATION,
+            managed_name=ManagedExpressionsEnum.GREATER_THAN,
+            statement=f"(({q1.safe_qid})) > 0",
+            context={"question_id": str(q1.id), "minimum_value": 0, "minimum_expression": None},
+        )
+
+        submission = factories.submission.build(collection=form.collection)
+        submission.data = {
+            str(group.id): [
+                {str(q1.id): {"value": 10}},
+                {str(q1.id): {"value": 20}},
+                {str(q1.id): {"value": 30}},
+            ]
+        }
+
+        helper = SubmissionHelper(submission)
+        validator = SubmissionValidator(helper)
+        assert validator.validate_all_reachable_questions() is None
+
+    def test_add_another_invalid_entry_caught(self, factories):
+        form = factories.form.build()
+        group = factories.group.build(form=form, id=uuid.uuid4(), add_another=True, order=0)
+        q1 = factories.question.build(
+            form=form, parent=group, id=uuid.uuid4(), data_type=QuestionDataType.INTEGER, order=0
+        )
+
+        factories.expression.build(
+            question=q1,
+            type_=ExpressionType.VALIDATION,
+            managed_name=ManagedExpressionsEnum.GREATER_THAN,
+            statement=f"(({q1.safe_qid})) > 0",
+            context={"question_id": str(q1.id), "minimum_value": 0, "minimum_expression": None},
+        )
+
+        submission = factories.submission.build(collection=form.collection)
+        submission.data = {
+            str(group.id): [
+                {str(q1.id): {"value": 10}},
+                {str(q1.id): {"value": -5}},
+                {str(q1.id): {"value": 30}},
+            ]
+        }
+
+        helper = SubmissionHelper(submission)
+        validator = SubmissionValidator(helper)
+
+        with pytest.raises(SubmissionValidationFailed) as e:
+            validator.validate_all_reachable_questions()
+
+        errors = e.value.errors
+        assert len(errors) == 1
+        assert errors[0].question_id == q1.id
+        assert errors[0].add_another_index == 1


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-593

## 📝 Description
When completing a submission, some questions may be validated based on answers to earlier questions. It's possible to go back and change previous answers at any time, which may then mean existing answers to future questions become invalid. We don't detect this when re-answering old questions, so currently if this happens nothing will detect it and it would be possible to submit with invalid data.

We don't have time to address this properly right now, so this patch adds a snapshot final check at submission time to revaldiate all of the data in the form. This will ensure data submitted is all valid together, but doesn't give the user a nice experience when this happens as we haven't had time to design a good experience around it. We'll show an error summary on the submission tasklist page and list all forms+question names+answers that have errored, to do a very rough attempt to help the user self-serve. But we'll direct them to support if they are stuck.

## 📸 Show the thing (screenshots, gifs)
<img width="1014" height="1095" alt="image" src="https://github.com/user-attachments/assets/44b219cc-3bb6-49ab-9569-15549f7225db" />

## 🧪 Testing
<!-- Describe how you've tested this change, and how a reviewer can test it -->

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested