### PR TITLE
BAU Preserve whitespace on multi line text answers

### DIFF
--- a/app/common/collections/types.py
+++ b/app/common/collections/types.py
@@ -76,7 +76,9 @@ class TextSingleLineAnswer(SubmissionAnswerRootModel[str]):
 
 
 class TextMultiLineAnswer(SubmissionAnswerRootModel[str]):
-    pass
+    @property
+    def _render_answer_template(self) -> str:
+        return "common/partials/answers/text_multi_line.html"
 
 
 class EmailAnswer(SubmissionAnswerRootModel[str]):

--- a/app/common/templates/common/partials/answers/text_multi_line.html
+++ b/app/common/templates/common/partials/answers/text_multi_line.html
@@ -1,0 +1,1 @@
+<span data-testid="answer-{{ question.name }}"><pre class="app-pre-markdown">{{ answer.root }}</pre></span>


### PR DESCRIPTION
Some questions in the initial forms are going to be longer form answers, we should anticipate that some degree of formatting will have been applied when users are answering these - especially when they've been asked about multiple outcomes for a given project.

## 📸 Show the thing (screenshots, gifs)
<!-- Include screenshots for UI changes, new features, or visual modifications -->
<!-- Use "Before" and "After" sections if showing changes to existing functionality -->

### Before
<img width="2384" height="3202" alt="funding communities gov localhost_8080_access_organisation_f5db3404-2b2b-4325-9758-a8693fd682fa_grants_caf0ce3f-5175-f69c-66a9-41e2c2245845_reports_bdf8cacf-ca96-4392-9023-b45a791390e6_check-your-answers_3c2d68ec-effb-45bc-8824-f6f1f9186ed9" src="https://github.com/user-attachments/assets/844d827d-7d84-42d4-9a55-0538799427de" />


### After
<img width="2384" height="3840" alt="funding communities gov localhost_8080_access_organisation_f5db3404-2b2b-4325-9758-a8693fd682fa_grants_caf0ce3f-5175-f69c-66a9-41e2c2245845_reports_bdf8cacf-ca96-4392-9023-b45a791390e6_check-your-answers_3c2d68ec-effb-45bc-8824-f6f1f918 (1)" src="https://github.com/user-attachments/assets/148d4a3b-0bed-43bd-883f-36ce7968d5f1" />

### Copying and pasting

https://github.com/user-attachments/assets/35e43e3c-6a5e-4732-b16b-3d8d2820777c

