### PR TITLE
FSPT-1261 Feature flag pre-award features

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -51,6 +51,7 @@ from app.common.filters import (
     to_ordinal,
 )
 from app.common.helpers.collections import SubmissionAuthorisationError
+from app.common.helpers.feature_flags import FeatureFlags
 from app.common.utils import comma_join_items, uppercase_first
 from app.config import get_settings
 from app.constants import DATA_SET_EXTERNAL_ID_COLUMN_HEADER, DATA_SET_GRANT_RECIPIENT_COLUMN_HEADER
@@ -317,6 +318,7 @@ def create_app() -> Flask:  # noqa: C901
                 maximum_file_size_enum=MaximumFileSize,
                 data_source_type_enum=DataSourceType,
             ),
+            feature_flags=FeatureFlags,
         )
 
     # TODO: Remove our basic auth application code when the app is deployed behind CloudFront and the app is not

--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-052_other_org
+053_pre_award_flag

--- a/app/common/data/migrations/versions/053_pre_award_flag.py
+++ b/app/common/data/migrations/versions/053_pre_award_flag.py
@@ -1,0 +1,25 @@
+"""Pre award feature flag
+
+Revision ID: 053_pre_award_flag
+Revises: 052_other_org
+Create Date: 2026-04-10 12:27:20.333508
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "053_pre_award_flag"
+down_revision = "052_other_org"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("grant", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("allow_pre_award", sa.Boolean(), nullable=False, server_default=sa.false()))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("grant", schema=None) as batch_op:
+        batch_op.drop_column("allow_pre_award")

--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -76,6 +76,8 @@ class Grant(BaseModel):
     grant_recipients: Mapped[list[GrantRecipient]] = relationship("GrantRecipient", back_populates="grant")
     privacy_policy_markdown: Mapped[str | None]
 
+    allow_pre_award: Mapped[bool] = mapped_column(default=False)
+
     invitations: Mapped[list[Invitation]] = relationship(
         "Invitation",
         back_populates="grant",

--- a/app/common/helpers/feature_flags.py
+++ b/app/common/helpers/feature_flags.py
@@ -7,13 +7,20 @@ Feature flags can pull from:
 - environment variables through Flask config
 - contextual URL models like grant, organisation or grant recipient
 
-Usage:
-    from app.common.helpers.feature_flags import PRE_AWARD_FEATURES
+Usage in codebase:
+    from app.common.helpers.feature_flags import FeatureFlags
 
-    if PRE_AWARD_FEATURES.is_enabled:
+    if FeatureFlags.PRE_AWARD.is_enabled:
         ...
 
-    if bool(PRE_AWARD_FEATURES):
+    if bool(FeatureFlags.PRE_AWARD):
+        ...
+
+Usage in templates:
+    {% if feature_flags.PRE_AWARD.is_enabled %}
+        ...
+
+    {% if feature_flags.PRE_AWARD %}
         ...
 """
 
@@ -43,11 +50,12 @@ class FeatureFlag:
 def _check_grant_allows_pre_award() -> bool:
     grant_id = request.view_args.get("grant_id") if request.view_args else None
     if not grant_id:
-        raise ValueError("grant_id required in URL for PRE_AWARD_FEATURES feature flag")
+        raise ValueError("grant_id required in URL for PRE_AWARD feature flag")
     return get_grant(grant_id).allow_pre_award
 
 
-PRE_AWARD_FEATURES = FeatureFlag(
-    description="Grant supports pre-award features",
-    resolver=_check_grant_allows_pre_award,
-)
+class FeatureFlags:
+    PRE_AWARD = FeatureFlag(
+        description="Grant supports pre-award features",
+        resolver=_check_grant_allows_pre_award,
+    )

--- a/app/common/helpers/feature_flags.py
+++ b/app/common/helpers/feature_flags.py
@@ -1,0 +1,53 @@
+"""
+Simple centralised registry for feature flags.
+
+Flags should be added and removed from this registry as they are needed in the code base.
+
+Feature flags can pull from:
+- environment variables through Flask config
+- contextual URL models like grant, organisation or grant recipient
+
+Usage:
+    from app.common.helpers.feature_flags import PRE_AWARD_FEATURES
+
+    if PRE_AWARD_FEATURES.is_enabled:
+        ...
+
+    if bool(PRE_AWARD_FEATURES):
+        ...
+"""
+
+from collections.abc import Callable
+
+from flask import request
+
+from app.common.data.interfaces.grants import get_grant
+
+
+class FeatureFlag:
+    def __init__(self, description: str, resolver: Callable[[], bool]) -> None:
+        self.description = description
+        self._resolver = resolver
+
+    @property
+    def is_enabled(self) -> bool:
+        return self._resolver()
+
+    def __bool__(self) -> bool:
+        return self.is_enabled
+
+
+# Features registry
+
+
+def _check_grant_allows_pre_award() -> bool:
+    grant_id = request.view_args.get("grant_id") if request.view_args else None
+    if not grant_id:
+        raise ValueError("grant_id required in URL for PRE_AWARD_FEATURES feature flag")
+    return get_grant(grant_id).allow_pre_award
+
+
+PRE_AWARD_FEATURES = FeatureFlag(
+    description="Grant supports pre-award features",
+    resolver=_check_grant_allows_pre_award,
+)

