### PR TITLE
BAU: Fix submitting preview submissions

### DIFF
--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -517,12 +517,13 @@ class SubmissionHelper:
             related_entity_id=self.submission.id,
         )
 
-        for unique_user in self.submission.grant_recipient.unique_data_providers_and_certifiers:
-            if unique_user is not None:
-                notification_service.send_access_submission_submitted(
-                    email_address=unique_user.email,
-                    submission_helper=self,
-                )
+        if not self.is_preview:
+            for unique_user in self.submission.grant_recipient.unique_data_providers_and_certifiers:
+                if unique_user is not None:
+                    notification_service.send_access_submission_submitted(
+                        email_address=unique_user.email,
+                        submission_helper=self,
+                    )
 
     def mark_as_sent_for_certification(self, user: "User") -> None:
         if self.is_locked_state:

--- a/tests/integration/common/helpers/test_collections.py
+++ b/tests/integration/common/helpers/test_collections.py
@@ -953,6 +953,20 @@ class TestSubmissionHelper:
             )
             assert len(mock_notification_service_calls) == 0
 
+        def test_submit_sends_no_emails_and_succeeds_for_preview(
+            self,
+            submission_ready_to_submit,
+            mock_notification_service_calls,
+            data_provider_user,
+        ):
+            submission_ready_to_submit.mode = SubmissionModeEnum.PREVIEW
+            helper = SubmissionHelper(submission_ready_to_submit)
+
+            helper.submit(user=data_provider_user)
+
+            assert helper.status == SubmissionStatusEnum.SUBMITTED
+            assert len(mock_notification_service_calls) == 0
+
     class TestSentForCertification:
         def test_mark_as_sent_for_certification(
             self, data_provider_user, certifier_user, submission_ready_to_submit, mock_notification_service_calls


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
We recently moved sending confirmation emails from routes to submission helper methods for consistency, but this would break when trying to submit a preview submission (ie when testing a form) as there's no grant recipient in a preview submission and we shouldn't be sending confirmation emails for previews.

This just adds a check to ensure emails only send if it's not a preview submission (ie. it's Test or Live).

## 🧪 Testing
Preview any report (preview preview, not test as grant recipient) and submit the report. It should be 'submitted' and you should return to the form builder.

## 📋 Developer Checklist

### Review Readiness
- [X] PR title and description provide sufficient context for reviewers
- [X] Commits are logical, self-contained, and have clear descriptions

### Testing
- [X] I have tested this change and it meets the acceptance criteria for the ticket
- ~[ ] I need the reviewer(s) to pull and run this change locally~
- ~[ ] New (non-developer) functionality has appropriate unit and integration tests~
- ~[ ] End-to-end tests have been updated (if applicable)~
- ~[ ] Edge cases and error conditions are tested~
