### PR TITLE
FIX Revoke platform admin permissions if not in the appropriate group at sign-in

### DIFF
--- a/tests/integration/common/auth/test_auth.py
+++ b/tests/integration/common/auth/test_auth.py
@@ -11,7 +11,7 @@ from app.common.data import interfaces
 from app.common.data.models_user import Invitation, MagicLink, User, UserRole
 from app.common.data.types import RoleEnum
 from tests.models import _get_grant_managing_organisation
-from tests.utils import AnyStringMatching, get_h1_text, get_h2_text, page_has_error, page_has_h2
+from tests.utils import AnyStringMatching, get_h1_text, page_has_error, page_has_h2
 
 
 class TestMagicLinkSignInView:


### PR DESCRIPTION
This reverts commit https://github.com/communitiesuk/funding-service/commit/1ac09da0c7ffb78054339e49be69944b8c65dd6f.

This can and does happen locally when using the local SSO stub server and we should be resilient to it happening for real, if not common. This preserves the behaviour to allow DGF users to log directly into testing AGF.

