### PR TITLE
Add another group validation

### DIFF
--- a/app/common/collections/validation.py
+++ b/app/common/collections/validation.py
@@ -46,7 +46,6 @@ class SubmissionValidator:
 
         for component in form.cached_all_components:
             if isinstance(component, Group):
-                # TODO[FSPT-1224]: run this for add-another groups with validations as well?
                 if (
                     component.validations
                     and component.add_another_container is None
@@ -72,20 +71,35 @@ class SubmissionValidator:
 
         return errors
 
-    def _validate_group(self, group: Group, form: Form) -> list[ValidationError]:
+    def _validate_group(self, group: Group, form: Form, add_another_index: int | None = None) -> list[ValidationError]:
         errors: list[ValidationError] = []
 
-        if not self.helper.is_component_visible(group, self.helper.cached_evaluation_context):
+        if not self.helper.is_component_visible(
+            group, self.helper.cached_evaluation_context, add_another_index=add_another_index
+        ):
             return errors
 
-        context = self.helper.cached_evaluation_context
+        if (add_another_index is not None and not group.add_another_container) or (
+            add_another_index is None and group.add_another_container
+        ):
+            raise ValueError(f"Cannot validate {group.add_another=} {group=} with {add_another_index=}")
+
+        if add_another_index is not None:
+            evaluation_context = self.helper.cached_evaluation_context.with_add_another_context(
+                group, self.helper, add_another_index=add_another_index, mode="evaluation"
+            )
+            interpolation_context = self.helper.cached_interpolation_context.with_add_another_context(
+                group, self.helper, add_another_index=add_another_index, mode="interpolation"
+            )
+        else:
+            evaluation_context = self.helper.cached_evaluation_context
+            interpolation_context = self.helper.cached_interpolation_context
 
         for validation_expr in group.validations:
             try:
-                if not evaluate(expression=validation_expr, context=context):
+                if not evaluate(expression=validation_expr, context=evaluation_context):
                     error_message = interpolate(
-                        validation_expr.evaluatable_expression.message,
-                        context=self.helper.cached_interpolation_context,
+                        validation_expr.evaluatable_expression.message, context=interpolation_context
                     )
                     errors.append(
                         ValidationError(
@@ -119,15 +133,18 @@ class SubmissionValidator:
         if not question.validations:
             return errors
 
-        context = self.helper.cached_evaluation_context
+        evaluation_context = self.helper.cached_evaluation_context
         if add_another_index is not None and question.add_another_container:
-            context = context.with_add_another_context(
-                question.add_another_container, submission_helper=self.helper, add_another_index=add_another_index
+            evaluation_context = evaluation_context.with_add_another_context(
+                question.add_another_container,
+                submission_helper=self.helper,
+                add_another_index=add_another_index,
+                mode="evaluation",
             )
 
         for validation_expr in question.validations:
             try:
-                if not evaluate(expression=validation_expr, context=context):
+                if not evaluate(expression=validation_expr, context=evaluation_context):
                     error_message = interpolate(
                         validation_expr.evaluatable_expression.message, context=self.helper.cached_interpolation_context
                     )
@@ -163,18 +180,22 @@ class SubmissionValidator:
 
         count = self.helper.get_count_for_add_another(container)
         for index in range(count):
-            context = self.helper.cached_evaluation_context.with_add_another_context(
-                container, submission_helper=self.helper, add_another_index=index
-            )
-
             questions = (
                 cast("Group", container).cached_questions if container.is_group else [cast("Question", container)]
             )
 
             for q in questions:
-                if self.helper.is_component_visible(q, context):
+                if self.helper.is_component_visible(q, self.helper.cached_evaluation_context, add_another_index=index):
                     answer = self.helper.cached_get_answer_for_question(q.id, add_another_index=index)
                     if answer is not None and answer != NOT_ANSWERED:
                         errors.extend(self._validate_question(q, form, add_another_index=index))
+
+            if container.is_group:
+                for group in set(cast(Group, container).cached_all_components).union({container}):
+                    if group.is_group:
+                        group = cast(Group, group)
+                        if group.validations and group.add_another_container is not None:
+                            errors.extend(self._validate_group(group, form, add_another_index=index))
+                        continue
 
         return errors

--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -844,7 +844,7 @@ class Group(Component):
             for component in self.cached_all_components
             # todo: sense check the lazy loading implications of this property
             for depends_on in component.depended_on_by
-            if depends_on.component not in self.cached_all_components
+            if depends_on.component not in (set(self.cached_all_components).union({self}))
         ]
         return bool(depended_on_outside_of_group_context)
 

--- a/app/developers/data/grants.json
+++ b/app/developers/data/grants.json
@@ -120,6 +120,12 @@
           "id": "218df1d6-ffbd-4858-aa6f-b0859189a13d"
         },
         {
+          "component_id": "5e7e9e11-08e8-422b-82a4-6a887b42f65d",
+          "depends_on_component_id": "bc31c9aa-7c57-45c5-a56f-a3820c0f4972",
+          "expression_id": "f0f93b94-10b0-4179-a114-a3f618889d3c",
+          "id": "296acbf1-b2c5-4e1e-88db-20a57603981f"
+        },
+        {
           "component_id": "4988b724-7b83-4b09-899b-3885fed52be1",
           "depends_on_component_id": "65664e18-722d-484f-8488-c851c5c5de36",
           "depends_on_data_source_item_id": "11dd117b-48b5-45a3-b838-a34d7e3fc405",
@@ -131,6 +137,12 @@
           "depends_on_component_id": "8b856525-892a-4117-8d00-3c72e85d5438",
           "expression_id": "14774416-72cc-46f8-b08a-a447a870f83f",
           "id": "365493a5-c0bc-4754-ae3c-d6a7a93af289"
+        },
+        {
+          "component_id": "5e7e9e11-08e8-422b-82a4-6a887b42f65d",
+          "depends_on_component_id": "62b4a7ca-868f-49cc-9c45-eb04dbfd10b0",
+          "expression_id": "f0f93b94-10b0-4179-a114-a3f618889d3c",
+          "id": "3b203ccb-d4aa-4188-add1-48892ca951c2"
         },
         {
           "component_id": "ea608b3b-ff0c-4733-9ff4-29ac31868200",
@@ -235,6 +247,12 @@
           "id": "8ffc5f8f-342f-4ac7-b990-317ad1091a80"
         },
         {
+          "component_id": "5e7e9e11-08e8-422b-82a4-6a887b42f65d",
+          "depends_on_component_id": "4580488e-8b3e-494f-ba27-9233bbe193ec",
+          "expression_id": "f0f93b94-10b0-4179-a114-a3f618889d3c",
+          "id": "9cbb5572-07ae-40c9-bea7-a5a3c35a16d7"
+        },
+        {
           "component_id": "46068ea5-7e83-476e-91f4-71e87a1cc1a0",
           "depends_on_component_id": "46068ea5-7e83-476e-91f4-71e87a1cc1a0",
           "expression_id": "cf097d73-7286-4c35-aca4-d68eb14718d8",
@@ -252,6 +270,12 @@
           "id": "a5df4911-602f-4f69-9d6d-11c5dc9baf74"
         },
         {
+          "component_id": "5e7e9e11-08e8-422b-82a4-6a887b42f65d",
+          "depends_on_component_id": "8d6ff2ae-0476-4294-b41f-681e59142a69",
+          "expression_id": "f0f93b94-10b0-4179-a114-a3f618889d3c",
+          "id": "aa65243b-8ce8-4606-8a7a-ea5c7fed4248"
+        },
+        {
           "component_id": "946bd001-a1a3-4f09-ba2f-a61966871e33",
           "depends_on_component_id": "53915cda-b1a2-4fb7-9e29-ee41014964b3",
           "expression_id": "a70ef8d9-feb9-41c8-bfb7-f6b4c391f182",
@@ -267,6 +291,12 @@
           "component_id": "b67ee3f1-d942-416a-8710-348c841d58d9",
           "depends_on_component_id": "80d29ce3-9ad0-4ef5-bd6d-09609ef4fcc3",
           "id": "c34ed257-30b4-42cb-9159-0e0ff3887dcf"
+        },
+        {
+          "component_id": "5e7e9e11-08e8-422b-82a4-6a887b42f65d",
+          "depends_on_component_id": "190f1e66-c064-46c6-874e-20ffd02c3eec",
+          "expression_id": "f0f93b94-10b0-4179-a114-a3f618889d3c",
+          "id": "da407736-8761-4390-8e35-1138a5dad5f9"
         },
         {
           "component_id": "0e6df617-b770-4525-9c06-6fdbcca72a10",
@@ -1326,6 +1356,19 @@
         },
         {
           "context": {
+            "custom_expression": "((q_8d6ff2ae04764294b41f681e59142a69)) >= ((q_bc31c9aa7c5745c5a56fa3820c0f4972)) + ((q_190f1e66c06446c6874e20ffd02c3eec)) + ((q_4580488e8b3e494fba279233bbe193ec)) + ((q_62b4a7ca868f49cc9c45eb04dbfd10b0))",
+            "custom_message": "Your total project spend cannot exceed the maximum project budget of ((q_8d6ff2ae04764294b41f681e59142a69))",
+            "expression_name": null,
+            "question_id": null
+          },
+          "created_by_id": "838de5cd-2874-4612-85de-43f7a485b3ff",
+          "id": "f0f93b94-10b0-4179-a114-a3f618889d3c",
+          "question_id": "5e7e9e11-08e8-422b-82a4-6a887b42f65d",
+          "statement": "((q_8d6ff2ae04764294b41f681e59142a69)) >= ((q_bc31c9aa7c5745c5a56fa3820c0f4972)) + ((q_190f1e66c06446c6874e20ffd02c3eec)) + ((q_4580488e8b3e494fba279233bbe193ec)) + ((q_62b4a7ca868f49cc9c45eb04dbfd10b0))",
+          "type_": "VALIDATION"
+        },
+        {
+          "context": {
             "question_id": "d99b94c3-66fa-4449-b4c4-ac5a2caeb8c9"
           },
           "created_by_id": "9ab212ee-6716-4921-b6a2-61a684bf2fe3",
@@ -1591,6 +1634,28 @@
         {
           "add_another": false,
           "conditions_operator": "ALL",
+          "data_options": {
+            "max_decimal_places": 2,
+            "number_type": "Decimal number"
+          },
+          "data_type": "A number",
+          "form_id": "549c1676-f5a5-4bfe-9ee7-ca22f7c785fe",
+          "hint": "",
+          "id": "190f1e66-c064-46c6-874e-20ffd02c3eec",
+          "name": "project q2 spend",
+          "order": 2,
+          "parent_id": "5e7e9e11-08e8-422b-82a4-6a887b42f65d",
+          "presentation_options": {
+            "prefix": "\u00a3",
+            "width": "govuk-input--width-10"
+          },
+          "slug": "what-is-your-projects-q2-spend",
+          "text": "What is your project's Q2 spend?",
+          "type": "QUESTION"
+        },
+        {
+          "add_another": false,
+          "conditions_operator": "ALL",
           "data_options": {},
           "data_type": "Multiple lines of text",
           "form_id": "8506d7ef-2421-40d5-b120-daf870e09968",
@@ -1748,6 +1813,28 @@
           "add_another": false,
           "conditions_operator": "ALL",
           "data_options": {
+            "max_decimal_places": 2,
+            "number_type": "Decimal number"
+          },
+          "data_type": "A number",
+          "form_id": "549c1676-f5a5-4bfe-9ee7-ca22f7c785fe",
+          "hint": "",
+          "id": "4580488e-8b3e-494f-ba27-9233bbe193ec",
+          "name": "project q3 spend",
+          "order": 3,
+          "parent_id": "5e7e9e11-08e8-422b-82a4-6a887b42f65d",
+          "presentation_options": {
+            "prefix": "\u00a3",
+            "width": "govuk-input--width-10"
+          },
+          "slug": "what-is-your-projects-q3-spend",
+          "text": "What is your project's Q3 spend?",
+          "type": "QUESTION"
+        },
+        {
+          "add_another": false,
+          "conditions_operator": "ALL",
+          "data_options": {
             "number_type": "Whole number"
           },
           "data_type": "A number",
@@ -1853,6 +1940,46 @@
           },
           "slug": "what-is-the-risk-status",
           "text": "What is the risk status?",
+          "type": "QUESTION"
+        },
+        {
+          "add_another": true,
+          "conditions_operator": "ALL",
+          "data_options": {},
+          "form_id": "549c1676-f5a5-4bfe-9ee7-ca22f7c785fe",
+          "id": "5e7e9e11-08e8-422b-82a4-6a887b42f65d",
+          "name": "projects",
+          "order": 5,
+          "presentation_options": {
+            "add_another_summary_line_question_ids": [
+              "a7b14644-ba27-4f3b-8657-35d5f32ee5ca"
+            ],
+            "show_questions_on_the_same_page": true
+          },
+          "slug": "projects",
+          "text": "projects",
+          "type": "GROUP"
+        },
+        {
+          "add_another": false,
+          "conditions_operator": "ALL",
+          "data_options": {
+            "max_decimal_places": 2,
+            "number_type": "Decimal number"
+          },
+          "data_type": "A number",
+          "form_id": "549c1676-f5a5-4bfe-9ee7-ca22f7c785fe",
+          "hint": "",
+          "id": "62b4a7ca-868f-49cc-9c45-eb04dbfd10b0",
+          "name": "project q4 spend",
+          "order": 4,
+          "parent_id": "5e7e9e11-08e8-422b-82a4-6a887b42f65d",
+          "presentation_options": {
+            "prefix": "\u00a3",
+            "width": "govuk-input--width-10"
+          },
+          "slug": "what-is-your-projects-q4-spend",
+          "text": "What is your project's Q4 spend?",
           "type": "QUESTION"
         },
         {
@@ -2091,6 +2218,27 @@
         {
           "add_another": false,
           "conditions_operator": "ALL",
+          "data_options": {
+            "max_decimal_places": 2,
+            "number_type": "Decimal number"
+          },
+          "data_type": "A number",
+          "form_id": "549c1676-f5a5-4bfe-9ee7-ca22f7c785fe",
+          "hint": "",
+          "id": "8d6ff2ae-0476-4294-b41f-681e59142a69",
+          "name": "per project budget",
+          "order": 4,
+          "presentation_options": {
+            "prefix": "\u00a3",
+            "width": "govuk-input--width-10"
+          },
+          "slug": "what-is-your-maximum-budget-per-project",
+          "text": "What is your maximum budget per project?",
+          "type": "QUESTION"
+        },
+        {
+          "add_another": false,
+          "conditions_operator": "ALL",
           "data_options": {},
           "data_type": "Single line of text",
           "form_id": "cd5fc00f-13d0-4c89-af8c-9f16c5c77afe",
@@ -2207,6 +2355,22 @@
           },
           "slug": "when-did-the-last-reporting-period-start",
           "text": "When did the last reporting period start?",
+          "type": "QUESTION"
+        },
+        {
+          "add_another": false,
+          "conditions_operator": "ALL",
+          "data_options": {},
+          "data_type": "Single line of text",
+          "form_id": "549c1676-f5a5-4bfe-9ee7-ca22f7c785fe",
+          "hint": "",
+          "id": "a7b14644-ba27-4f3b-8657-35d5f32ee5ca",
+          "name": "project name",
+          "order": 0,
+          "parent_id": "5e7e9e11-08e8-422b-82a4-6a887b42f65d",
+          "presentation_options": {},
+          "slug": "what-is-the-project-name",
+          "text": "What is the project name?",
           "type": "QUESTION"
         },
         {
@@ -2348,6 +2512,28 @@
           },
           "slug": "what-kind-of-data-certifier-is-the-lead-contact",
           "text": "What kind of data certifier is the lead contact?",
+          "type": "QUESTION"
+        },
+        {
+          "add_another": false,
+          "conditions_operator": "ALL",
+          "data_options": {
+            "max_decimal_places": 2,
+            "number_type": "Decimal number"
+          },
+          "data_type": "A number",
+          "form_id": "549c1676-f5a5-4bfe-9ee7-ca22f7c785fe",
+          "hint": "",
+          "id": "bc31c9aa-7c57-45c5-a56f-a3820c0f4972",
+          "name": "project q1 spend",
+          "order": 1,
+          "parent_id": "5e7e9e11-08e8-422b-82a4-6a887b42f65d",
+          "presentation_options": {
+            "prefix": "\u00a3",
+            "width": "govuk-input--width-10"
+          },
+          "slug": "what-is-your-projects-q1-spend",
+          "text": "What is your project's Q1 spend?",
           "type": "QUESTION"
         },
         {

--- a/tests/unit/common/collections/test_validation.py
+++ b/tests/unit/common/collections/test_validation.py
@@ -3,8 +3,9 @@ import uuid
 import pytest
 
 from app.common.collections.validation import SubmissionValidator
-from app.common.data.types import ExpressionType, ManagedExpressionsEnum, QuestionDataType
+from app.common.data.types import ExpressionType, ManagedExpressionsEnum, QuestionDataType, QuestionPresentationOptions
 from app.common.exceptions import SubmissionValidationFailed
+from app.common.expressions.custom import CustomExpression
 from app.common.helpers.collections import SubmissionHelper
 
 
@@ -245,3 +246,98 @@ class TestSubmissionValidator:
         assert len(errors) == 1
         assert errors[0].question_id == q1.id
         assert errors[0].add_another_index == 1
+
+    def test_add_another_same_page_group_validation_caught(self, factories):
+        form = factories.form.build()
+        group = factories.group.build(
+            form=form,
+            id=uuid.uuid4(),
+            add_another=True,
+            order=0,
+            presentation_options=QuestionPresentationOptions(show_questions_on_the_same_page=True),
+        )
+        q1 = factories.question.build(
+            form=form, parent=group, id=uuid.uuid4(), data_type=QuestionDataType.NUMBER, order=0
+        )
+        q2 = factories.question.build(
+            form=form, parent=group, id=uuid.uuid4(), data_type=QuestionDataType.NUMBER, order=1
+        )
+
+        custom = CustomExpression(
+            custom_expression=f"(({q1.safe_qid})) + (({q2.safe_qid})) == 100",
+            custom_message="Total must be 100",
+        )
+        factories.expression.build(
+            question=group,
+            type_=ExpressionType.VALIDATION,
+            statement=custom.statement,
+            context=custom.model_dump(mode="json"),
+        )
+
+        submission = factories.submission.build(collection=form.collection)
+        submission.data = {
+            str(group.id): [
+                {str(q1.id): {"value": 60}, str(q2.id): {"value": 40}},
+                {str(q1.id): {"value": 30}, str(q2.id): {"value": 30}},
+            ]
+        }
+
+        helper = SubmissionHelper(submission)
+        validator = SubmissionValidator(helper)
+
+        with pytest.raises(SubmissionValidationFailed) as e:
+            validator.validate_all_reachable_questions()
+
+        errors = e.value.errors
+        assert len(errors) == 1
+        assert errors[0].question_id == group.id
+        assert errors[0].form_id == form.id
+        assert errors[0].error_message == "Total must be 100"
+
+    def test_add_another_nested_same_page_group_validation_caught(self, factories):
+        form = factories.form.build()
+        outer_group = factories.group.build(form=form, id=uuid.uuid4(), add_another=True, order=0)
+        inner_group = factories.group.build(
+            form=form,
+            parent=outer_group,
+            id=uuid.uuid4(),
+            order=0,
+            presentation_options=QuestionPresentationOptions(show_questions_on_the_same_page=True),
+        )
+        q1 = factories.question.build(
+            form=form, parent=inner_group, id=uuid.uuid4(), data_type=QuestionDataType.NUMBER, order=0
+        )
+        q2 = factories.question.build(
+            form=form, parent=inner_group, id=uuid.uuid4(), data_type=QuestionDataType.NUMBER, order=1
+        )
+
+        custom = CustomExpression(
+            custom_expression=f"(({q1.safe_qid})) + (({q2.safe_qid})) == 100",
+            custom_message="Total must be 100",
+        )
+        factories.expression.build(
+            question=inner_group,
+            type_=ExpressionType.VALIDATION,
+            statement=custom.statement,
+            context=custom.model_dump(mode="json"),
+        )
+
+        submission = factories.submission.build(collection=form.collection)
+        submission.data = {
+            str(outer_group.id): [
+                {str(q1.id): {"value": 60}, str(q2.id): {"value": 40}},
+                {str(q1.id): {"value": 30}, str(q2.id): {"value": 30}},
+            ]
+        }
+
+        helper = SubmissionHelper(submission)
+        validator = SubmissionValidator(helper)
+
+        with pytest.raises(SubmissionValidationFailed) as e:
+            validator.validate_all_reachable_questions()
+
+        errors = e.value.errors
+        assert len(errors) == 1
+        assert errors[0].question_id == inner_group.id
+        assert errors[0].form_id == form.id
+        assert errors[0].error_message == "Total must be 100"


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-1266

## 📝 Description
Enable final submission validation checks to re-validate add another groups that have group validation attached.

Add-another group validation already works at the point of data entry, but we also re-validate all data when trying to submit a report, and this would skip group validation on add-another groups. Now it doesn't.

This patch also updates the seeded calculations report to include an add-another group with validation.

## 📸 Show the thing (screenshots, gifs)

<img width="1005" height="1523" alt="image" src="https://github.com/user-attachments/assets/bd7c9500-de78-4e8b-8ddd-bdb5a2c42cfb" />

<img width="1007" height="1524" alt="image" src="https://github.com/user-attachments/assets/bd3d24aa-298a-4b71-abc8-c24c7690b4de" />

<img width="1012" height="1081" alt="image" src="https://github.com/user-attachments/assets/e7b424f3-4ef8-40f9-98ff-cbc86287ec20" />


## 🧪 Testing
<!-- Describe how you've tested this change, and how a reviewer can test it -->

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested