### PR TITLE
FSPT-1049 Move overdue out of the submission status into its own property

### DIFF
--- a/app/access_grant_funding/templates/access_grant_funding/report_list.html
+++ b/app/access_grant_funding/templates/access_grant_funding/report_list.html
@@ -47,7 +47,7 @@
           {% set submission = submissions | selectattr("collection_id", "equalto", report.id) | first %}
           {% set submission_status = submission.status if submission else enum.submission_status.NOT_STARTED %}
           {% set submission_status_html %}
-            {{ submissionStatusTag(submission_status) }}
+            {{ submissionStatusTag(submission_status, submission.is_overdue if submission else report.is_overdue) }}
           {% endset %}
           {% set report_action_html %}
             <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('access_grant_funding.route_to_submission', organisation_id=grant_recipient.organisation.id, grant_id=grant_recipient.grant.id, collection_id=report.id) }}">

--- a/app/access_grant_funding/templates/access_grant_funding/reports/tasklist.html
+++ b/app/access_grant_funding/templates/access_grant_funding/reports/tasklist.html
@@ -48,7 +48,7 @@
       </dl>
       <dl class="app-metadata govuk-!-margin-bottom-7">
         <dt class="app-metadata__key">Status:</dt>
-        <dd class="app-metadata__value" data-testid="submission-status">{{ submissionStatusTag(runner.submission.status) }}</dd>
+        <dd class="app-metadata__value" data-testid="submission-status">{{ submissionStatusTag(runner.submission.status, runner.submission.is_overdue) }}</dd>
       </dl>
     </div>
   </div>

--- a/app/access_grant_funding/templates/access_grant_funding/view_locked_report.html
+++ b/app/access_grant_funding/templates/access_grant_funding/view_locked_report.html
@@ -81,7 +81,7 @@
         </dl>
         <dl class="app-metadata govuk-!-margin-bottom-9">
           <dt class="app-metadata__key">Status:</dt>
-          <dd class="app-metadata__value" data-testid="submission-status">{{ submissionStatusTag(submission.status) }}</dd>
+          <dd class="app-metadata__value" data-testid="submission-status">{{ submissionStatusTag(submission.status, submission.is_overdue) }}</dd>
         </dl>
       {% endif %}
 

--- a/app/access_grant_funding/templates/access_grant_funding/view_locked_report_print_baseline.html
+++ b/app/access_grant_funding/templates/access_grant_funding/view_locked_report_print_baseline.html
@@ -69,7 +69,7 @@
         </dl>
         <dl class="app-metadata">
           <dt class="app-metadata__key">Status:</dt>
-          <dd class="app-metadata__value">{{ submissionStatusTag(submission.status) }}</dd>
+          <dd class="app-metadata__value">{{ submissionStatusTag(submission.status, submission.is_overdue) }}</dd>
         </dl>
         {% if submission.sent_for_certification_by %}
           <dl class="app-metadata">

--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -254,6 +254,12 @@ class Collection(BaseModel):
     def is_open(self) -> bool:
         return self.status == CollectionStatusEnum.OPEN
 
+    @property
+    def is_overdue(self) -> bool:
+        if not self.submission_period_end_date:
+            return False
+        return self.submission_period_end_date < datetime.date.today()
+
 
 class Submission(BaseModel):
     __tablename__ = "submission"

--- a/app/common/data/types.py
+++ b/app/common/data/types.py
@@ -120,7 +120,6 @@ class SubmissionStatusEnum(enum.StrEnum):
     READY_TO_SUBMIT = "Ready to submit"
     AWAITING_SIGN_OFF = "Awaiting sign off"
     SUBMITTED = "Submitted"
-    OVERDUE = "Overdue"
 
 
 class TasklistSectionStatusEnum(enum.StrEnum):

--- a/app/common/templates/common/macros/status.html
+++ b/app/common/templates/common/macros/status.html
@@ -48,7 +48,7 @@
   {{ govukTag({"text": status, "classes": classMap[status] }) }}
 {% endmacro %}
 
-{% macro submissionStatusTag(status) %}
+{% macro submissionStatusTag(status, is_overdue) %}
   {% set show_without_tag = [ enum.submission_status.SUBMITTED ] %}
   {%
     set classMap = {
@@ -56,13 +56,13 @@
         enum.submission_status.IN_PROGRESS: "govuk-tag--light-blue",
         enum.submission_status.READY_TO_SUBMIT: "govuk-tag--blue",
         enum.submission_status.AWAITING_SIGN_OFF: "govuk-tag--purple",
-        enum.submission_status.OVERDUE: "govuk-tag--yellow",
     }
   %}
