### PR TITLE
BAU Update admin page monitoring officer invite email report link

### DIFF
--- a/app/deliver_grant_funding/admin/views.py
+++ b/app/deliver_grant_funding/admin/views.py
@@ -871,9 +871,10 @@ class PlatformAdminReportingLifecycleView(FlaskAdminPlatformMemberAccessibleMixi
             report_deadline = format_date(collection.submission_period_end_date)
 
             grant_report_url = url_for(
-                "access_grant_funding.list_reports",
+                "access_grant_funding.route_to_submission",
                 organisation_id=grant_recipient.organisation.id,
                 grant_id=grant_recipient.grant.id,
+                collection_id=collection.id,
                 _external=True,
             )
 

--- a/tests/integration/deliver_grant_funding/admin/test_views.py
+++ b/tests/integration/deliver_grant_funding/admin/test_views.py
@@ -918,7 +918,7 @@ class TestSendEmailsToRecipients:
         assert all("Test Grant" in line for line in lines[1:])
         assert all("Q1 Report" in line for line in lines[1:])
         assert all("Wednesday 30 April 2025" in line for line in lines[1:])
-        assert all(f"/grants/{grant.id}/reports" in line for line in lines[1:])
+        assert all(f"/grants/{grant.id}/collection/{collection.id}" in line for line in lines[1:])
 
     def test_download_csv_format_and_content_deadline_reminder(
         self, authenticated_platform_admin_client, factories, db_session
@@ -1044,7 +1044,7 @@ class TestSendEmailsToRecipients:
         assert all("Test Grant" in line for line in lines[1:])
         assert all("Q1 Report" in line for line in lines[1:])
         assert all("Wednesday 30 April 2025" in line for line in lines[1:])
-        assert all(f"/grants/{grant.id}/reports" in line for line in lines[1:])
+        assert all(f"/grants/{grant.id}/collection/{collection.id}" in line for line in lines[1:])
 
 
 class TestSetUpCertifiers:


### PR DESCRIPTION
The route to submission link didn't exist when the admin pages were put together, link the monititoring officer to their specific report in the invite email.