--- a/app/deliver_grant_funding/admin/entities.py
+++ b/app/deliver_grant_funding/admin/entities.py
@@ -231,9 +231,21 @@ class PlatformAdminGrantView(FlaskAdminPlatformAdminAccessibleMixin, PlatformAdm
     column_list = ["name", "code", "status", "ggis_number", "organisation.name"]
     column_filters = ["name", "code", "status", "ggis_number", "organisation.name"]
     column_searchable_list = ["name", "code", "ggis_number"]
-    column_labels = {"ggis_number": "GGIS number", "organisation.name": "Organisation name"}
+    column_labels = {
+        "ggis_number": "GGIS number",
+        "organisation.name": "Organisation name",
+        "allow_pre_award": "Allow pre-award features",
+    }
 
-    form_columns = ["name", "code", "organisation", "ggis_number", "status", "privacy_policy_markdown"]
+    form_columns = [
+        "name",
+        "code",
+        "organisation",
+        "ggis_number",
+        "status",
+        "privacy_policy_markdown",
+        "allow_pre_award",
+    ]
 
     form_args = {
         "organisation": {

--- a/app/developers/data/grants.json
+++ b/app/developers/data/grants.json
@@ -1480,6 +1480,7 @@
         }
       ],
       "grant": {
+        "allow_pre_award": false,
         "code": "CIP",
         "description": "Funding to help local cheesemongers provide samples to park visitors, with the intention to increase the local community's satisfaction with the variety and quality of local cheeses.",
         "ggis_number": "GGIS-000000",
@@ -3720,6 +3721,7 @@
         }
       ],
       "grant": {
+        "allow_pre_award": false,
         "code": "CFA",
         "description": "Fill me in later",
         "ggis_number": "G2-SCH-2025-123456",

--- a/tests/unit/common/helpers/test_feature_flags.py
+++ b/tests/unit/common/helpers/test_feature_flags.py
@@ -1,0 +1,40 @@
+from unittest.mock import patch
+
+import pytest
+from flask import Flask
+
+from app.common.helpers.feature_flags import PRE_AWARD_FEATURES, FeatureFlag
+
+
+class TestFeatureFlag:
+    def test_resolver(self) -> None:
+        flag = FeatureFlag(description="Always on", resolver=lambda: True)
+        assert flag.is_enabled is True
+
+        flag = FeatureFlag(description="Always off", resolver=lambda: False)
+        assert flag.is_enabled is False
+
+    def test_bool(self) -> None:
+        assert bool(FeatureFlag(description="Always on", resolver=lambda: True)) is True
+        assert bool(FeatureFlag(description="Always off", resolver=lambda: False)) is False
+
+
+class TestPreAwardFeaturesFlag:
+    def test_enabled(self, app: Flask, factories) -> None:
+        grant = factories.grant.build(allow_pre_award=True)
+
+        with app.test_request_context(f"/deliver/grant/{grant.id}/reports"):
+            with patch("app.common.helpers.feature_flags.get_grant", return_value=grant):
+                assert PRE_AWARD_FEATURES.is_enabled is True
+
+    def test_disabled(self, app: Flask, factories) -> None:
+        grant = factories.grant.build(allow_pre_award=False)
+
+        with app.test_request_context(f"/deliver/grant/{grant.id}/reports"):
+            with patch("app.common.helpers.feature_flags.get_grant", return_value=grant):
+                assert PRE_AWARD_FEATURES.is_enabled is False
+
+    def test_raises(self, app: Flask) -> None:
+        with app.test_request_context("/"):
+            with pytest.raises(ValueError, match="grant_id required"):
+                assert PRE_AWARD_FEATURES.is_enabled

--- a/tests/unit/common/helpers/test_feature_flags.py
+++ b/tests/unit/common/helpers/test_feature_flags.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 import pytest
 from flask import Flask
 
-from app.common.helpers.feature_flags import PRE_AWARD_FEATURES, FeatureFlag
+from app.common.helpers.feature_flags import FeatureFlag, FeatureFlags
 
 
 class TestFeatureFlag:
@@ -25,16 +25,16 @@ class TestPreAwardFeaturesFlag:
 
         with app.test_request_context(f"/deliver/grant/{grant.id}/reports"):
             with patch("app.common.helpers.feature_flags.get_grant", return_value=grant):
-                assert PRE_AWARD_FEATURES.is_enabled is True
+                assert FeatureFlags.PRE_AWARD.is_enabled is True
 
     def test_disabled(self, app: Flask, factories) -> None:
         grant = factories.grant.build(allow_pre_award=False)
 
         with app.test_request_context(f"/deliver/grant/{grant.id}/reports"):
             with patch("app.common.helpers.feature_flags.get_grant", return_value=grant):
-                assert PRE_AWARD_FEATURES.is_enabled is False
+                assert FeatureFlags.PRE_AWARD.is_enabled is False
 
     def test_raises(self, app: Flask) -> None:
         with app.test_request_context("/"):
             with pytest.raises(ValueError, match="grant_id required"):
-                assert PRE_AWARD_FEATURES.is_enabled
+                assert FeatureFlags.PRE_AWARD.is_enabled


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-1261

## 📝 Description
Proposes a feature flag registry so that there is one place where our temporary feature flags live during development. This should let devs know where they can gate functionality and also make sure we've removed it from everywhere when we are finished.

Allows individual grants to specify if they should allow pre-award features or not which should allow us to test the features as we build them in different environments without interrupting exsiting users in Deliver.