### PR TITLE
Make reporting dates optional

### DIFF
--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -180,21 +180,29 @@ def update_collection(  # noqa: C901
                     raise GrantMustBeLiveError(f"{collection.grant.name} must be made live before {actioning} a report")
 
                 try:
-                    assert collection.reporting_period_start_date
-                    assert collection.reporting_period_end_date
                     assert collection.submission_period_start_date
                     assert collection.submission_period_end_date
                 except AssertionError as e:
                     raise CollectionChronologyError(
-                        f"Cannot change collection status to {status.value}: "
-                        f"all reporting and submission period dates must be set"
+                        f"Cannot change collection status to {status.value}: submission period dates must be set"
                     ) from e
 
-                if not (
+                if (collection.reporting_period_start_date or collection.reporting_period_end_date) and not (
+                    collection.reporting_period_start_date and collection.reporting_period_end_date
+                ):
+                    raise CollectionChronologyError(
+                        "reporting_period_start_date and reporting_period_end_date must both be unset or both be set"
+                    )
+
+                if (
                     collection.reporting_period_start_date
-                    < collection.reporting_period_end_date
-                    < collection.submission_period_start_date
-                    < collection.submission_period_end_date
+                    and collection.reporting_period_end_date
+                    and not (
+                        collection.reporting_period_start_date
+                        < collection.reporting_period_end_date
+                        < collection.submission_period_start_date
+                        < collection.submission_period_end_date
+                    )
                 ):
                     raise CollectionChronologyError("Reporting dates must be chronological and before submission dates")
 

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/admin/reporting-lifecycle-tasklist.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/admin/reporting-lifecycle-tasklist.html
@@ -128,7 +128,7 @@
         {% if collection.reporting_period_start_date and collection.reporting_period_end_date %}
           {{ govukTag({"text": "Completed" , "classes": "govuk-tag--green"}) }}
         {% else %}
-          {{ govukTag({"text": "To do", "classes": "govuk-tag--grey"}) }}
+          {{ govukTag({"text": "Optional", "classes": "govuk-tag--blue"}) }}
         {% endif %}
       {% endset %}
       {%
@@ -157,7 +157,7 @@
         })
       %}
 
-      {% set dates_are_set = collection.reporting_period_start_date and collection.reporting_period_end_date and collection.submission_period_start_date and collection.submission_period_end_date %}
+      {% set dates_are_set = collection.submission_period_start_date and collection.submission_period_end_date %}
       {% set all_recipients_have_users = grant_recipients_count > 0 and grant_recipient_users_count >= grant_recipients_count %}
       {% set prerequisites_met = grant.status == enum.grant_status.LIVE and grant_recipients_count > 0 and dates_are_set and all_recipients_have_users %}
       {% set scheduledReportStatus = {"tag": {"text": "To do", "classes": "govuk-tag--grey"} } %}

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -573,13 +573,11 @@ class TestUpdateCollection:
     @pytest.mark.parametrize(
         "missing_date_field",
         (
-            "reporting_period_start_date",
-            "reporting_period_end_date",
             "submission_period_start_date",
             "submission_period_end_date",
         ),
     )
-    def test_draft_to_scheduled_requires_all_dates(self, db_session, factories, missing_date_field):
+    def test_draft_to_scheduled_requires_submission_dates(self, db_session, factories, missing_date_field):
         grant = factories.grant.create(status=GrantStatusEnum.LIVE)
         date_kwargs = {
             "reporting_period_start_date": datetime.date(2024, 1, 1),
@@ -594,7 +592,7 @@ class TestUpdateCollection:
         with pytest.raises(CollectionChronologyError) as exc_info:
             update_collection(collection, status=CollectionStatusEnum.SCHEDULED)
 
-        assert "all reporting and submission period dates must be set" in str(exc_info.value)
+        assert "submission period dates must be set" in str(exc_info.value)
 
 
 def test_get_submission(db_session, factories):

--- a/tests/integration/deliver_grant_funding/admin/test_views.py
+++ b/tests/integration/deliver_grant_funding/admin/test_views.py
@@ -394,8 +394,8 @@ class TestReportingLifecycleTasklist:
 
         task_status = set_reporting_dates_task.find("strong", {"class": "govuk-tag"})
         assert task_status is not None
-        assert "To do" in task_status.get_text(strip=True)
-        assert "govuk-tag--grey" in task_status.get("class")
+        assert "Optional" in task_status.get_text(strip=True)
+        assert "govuk-tag--blue" in task_status.get("class")
 
         set_submission_dates_task = report_task_items[1]
         task_title = set_submission_dates_task.find("a", {"class": "govuk-link"})
@@ -3203,9 +3203,7 @@ class TestMakeReportLive:
         assert response.status_code == 200
 
         soup = BeautifulSoup(response.data, "html.parser")
-        assert page_has_error(
-            soup, "Cannot change collection status to Open: all reporting and submission period dates must be set"
-        )
+        assert page_has_error(soup, "Cannot change collection status to Open: submission period dates must be set")
 
         db_session.refresh(collection)
         assert collection.status == CollectionStatusEnum.SCHEDULED


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
Our first grants are doing 'baseline' reports, which don't cover a specific period, instead of periodic reporting taht does.

So our assumption that reporting dates are always required has been proven false. This removes the need to set reporting dates.