### PR TITLE
BAU Add another remove link for complete and incomplete entries

### DIFF
--- a/app/common/templates/common/macros/collections.html
+++ b/app/common/templates/common/macros/collections.html
@@ -412,25 +412,31 @@
       {% endset %}
 
       {% set entry_hidden_description = summary if is_answered else to_ordinal(i + 1) ~ " " ~ (add_another_container.name | lower) %}
+      {% set actions = [] %}
+      {% if is_answered %}
+        {%
+          do actions.append({
+            "href": runner.to_url(enum.form_runner_state.QUESTION, question=runner.questions[0], add_another_index=i),
+            "text": "Change",
+            "visuallyHiddenText": entry_hidden_description,
+            "classes": "govuk-link--no-visited-state"
+          })
+        %}
+      {% endif %}
+      {%
+        do actions.append({
+          "href": runner.to_url(enum.form_runner_state.QUESTION, question=runner.questions[0], add_another_index=i, is_removing=True),
+          "text": "Remove",
+          "visuallyHiddenText": entry_hidden_description,
+          "classes": "govuk-link--no-visited-state"
+        })
+      %}
       {%
         do rows.append({
           "key": { "html": key_html, "classes": "govuk-!-width-two-thirds" },
           "value": { "classes": "govuk-!-display-none"},
           "actions": {
-            "items": [
-              {
-                "href": runner.to_url(enum.form_runner_state.QUESTION, question=runner.questions[0], add_another_index=i),
-                "text": "Change",
-                "visuallyHiddenText": entry_hidden_description,
-                "classes": "govuk-link--no-visited-state"
-              },
-              {
-                "href": runner.to_url(enum.form_runner_state.QUESTION, question=runner.questions[0], add_another_index=i, is_removing=True),
-                "text": "Remove",
-                "visuallyHiddenText": entry_hidden_description,
-                "classes": "govuk-link--no-visited-state"
-              }
-            ] if is_answered else [],
+            "items": actions,
             "classes": "govuk-!-width-one-third"
           }
         })

--- a/tests/integration/access_grant_funding/routes/test_runner.py
+++ b/tests/integration/access_grant_funding/routes/test_runner.py
@@ -892,6 +892,21 @@ class TestAskAQuestion:
             # each entry in the row respects the summary line configuration even if more answers are available
             assert soup.find_all("dt", {"class": "govuk-summary-list__key"})[2].text.strip() == "E3A1"
 
+            # All rows have remove links
+            rows = soup.find_all("div", {"class": "govuk-summary-list__row"})
+
+            # first data entries are incomplete so have no change but have remove
+            assert page_has_link(rows[0], "Remove") is not None
+            assert page_has_link(rows[0], "Change") is None
+            assert page_has_link(rows[1], "Remove") is not None
+            assert page_has_link(rows[1], "Change") is None
+
+            # subsequent data entires are complete and have both change and remove
+            assert page_has_link(rows[2], "Remove") is not None
+            assert page_has_link(rows[2], "Change") is not None
+            assert page_has_link(rows[3], "Remove") is not None
+            assert page_has_link(rows[3], "Change") is not None
+
             # do you want to add another component is shown and defaults to nothing selected
             assert "govuk-!-display-none" not in soup.find("div", {"class": "govuk-radios"}).get("class")
             assert soup.find("input", {"name": "add_another", "value": "yes"}).get("checked") is None


### PR DESCRIPTION
This will allow form users to remove work in progress answers in an add another group.

Previously you had to fill in every answer before it removed the call to action to finish and allow you to "Change" and "Remove".

This anticipated have two or three questions in a question group but the reality of add another for upcoming forms are ~10-20 questions.

With the current behaviour you'd have to fill in "dummy" answers to get to the point where you could remove it - if you undestood that was the implication.

Allow removing any entry thats been started.

## 📸 Show the thing (screenshots, gifs)
<!-- Include screenshots for UI changes, new features, or visual modifications -->
<!-- Use "Before" and "After" sections if showing changes to existing functionality -->

### Before
<img width="888" height="684" alt="Screenshot 2025-12-17 at 12 51 27" src="https://github.com/user-attachments/assets/d004b9db-f506-4a2e-9158-bba44b28dbca" />


### After
<img width="895" height="679" alt="Screenshot 2025-12-17 at 12 46 45" src="https://github.com/user-attachments/assets/6a543778-0818-4e98-b555-365f232522fe" />
