### PR TITLE
FSPT-1072 Tweak submission confirmation journey

### DIFF
--- a/app/access_grant_funding/templates/access_grant_funding/decline_report.html
+++ b/app/access_grant_funding/templates/access_grant_funding/decline_report.html
@@ -4,11 +4,13 @@
 {% set page_title = "Decline sign off: " + submission.name %}
 
 {% set active_item_identifier = "reports" %}
+
+{% set return_link = url_for("access_grant_funding.route_to_submission", organisation_id=grant_recipient.organisation.id, grant_id=grant_recipient.grant.id, collection_id = submission.collection_id) %}
 {% block beforeContent %}
   {{ super() }}
   {{
     govukBackLink({
-      "href": url_for("access_grant_funding.route_to_submission", organisation_id=grant_recipient.organisation.id, grant_id=grant_recipient.grant.id, collection_id = submission.collection_id),
+      "href": return_link,
       "text": "Back"
     })
   }}
@@ -18,6 +20,7 @@
     <div class="govuk-grid-column-two-thirds">
       <form method="POST" novalidate>
         {{ form.csrf_token }}
+
         {{
           form.decline_reason(
             params={
@@ -27,14 +30,17 @@
               "text": "Why are you declining sign off for the " + submission.collection.name + " report?"
             },
             "hint":{
-               "text": "Tell " + (submission.sent_for_certification_by.name if submission.sent_for_certification_by else "the submitter")
-               + " why you are declining sign off so they can update and resubmit the report."
+              "text": "Tell " + (submission.sent_for_certification_by.name if submission.sent_for_certification_by else "the submitter")
+              + " why you are declining sign off so they can update and resubmit the report."
             }
             }
 
           )
         }}
-        {{ form.submit }}
+        <div class="govuk-button-group">
+          {{ form.submit }}
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ return_link }}">Cancel</a>
+        </div>
       </form>
     </div>
   </div>

--- a/app/access_grant_funding/templates/access_grant_funding/reports/submit_report.html
+++ b/app/access_grant_funding/templates/access_grant_funding/reports/submit_report.html
@@ -1,7 +1,9 @@
 {% extends "access_grant_funding/base.html" %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
-{% set page_title = "Confirm and submit report: " + submission_helper.name %}
+{% set title_text = "Confirm sign off and submit report" if submission_helper.collection.requires_certification else "Confirm and submit report" %}
+{% set action_text = "Confirm sign off and submit" if submission_helper.collection.requires_certification else "Confirm and submit" %}
+{% set page_title = title_text ~ ": " ~ submission_helper.name %}
 
 {% set active_item_identifier = "reports" %}
 
@@ -20,15 +22,15 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">Confirm and submit report</h1>
+      <h1 class="govuk-heading-l">{{ title_text }}</h1>
       <p class="govuk-body">You are submitting the {{ submission_helper.name }} report for {{ submission_helper.grant.name }}.</p>
       <p class="govuk-body">By submitting this report, you confirm that the information provided in the report is correct.</p>
 
       <form method="POST" novalidate>
         <div class="govuk-button-group">
           {{ form.csrf_token }}
-          {{ form.submit(params={"text": "Confirm and submit" }) }}
-          <a class="govuk-link govuk-link--no-visited-state" href="{{ return_link }}"> Cancel </a>
+          {{ form.submit(params={"text": action_text }) }}
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ return_link }}">Cancel</a>
         </div>
       </form>
     </div>

--- a/app/access_grant_funding/templates/access_grant_funding/reports/tasklist.html
+++ b/app/access_grant_funding/templates/access_grant_funding/reports/tasklist.html
@@ -67,7 +67,7 @@
   {% else %}
     {% set before_submission %}
       <h2 class="govuk-heading-m">Submit your report</h2>
-      <p class="govuk-body">You can submit your report to the {{ runner.submission.collection.grant.organisation.name }}.</p>
+      <p class="govuk-body">Once you've completed your report, you can submit it to the {{ runner.submission.collection.grant.organisation.name }}.</p>
     {% endset %}
     {% set submit_text="Continue to submit" %}
   {% endif %}

--- a/tests/integration/access_grant_funding/routes/test_reports.py
+++ b/tests/integration/access_grant_funding/routes/test_reports.py
@@ -520,7 +520,7 @@ class TestConfirmReportSubmission:
         else:
             assert response.status_code == 200
             soup = BeautifulSoup(response.data, "html.parser")
-            assert get_h1_text(soup) == "Confirm and submit report"
+            assert get_h1_text(soup) == "Confirm sign off and submit report"
 
     def test_get_redirects_if_requires_certification_and_not_awaiting_sign_off(
         self, authenticated_grant_recipient_certifier_client, submission_ready_to_submit


### PR DESCRIPTION
This commit:
- updates the submission confirmation header and button text based on if you're certifying or not
- tweaks the tasklist content for direct submission to line up with the latest changes
- adds a cancel link to the decline flow

## 📸 Show the thing (screenshots, gifs)
<!-- Include screenshots for UI changes, new features, or visual modifications -->
<!-- Use "Before" and "After" sections if showing changes to existing functionality -->
<img width="1179" height="907" alt="funding communities gov localhost_8080_access_organisation_137e709e-b2a7-4ee9-b881-4aa722d1ec22_grants_caf0ce3f-5175-f69c-66a9-41e2c2245845_reports_740fb0c6-5e92-48c1-81cc-ff9cd5c7aac4_confirm-report-submission" src="https://github.com/user-attachments/assets/91eb0ee1-da8a-4266-b0f6-b5b7ed8509ec" />

<img width="1179" height="907" alt="funding communities gov localhost_8080_access_organisation_137e709e-b2a7-4ee9-b881-4aa722d1ec22_grants_caf0ce3f-5175-f69c-66a9-41e2c2245845_reports_b8f4e1b4-088d-4dbb-9e11-86b4e67399b9_confirm-report-submission-certify" src="https://github.com/user-attachments/assets/fd1e1f81-08bb-4abd-a757-b0c0884d9f43" />

<img width="1264" height="956" alt="funding communities gov localhost_8080_access_organisation_137e709e-b2a7-4ee9-b881-4aa722d1ec22_grants_caf0ce3f-5175-f69c-66a9-41e2c2245845_reports_b8f4e1b4-088d-4dbb-9e11-86b4e67399b9_decline" src="https://github.com/user-attachments/assets/606335e1-fcb0-40b7-9cbe-d3e6ddc7cf79" />

<img width="1264" height="1009" alt="funding communities gov localhost_8080_access_organisation_137e709e-b2a7-4ee9-b881-4aa722d1ec22_grants_caf0ce3f-5175-f69c-66a9-41e2c2245845_reports_740fb0c6-5e92-48c1-81cc-ff9cd5c7aac4_tasklist" src="https://github.com/user-attachments/assets/5ebd3f07-dee3-435f-862f-9afc5cdcd782" />

