### PR TITLE
BAU: Fix field attachment for custom expression errors

### DIFF
--- a/app/common/expressions/forms.py
+++ b/app/common/expressions/forms.py
@@ -367,6 +367,10 @@ class CustomValidationExpressionForm(ExceptionRenderingFormMixin, FlaskForm):
                 validate_with_evaluation=True,
                 evaluation_context=self.evaluation_context,
             )
+        except WTFormRenderableException as e:
+            self.handle_exception(e, field_name="custom_expression")
+            return False
+        try:
             _validate_custom_syntax(
                 self.component,
                 self.interpolation_context,
@@ -375,7 +379,6 @@ class CustomValidationExpressionForm(ExceptionRenderingFormMixin, FlaskForm):
                 "custom_message",
                 validate_with_evaluation=False,
             )
-
         except WTFormRenderableException as e:
             self.handle_exception(e, field_name="custom_message")
             return False

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -9279,11 +9279,14 @@ class TestAddCustomQuestionValidation:
 
         assert response.status_code == 200
 
+        soup = BeautifulSoup(response.data, "html.parser")
+
         assert len(q3.expressions) == 0
         assert page_has_error(
-            BeautifulSoup(response.data, "html.parser"),
+            soup,
             "You cannot use Later question name because it comes after this question",
         )
+        assert soup.find("p", id="custom_expression-error") is not None
 
     def test_post_error_in_message(self, authenticated_platform_admin_client, factories, db_session):
         report = factories.collection.create(name="Test Report")
@@ -9321,10 +9324,13 @@ class TestAddCustomQuestionValidation:
         assert response.status_code == 200
 
         assert len(q3.expressions) == 0
+
+        soup = BeautifulSoup(response.data, "html.parser")
         assert page_has_error(
-            BeautifulSoup(response.data, "html.parser"),
+            soup,
             "You cannot use ((bad_reference)) because it does not exist",
         )
+        assert soup.find("p", id="custom_message-error") is not None
 
     def test_post_error_in_expression_and_message(self, authenticated_platform_admin_client, factories, db_session):
         report = factories.collection.create(name="Test Report")


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
When adding a custom expression (condition or validation), if there was an error in the custom expression field, the error message would incorrectly attach to the custom message field.

This fixes that little bug and makes sure the error is attached to the input to which it belongs.

## 📸 Show the thing (screenshots, gifs)

### Before
<img width="594" height="770" alt="image" src="https://github.com/user-attachments/assets/b849bf41-d0f1-4a00-a552-dd1d96ff4738" />

### After
<img width="543" height="766" alt="image" src="https://github.com/user-attachments/assets/7004c878-90b8-4c54-9953-04591efc7612" />

## 🧪 Testing
Chuck an error in a custom validation.

## 📋 Developer Checklist

### Review Readiness
- [X] PR title and description provide sufficient context for reviewers
- [X] Commits are logical, self-contained, and have clear descriptions

### Testing
- [X] I have tested this change and it meets the acceptance criteria for the ticket
- ~[ ] I need the reviewer(s) to pull and run this change locally~
- [X] New (non-developer) functionality has appropriate unit and integration tests
- ~[ ] End-to-end tests have been updated (if applicable)~
- [X] Edge cases and error conditions are tested