+  {% set status_text = status ~ (" (Overdue)" if is_overdue else "") %}
   {% if status in show_without_tag %}
-    <span class="govuk-body govuk-!-margin-bottom-0">{{ status }}</span>
+    <span class="govuk-body govuk-!-margin-bottom-0">{{ status_text }}</span>
   {% else %}
-    {{ govukTag({"text": status, "classes": "app-status-tag " ~ classMap[status] }) }}
+    {{ govukTag({"text": status_text, "classes": "app-status-tag " ~ (classMap[status] if not is_overdue else "govuk-tag--yellow") }) }}
   {% endif %}
 {% endmacro %}
 

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_submissions.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_submissions.html
@@ -83,7 +83,7 @@
             {
               "html": link_to_submission,
             }, {
-              "html": submissionStatusTag(grant_recipient_submission_helper.status if grant_recipient_submission_helper else enum.submission_status.NOT_STARTED)
+              "html": submissionStatusTag(grant_recipient_submission_helper.status if grant_recipient_submission_helper else enum.submission_status.NOT_STARTED, grant_recipient_submission_helper.is_overdue if grant_recipient_submission_helper else report.is_overdue)
             }, {
               "text": format_date_short(grant_recipient_submission_helper.submission.updated_at_utc) if grant_recipient_submission_helper else ''
             }

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/view_submission.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/view_submission.html
@@ -34,7 +34,7 @@
   <span class="govuk-caption-l">{{ helper.submission.grant_recipient.organisation.name if helper.submission.grant_recipient else helper.submission.created_by.email }}</span>
   <div class="app-aligned-header-tag govuk-!-margin-bottom-6">
     <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Submission</h1>
-    {{ submissionStatusTag(helper.status) }}
+    {{ submissionStatusTag(helper.status, helper.is_overdue) }}
   </div>
 
   {% for form in helper.get_ordered_visible_forms() %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/runner/collection_tasklist.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/runner/collection_tasklist.html
@@ -24,7 +24,7 @@
 
       <dl class="app-metadata govuk-!-margin-bottom-7">
         <dt class="app-metadata__key">Status:</dt>
-        <dd class="app-metadata__value" data-testid="submission-status">{{ submissionStatusTag(runner.submission.status) }}</dd>
+        <dd class="app-metadata__value" data-testid="submission-status">{{ submissionStatusTag(runner.submission.status, runner.submission.is_overdue) }}</dd>
       </dl>
     </div>
   </div>


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-1049

## 📝 Description
This moves the overdue state out of the status calculation and into its own property. This allows all of the existing workflows to continue to work even if a submission is overdue but gives us the option to visually differentiate overdue submissions.

Overdue is calculated by checking if the submission deadline has passed for the collection, and that the submission isn't in a terminal (submitted) state.

This lets us tweak what it means for a given submission (test, preview, live) to be overdue but means we can check if a collection is the past uniformly (for example there is no submission if the user hasn't started one).

Updates the status tag to visually differentiate overdue submissions.

## 📸 Show the thing (screenshots, gifs)
<img width="1079" height="887" alt="funding communities gov localhost_8080_access_organisation_137e709e-b2a7-4ee9-b881-4aa722d1ec22_grants_caf0ce3f-5175-f69c-66a9-41e2c2245845_reports" src="https://github.com/user-attachments/assets/6f69a496-c4ba-4462-b1df-ecb018609888" />

<img width="1079" height="1145" alt="funding communities gov localhost_8080_access_organisation_137e709e-b2a7-4ee9-b881-4aa722d1ec22_grants_caf0ce3f-5175-f69c-66a9-41e2c2245845_reports_4b25d51e-966f-49dc-8dc6-62472f8c84aa_tasklist" src="https://github.com/user-attachments/assets/fef0fc9d-58dc-4d9b-b89f-487af4a738ee" />

<img width="1079" height="1527" alt="funding communities gov localhost_8080_access_organisation_137e709e-b2a7-4ee9-b881-4aa722d1ec22_grants_caf0ce3f-5175-f69c-66a9-41e2c2245845_reports_4b25d51e-966f-49dc-8dc6-62472f8c84aa_view" src="https://github.com/user-attachments/assets/1ce0d785-3e6e-476f-9ca9-7dbc7c816520" />

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested
