### PR TITLE
Updating export script to use a consistent name/email pair for anonymised users

### DIFF
--- a/app/developers/commands.py
+++ b/app/developers/commands.py
@@ -232,8 +232,10 @@ def export_grants(grant_ids: list[uuid.UUID], output: str) -> None:  # noqa: C90
         # Anonymise the user, but in a consistent way
         faker = Faker()
         faker.seed_instance(int(hashlib.md5(str(user_data["id"]).encode()).hexdigest(), 16))
-        user_data["email"] = faker.email(domain="test.communities.gov.uk")
-        user_data["name"] = faker.name()
+        first_name = faker.first_name()
+        last_name = faker.last_name()
+        user_data["email"] = f"{first_name.lower()}.{last_name.lower()}@test.communities.gov.uk"
+        user_data["name"] = f"{first_name} {last_name}"
 
         export_data["users"].append(user_data)
 

--- a/app/developers/data/grants.json
+++ b/app/developers/data/grants.json
@@ -3898,6 +3898,14 @@
       "user_id": "62ee98f5-cf10-4848-95a4-5b6280529046"
     },
     {
+      "id": "68e3b145-1ce2-4561-b0fc-0225c39f87ef",
+      "permissions": [
+        "admin",
+        "member"
+      ],
+      "user_id": "838de5cd-2874-4612-85de-43f7a485b3ff"
+    },
+    {
       "grant_id": "caf0ce3f-5175-f69c-66a9-41e2c2245845",
       "id": "43b54bff-39ea-4a06-90ac-5348b8dd269c",
       "organisation_id": "d9e644d8-26ed-4287-a2d8-c0c841399ad4",
@@ -3946,64 +3954,64 @@
   ],
   "users": [
     {
-      "azure_ad_subject_id": "ENrQThzOCWIVUnrnjPiPBiKHM",
-      "email": "bharrington@test.communities.gov.uk",
-      "id": "e8f81083-7d87-4c20-af0a-4ec4b3378cdb",
-      "last_logged_in_at_utc": "Thu, 03 Jul 2025 14:37:06 GMT",
-      "name": "Rachel Johnson"
+      "azure_ad_subject_id": "36f6f23d57459ed3eef25d2835e2d31a",
+      "email": "brandy.santos@test.communities.gov.uk",
+      "id": "838de5cd-2874-4612-85de-43f7a485b3ff",
+      "last_logged_in_at_utc": "Mon, 05 Jan 2026 14:57:41 GMT",
+      "name": "Brandy Santos"
     },
     {
-      "azure_ad_subject_id": "mDLVWMQVmvxRxPNKpKUFODrcU",
-      "email": "johnsonlori@test.communities.gov.uk",
-      "id": "62ee98f5-cf10-4848-95a4-5b6280529046",
-      "last_logged_in_at_utc": "Thu, 03 Jul 2025 14:37:06 GMT",
-      "name": "Margaret Ballard"
+      "email": "christina.sanders@test.communities.gov.uk",
+      "id": "4f990e2b-690b-4c97-a47b-c9a073e92827",
+      "last_logged_in_at_utc": "Thu, 11 Dec 2025 10:54:46 GMT",
+      "name": "Christina Sanders"
     },
     {
       "azure_ad_subject_id": "789779cf9692b89ab3fd5e4d725e44c5",
-      "email": "nancy45@test.communities.gov.uk",
+      "email": "connie.livingston@test.communities.gov.uk",
       "id": "78371bda-d2e5-4113-8cee-3daad6dd55ab",
       "last_logged_in_at_utc": "Mon, 04 Aug 2025 09:36:18 GMT",
-      "name": "Leah Hobbs"
-    },
-    {
-      "azure_ad_subject_id": "aef0d89750aa6dcb4d10040f6e5766c1",
-      "email": "nrose@test.communities.gov.uk",
-      "id": "b538317c-82d9-41ae-82e7-a0578bc7ea0c",
-      "last_logged_in_at_utc": "Thu, 11 Dec 2025 10:06:08 GMT",
-      "name": "Amber Greene"
-    },
-    {
-      "email": "raymondpearson@test.communities.gov.uk",
-      "id": "4f990e2b-690b-4c97-a47b-c9a073e92827",
-      "last_logged_in_at_utc": "Thu, 11 Dec 2025 10:54:46 GMT",
-      "name": "Timothy Garrett"
+      "name": "Connie Livingston"
     },
     {
       "azure_ad_subject_id": "40e16bf9d02fa7f67c6bb767b197e544",
-      "email": "sclark@test.communities.gov.uk",
+      "email": "crystal.wheeler@test.communities.gov.uk",
       "id": "9ab212ee-6716-4921-b6a2-61a684bf2fe3",
       "last_logged_in_at_utc": "Thu, 20 Nov 2025 09:49:40 GMT",
-      "name": "Willie Brown"
+      "name": "Crystal Wheeler"
     },
     {
-      "azure_ad_subject_id": "36f6f23d57459ed3eef25d2835e2d31a",
-      "email": "thompsonedwin@test.communities.gov.uk",
-      "id": "838de5cd-2874-4612-85de-43f7a485b3ff",
-      "last_logged_in_at_utc": "Mon, 29 Dec 2025 17:48:08 GMT",
-      "name": "Erik Ramirez"
-    },
-    {
-      "email": "turnerjames@test.communities.gov.uk",
-      "id": "a08a325c-645a-4a36-9787-c2acd75dd0f2",
-      "name": "Christopher Lozano"
+      "azure_ad_subject_id": "mDLVWMQVmvxRxPNKpKUFODrcU",
+      "email": "darin.lewis@test.communities.gov.uk",
+      "id": "62ee98f5-cf10-4848-95a4-5b6280529046",
+      "last_logged_in_at_utc": "Thu, 03 Jul 2025 14:37:06 GMT",
+      "name": "Darin Lewis"
     },
     {
       "azure_ad_subject_id": "baf97a91d41d4a5690488c56c4c10558",
-      "email": "zacharystark@test.communities.gov.uk",
+      "email": "john.floyd@test.communities.gov.uk",
       "id": "acc47c80-8620-49d9-aa40-df1703286d43",
       "last_logged_in_at_utc": "Mon, 18 Aug 2025 15:36:18 GMT",
-      "name": "John Gray"
+      "name": "John Floyd"
+    },
+    {
+      "azure_ad_subject_id": "aef0d89750aa6dcb4d10040f6e5766c1",
+      "email": "lisa.little@test.communities.gov.uk",
+      "id": "b538317c-82d9-41ae-82e7-a0578bc7ea0c",
+      "last_logged_in_at_utc": "Thu, 11 Dec 2025 10:06:08 GMT",
+      "name": "Lisa Little"
+    },
+    {
+      "email": "michelle.turner@test.communities.gov.uk",
+      "id": "a08a325c-645a-4a36-9787-c2acd75dd0f2",
+      "name": "Michelle Turner"
+    },
+    {
+      "azure_ad_subject_id": "ENrQThzOCWIVUnrnjPiPBiKHM",
+      "email": "roger.walker@test.communities.gov.uk",
+      "id": "e8f81083-7d87-4c20-af0a-4ec4b3378cdb",
+      "last_logged_in_at_utc": "Thu, 03 Jul 2025 14:37:06 GMT",
+      "name": "Roger Walker"
     }
   ]
 }


### PR DESCRIPTION
Makes a small change to the export script so that when we anonymise users, the new users get a consistent first name/last name pair for email and name.

## Before
<img width="1287" height="116" alt="Screenshot 2026-01-05 at 15 02 43" src="https://github.com/user-attachments/assets/4cfae03b-a15f-48ff-a956-0212c607c3ee" />


## After
<img width="1300" height="596" alt="Screenshot 2026-01-05 at 15 01 48" src="https://github.com/user-attachments/assets/de8d8d52-80b5-455d-bb12-0efb8ce71f7f" />
