### PR TITLE
Remove component self-references

### DIFF
--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -1057,9 +1057,13 @@ def raise_if_question_has_any_dependencies(question: Question | Group) -> Never 
     child_components_ids = [
         c.id for c in [question] + (question.cached_all_components if isinstance(question, Group) else [])
     ]
+    # Only consider references whose dependent component is *outside* the subtree being deleted.
+    # Internal references (e.g. a group validation that references its own child questions) will be
+    # cascaded away alongside the subtree, so they should not block deletion.
     component_reference = (
         db.session.query(ComponentReference)
         .where(ComponentReference.depends_on_component_id.in_(child_components_ids))
+        .where(ComponentReference.component_id.notin_(child_components_ids))
         .all()
     )
     if component_reference:

--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -1634,7 +1634,12 @@ def _validate_and_sync_expression_references(expression: Expression) -> None:  #
                 question_to_test=None,
             )
 
-        referenced_questions.add(expr_impl.referenced_question)  # ty:ignore[unresolved-attribute]
+        # For a managed validation attached to a question, expr_impl.referenced_question *is* the
+        # question the expression is attached to (the answer being validated). Don't record a
+        # self-reference — it would create a bogus ComponentReference row that falsely blocks
+        # deletion and same-page grouping.
+        if expr_impl.referenced_question != expression.question:  # ty:ignore[unresolved-attribute]
+            referenced_questions.add(expr_impl.referenced_question)  # ty:ignore[unresolved-attribute]
 
     for field in expr_impl.reference_aware_fields:
         field_value = getattr(expr_impl, field)
@@ -1661,6 +1666,8 @@ def _validate_and_sync_expression_references(expression: Expression) -> None:  #
             referenced_questions.add(referenced_question)
 
     for referenced_question in referenced_questions:
