### PR TITLE
Refactor submission event data

### DIFF
--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-034_add_audit_events
+035_remove_static_event_data

--- a/app/common/data/migrations/versions/035_remove_static_event_data.py
+++ b/app/common/data/migrations/versions/035_remove_static_event_data.py
@@ -1,0 +1,88 @@
+"""Remove static data from submission events
+
+Revision ID: 035_remove_static_event_data
+Revises: 034_add_audit_events
+Create Date: 2025-12-29
+
+"""
+
+from alembic import op
+
+revision = "035_remove_static_event_data"
+down_revision = "034_add_audit_events"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE submission_event
+        SET data = data - 'is_completed'
+        WHERE event_type IN
+        ('FORM_RUNNER_FORM_COMPLETED', 'FORM_RUNNER_FORM_RESET_TO_IN_PROGRESS', 'FORM_RUNNER_FORM_RESET_BY_CERTIFIER')
+        """
+    )
+    op.execute(
+        """
+        UPDATE submission_event
+        SET data = data - 'is_awaiting_sign_off' - 'is_approved'
+        WHERE event_type IN (
+            'SUBMISSION_SENT_FOR_CERTIFICATION',
+            'SUBMISSION_DECLINED_BY_CERTIFIER',
+            'SUBMISSION_APPROVED_BY_CERTIFIER'
+        )
+        """
+    )
+    op.execute(
+        """
+        UPDATE submission_event
+        SET data = data - 'is_submitted'
+        WHERE event_type = 'SUBMISSION_SUBMITTED'
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        UPDATE submission_event
+        SET data = data || '{"is_completed": true}'::jsonb
+        WHERE event_type = 'FORM_RUNNER_FORM_COMPLETED'
+        """
+    )
+    op.execute(
+        """
+        UPDATE submission_event
+        SET data = data || '{"is_completed": false}'::jsonb
+        WHERE event_type IN ('FORM_RUNNER_FORM_RESET_TO_IN_PROGRESS', 'FORM_RUNNER_FORM_RESET_BY_CERTIFIER')
+        """
+    )
+    op.execute(
+        """
+        UPDATE submission_event
+        SET data = data || '{"is_awaiting_sign_off": true, "is_approved": false}'::jsonb
+        WHERE event_type = 'SUBMISSION_SENT_FOR_CERTIFICATION'
+        """
+    )
+    op.execute(
+        """
+        UPDATE submission_event
+        SET data = data || '{"is_awaiting_sign_off": false, "is_approved": false}'::jsonb
+        WHERE event_type = 'SUBMISSION_DECLINED_BY_CERTIFIER'
+        """
+    )
+    op.execute(
+        """
+        UPDATE submission_event
+        SET data = data || '{"is_awaiting_sign_off": false, "is_approved": true}'::jsonb
+        WHERE event_type = 'SUBMISSION_APPROVED_BY_CERTIFIER'
+        """
+    )
+    op.execute(
+        """
+        UPDATE submission_event
+        SET data = data || '{"is_submitted": true}'::jsonb
+        WHERE event_type = 'SUBMISSION_SUBMITTED'
+        """
+    )


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-1047

## 📝 Description
Stop storing static submission event data (ie attributes that are implicit in the event type and never vary). We only need to store data that can vary by individual event instance, which in our case so far is just the 'declined reason' of a certifier declining a report.

All other attributes can be inferred based on the event type, so let's do that.

The DB migration is not backwards-compatible, but I believe we can manage the risk of deploying this now given very low service traffic.

## 📸 Show the thing (screenshots, gifs)
<!-- Include screenshots for UI changes, new features, or visual modifications -->
<!-- Use "Before" and "After" sections if showing changes to existing functionality -->

### Before
<!-- Screenshot or description of previous state -->

### After
<!-- Screenshot or description of new state -->

## 🧪 Testing
<!-- Describe how you've tested this change, and how a reviewer can test it -->

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested