### PR TITLE
Fixing link to dependent questions on edit question dependency error message

### DIFF
--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -769,6 +769,7 @@ class DataSourceItemReferenceDependencyException(Exception, FlashableException):
         for dependent_question, data_source_items in self.data_source_item_dependency_map.items():
             flash_context: dict[str, str | bool] = {
                 "message": self.message,
+                "grant_id": str(self.question_being_edited.form.collection.grant_id),  # Required for URL routing
                 "question_id": str(dependent_question.id),
                 "question_text": dependent_question.text,
                 "question_is_group": dependent_question.is_group,


### PR DESCRIPTION
Adding grant_id to the flash_context of DataSourceItemReferenceDependencyException so that we can correctly call get_url to generate links to the dependent question that caused the exception.

## 🎫 Ticket
[FSPT-1086](https://mhclgdigital.atlassian.net/browse/FSPT-1086) 

## 📝 Description
When editing a question to remove an option from a list, if another question depends on that option, we generate a `DataSourceItemReferenceDependencyException` and then use the data from that to show an error message to the user (see screenshot).

That error message includes links to the question that depends on the option being removed, but these links were broken as the `grant_id` was not available to correctly populate the parameters of `url_for()` when generating the link. The user was getting a `404 Not Found`.

Small change to add the grant id into the exception data so we can use in `url_for()`.

## 📸 Show the thing (screenshots, gifs)
<img width="651" height="467" alt="Screenshot 2026-01-07 at 16 42 45" src="https://github.com/user-attachments/assets/d686a14e-6724-4dc8-a57c-03db92956e59" />


## 🧪 Testing
- Create a question that has a list of options
- Create a later question that has a condition that references one of those options
- Try and delete the option that is depended on by another question
- You should see an error stopping you from deleting, and the links in that error message should work.


[FSPT-1086]: https://mhclgdigital.atlassian.net/browse/FSPT-1086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