### PR TITLE
Adding check if the cookies page form exists

### DIFF
--- a/app/assets/js/cookie-consent/index.js
+++ b/app/assets/js/cookie-consent/index.js
@@ -78,30 +78,31 @@ function initCookieConsent() {
 
 function initCookiesPageConsentForm() {
     const cookie_form = document.getElementById("cookies_form");
-    const cookies_no_js = document.getElementById("cookies_no_js");
-    const cookies_yes = document.getElementById("cookie_choice_yes");
-    const cookies_no = document.getElementById("cookie_choice_no");
-    const cookie_success_banner = document.getElementById(
-        "cookie_success_banner",
-    );
-    const btn_submit_cookie_form = document.getElementById(
-        "btn_submit_cookies_form",
-    );
-
-    if (localStorage.getItem("consentGranted") === "true") {
-        cookies_yes.checked = true;
-    } else if (localStorage.getItem("consentGranted") === "false") {
-        cookies_no.checked = true;
-    }
-    btn_submit_cookie_form.addEventListener("click", function () {
-        let consentValue = cookies_yes.checked;
-        updateConsentValueLocal(consentValue);
-        updateConsentValueGtag(consentValue);
-        cookie_success_banner.removeAttribute("hidden");
-        cookie_success_banner.scrollIntoView();
-    });
 
     if (cookie_form) {
+        const cookies_no_js = document.getElementById("cookies_no_js");
+        const cookies_yes = document.getElementById("cookie_choice_yes");
+        const cookies_no = document.getElementById("cookie_choice_no");
+        const cookie_success_banner = document.getElementById(
+            "cookie_success_banner",
+        );
+        const btn_submit_cookie_form = document.getElementById(
+            "btn_submit_cookies_form",
+        );
+
+        if (localStorage.getItem("consentGranted") === "true") {
+            cookies_yes.checked = true;
+        } else if (localStorage.getItem("consentGranted") === "false") {
+            cookies_no.checked = true;
+        }
+        btn_submit_cookie_form.addEventListener("click", function () {
+            let consentValue = cookies_yes.checked;
+            updateConsentValueLocal(consentValue);
+            updateConsentValueGtag(consentValue);
+            cookie_success_banner.removeAttribute("hidden");
+            cookie_success_banner.scrollIntoView();
+        });
+
         cookies_no_js.hidden = true;
         cookie_form.removeAttribute("hidden");
     }


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
Making sure we don't try and do things to page elements that don't exist.

The previous JS was trying to set event handlers on html elements that didn't exist unless you were on the cookies page. This checks if the form those elements are on exists before trying to set things (so we don't get errors on every page)