### PR TITLE
Fspt 1251 end to end tests for add another scenarios

### DIFF
--- a/tests/e2e/deliver_grant_funding/reports_pages.py
+++ b/tests/e2e/deliver_grant_funding/reports_pages.py
@@ -1678,6 +1678,20 @@ class AddQuestionGroupDisplayOptionsPage(ReportsBasePage):
         expect(group_add_another_page.heading).to_be_visible()
         return group_add_another_page
 
+    def click_submit_nested(self, parent_group_name: str) -> EditQuestionGroupPage:
+        self.page.get_by_role("button", name="Add question group").click()
+        edit_question_group_page = EditQuestionGroupPage(
+            self.page,
+            self.domain,
+            grant_name=self.grant_name,
+            report_name=self.report_name,
+            section_name=self.section_name,
+            group_name=self.group_name,
+            parent_group_name=parent_group_name,
+        )
+        expect(edit_question_group_page.heading).to_be_visible()
+        return edit_question_group_page
+
 
 class AddQuestionGroupAddAnotherPage(ReportsBasePage):
     def __init__(

--- a/tests/e2e/deliver_grant_funding/reports_pages.py
+++ b/tests/e2e/deliver_grant_funding/reports_pages.py
@@ -1476,6 +1476,76 @@ class RunnerCheckYourAnswersPage(ReportsBasePage):
         return task_list_page
 
 
+class RunnerAddAnotherSummaryPage(ReportsBasePage):
+    def __init__(
+        self,
+        page: Page,
+        domain: str,
+        grant_name: str,
+        group_name: str,
+    ) -> None:
+        super().__init__(
+            page,
+            domain,
+            grant_name=grant_name,
+            heading=page.get_by_role("heading", name=group_name, exact=True),
+        )
+        self.group_name = group_name
+
+    def expect_empty(self) -> None:
+        expect(self.heading).to_be_visible()
+        expect(self.page.get_by_text(f"You have not added any {self.group_name}.")).to_be_visible()
+
+    def expect_count(self, count: int) -> None:
+        expect(self.heading).to_be_visible()
+        expect(self.page.get_by_text(f"You have added {count} {self.group_name}")).to_be_visible()
+
+    def click_add_first_answer(self) -> None:
+        self.page.get_by_role("button", name="Add the first answer").click()
+
+    def click_add_another_yes(self) -> None:
+        self.page.get_by_role("radio", name="Yes").click()
+        self.page.get_by_role("button", name="Continue").click()
+
+    def click_add_another_no(self) -> None:
+        self.page.get_by_role("radio", name="No").click()
+        self.page.get_by_role("button", name="Continue").click()
+
+    def click_change(self, index: int = 0) -> None:
+        self.page.get_by_role("link", name="Change", exact=False).nth(index).click()
+
+    def click_remove_first(self) -> None:
+        self.page.get_by_role("link", name="Remove", exact=False).first.click()
+
+    def click_remove_last(self) -> None:
+        self.page.get_by_role("link", name="Remove", exact=False).last.click()
+
+
+class RunnerAddAnotherRemovePage(ReportsBasePage):
+    def __init__(
+        self,
+        page: Page,
+        domain: str,
+        grant_name: str,
+    ) -> None:
+        super().__init__(
+            page,
+            domain,
+            grant_name=grant_name,
+            heading=page.get_by_role("heading", name="Are you sure you want to remove", exact=False),
+        )
+
+    def confirm_remove(self) -> None:
+        expect(self.heading).to_be_visible()
+        self.page.get_by_role("radio", name="Yes").click()
+        self.page.get_by_role("button", name="Continue").click()
+
+    def cancel_remove(self) -> None:
+        expect(self.heading).to_be_visible()
+        self.page.get_by_role("radio", name="No").click()
+        self.page.get_by_role("button", name="Continue").click()
+
+
 class SubmissionsListPage(ReportsBasePage):
     report_name: str
 

--- a/tests/e2e/deliver_grant_funding/test_add_another.py
+++ b/tests/e2e/deliver_grant_funding/test_add_another.py
@@ -26,6 +26,7 @@ _shared_setup_data: dict | None = None
 
 recipient_section_name = "Add another one per page section"
 address_section_name = "Add another same page section"
+organisation_section_name = "Add another nested group section"
 
 add_another_one_per_page_group: QuestionGroupDict = {
     "type": "group",
@@ -77,6 +78,46 @@ add_another_all_on_same_page_group: QuestionGroupDict = {
     ],
 }
 
+add_another_nested_group: QuestionGroupDict = {
+    "type": "group",
+    "text": "Organisation",
+    "display_options": GroupDisplayOptions.ONE_QUESTION_PER_PAGE,
+    "add_another": True,
+    "questions": [
+        QuestionDict(
+            {
+                "type": QuestionDataType.TEXT_SINGLE_LINE,
+                "text": "What is the organisation name?",
+                "display_text": "Organisation name",
+                "answers": [QuestionResponse("Acme Corp"), QuestionResponse("Globex")],
+            }
+        ),
+        {
+            "type": "group",
+            "text": "Contact details",
+            "display_options": GroupDisplayOptions.ALL_QUESTIONS_ON_SAME_PAGE,
+            "questions": [
+                QuestionDict(
+                    {
+                        "type": QuestionDataType.TEXT_SINGLE_LINE,
+                        "text": "What is the contact name?",
+                        "display_text": "Contact name",
+                        "answers": [QuestionResponse("Alice Smith"), QuestionResponse("Bob Jones")],
+                    }
+                ),
+                QuestionDict(
+                    {
+                        "type": QuestionDataType.EMAIL,
+                        "text": "What is the contact email?",
+                        "display_text": "Contact email",
+                        "answers": [QuestionResponse("alice@example.com"), QuestionResponse("bob@example.com")],
+                    }
+                ),
+            ],
+        },
+    ],
+}
+
 
 def test_add_another_setup(
     page: Page, domain: str, e2e_test_secrets: EndToEndTestSecrets, authenticated_browser_sso: E2ETestUser, email
@@ -118,6 +159,15 @@ def test_add_another_setup(
     report_sections_page.check_section_exists(address_section_name)
     manage_section_page = report_sections_page.click_manage_section(address_section_name)
     create_question_or_group(add_another_all_on_same_page_group, manage_section_page)
+
+    # Section 3
+    report_sections_page = navigate_to_report_sections_page(page, domain, grant_name, report_name)
+    add_section_page = report_sections_page.click_add_section()
+    add_section_page.fill_in_section_name(organisation_section_name)
+    report_sections_page = add_section_page.click_add_section()
+    report_sections_page.check_section_exists(organisation_section_name)
+    manage_section_page = report_sections_page.click_manage_section(organisation_section_name)
+    create_question_or_group(add_another_nested_group, manage_section_page)
 
     _shared_setup_data = {
         "grant_name": grant_name,
@@ -267,6 +317,58 @@ def test_add_another_preview_and_fill(
     expect(check_your_answers_page.heading).to_be_visible()
     expect(page.get_by_role("heading", name="789 New Lane, Bristol", exact=False)).to_be_visible()
     expect(page.get_by_role("heading", name="456 Real Road, Manchester", exact=False)).not_to_be_visible()
+
+    check_your_answers_page.click_mark_as_complete_yes()
+    tasklist_page = check_your_answers_page.click_save_and_continue(report_name=data["report_name"])
+
+    # Scenario 3
+    tasklist_page.click_on_section(organisation_section_name)
+    organisation_summary = RunnerAddAnotherSummaryPage(page, domain, data["grant_name"], "Organisation")
+    organisation_summary.expect_empty()
+    organisation_summary.click_add_first_answer()
+
+    fill_entry(page, domain, data["grant_name"], add_another_nested_group, answer_index=0)
+
+    organisation_summary.expect_count(1)
+    organisation_summary.click_add_another_yes()
+
+    fill_entry(page, domain, data["grant_name"], add_another_nested_group, answer_index=1)
+
+    organisation_summary.expect_count(2)
+    organisation_summary.click_add_another_no()
+
+    check_your_answers_page = RunnerCheckYourAnswersPage(page, domain, data["grant_name"])
+    expect(check_your_answers_page.heading).to_be_visible()
+    expect(page.get_by_role("heading", name="Acme Corp", exact=False)).to_be_visible()
+    expect(page.get_by_role("heading", name="Globex", exact=False)).to_be_visible()
+
+    page.get_by_role("link", name="Back").click()
+    organisation_summary.click_change(index=0)
+
+    org_name_page = RunnerQuestionPage(page, domain, data["grant_name"], "Organisation name")
+    expect(org_name_page.heading).to_be_visible()
+    org_name_page.respond_to_question(QuestionDataType.TEXT_SINGLE_LINE, "Organisation name", "Acme Corp Ltd")
+    org_name_page.click_continue()
+
+    contact_page = RunnerQuestionPage(page, domain, data["grant_name"], "Contact name", is_in_a_same_page_group=True)
+    contact_page.respond_to_question(QuestionDataType.TEXT_SINGLE_LINE, "Contact name", "Alice Jones")
+    contact_page.respond_to_question(QuestionDataType.EMAIL, "Contact email", "alice.jones@example.com")
+    contact_page.click_continue()
+
+    expect(page.locator("span").filter(has_text=re.compile(r"^Acme Corp Ltd"))).to_be_visible()
+    organisation_summary.click_remove_last()
+
+    remove_page = RunnerAddAnotherRemovePage(page, domain, data["grant_name"])
+    remove_page.confirm_remove()
+
+    organisation_summary.expect_count(1)
+    expect(page.locator("span").filter(has_text=re.compile(r"^Globex"))).not_to_be_visible()
+    organisation_summary.click_add_another_no()
+
+    check_your_answers_page = RunnerCheckYourAnswersPage(page, domain, data["grant_name"])
+    expect(check_your_answers_page.heading).to_be_visible()
+    expect(page.get_by_role("heading", name="Acme Corp Ltd", exact=False)).to_be_visible()
+    expect(page.get_by_role("heading", name="Globex", exact=False)).not_to_be_visible()
 
     check_your_answers_page.click_mark_as_complete_yes()
     tasklist_page = check_your_answers_page.click_save_and_continue(report_name=data["report_name"])

--- a/tests/e2e/deliver_grant_funding/test_add_another.py
+++ b/tests/e2e/deliver_grant_funding/test_add_another.py
@@ -53,7 +53,7 @@ add_another_one_per_page_group: QuestionGroupDict = {
 def test_add_another_setup(
     page: Page, domain: str, e2e_test_secrets: EndToEndTestSecrets, authenticated_browser_sso: E2ETestUser, email
 ) -> None:
-    """creates a grant/eport with one section containing a single add-another group (one question per page)."""
+    """creates a grant/report with one section containing a single add-another group (one question per page)."""
     global _shared_setup_data
 
     grant_name_uuid = str(uuid.uuid4())
@@ -93,17 +93,35 @@ def test_add_another_setup(
     }
 
 
-def fill_entry(page: Page, grant_name: str, domain: str, first_name: str, last_name: str) -> None:
-    """Fill one complete add-another entry (first name → last name)."""
-    first_name_page = RunnerQuestionPage(page, domain, grant_name, "First name")
-    expect(first_name_page.heading).to_be_visible()
-    first_name_page.respond_to_question(QuestionDataType.TEXT_SINGLE_LINE, "First name", first_name)
-    first_name_page.click_continue()
+def fill_entry(
+    page: Page,
+    domain: str,
+    grant_name: str,
+    group: QuestionGroupDict,
+    answer_index: int,
+) -> None:
+    """Fill one add-another entry using the answer at answer_index, handling nested groups."""
+    for question in group["questions"]:
+        if question["type"] == "group":
+            fill_entry(page, domain, grant_name, question, answer_index)
+        else:
+            question_page = RunnerQuestionPage(
+                page,
+                domain,
+                grant_name,
+                question["display_text"],
+                is_in_a_same_page_group=group["display_options"] == GroupDisplayOptions.ALL_QUESTIONS_ON_SAME_PAGE,
+            )
+            question_page.respond_to_question(
+                question_type=question["type"],
+                question_text=question["display_text"],
+                answer=question["answers"][answer_index].answer,
+            )
+        if group["display_options"] == GroupDisplayOptions.ONE_QUESTION_PER_PAGE:
+            question_page.click_continue()
 
-    last_name_page = RunnerQuestionPage(page, domain, grant_name, "Last name")
-    expect(last_name_page.heading).to_be_visible()
-    last_name_page.respond_to_question(QuestionDataType.TEXT_SINGLE_LINE, "Last name", last_name)
-    last_name_page.click_continue()
+    if group["display_options"] == GroupDisplayOptions.ALL_QUESTIONS_ON_SAME_PAGE:
+        question_page.click_continue()
 
 
 def test_add_another_preview_and_fill(
@@ -131,7 +149,7 @@ def test_add_another_preview_and_fill(
     page.get_by_role("button", name="Add the first answer").click()
 
     # Fill entry 1
-    fill_entry(page, data["grant_name"], domain, first_name="Alice", last_name="Smith")
+    fill_entry(page, domain, data["grant_name"], add_another_one_per_page_group, answer_index=0)
 
     # Back on summary
     expect(page.get_by_role("heading", name="Recipient", exact=True)).to_be_visible()
@@ -140,7 +158,7 @@ def test_add_another_preview_and_fill(
     page.get_by_role("button", name="Continue").click()
 
     # Fill entry 2
-    fill_entry(page, data["grant_name"], domain, first_name="Bob", last_name="Jones")
+    fill_entry(page, domain, data["grant_name"], add_another_one_per_page_group, answer_index=1)
 
     # Back on summary
     expect(page.get_by_role("heading", name="Recipient", exact=True)).to_be_visible()

--- a/tests/e2e/deliver_grant_funding/test_add_another.py
+++ b/tests/e2e/deliver_grant_funding/test_add_another.py
@@ -14,6 +14,8 @@ from tests.e2e.deliver_grant_funding.helpers import (
 )
 from tests.e2e.deliver_grant_funding.pages import AllGrantsPage
 from tests.e2e.deliver_grant_funding.reports_pages import (
+    RunnerAddAnotherRemovePage,
+    RunnerAddAnotherSummaryPage,
     RunnerCheckYourAnswersPage,
     RunnerQuestionPage,
 )
@@ -22,7 +24,8 @@ from tests.e2e.helpers import delete_grant_through_admin
 
 _shared_setup_data: dict | None = None
 
-section_name = "Add another test section"
+recipient_section_name = "Add another one per page section"
+address_section_name = "Add another same page section"
 
 add_another_one_per_page_group: QuestionGroupDict = {
     "type": "group",
@@ -49,11 +52,36 @@ add_another_one_per_page_group: QuestionGroupDict = {
     ],
 }
 
+add_another_all_on_same_page_group: QuestionGroupDict = {
+    "type": "group",
+    "text": "Address",
+    "display_options": GroupDisplayOptions.ALL_QUESTIONS_ON_SAME_PAGE,
+    "add_another": True,
+    "questions": [
+        QuestionDict(
+            {
+                "type": QuestionDataType.TEXT_SINGLE_LINE,
+                "text": "What is your street?",
+                "display_text": "Street",
+                "answers": [QuestionResponse("123 Fake Street"), QuestionResponse("456 Real Road")],
+            }
+        ),
+        QuestionDict(
+            {
+                "type": QuestionDataType.TEXT_SINGLE_LINE,
+                "text": "What is your city?",
+                "display_text": "City",
+                "answers": [QuestionResponse("London"), QuestionResponse("Manchester")],
+            }
+        ),
+    ],
+}
+
 
 def test_add_another_setup(
     page: Page, domain: str, e2e_test_secrets: EndToEndTestSecrets, authenticated_browser_sso: E2ETestUser, email
 ) -> None:
-    """creates a grant/report with one section containing a single add-another group (one question per page)."""
+    """Creates a grant/report with two sections, one per scenario."""
     global _shared_setup_data
 
     grant_name_uuid = str(uuid.uuid4())
@@ -73,16 +101,23 @@ def test_add_another_setup(
     grant_reports_page = add_report_page.click_submit(grant_name)
     grant_reports_page.check_report_exists(report_name)
 
-    # Section
+    # Section 1
     add_section_page = grant_reports_page.click_add_section(report_name=report_name, grant_name=grant_name)
     collection_id = extract_uuid_from_url(page.url, r"/report/(?P<uuid>[a-f0-9-]+)")
-    add_section_page.fill_in_section_name(section_name)
+    add_section_page.fill_in_section_name(recipient_section_name)
     report_sections_page = add_section_page.click_add_section()
-    report_sections_page.check_section_exists(section_name)
-
-    # Add another group
-    manage_section_page = report_sections_page.click_manage_section(section_name)
+    report_sections_page.check_section_exists(recipient_section_name)
+    manage_section_page = report_sections_page.click_manage_section(recipient_section_name)
     create_question_or_group(add_another_one_per_page_group, manage_section_page)
+
+    # Section 2
+    report_sections_page = navigate_to_report_sections_page(page, domain, grant_name, report_name)
+    add_section_page = report_sections_page.click_add_section()
+    add_section_page.fill_in_section_name(address_section_name)
+    report_sections_page = add_section_page.click_add_section()
+    report_sections_page.check_section_exists(address_section_name)
+    manage_section_page = report_sections_page.click_manage_section(address_section_name)
+    create_question_or_group(add_another_all_on_same_page_group, manage_section_page)
 
     _shared_setup_data = {
         "grant_name": grant_name,
@@ -100,7 +135,6 @@ def fill_entry(
     group: QuestionGroupDict,
     answer_index: int,
 ) -> None:
-    """Fill one add-another entry using the answer at answer_index, handling nested groups."""
     for question in group["questions"]:
         if question["type"] == "group":
             fill_entry(page, domain, grant_name, question, answer_index)
@@ -127,11 +161,9 @@ def fill_entry(
 def test_add_another_preview_and_fill(
     page: Page, domain: str, e2e_test_secrets: EndToEndTestSecrets, authenticated_browser_sso: E2ETestUser, email
 ) -> None:
-    """Preview the report and fill in two entries via the add-another journey."""
     assert _shared_setup_data is not None, "Setup test must run first"
     data = _shared_setup_data
 
-    # Navigate to sections and click preview
     report_sections_page = navigate_to_report_sections_page(page, domain, data["grant_name"], data["report_name"])
     tasklist_page = report_sections_page.click_preview_report()
 
@@ -140,81 +172,102 @@ def test_add_another_preview_and_fill(
     ).to_be_visible()
     expect(tasklist_page.submit_button).to_be_disabled()
 
-    # Click the section
-    tasklist_page.click_on_section(section_name)
-    expect(page.get_by_role("heading", name="Recipient", exact=True)).to_be_visible()
-    expect(page.get_by_text("You have not added any Recipient.")).to_be_visible()
+    # Scenario 1
+    tasklist_page.click_on_section(recipient_section_name)
+    recipient_summary = RunnerAddAnotherSummaryPage(page, domain, data["grant_name"], "Recipient")
+    recipient_summary.expect_empty()
+    recipient_summary.click_add_first_answer()
 
-    # Add the first answer
-    page.get_by_role("button", name="Add the first answer").click()
-
-    # Fill entry 1
     fill_entry(page, domain, data["grant_name"], add_another_one_per_page_group, answer_index=0)
 
-    # Back on summary
-    expect(page.get_by_role("heading", name="Recipient", exact=True)).to_be_visible()
-    expect(page.get_by_text("You have added 1 Recipient")).to_be_visible()
-    page.get_by_role("radio", name="Yes").click()
-    page.get_by_role("button", name="Continue").click()
+    recipient_summary.expect_count(1)
+    recipient_summary.click_add_another_yes()
 
-    # Fill entry 2
     fill_entry(page, domain, data["grant_name"], add_another_one_per_page_group, answer_index=1)
 
-    # Back on summary
-    expect(page.get_by_role("heading", name="Recipient", exact=True)).to_be_visible()
-    expect(page.get_by_text("You have added 2 Recipient")).to_be_visible()
-    page.get_by_role("radio", name="No").click()
-    page.get_by_role("button", name="Continue").click()
+    recipient_summary.expect_count(2)
+    recipient_summary.click_add_another_no()
 
-    # Check your answers
     check_your_answers_page = RunnerCheckYourAnswersPage(page, domain, data["grant_name"])
     expect(check_your_answers_page.heading).to_be_visible()
     expect(page.get_by_role("heading", name="Alice, Smith", exact=False)).to_be_visible()
     expect(page.get_by_role("heading", name="Bob, Jones", exact=False)).to_be_visible()
 
     page.get_by_role("link", name="Back").click()
-    expect(page.get_by_role("heading", name="Recipient", exact=True)).to_be_visible()
+    recipient_summary.click_change(index=0)
 
-    page.get_by_role("link", name="Change", exact=False).first.click()
-
-    # change first name
     first_name_page = RunnerQuestionPage(page, domain, data["grant_name"], "First name")
     expect(first_name_page.heading).to_be_visible()
     first_name_page.respond_to_question(QuestionDataType.TEXT_SINGLE_LINE, "First name", "Alicia")
     first_name_page.click_continue()
 
-    # back to summary
     last_name_page = RunnerQuestionPage(page, domain, data["grant_name"], "Last name")
     expect(last_name_page.heading).to_be_visible()
     last_name_page.respond_to_question(QuestionDataType.TEXT_SINGLE_LINE, "Last name", "Smith")
     last_name_page.click_continue()
 
-    # Back on summary — verify the change is reflected in the entry summary span
-    expect(page.get_by_role("heading", name="Recipient", exact=True)).to_be_visible()
     expect(page.locator("span").filter(has_text=re.compile(r"^Alicia, Smith"))).to_be_visible()
+    recipient_summary.click_remove_last()
 
-    page.get_by_role("link", name="Remove", exact=False).last.click()
+    remove_page = RunnerAddAnotherRemovePage(page, domain, data["grant_name"])
+    remove_page.confirm_remove()
 
-    # Confirm remove page"
-    expect(page.get_by_role("heading", name="Are you sure you want to remove", exact=False)).to_be_visible()
-    page.get_by_role("radio", name="Yes").click()
-    page.get_by_role("button", name="Continue").click()
-
-    # Back on summary
-    expect(page.get_by_role("heading", name="Recipient", exact=True)).to_be_visible()
-    expect(page.get_by_text("You have added 1 Recipient")).to_be_visible()
+    recipient_summary.expect_count(1)
     expect(page.locator("span").filter(has_text=re.compile(r"^Bob, Jones"))).not_to_be_visible()
-
-    # Finish
-    page.get_by_role("radio", name="No").click()
-    page.get_by_role("button", name="Continue").click()
+    recipient_summary.click_add_another_no()
 
     check_your_answers_page = RunnerCheckYourAnswersPage(page, domain, data["grant_name"])
     expect(check_your_answers_page.heading).to_be_visible()
     expect(page.get_by_role("heading", name="Alicia, Smith", exact=False)).to_be_visible()
     expect(page.get_by_role("heading", name="Bob, Jones", exact=False)).not_to_be_visible()
 
-    # Mark as complete
+    check_your_answers_page.click_mark_as_complete_yes()
+    tasklist_page = check_your_answers_page.click_save_and_continue(report_name=data["report_name"])
+
+    # Scenario 2
+    tasklist_page.click_on_section(address_section_name)
+    address_summary = RunnerAddAnotherSummaryPage(page, domain, data["grant_name"], "Address")
+    address_summary.expect_empty()
+    address_summary.click_add_first_answer()
+
+    fill_entry(page, domain, data["grant_name"], add_another_all_on_same_page_group, answer_index=0)
+
+    address_summary.expect_count(1)
+    address_summary.click_add_another_yes()
+
+    fill_entry(page, domain, data["grant_name"], add_another_all_on_same_page_group, answer_index=1)
+
+    address_summary.expect_count(2)
+    address_summary.click_add_another_no()
+
+    check_your_answers_page = RunnerCheckYourAnswersPage(page, domain, data["grant_name"])
+    expect(check_your_answers_page.heading).to_be_visible()
+    expect(page.get_by_role("heading", name="123 Fake Street, London", exact=False)).to_be_visible()
+    expect(page.get_by_role("heading", name="456 Real Road, Manchester", exact=False)).to_be_visible()
+
+    page.get_by_role("link", name="Back").click()
+    address_summary.click_change(index=0)
+
+    address_page = RunnerQuestionPage(page, domain, data["grant_name"], "Street", is_in_a_same_page_group=True)
+    address_page.respond_to_question(QuestionDataType.TEXT_SINGLE_LINE, "Street", "789 New Lane")
+    address_page.respond_to_question(QuestionDataType.TEXT_SINGLE_LINE, "City", "Bristol")
+    address_page.click_continue()
+
+    expect(page.locator("span").filter(has_text=re.compile(r"^789 New Lane"))).to_be_visible()
+    address_summary.click_remove_last()
+
+    remove_page = RunnerAddAnotherRemovePage(page, domain, data["grant_name"])
+    remove_page.confirm_remove()
+
+    address_summary.expect_count(1)
+    expect(page.locator("span").filter(has_text=re.compile(r"^456 Real Road"))).not_to_be_visible()
+    address_summary.click_add_another_no()
+
+    check_your_answers_page = RunnerCheckYourAnswersPage(page, domain, data["grant_name"])
+    expect(check_your_answers_page.heading).to_be_visible()
+    expect(page.get_by_role("heading", name="789 New Lane, Bristol", exact=False)).to_be_visible()
+    expect(page.get_by_role("heading", name="456 Real Road, Manchester", exact=False)).not_to_be_visible()
+
     check_your_answers_page.click_mark_as_complete_yes()
     tasklist_page = check_your_answers_page.click_save_and_continue(report_name=data["report_name"])
 
@@ -226,7 +279,6 @@ def test_add_another_preview_and_fill(
 def test_zzz_add_another_cleanup(
     page: Page, domain: str, e2e_test_secrets: EndToEndTestSecrets, authenticated_browser_sso: E2ETestUser, email
 ) -> None:
-    """Cleanup: delete the grant. Named zzz_ so pytest always runs it last."""
     if _shared_setup_data is None:
         pytest.skip("No setup data to clean up")
 

--- a/tests/e2e/deliver_grant_funding/test_create_preview_collection.py
+++ b/tests/e2e/deliver_grant_funding/test_create_preview_collection.py
@@ -619,6 +619,7 @@ def create_question_or_group(
     question_definition: TQuestionToTest,
     manage_section_page: ManageSectionPage | EditQuestionGroupPage,
     parent_group_name: str | None = None,
+    parent_add_another: bool = False,
 ):
     if question_definition["type"] == "group":
         add_question_group_page = manage_section_page.click_add_question_group(question_definition["text"])
@@ -626,12 +627,12 @@ def create_question_or_group(
         group_display_options_page = add_question_group_page.click_continue()
         group_display_options_page.click_question_group_display_type(question_definition["display_options"])
 
-        if parent_group_name is None:
+        if parent_add_another:
+            edit_question_group_page = group_display_options_page.click_submit_nested(parent_group_name)
+        else:
             add_another_options_page = group_display_options_page.click_submit()
             add_another_options_page.click_add_another(question_definition.get("add_another", False))
             edit_question_group_page = add_another_options_page.click_submit(parent_group_name)
-        else:
-            edit_question_group_page = group_display_options_page.click_submit_nested(parent_group_name)
         if (
             question_definition.get("guidance") is not None
             and question_definition.get("display_options") == GroupDisplayOptions.ALL_QUESTIONS_ON_SAME_PAGE
@@ -640,7 +641,12 @@ def create_question_or_group(
         if question_definition.get("condition") is not None:
             add_condition(edit_question_group_page, question_definition["condition"])
         for question in question_definition["questions"]:
-            create_question_or_group(question, edit_question_group_page, parent_group_name=question_definition["text"])
+            create_question_or_group(
+                question,
+                edit_question_group_page,
+                parent_group_name=question_definition["text"],
+                parent_add_another=question_definition.get("add_another", False),
+            )
         if parent_group_name:
             edit_question_group_page.click_parent_group_breadcrumb()
         else:

--- a/tests/e2e/deliver_grant_funding/test_create_preview_collection.py
+++ b/tests/e2e/deliver_grant_funding/test_create_preview_collection.py
@@ -626,9 +626,12 @@ def create_question_or_group(
         group_display_options_page = add_question_group_page.click_continue()
         group_display_options_page.click_question_group_display_type(question_definition["display_options"])
 
-        add_another_options_page = group_display_options_page.click_submit()
-        add_another_options_page.click_add_another(question_definition.get("add_another", False))
-        edit_question_group_page = add_another_options_page.click_submit(parent_group_name)
+        if parent_group_name is None:
+            add_another_options_page = group_display_options_page.click_submit()
+            add_another_options_page.click_add_another(question_definition.get("add_another", False))
+            edit_question_group_page = add_another_options_page.click_submit(parent_group_name)
+        else:
+            edit_question_group_page = group_display_options_page.click_submit_nested(parent_group_name)
         if (
             question_definition.get("guidance") is not None
             and question_definition.get("display_options") == GroupDisplayOptions.ALL_QUESTIONS_ON_SAME_PAGE


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-1252

## 📝 Description
Add a new e2e test scenario for the add another feature which is used across all live forms. The existing test coverage for add another only covered unit and integration tests, this adds end to end coverage to catch high level bugs like the one patched in [PR #1360](https://github.com/communitiesuk/funding-service/pull/1360).

Sets up a form with three add-another scenarios and runs through the full journey for each — adding two entries, changing an entry and removing an entry.

Scenario 1: add-another group with one question per page
Scenario 2: add-another group with all questions on the same page
Scenario 3: add-another group with one question per page and a nested group with all questions on the same page

## 📸 Show the thing (screenshots, gifs)

### Before
No e2e tests existed for the add another journey. 

### After


https://github.com/user-attachments/assets/3b0ea72a-32d7-4de4-b583-3608c9d8c3dc




## 🧪 Testing
To test checkout `FSPT-1251-end-to-end-tests-for-add-another` and run 
`uv run pytest --e2e --headed --slowmo 1000 tests/e2e/deliver_grant_funding/test_add_another.py`

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions


### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [ ] New (non-developer) functionality has appropriate unit and integration tests
- [x] End-to-end tests have been updated (if applicable)
- [ ] Edge cases and error conditions are tested