+        if referenced_question == expression.question:
+            continue
         cr = ComponentReference(
             component=expression.question,
             expression=expression,
@@ -1715,6 +1722,8 @@ def _validate_and_sync_component_references(component: Component, expression_con
             # TODO: Add data_source wrangling for creating component references
 
     for component_id, depends_on_component_id in references_to_set_up:
+        if component_id == depends_on_component_id:
+            continue
         db.session.add(ComponentReference(component_id=component_id, depends_on_component_id=depends_on_component_id))
 
 

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -3803,6 +3803,23 @@ class TestValidateAndSyncExpressionReferences:
         assert reference.expression == expression
         assert reference.depends_on_component == referenced_question
 
+    def test_managed_validation_referencing_only_itself_creates_no_references(self, db_session, factories):
+        user = factories.user.create()
+        question = factories.question.create(data_type=QuestionDataType.NUMBER)
+
+        expression = Expression.from_evaluatable_expression(
+            GreaterThan(question_id=question.id, minimum_value=0, inclusive=True),
+            ExpressionType.VALIDATION,
+            user,
+        )
+        question.expressions.append(expression)
+        db_session.add(expression)
+        db_session.flush()
+
+        _validate_and_sync_expression_references(expression)
+
+        assert expression.component_references == []
+
     def test_replaces_existing_component_references(self, db_session, factories):
         user = factories.user.create()
         referenced_question = factories.question.create(data_type=QuestionDataType.NUMBER)
@@ -3919,9 +3936,9 @@ class TestValidateAndSyncExpressionReferences:
             del form.cached_all_components
 
         _validate_and_sync_expression_references(expression)
-        assert len(expression.component_references) == 2
+        assert len(expression.component_references) == 1
         referenced_components = {ref.depends_on_component for ref in expression.component_references}
-        assert referenced_components == {target_question, first_referenced_question}
+        assert referenced_components == {first_referenced_question}
         assert all(ref.component == target_question for ref in expression.component_references)
 
     def test_raises_dependency_order_exception(self, db_session, factories):
@@ -4105,11 +4122,11 @@ class TestValidateAndSyncExpressionReferences:
 
         _validate_and_sync_expression_references(expression)
 
-        assert len(expression.component_references) == 4
+        assert len(expression.component_references) == 3
 
         assert all(ref.component == q3 for ref in expression.component_references)
         assert all(ref.expression == expression for ref in expression.component_references)
-        assert all(ref.depends_on_component in {q0, q1, q2, q3} for ref in expression.component_references)
+        assert all(ref.depends_on_component in {q0, q1, q2} for ref in expression.component_references)
 
     def test_creates_component_references_for_calculated_condition(self, db_session, factories):
         user = factories.user.create()
@@ -4916,4 +4933,4 @@ class TestAddComponentValidationCustomExpression:
 
         q3_from_db = get_question_by_id(q3.id)
         assert len(q3_from_db.expressions) == 1
-        assert len(q3_from_db.owned_component_references) == 3
+        assert len(q3_from_db.owned_component_references) == 2

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -2054,6 +2054,84 @@ class TestListGroupQuestions:
         soup = BeautifulSoup(response.data, "html.parser")
         assert "You cannot delete an answer that other questions depend on" in soup.text
 
+    def test_can_delete_group_with_only_internal_group_validation(
+        self, authenticated_grant_admin_client, factories, db_session
+    ):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant, name="Test Report")
+        db_form = factories.form.create(collection=report, title="Organisation information")
+        group = factories.group.create(
+            form=db_form,
+            name="Test group",
+            presentation_options=QuestionPresentationOptions(show_questions_on_the_same_page=True),
+        )
+        q1 = factories.question.create(form=db_form, parent=group, data_type=QuestionDataType.NUMBER)
+        q2 = factories.question.create(form=db_form, parent=group, data_type=QuestionDataType.NUMBER)
+        add_component_validation(
+            group,
+            factories.user.create(),
+            CustomExpression(
+                custom_expression=f"(({q1.safe_qid})) + (({q2.safe_qid})) > 100",
+                custom_message="Total must exceed 100",
+            ),
+        )
+        db_session.commit()
+        group_id = group.id
+
+        confirm_form = GenericConfirmDeletionForm(data={"confirm_deletion": True})
+        response = authenticated_grant_admin_client.post(
+            url_for(
+                "deliver_grant_funding.list_group_questions",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                group_id=group_id,
+                delete="",
+            ),
+            data=get_form_data(confirm_form),
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 302
+        assert db_session.get(Group, group_id) is None
+
+    def test_can_delete_outer_group_when_only_nested_group_has_internal_validation(
+        self, authenticated_grant_admin_client, factories, db_session
+    ):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant, name="Test Report")
+        db_form = factories.form.create(collection=report, title="Organisation information")
+        outer_group = factories.group.create(form=db_form, name="Outer group")
+        inner_group = factories.group.create(
+            form=db_form,
+            parent=outer_group,
+            name="Inner group",
+            presentation_options=QuestionPresentationOptions(show_questions_on_the_same_page=True),
+        )
+        q1 = factories.question.create(form=db_form, parent=inner_group, data_type=QuestionDataType.NUMBER)
+        q2 = factories.question.create(form=db_form, parent=inner_group, data_type=QuestionDataType.NUMBER)
+        add_component_validation(
+            inner_group,
+            factories.user.create(),
+            CustomExpression(
+                custom_expression=f"(({q1.safe_qid})) + (({q2.safe_qid})) > 100",
+                custom_message="Total must exceed 100",
+            ),
+        )
+        db_session.commit()
+        outer_group_id = outer_group.id
+
+        confirm_form = GenericConfirmDeletionForm(data={"confirm_deletion": True})
+        response = authenticated_grant_admin_client.post(
+            url_for(
+                "deliver_grant_funding.list_group_questions",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                group_id=outer_group_id,
+                delete="",
+            ),
+            data=get_form_data(confirm_form),
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 302
+        assert db_session.get(Group, outer_group_id) is None
+
 
 class TestListSectionQuestions:
     def test_404(self, authenticated_grant_member_client):

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -1390,6 +1390,39 @@ class TestChangeGroupDisplayOptions:
             soup, "A question group cannot display on the same page if questions depend on answers within the group"
         )
 
+    def test_post_change_same_page_allowed_with_only_self_referencing_validations(
+        self, authenticated_grant_admin_client, factories, db_session
+    ):
+        db_form = factories.form.create(
+            collection__grant=authenticated_grant_admin_client.grant, title="Organisation information"
+        )
+        db_group = factories.group.create(
+            form=db_form,
+            name="Test group",
+            presentation_options=QuestionPresentationOptions(show_questions_on_the_same_page=False),
+        )
+        q1 = factories.question.create(form=db_form, parent=db_group, data_type=QuestionDataType.NUMBER)
+        q2 = factories.question.create(form=db_form, parent=db_group, data_type=QuestionDataType.NUMBER)
+        user = factories.user.create()
+        add_component_validation(q1, user, GreaterThan(question_id=q1.id, minimum_value=0, inclusive=True))
+        add_component_validation(q2, user, GreaterThan(question_id=q2.id, minimum_value=0, inclusive=True))
+        db_session.commit()
+
+        form = GroupDisplayOptionsForm(data={"show_questions_on_the_same_page": "all-questions-on-same-page"})
+        response = authenticated_grant_admin_client.post(
+            url_for(
+                "deliver_grant_funding.change_group_display_options",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                group_id=db_group.id,
+            ),
+            data=get_form_data(form),
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 302
+        updated_group = db_session.get(Group, db_group.id)
+        assert updated_group.presentation_options.show_questions_on_the_same_page is True
+
     def test_post_change_same_page_with_internal_question_references(
         self, authenticated_grant_admin_client, factories, db_session
     ):
@@ -4042,6 +4075,40 @@ class TestEditQuestion:
         expected_q1_href = url_for("deliver_grant_funding.edit_question", grant_id=grant.id, question_id=q1.id)
         assert links[1]["href"] == expected_q1_href
         assert links[1].get_text(strip=True) == q1.text
+
+    def test_post_can_delete_question_with_only_self_referencing_managed_validation(
+        self, authenticated_grant_admin_client, factories, db_session
+    ):
+        grant = authenticated_grant_admin_client.grant
+        report = factories.collection.create(grant=grant, name="Test Report")
+        db_form = factories.form.create(collection=report, title="Organisation information")
+        question = factories.question.create(
+            form=db_form,
+            text="Self-validated number",
+            data_type=QuestionDataType.NUMBER,
+        )
+        add_component_validation(
+            question,
+            factories.user.create(),
+            GreaterThan(question_id=question.id, minimum_value=0, inclusive=True),
+        )
+        db_session.commit()
+        question_id = question.id
+
+        confirm_form = GenericConfirmDeletionForm(data={"confirm_deletion": True})
+        response = authenticated_grant_admin_client.post(
+            url_for(
+                "deliver_grant_funding.edit_question",
+                grant_id=grant.id,
+                question_id=question_id,
+                delete="",
+            ),
+            data=get_form_data(confirm_form),
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 302
+        assert db_session.get(Question, question_id) is None
 
     def test_restore_from_session_when_returning_from_add_session_flow(
         self, authenticated_grant_admin_client, factories
@@ -9655,7 +9722,7 @@ class TestEditCustomQuestionValidation:
 
         assert len(q3.expressions) == 1
         expression = q3.expressions[0]
-        assert len(expression.component_references) == 3
+        assert len(expression.component_references) == 2
 
     def test_post_error_in_expression_and_message(self, authenticated_platform_admin_client, factories, db_session):
         report = factories.collection.create(name="Test Report")


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
We've had a couple of form design friction points lately:

- Unable to delete a question that has validation on itself only (eg answer >= 0) - forced to delete the validation first.
- Can't delete a question group where the questions inside that group also contain only references to things inside the group - forced to clean all of those internal references first.


## 🧪 Testing
<!-- Describe how you've tested this change, and how a reviewer can test it -->

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [-] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested