### PR TITLE
Fspt 1147 data set referencing flow

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -38,6 +38,7 @@ from app.common.data.types import (
     TasklistSectionStatusEnum,
 )
 from app.common.exceptions import RedirectException
+from app.common.expressions.references import ExpressionReference
 from app.common.filters import (
     format_date,
     format_date_approximate,
@@ -162,7 +163,15 @@ def _register_custom_converters(app: Flask) -> None:
         def to_url(self, value: t.Any) -> str:
             return str(value).lower()
 
+    class ExpressionReferenceConverter(BaseConverter):
+        def to_python(self, value: str) -> ExpressionReference:
+            return ExpressionReference(value)
+
+        def to_url(self, value: str | ExpressionReference) -> str | ExpressionReference:
+            return value
+
     app.url_map.converters["submission_mode"] = SubmissionModeConverter
+    app.url_map.converters["expression_reference"] = ExpressionReferenceConverter
 
 
 def _setup_flask_admin(app: Flask, db_: SQLAlchemy) -> None:

--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -1706,9 +1706,10 @@ def _validate_and_sync_expression_references(expression: Expression) -> None:  #
             component_references.append(cr)
     elif expression.is_managed:
         if expression.type_ == ExpressionType.CONDITION:
+            assert expr_impl.subject_reference is not None
             # validate the referenced question - the one that is compared against the expression
             _validate_reference(
-                reference=ExpressionReference.from_question(expr_impl.referenced_question),  # ty:ignore[unresolved-attribute]
+                reference=expr_impl.subject_reference,
                 attached_to_component=expression.question,
                 expression_context=ExpressionContext.build_expression_context(
                     expression.question.form.collection, "interpolation", None, None
@@ -1718,12 +1719,18 @@ def _validate_and_sync_expression_references(expression: Expression) -> None:  #
                 question_to_test=None,
             )
 
-        # For a managed validation attached to a question, expr_impl.referenced_question *is* the
+        # For a managed validation attached to a question, expr_impl.subject_reference.question *is* the
         # question the expression is attached to (the answer being validated). Don't record a
         # self-reference — it would create a bogus ComponentReference row that falsely blocks
         # deletion and same-page grouping.
-        if expr_impl.referenced_question != expression.question:  # ty:ignore[unresolved-attribute]
-            referenced_questions.add(expr_impl.referenced_question)  # ty:ignore[unresolved-attribute]
+
+        referenced_question = expr_impl.subject_reference.question  # ty:ignore[unresolved-attribute]
+        referenced_data_set_ref = expr_impl.subject_reference.data_source_reference  # ty:ignore[unresolved-attribute]
+
+        if referenced_question and referenced_question != expression.question:
+            referenced_questions.add(referenced_question)
+        elif referenced_data_set_ref:
+            data_source_references.add(referenced_data_set_ref)
 
     for field in expr_impl.reference_aware_fields:
         field_value = getattr(expr_impl, field)
@@ -1745,7 +1752,7 @@ def _validate_and_sync_expression_references(expression: Expression) -> None:  #
                 ),
                 expression_type=expression.type_,
                 field_name_for_error_message=field,
-                question_to_test=expr_impl.referenced_question if expression.is_managed else None,  # ty:ignore[unresolved-attribute]
+                question_to_test=expr_impl.subject_reference.question if expression.is_managed else None,  # ty:ignore[unresolved-attribute]
             )
 
             if referenced_question := valid_reference.question:

--- a/app/common/expressions/__init__.py
+++ b/app/common/expressions/__init__.py
@@ -177,7 +177,7 @@ class ExpressionContext(ChainMap[str, Any]):
         SECTION = "A previous question in this section"
         PREVIOUS_SECTION = "A question in a previous section"
         PREVIOUS_COLLECTION = "A question in a previous collection"
-        DATASET = "An uploaded dataset"
+        DATASET = "An uploaded data set"
 
     def __init__(
         self,

--- a/app/common/expressions/forms.py
+++ b/app/common/expressions/forms.py
@@ -119,7 +119,7 @@ def build_managed_expression_form(
     """
     match type_:
         case ExpressionType.CONDITION:
-            type_validation_message = "Select what the answer should be to show this question"
+            type_validation_message = "Select what the value should be to show this question"
             managed_expressions = get_managed_conditions_by_data_type(subject_reference.data_type)
         case ExpressionType.VALIDATION:
             type_validation_message = "Select the kind of validation to apply"

--- a/app/common/expressions/references.py
+++ b/app/common/expressions/references.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from functools import cached_property
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
@@ -102,7 +103,7 @@ class ExpressionReference(str):
             return None
         return DataSourceReference(data_source_id, column_name)
 
-    @property
+    @cached_property
     def question(self) -> Question | None:
         from app.common.data.interfaces.collections import get_question_by_id
 
@@ -115,8 +116,24 @@ class ExpressionReference(str):
         except NoResultFound:
             return None
 
-    @property
+    @cached_property
     def data_source_column(self) -> DataSourceSchemaColumn | None:
+        ds_ref = self.data_source_reference
+        if not ds_ref:
+            return None
+
+        data_source = self.data_source
+        if not data_source:
+            return None
+
+        schema = data_source.schema
+        if not schema:
+            return None
+
+        return schema.root.get(ds_ref.column_name)
+
+    @cached_property
+    def data_source(self) -> DataSource | None:
         from app.common.data.interfaces.data_sets import get_data_source
 
         ds_ref = self.data_source_reference
@@ -131,11 +148,17 @@ class ExpressionReference(str):
         if not data_source:
             return None
 
-        schema = data_source.schema
-        if not schema:
-            return None
+        return data_source
 
-        return schema.root.get(ds_ref.column_name)
+    @property
+    def label(self) -> str:
+        if question := self.question:
+            return question.data_reference_label
+
+        if (column := self.data_source_column) and (data_source := self.data_source):
+            return f"{column.original_column_name} from {data_source.name} data set"
+
+        raise ValueError(f"Can't resolve ExpressionReference {self!r} to a specific label; unknown reference shape")
 
     @property
     def data_type(self) -> QuestionDataType:

--- a/app/deliver_grant_funding/forms.py
+++ b/app/deliver_grant_funding/forms.py
@@ -44,6 +44,7 @@ from app.common.data.types import (
     QuestionDataType,
 )
 from app.common.expressions import ExpressionContext
+from app.common.expressions.references import ExpressionReference
 from app.common.expressions.registry import get_registered_data_types
 from app.common.forms.fields import MHCLGAccessibleAutocomplete
 from app.common.forms.helpers import get_referenceable_questions
@@ -643,6 +644,7 @@ class SelectDataSourceQuestionForm(FlaskForm):
     question = SelectField(
         "Select which question's answer to use",
         choices=[],
+        coerce=ExpressionReference,
         validators=[DataRequired("Select the question")],
         widget=MHCLGAccessibleAutocomplete(),
     )
@@ -683,7 +685,8 @@ class SelectDataSourceQuestionForm(FlaskForm):
 
         if referenceable_questions:
             self.question.choices = [("", "")] + [
-                (str(question.id), interpolate(question.text)) for question in referenceable_questions
+                (ExpressionReference.from_question(question), interpolate(question.text))
+                for question in referenceable_questions
             ]
 
 

--- a/app/deliver_grant_funding/forms.py
+++ b/app/deliver_grant_funding/forms.py
@@ -54,7 +54,7 @@ from app.deliver_grant_funding.data_sets import CellError, DataTypeError, Decima
 from app.deliver_grant_funding.session_models import DataSetColumnMapping
 
 if TYPE_CHECKING:
-    from app.common.data.models import Component, Form, GrantRecipient, Group, Question
+    from app.common.data.models import Collection, Component, Form, GrantRecipient, Group, Question
     from app.deliver_grant_funding.session_models import AddContextToComponentSessionModel
 
 
@@ -684,6 +684,26 @@ class SelectDataSourceQuestionForm(FlaskForm):
             self.question.choices = [("", "")] + [
                 (str(question.id), interpolate(question.text)) for question in referenceable_questions
             ]
+
+
+class SelectDataSourceDataSetForm(FlaskForm):
+    data_set = RadioField(
+        "Select uploaded data set",
+        choices=[],
+        validators=[DataRequired("Select a data set")],
+        widget=GovRadioInput(),
+    )
+    submit = SubmitField(widget=GovSubmitInput())
+
+    def __init__(
+        self,
+        collection: Collection,
+        *args: Any,
+        **kwargs: Any,
+    ):
+        super().__init__(*args, **kwargs)
+
+        self.data_set.choices = [(d.id, cast(str, d.name)) for d in collection.data_sources]
 
 
 class GrantAddUserForm(FlaskForm):

--- a/app/deliver_grant_funding/forms.py
+++ b/app/deliver_grant_funding/forms.py
@@ -656,6 +656,7 @@ class SelectDataSourceQuestionForm(FlaskForm):
         form: Form,
         interpolate: Callable[[str], str],
         current_component: TOptional[Component],
+        subject_reference: TOptional[ExpressionReference],
         *args: Any,
         expression_type: TOptional[ExpressionType],
         managed_expression_name: TOptional[ManagedExpressionsEnum],
@@ -672,12 +673,23 @@ class SelectDataSourceQuestionForm(FlaskForm):
         if expression_type is not None:
             if managed_expression_name is None:
                 limit_to_data_types = {QuestionDataType.NUMBER}
-            elif current_component and current_component.data_type:
-                limit_to_data_types = {current_component.data_type}
+            else:
+                if subject_reference:
+                    limit_to_data_types = {subject_reference.data_type}
+                elif current_component and current_component.data_type:
+                    limit_to_data_types = {current_component.data_type}
+
+        limit_to_component = (
+            subject_reference.question
+            if subject_reference and subject_reference.question
+            else current_component
+            if current_component and current_component.form == form
+            else None
+        )
 
         referenceable_questions = get_referenceable_questions(
             form,
-            current_component if current_component and current_component.form == form else None,
+            limit_to_component,
             parent_component if parent_component and parent_component.form == form else None,
             limit_to_data_type=limit_to_data_types,
             include_this_component=self.include_this_component,

--- a/app/deliver_grant_funding/forms.py
+++ b/app/deliver_grant_funding/forms.py
@@ -49,12 +49,13 @@ from app.common.forms.fields import MHCLGAccessibleAutocomplete
 from app.common.forms.helpers import get_referenceable_questions
 from app.common.forms.validators import CommunitiesEmail, WordRange
 from app.common.helpers.feature_flags import FeatureFlags
+from app.common.utils import uppercase_first
 from app.constants import DATA_SET_IDENTIFIER_COLUMN_HEADERS
 from app.deliver_grant_funding.data_sets import CellError, DataTypeError, DecimalError, PrefixError, SuffixError
 from app.deliver_grant_funding.session_models import DataSetColumnMapping
 
 if TYPE_CHECKING:
-    from app.common.data.models import Collection, Component, Form, GrantRecipient, Group, Question
+    from app.common.data.models import Collection, Component, DataSource, Form, GrantRecipient, Group, Question
     from app.deliver_grant_funding.session_models import AddContextToComponentSessionModel
 
 
@@ -704,6 +705,32 @@ class SelectDataSourceDataSetForm(FlaskForm):
         super().__init__(*args, **kwargs)
 
         self.data_set.choices = [(d.id, cast(str, d.name)) for d in collection.data_sources]
+
+
+class SelectDataSourceDataSetColumnForm(FlaskForm):
+    column = RadioField(
+        choices=[],
+        validators=[DataRequired("Select a column")],
+        widget=GovRadioInput(),
+    )
+    submit = SubmitField(widget=GovSubmitInput())
+
+    def __init__(
+        self,
+        data_set: DataSource,
+        *args: Any,
+        **kwargs: Any,
+    ):
+        super().__init__(*args, **kwargs)
+
+        assert data_set.schema is not None
+
+        self.column.label.text = f"Select column in {data_set.name} data set"
+
+        self.column.choices = [
+            (safe_column_id, uppercase_first(column_schema.original_column_name) or "")
+            for safe_column_id, column_schema in data_set.schema.root.items()
+        ]
 
 
 class GrantAddUserForm(FlaskForm):

--- a/app/deliver_grant_funding/routes/reports.py
+++ b/app/deliver_grant_funding/routes/reports.py
@@ -1562,7 +1562,15 @@ def select_context_source_data_set_column(grant_id: UUID, form_id: UUID, data_se
 
         match add_context_data:
             case AddConditionDependsOnSessionModel():
-                raise NotImplementedError("need to handle using data set references in conditions")
+                del session["question"]
+                return redirect(
+                    url_for(
+                        "deliver_grant_funding.add_question_condition",
+                        grant_id=grant_id,
+                        component_id=add_context_data.component_id,
+                        subject_reference=reference,
+                    )
+                )
 
             case AddContextToComponentSessionModel():
                 return_url = (

--- a/app/deliver_grant_funding/routes/reports.py
+++ b/app/deliver_grant_funding/routes/reports.py
@@ -1728,19 +1728,14 @@ def select_context_source_question(grant_id: UUID, form_id: UUID) -> ResponseRet
     assert add_context_data.form_id
     target_form = get_form_by_id(add_context_data.form_id)
 
-    # TODO: Add depends_on_question_id as a nullable attribute to all session models to simplify this check?
-    current_component = (
-        subject_reference.question
-        if (subject_reference := getattr(add_context_data, "subject_reference", None))
-        else get_component_by_id(add_context_data.component_id)
-        if add_context_data.component_id
-        else None
-    )
+    subject_reference = getattr(add_context_data, "subject_reference", None)
+    current_component = get_component_by_id(add_context_data.component_id) if add_context_data.component_id else None
 
     wtform = SelectDataSourceQuestionForm(
         form=target_form,
         interpolate=SubmissionHelper.get_interpolator(collection=db_form.collection),
         current_component=current_component,
+        subject_reference=subject_reference,
         parent_component=get_group_by_id(add_context_data.parent_id) if add_context_data.parent_id else None,
         expression_type=add_context_data.field if isinstance(add_context_data, AddContextToExpressionsModel) else None,
         managed_expression_name=add_context_data.managed_expression_name

--- a/app/deliver_grant_funding/routes/reports.py
+++ b/app/deliver_grant_funding/routes/reports.py
@@ -127,6 +127,7 @@ from app.deliver_grant_funding.forms import (
     QuestionForm,
     QuestionTypeForm,
     SelectConditionCalculationForm,
+    SelectDataSourceDataSetColumnForm,
     SelectDataSourceDataSetForm,
     SelectDataSourceQuestionForm,
     SelectDataSourceSectionForm,
@@ -1396,13 +1397,14 @@ def select_context_source(grant_id: UUID, form_id: UUID) -> ResponseReturnValue:
         parent_component=get_group_by_id(add_context_data.parent_id) if add_context_data.parent_id else None,
         include_this_component=add_context_data.include_current_component_when_referencing_data(this_component),
     )
+    question = cast("Question", this_component)
     if wtform.validate_on_submit():
         if wtform.data_source.data == "THIS_QUESTION":
             redirect_response = redirect(
-                _determine_return_url_and_update_session_after_choosing_referenced_question_for_expression(
+                _determine_return_url_and_update_session_after_choosing_reference_for_expression(
                     grant_id,
                     add_context_data,  # ty:ignore[invalid-argument-type]
-                    cast("Question", this_component),
+                    ExpressionReference.from_question(question),
                 )
             )
         else:
@@ -1514,7 +1516,7 @@ def select_context_source_data_set(grant_id: UUID, form_id: UUID) -> ResponseRet
     if not add_context_data:
         return abort(400)
 
-    wtform = SelectDataSourceDataSetForm(collection=db_form.collection)
+    wtform = SelectDataSourceDataSetForm(collection=db_form.collection, data=request.args)
 
     if wtform.validate_on_submit():
         reference_data_set = get_data_source(uuid.UUID(wtform.data_set.data))
@@ -1543,18 +1545,90 @@ def select_context_source_data_set(grant_id: UUID, form_id: UUID) -> ResponseRet
 @has_deliver_grant_role(RoleEnum.ADMIN)
 @collection_is_editable()
 def select_context_source_data_set_column(grant_id: UUID, form_id: UUID, data_set_id: UUID) -> ResponseReturnValue:
-    return abort(404)
+    db_form = get_form_by_id(form_id)
+    data_set = get_data_source(data_set_id)
+
+    if data_set.collection_id != db_form.collection_id:
+        return abort(404)
+
+    add_context_data = _extract_add_context_data_from_session()
+    if not add_context_data:
+        return abort(400)
+
+    wtform = SelectDataSourceDataSetColumnForm(data_set=data_set)
+
+    if wtform.validate_on_submit():
+        safe_column_id = wtform.column.data
+        reference = ExpressionReference.from_data_source_column(data_set, safe_column_id)
+
+        match add_context_data:
+            case AddConditionDependsOnSessionModel():
+                raise NotImplementedError("need to handle using data set references in conditions")
+
+            case AddContextToComponentSessionModel():
+                return_url = (
+                    url_for(
+                        "deliver_grant_funding.add_question",
+                        grant_id=grant_id,
+                        form_id=form_id,
+                        parent_id=add_context_data.parent_id,
+                        question_data_type=add_context_data.data_type.name,
+                    )
+                    if add_context_data.component_id is None
+                    else url_for(
+                        "deliver_grant_funding.edit_question",
+                        grant_id=grant_id,
+                        question_id=add_context_data.component_id,
+                    )
+                )
+
+                if add_context_data and isinstance(add_context_data, AddContextToComponentSessionModel):
+                    target_field = add_context_data.component_form_data["add_context"]
+                    add_context_data.component_form_data[target_field] += f" {reference.wrapped}"
+
+            case AddContextToComponentGuidanceSessionModel():
+                return_url = (
+                    url_for(
+                        "deliver_grant_funding.manage_guidance",
+                        grant_id=grant_id,
+                        question_id=add_context_data.component_id,
+                    )
+                    if add_context_data.is_add_another_guidance is False
+                    else url_for(
+                        "deliver_grant_funding.manage_add_another_guidance",
+                        grant_id=grant_id,
+                        group_id=add_context_data.component_id,
+                    )
+                )
+                if add_context_data and isinstance(add_context_data, AddContextToComponentGuidanceSessionModel):
+                    target_field = add_context_data.component_form_data["add_context"]
+                    add_context_data.component_form_data[target_field] += f" {reference.wrapped}"
+
+            case AddContextToExpressionsModel():
+                return_url = _determine_return_url_and_update_session_after_choosing_reference_for_expression(
+                    grant_id, add_context_data, reference
+                )
+
+        session["question"] = add_context_data.model_dump(mode="json")
+        return redirect(return_url)
+
+    return render_template(
+        "deliver_grant_funding/reports/select_context_source_data_set_column.html",
+        grant=db_form.collection.grant,
+        form=wtform,
+        db_form=db_form,
+        data_set=data_set,
+        add_context_data=add_context_data,
+    )
 
 
-def _determine_return_url_and_update_session_after_choosing_referenced_question_for_expression(
-    grant_id: UUID, add_context_data: AddContextToExpressionsModel, referenced_question: Question
+def _determine_return_url_and_update_session_after_choosing_reference_for_expression(
+    grant_id: UUID, add_context_data: AddContextToExpressionsModel, reference: ExpressionReference
 ) -> str:
-    # TODO[FSPT-1284]: use `expression.managed.subject_reference` instead?
     if add_context_data and isinstance(add_context_data, AddContextToExpressionsModel):
         target_field = add_context_data.expression_form_data["add_context"]
-        reference = ExpressionReference.from_question(referenced_question)
         if add_context_data.managed_expression_name is None:
-            add_context_data.expression_form_data[target_field] += reference.wrapped
+            add_context_data.expression_form_data[target_field] += f" {reference.wrapped}"
         else:
             add_context_data.expression_form_data[target_field] = reference.wrapped
 
@@ -1670,19 +1744,19 @@ def select_context_source_question(grant_id: UUID, form_id: UUID) -> ResponseRet
 
     if wtform.validate_on_submit():
         referenced_question = get_question_by_id(UUID(wtform.question.data))
-
-        if isinstance(add_context_data, AddConditionDependsOnSessionModel):
-            del session["question"]
-            return redirect(
-                url_for(
-                    "deliver_grant_funding.add_question_condition",
-                    grant_id=grant_id,
-                    component_id=add_context_data.component_id,
-                    depends_on_question_id=referenced_question.id,
-                )
-            )
+        reference = ExpressionReference.from_question(referenced_question)
 
         match add_context_data:
+            case AddConditionDependsOnSessionModel():
+                del session["question"]
+                return redirect(
+                    url_for(
+                        "deliver_grant_funding.add_question_condition",
+                        grant_id=grant_id,
+                        component_id=add_context_data.component_id,
+                        depends_on_question_id=referenced_question.id,
+                    )
+                )
             case AddContextToComponentSessionModel():
                 return_url = (
                     url_for(
@@ -1702,7 +1776,7 @@ def select_context_source_question(grant_id: UUID, form_id: UUID) -> ResponseRet
 
                 if add_context_data and isinstance(add_context_data, AddContextToComponentSessionModel):
                     target_field = add_context_data.component_form_data["add_context"]
-                    reference = ExpressionReference.from_question(referenced_question)
+                    reference = reference
                     add_context_data.component_form_data[target_field] += " " + reference.wrapped
 
             case AddContextToComponentGuidanceSessionModel():
@@ -1721,12 +1795,12 @@ def select_context_source_question(grant_id: UUID, form_id: UUID) -> ResponseRet
                 )
                 if add_context_data and isinstance(add_context_data, AddContextToComponentGuidanceSessionModel):
                     target_field = add_context_data.component_form_data["add_context"]
-                    reference = ExpressionReference.from_question(referenced_question)
+                    reference = reference
                     add_context_data.component_form_data[target_field] += " " + reference.wrapped
 
             case AddContextToExpressionsModel():
-                return_url = _determine_return_url_and_update_session_after_choosing_referenced_question_for_expression(
-                    grant_id, add_context_data, referenced_question
+                return_url = _determine_return_url_and_update_session_after_choosing_reference_for_expression(
+                    grant_id, add_context_data, reference
                 )
 
         session["question"] = add_context_data.model_dump(mode="json")

--- a/app/deliver_grant_funding/routes/reports.py
+++ b/app/deliver_grant_funding/routes/reports.py
@@ -1210,7 +1210,7 @@ def _store_question_state_and_redirect_to_add_context(
     expression_type: ExpressionType | None = None,
     managed_expression_name: ManagedExpressionsEnum | None = None,
     expression_id: UUID | None = None,
-    depends_on_question_id: UUID | None = None,
+    subject_reference: ExpressionReference | None = None,
     is_add_another_guidance: bool | None = False,
     is_custom: bool | None = False,
     is_group: bool = False,
@@ -1241,7 +1241,7 @@ def _store_question_state_and_redirect_to_add_context(
                 component_id=component_id,  # type: ignore[arg-type]
                 parent_id=parent_id,
                 expression_id=expression_id,
-                depends_on_question_id=depends_on_question_id,
+                subject_reference=subject_reference,
                 is_custom=is_custom or False,
                 is_group=is_group,
             )
@@ -1260,7 +1260,7 @@ def _handle_remove_context_for_expression_forms(
     expression_type: ExpressionType,
     expression: Expression | None = None,
     add_context_data: AddContextToExpressionsModel | None = None,
-    depends_on_question_id: UUID | None = None,
+    subject_reference: ExpressionReference | None = None,
 ) -> None:
     field_to_clear = form.remove_context.data  # ty: ignore[unresolved-attribute]
     if not field_to_clear:
@@ -1279,7 +1279,7 @@ def _handle_remove_context_for_expression_forms(
             expression_form_data=form_data,
             component_id=component_id,
             expression_id=expression.id,
-            depends_on_question_id=depends_on_question_id,
+            subject_reference=subject_reference,
         )
     else:
         add_context_data.expression_form_data.update(form_data)
@@ -1482,8 +1482,7 @@ def select_context_source_section(grant_id: UUID, form_id: UUID) -> ResponseRetu
 
     assert add_context_data.collection_id
 
-    # We don't look at `depends_on_question_id` here - we want to show all sections before the section that the source
-    # component is in
+    # We want to show all sections before the section that the source component is in
     current_component = get_component_by_id(add_context_data.component_id) if add_context_data.component_id else None
 
     wtform = SelectDataSourceSectionForm(current_form=current_component.form if current_component else db_form)
@@ -1645,7 +1644,7 @@ def _determine_return_url_and_update_session_after_choosing_reference_for_expres
                     "deliver_grant_funding.add_question_condition",
                     grant_id=grant_id,
                     component_id=add_context_data.component_id,
-                    depends_on_question_id=add_context_data.depends_on_question_id,
+                    subject_reference=add_context_data.subject_reference,
                 )
         else:
             if add_context_data.managed_expression_name is None:
@@ -1723,8 +1722,8 @@ def select_context_source_question(grant_id: UUID, form_id: UUID) -> ResponseRet
 
     # TODO: Add depends_on_question_id as a nullable attribute to all session models to simplify this check?
     current_component = (
-        get_component_by_id(add_context_data.depends_on_question_id)  # type: ignore[union-attr, arg-type]
-        if getattr(add_context_data, "depends_on_question_id", None)
+        subject_reference.question
+        if (subject_reference := getattr(add_context_data, "subject_reference", None))
         else get_component_by_id(add_context_data.component_id)
         if add_context_data.component_id
         else None
@@ -1743,8 +1742,9 @@ def select_context_source_question(grant_id: UUID, form_id: UUID) -> ResponseRet
     )
 
     if wtform.validate_on_submit():
-        referenced_question = get_question_by_id(UUID(wtform.question.data))
-        reference = ExpressionReference.from_question(referenced_question)
+        reference = wtform.question.data
+        if not reference.question and not reference.data_source_column:
+            abort(400)
 
         match add_context_data:
             case AddConditionDependsOnSessionModel():
@@ -1754,7 +1754,7 @@ def select_context_source_question(grant_id: UUID, form_id: UUID) -> ResponseRet
                         "deliver_grant_funding.add_question_condition",
                         grant_id=grant_id,
                         component_id=add_context_data.component_id,
-                        depends_on_question_id=referenced_question.id,
+                        subject_reference=reference,
                     )
                 )
             case AddContextToComponentSessionModel():
@@ -1776,7 +1776,6 @@ def select_context_source_question(grant_id: UUID, form_id: UUID) -> ResponseRet
 
                 if add_context_data and isinstance(add_context_data, AddContextToComponentSessionModel):
                     target_field = add_context_data.component_form_data["add_context"]
-                    reference = reference
                     add_context_data.component_form_data[target_field] += " " + reference.wrapped
 
             case AddContextToComponentGuidanceSessionModel():
@@ -1795,7 +1794,6 @@ def select_context_source_question(grant_id: UUID, form_id: UUID) -> ResponseRet
                 )
                 if add_context_data and isinstance(add_context_data, AddContextToComponentGuidanceSessionModel):
                     target_field = add_context_data.component_form_data["add_context"]
-                    reference = reference
                     add_context_data.component_form_data[target_field] += " " + reference.wrapped
 
             case AddContextToExpressionsModel():
@@ -2372,25 +2370,22 @@ def add_question_condition_select_question(grant_id: UUID, component_id: UUID) -
 
 
 @deliver_grant_funding_blueprint.route(
-    "/grant/<uuid:grant_id>/question/<uuid:component_id>/add-condition/<uuid:depends_on_question_id>",
+    "/grant/<uuid:grant_id>/question/<uuid:component_id>/add-condition/<expression_reference:subject_reference>",
     methods=["GET", "POST"],
 )
 @has_deliver_grant_role(RoleEnum.ADMIN)
 @collection_is_editable()
 @auto_commit_after_request
-def add_question_condition(grant_id: UUID, component_id: UUID, depends_on_question_id: UUID) -> ResponseReturnValue:
+def add_question_condition(
+    grant_id: UUID, component_id: UUID, subject_reference: ExpressionReference
+) -> ResponseReturnValue:
     component = get_component_by_id(component_id)
-    depends_on_question = get_question_by_id(depends_on_question_id)
 
     add_context_data = _extract_add_context_data_from_session(
         session_model=AddContextToExpressionsModel, component_id=component_id
     )
 
-    # TODO[FSPT-1284]: we should refactor the URL here to pass the expression reference rather than build it from
-    #                  `depends_on_question_id`
-    ConditionForm = build_managed_expression_form(
-        ExpressionType.CONDITION, ExpressionReference.from_question(depends_on_question)
-    )
+    ConditionForm = build_managed_expression_form(ExpressionType.CONDITION, subject_reference)
     form = (
         ConditionForm(data=add_context_data._prepared_form_data if add_context_data else None)  # type: ignore[union-attr]
         if ConditionForm
@@ -2408,7 +2403,7 @@ def add_question_condition(grant_id: UUID, component_id: UUID, depends_on_questi
             form_data=form_data,
             expression_type=ExpressionType.CONDITION,
             managed_expression_name=ManagedExpressionsEnum(form.type.data),
-            depends_on_question_id=depends_on_question_id,
+            subject_reference=subject_reference,
         )
 
     if form and form.is_submitted_to_remove_context():
@@ -2417,12 +2412,12 @@ def add_question_condition(grant_id: UUID, component_id: UUID, depends_on_questi
             component_id=component.id,
             expression_type=ExpressionType.CONDITION,
             add_context_data=add_context_data,  # type: ignore[arg-type]
-            depends_on_question_id=depends_on_question_id,
+            subject_reference=subject_reference,
         )
         return redirect(request.url)
 
     if form and form.validate_on_submit():
-        expression = form.get_expression(ExpressionReference.from_question(depends_on_question))
+        expression = form.get_expression(subject_reference)
 
         try:
             interfaces.collections.add_component_condition(component, interfaces.user.get_current_user(), expression)
@@ -2457,7 +2452,7 @@ def add_question_condition(grant_id: UUID, component_id: UUID, depends_on_questi
     return render_template(
         "deliver_grant_funding/reports/manage_question_condition_select_condition_type.html",
         component=component,
-        depends_on_question=depends_on_question,
+        subject_reference=subject_reference,
         grant=component.form.collection.grant,
         form=form,
         QuestionDataType=QuestionDataType,
@@ -2475,8 +2470,7 @@ def add_question_condition(grant_id: UUID, component_id: UUID, depends_on_questi
 def edit_question_condition(grant_id: UUID, expression_id: UUID) -> ResponseReturnValue:
     expression = get_expression_by_id(expression_id)
     component = expression.question
-    # TODO[FSPT-1284]: use `expression.managed.subject_reference` instead?
-    depends_on_question = expression.managed.referenced_question
+    reference = expression.managed.subject_reference
 
     return_url = (
         url_for("deliver_grant_funding.edit_question", grant_id=grant_id, question_id=component.id)
@@ -2497,9 +2491,7 @@ def edit_question_condition(grant_id: UUID, expression_id: UUID) -> ResponseRetu
         session_model=AddContextToExpressionsModel, component_id=component.id, expression_id=expression_id
     )
 
-    ConditionForm = build_managed_expression_form(
-        ExpressionType.CONDITION, ExpressionReference.from_question(depends_on_question), expression
-    )
+    ConditionForm = build_managed_expression_form(ExpressionType.CONDITION, reference, expression)
     form = (
         ConditionForm(data=add_context_data._prepared_form_data if add_context_data else None)  # type: ignore[union-attr]
         if ConditionForm
@@ -2517,7 +2509,7 @@ def edit_question_condition(grant_id: UUID, expression_id: UUID) -> ResponseRetu
             form_data=form_data,
             expression_type=ExpressionType.CONDITION,
             managed_expression_name=ManagedExpressionsEnum(form.type.data),
-            depends_on_question_id=depends_on_question.id,
+            subject_reference=reference,
             expression_id=expression_id,
         )
 
@@ -2528,12 +2520,12 @@ def edit_question_condition(grant_id: UUID, expression_id: UUID) -> ResponseRetu
             expression_type=ExpressionType.CONDITION,
             expression=expression,
             add_context_data=add_context_data,  # type: ignore[arg-type]
-            depends_on_question_id=depends_on_question.id,
+            subject_reference=reference,
         )
         return redirect(request.url)
 
     if form and form.validate_on_submit():
-        updated_managed_expression = form.get_expression(ExpressionReference.from_question(depends_on_question))
+        updated_managed_expression = form.get_expression(reference)
 
         try:
             interfaces.collections.update_question_expression(expression, updated_managed_expression)
@@ -2559,7 +2551,7 @@ def edit_question_condition(grant_id: UUID, expression_id: UUID) -> ResponseRetu
         confirm_deletion_form=confirm_deletion_form if "delete" in request.args else None,
         expression=expression,
         QuestionDataType=QuestionDataType,
-        depends_on_question=depends_on_question,
+        subject_reference=reference,
         interpolate=SubmissionHelper.get_interpolator(component.form.collection),
     )
 

--- a/app/deliver_grant_funding/routes/reports.py
+++ b/app/deliver_grant_funding/routes/reports.py
@@ -127,6 +127,7 @@ from app.deliver_grant_funding.forms import (
     QuestionForm,
     QuestionTypeForm,
     SelectConditionCalculationForm,
+    SelectDataSourceDataSetForm,
     SelectDataSourceQuestionForm,
     SelectDataSourceSectionForm,
     SetUpReportForm,
@@ -1433,6 +1434,13 @@ def select_context_source(grant_id: UUID, form_id: UUID) -> ResponseReturnValue:
                         )
                     )
 
+                case ExpressionContext.ContextSources.DATASET:
+                    redirect_response = redirect(
+                        url_for(
+                            "deliver_grant_funding.select_context_source_data_set", grant_id=grant_id, form_id=form_id
+                        )
+                    )
+
                 case _:
                     wtform.form_errors.append("Unknown data source selected")
 
@@ -1492,6 +1500,50 @@ def select_context_source_section(grant_id: UUID, form_id: UUID) -> ResponseRetu
         form=wtform,
         add_context_data=add_context_data,
     )
+
+
+@deliver_grant_funding_blueprint.route(
+    "/grant/<uuid:grant_id>/section/<uuid:form_id>/add-context/select-data-set", methods=["GET", "POST"]
+)
+@has_deliver_grant_role(RoleEnum.ADMIN)
+@collection_is_editable()
+def select_context_source_data_set(grant_id: UUID, form_id: UUID) -> ResponseReturnValue:
+    db_form = get_form_by_id(form_id)
+
+    add_context_data = _extract_add_context_data_from_session()
+    if not add_context_data:
+        return abort(400)
+
+    wtform = SelectDataSourceDataSetForm(collection=db_form.collection)
+
+    if wtform.validate_on_submit():
+        reference_data_set = get_data_source(uuid.UUID(wtform.data_set.data))
+        return redirect(
+            url_for(
+                "deliver_grant_funding.select_context_source_data_set_column",
+                grant_id=grant_id,
+                form_id=form_id,
+                data_set_id=reference_data_set.id,
+            )
+        )
+
+    return render_template(
+        "deliver_grant_funding/reports/select_context_source_data_set.html",
+        grant=db_form.collection.grant,
+        form=wtform,
+        db_form=db_form,
+        add_context_data=add_context_data,
+    )
+
+
+@deliver_grant_funding_blueprint.route(
+    "/grant/<uuid:grant_id>/section/<uuid:form_id>/add-context/data-set/<uuid:data_set_id>/select-column",
+    methods=["GET", "POST"],
+)
+@has_deliver_grant_role(RoleEnum.ADMIN)
+@collection_is_editable()
+def select_context_source_data_set_column(grant_id: UUID, form_id: UUID, data_set_id: UUID) -> ResponseReturnValue:
+    return abort(404)
 
 
 def _determine_return_url_and_update_session_after_choosing_referenced_question_for_expression(

--- a/app/deliver_grant_funding/session_models.py
+++ b/app/deliver_grant_funding/session_models.py
@@ -12,6 +12,7 @@ from app.common.data.types import (
     TUnvalidatedDataSetRows,
 )
 from app.common.expressions import ExpressionContext
+from app.common.expressions.references import ExpressionReference
 
 if TYPE_CHECKING:
     from app.common.data.models import Component
@@ -103,8 +104,9 @@ class AddContextToExpressionsModel(_ReferenceDataSessionModel):
     form_id: UUID | None = None
 
     data_source: ExpressionContext.ContextSources | None = None
-    depends_on_question_id: UUID | None = None
     expression_id: UUID | None = None
+
+    subject_reference: ExpressionReference | None = None
 
     is_custom: bool = False
     is_group: bool = False

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/macros/select_context_source_return_url.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/macros/select_context_source_return_url.html
@@ -18,7 +18,7 @@
       {% if add_context_data.is_custom == true %}
         {% set return_url = url_for("deliver_grant_funding.add_calculated_condition", grant_id=grant.id, component_id=add_context_data.component_id) %}
       {% else %}
-        {% set return_url = url_for("deliver_grant_funding.add_question_condition",grant_id=grant.id, component_id=add_context_data.component_id, depends_on_question_id=add_context_data.depends_on_question_id) %}
+        {% set return_url = url_for("deliver_grant_funding.add_question_condition",grant_id=grant.id, component_id=add_context_data.component_id, subject_reference=add_context_data.subject_reference) %}
       {% endif %}
     {% else %}
       {% if add_context_data.is_custom == true %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/partials/_explicit-conditions.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/partials/_explicit-conditions.html
@@ -1,12 +1,12 @@
 {% for condition in component.conditions %}
   {% if condition.is_managed %}
     {% set managed = condition.managed %}
-    {% set depends_on = managed.referenced_question %}
+    {% set depends_on = managed.subject_reference %}
 
 
     {% set key_html %}
       {# todo: would users find it useful to be able to link to the question being depended on from here? #}
-      <span>{{ depends_on.data_reference_label }}</span>
+      <span>{{ depends_on.label }}</span>
     {% endset %}
 
 

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/_add_question_condition_context.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/_add_question_condition_context.html
@@ -1,6 +1,6 @@
 {% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
 
-{% if not depends_on_question %}
+{% if not subject_reference %}
   {% set depends_on_html %}
     <form method="post" novalidate>
       {{ form.csrf_token }}
@@ -17,7 +17,7 @@
       "value": { "text": interpolate(component.text) },
     }, {
       "key": { "text": "Depends on" },
-      "value": { "html": depends_on_html } if not depends_on_question else { "text": interpolate(depends_on_question.text, with_interpolation_highlighting=True) },
+      "value": { "html": depends_on_html } if not subject_reference else { "text": interpolate(subject_reference.question.text if subject_reference.question else subject_reference.label, with_interpolation_highlighting=True) },
     }],
     "classes": "app-!-border-top-line govuk-!-margin-bottom-8"
   })

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/_add_question_condition_context.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/_add_question_condition_context.html
@@ -16,7 +16,7 @@
       "key": { "text": "The question" if not component.is_group else "The question group" },
       "value": { "text": interpolate(component.text) },
     }, {
-      "key": { "text": "Depends on the answer to" },
+      "key": { "text": "Depends on" },
       "value": { "html": depends_on_html } if not depends_on_question else { "text": interpolate(depends_on_question.text, with_interpolation_highlighting=True) },
     }],
     "classes": "app-!-border-top-line govuk-!-margin-bottom-8"

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/change_conditions_operator.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/change_conditions_operator.html
@@ -31,11 +31,11 @@
       {% for condition in component.conditions %}
         {% if condition.is_managed %}
           {% set managed = condition.managed %}
-          {% set depends_on = managed.referenced_question %}
+          {% set depends_on = managed.subject_reference.question.text if managed.subject_reference.question else managed.subject_reference.label %}
 
 
           {% set key_html %}
-            <span>{{ interpolate(depends_on.text, with_interpolation_highlighting=True) }}</span>
+            <span>{{ interpolate(depends_on, with_interpolation_highlighting=True) }}</span>
           {% endset %}
 
 

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/manage_question_condition_select_condition_type.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/manage_question_condition_select_condition_type.html
@@ -47,7 +47,7 @@
 
       {% if form is not none %}
         {% set label_html %}
-          What does the answer <span class="govuk-visually-hidden">to {{ interpolate(depends_on_question.text) }}</span> need to be?
+          What does the value <span class="govuk-visually-hidden">to {{ interpolate(depends_on_question.text) }}</span> need to be?
         {% endset %}
         {{ render_managed_expression_form(form, label_html=label_html, submit_label=submit_label) }}
       {% else %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/manage_question_condition_select_condition_type.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/manage_question_condition_select_condition_type.html
@@ -47,7 +47,7 @@
 
       {% if form is not none %}
         {% set label_html %}
-          What does the value <span class="govuk-visually-hidden">to {{ interpolate(depends_on_question.text) }}</span> need to be?
+          What does the value <span class="govuk-visually-hidden">to {{ interpolate(subject_reference.question.text if subject_reference.question else subject_reference.label) }}</span> need to be?
         {% endset %}
         {{ render_managed_expression_form(form, label_html=label_html, submit_label=submit_label) }}
       {% else %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/select_context_source_data_set.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/select_context_source_data_set.html
@@ -1,0 +1,50 @@
+{% extends "deliver_grant_funding/grant_base.html" %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% from "deliver_grant_funding/macros/select_context_source_header_caption.html" import context_source_heading_caption %}
+{% from "deliver_grant_funding/macros/select_context_source_return_url.html" import context_source_return_url %}
+
+{% set page_title = "Select uploaded data set - " ~ db_form.title %}
+{% set active_item_identifier = "reports" %}
+
+{# FIXME: handle back link generation in the view #}
+{% set back_url = url_for("deliver_grant_funding.select_context_source", grant_id=grant.id, form_id=db_form.id) %}
+
+{# Set heading caption and cancel button to for what initiated the `add data` flow #}
+{% set heading_caption = context_source_heading_caption(add_context_data) %}
+{% set cancel_url = context_source_return_url(add_context_data, grant, db_form, enum) %}
+
+{% block beforeContent %}
+  {{
+    govukBackLink({
+        "text": "Back",
+        "href": back_url
+    })
+  }}
+{% endblock beforeContent %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if form.data_set.choices | length > 0 %}
+        <span class="govuk-caption-l">Question {{ heading_caption }}</span>
+
+        <form method="post" novalidate>
+          {{ form.csrf_token }}
+          {{ form.data_set(params={"fieldset": {"legend": {"text": form.data_set.label.text, "isPageHeading": true, "classes": "govuk-fieldset__legend--l"} } }) }}
+
+          <span class="govuk-button-group">
+            {{ form.submit(params={"text": "Select data set"}) }}
+
+            <a class="govuk-link govuk-link--no-visited-state" href="{{ cancel_url }}">Cancel</a>
+          </span>
+        </form>
+      {% else %}
+        <h1 class="govuk-heading-l">
+          <span class="govuk-caption-l">Question {{ heading_caption }}</span>
+          {{ form.data_set.label.text }}
+        </h1>
+        <p class="govuk-body">There are no data sets to reference in this collection.</p>
+      {% endif %}
+    </div>
+  </div>
+{% endblock content %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/select_context_source_data_set_column.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/select_context_source_data_set_column.html
@@ -1,0 +1,42 @@
+{% extends "deliver_grant_funding/grant_base.html" %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% from "deliver_grant_funding/macros/select_context_source_header_caption.html" import context_source_heading_caption %}
+{% from "deliver_grant_funding/macros/select_context_source_return_url.html" import context_source_return_url %}
+
+{% set page_title = "Select column in " ~ data_set.name ~ " data set - " ~ db_form.title %}
+{% set active_item_identifier = "reports" %}
+
+{# FIXME: handle back link generation in the view #}
+{% set back_url = url_for("deliver_grant_funding.select_context_source_data_set", grant_id=grant.id, form_id=db_form.id, data_set=data_set.id) %}
+
+{# Set heading caption and cancel button to for what initiated the `add data` flow #}
+{% set heading_caption = context_source_heading_caption(add_context_data) %}
+{% set cancel_url = context_source_return_url(add_context_data, grant, db_form, enum) %}
+
+{% block beforeContent %}
+  {{
+    govukBackLink({
+        "text": "Back",
+        "href": back_url
+    })
+  }}
+{% endblock beforeContent %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l">Question {{ heading_caption }}</span>
+
+      <form method="post" novalidate>
+        {{ form.csrf_token }}
+        {{ form.column(params={"fieldset": {"legend": {"text": form.column.label.text, "isPageHeading": true, "classes": "govuk-fieldset__legend--l"} } }) }}
+
+        <span class="govuk-button-group">
+          {{ form.submit(params={"text": "Select column"}) }}
+
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ cancel_url }}">Cancel</a>
+        </span>
+      </form>
+    </div>
+  </div>
+{% endblock content %}

--- a/tests/integration/common/expressions/test_references.py
+++ b/tests/integration/common/expressions/test_references.py
@@ -30,6 +30,19 @@ class TestExpressionReference:
             reference = ExpressionReference(f"d_{uuid4().hex}.c_col")
             assert reference.question is None
 
+        def test_question_only_queries_db_on_first_access(self, factories, track_sql_queries):
+            q = factories.question.create()
+            reference = ExpressionReference(q.safe_qid)
+
+            _ = reference.question
+
+            with track_sql_queries() as queries:
+                _ = reference.question
+                _ = reference.question.text
+                _ = reference.question.data_type
+
+            assert queries == []
+
     class TestDataSourceColumn:
         def test_data_source_exists(self, factories):
             collection = factories.collection.create()
@@ -57,6 +70,37 @@ class TestExpressionReference:
         def test_data_source_is_none_for_non_data_source_reference(self):
             reference = ExpressionReference(f"q_{uuid4().hex}")
             assert reference.data_source_column is None
+
+        def test_data_source_column_only_queries_db_on_first_access(self, factories, track_sql_queries):
+            collection = factories.collection.create()
+            data_source = factories.data_source.create(
+                grant=collection.grant,
+                collection=collection,
+                type=DataSourceType.GRANT_RECIPIENT,
+                items=None,
+                schema=DataSourceSchema.model_validate(
+                    {
+                        "c_allocation": DataSourceSchemaColumn(
+                            data_type=QuestionDataType.NUMBER,
+                            presentation_options=QuestionPresentationOptions(prefix="£"),
+                            data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                            original_column_name="Allocation",
+                        ),
+                    }
+                ),
+            )
+            reference = ExpressionReference(f"{data_source.safe_did}.c_allocation")
+
+            # warm the cache (first access)
+            _ = reference.data_source_column
+
+            # subsequent accesses should not fire additional queries
+            with track_sql_queries() as queries:
+                _ = reference.data_source_column
+                _ = reference.data_source_column.data_type
+                _ = reference.data_source_column.original_column_name
+
+            assert queries == []
 
     class TestGetDataType:
         def test_raises_none_for_question_reference_to_missing_question(self):
@@ -129,3 +173,92 @@ class TestExpressionReference:
 
             with pytest.raises(ValueError):
                 _ = reference.data_type
+
+    class TestGetDataSource:
+        def test_data_source_exists(self, factories):
+            collection = factories.collection.create()
+            allocation_column = DataSourceSchemaColumn(
+                data_type=QuestionDataType.NUMBER,
+                presentation_options=QuestionPresentationOptions(prefix="£"),
+                data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                original_column_name="Allocation",
+            )
+            data_source = factories.data_source.create(
+                grant=collection.grant,
+                collection=collection,
+                type=DataSourceType.GRANT_RECIPIENT,
+                items=None,
+                schema=DataSourceSchema.model_validate({"c_allocation": allocation_column}),
+            )
+
+            reference = ExpressionReference(f"{data_source.safe_did}.c_allocation")
+            assert reference.data_source == data_source
+
+        def test_data_source_does_not_exist(self):
+            reference = ExpressionReference(f"d_{uuid4().hex}.c_col")
+            assert reference.data_source is None
+
+        def test_data_source_is_none_for_non_data_source_reference(self):
+            reference = ExpressionReference(f"q_{uuid4().hex}")
+            assert reference.data_source is None
+
+        def test_data_source_only_queries_db_on_first_access(self, factories, track_sql_queries):
+            collection = factories.collection.create()
+            data_source = factories.data_source.create(
+                grant=collection.grant,
+                collection=collection,
+                type=DataSourceType.GRANT_RECIPIENT,
+                items=None,
+                schema=DataSourceSchema.model_validate(
+                    {
+                        "c_allocation": DataSourceSchemaColumn(
+                            data_type=QuestionDataType.NUMBER,
+                            presentation_options=QuestionPresentationOptions(prefix="£"),
+                            data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                            original_column_name="Allocation",
+                        ),
+                    }
+                ),
+            )
+            reference = ExpressionReference(f"{data_source.safe_did}.c_allocation")
+
+            _ = reference.data_source
+
+            with track_sql_queries() as queries:
+                _ = reference.data_source
+                _ = reference.data_source.name
+                _ = reference.data_source.type
+
+            assert queries == []
+
+    class TestLabel:
+        def test_question_label(self, factories):
+            q = factories.question.create()
+
+            reference = ExpressionReference(q.safe_qid)
+            assert reference.label == q.data_reference_label
+
+        def test_data_source_label(self, factories):
+            collection = factories.collection.create()
+            allocation_column = DataSourceSchemaColumn(
+                data_type=QuestionDataType.NUMBER,
+                presentation_options=QuestionPresentationOptions(prefix="£"),
+                data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                original_column_name="Allocation",
+            )
+            data_source = factories.data_source.create(
+                grant=collection.grant,
+                collection=collection,
+                type=DataSourceType.GRANT_RECIPIENT,
+                items=None,
+                schema=DataSourceSchema.model_validate({"c_allocation": allocation_column}),
+            )
+
+            reference = ExpressionReference(f"{data_source.safe_did}.c_allocation")
+            assert reference.label == f"{allocation_column.original_column_name} from {data_source.name} data set"
+
+        def test_invalid_reference_error(self):
+            reference = ExpressionReference("something_else")
+
+            with pytest.raises(ValueError):
+                _ = reference.label

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -3736,6 +3736,219 @@ class TestSelectContextSourceQuestion:
                 )
 
 
+class TestSelectContextSourceDataSet:
+    @pytest.mark.parametrize(
+        "client_fixture, can_access",
+        (
+            ("authenticated_grant_member_client", False),
+            ("authenticated_grant_admin_client", True),
+        ),
+    )
+    def test_get(self, request, client_fixture, can_access, factories, db_session):
+        client = request.getfixturevalue(client_fixture)
+        report = factories.collection.create(grant=client.grant)
+        form = factories.form.create(collection=report)
+
+        with client.session_transaction() as sess:
+            sess["question"] = AddContextToComponentSessionModel(
+                data_type=QuestionDataType.TEXT_SINGLE_LINE,
+                component_form_data={
+                    "text": "Test question text",
+                    "name": "Test question name",
+                    "hint": "Test question hint",
+                    "add_context": "text",
+                },
+            ).model_dump(mode="json")
+
+        response = client.get(
+            url_for(
+                "deliver_grant_funding.select_context_source_data_set",
+                grant_id=client.grant.id,
+                form_id=form.id,
+            )
+        )
+
+        if not can_access:
+            assert response.status_code == 403
+        else:
+            assert response.status_code == 200
+
+    def test_get_fails_with_empty_session(self, authenticated_grant_admin_client, factories):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant)
+        form = factories.form.create(collection=report)
+
+        response = authenticated_grant_admin_client.get(
+            url_for(
+                "deliver_grant_funding.select_context_source_data_set",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                form_id=form.id,
+            )
+        )
+        assert response.status_code == 400
+
+    def test_get_shows_available_data_set_choices(self, authenticated_grant_admin_client, factories):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant)
+        report_2 = factories.collection.create(grant=authenticated_grant_admin_client.grant)
+        form = factories.form.create(collection=report)
+
+        data_source = factories.data_source.create(
+            grant=authenticated_grant_admin_client.grant,
+            collection=report,
+            name="Test data set",
+            type=DataSourceType.GRANT_RECIPIENT,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_capital_allocation": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Capital Allocation",
+                    )
+                }
+            ),
+        )
+
+        data_source_2 = factories.data_source.create(
+            grant=authenticated_grant_admin_client.grant,
+            collection=report,
+            name="Second data set",
+            type=DataSourceType.GRANT_RECIPIENT,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_capital_allocation": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Capital Allocation",
+                    )
+                }
+            ),
+        )
+
+        data_source_3 = factories.data_source.create(
+            grant=authenticated_grant_admin_client.grant,
+            collection=report_2,
+            name="Data set that shouldn't be shown",
+            type=DataSourceType.GRANT_RECIPIENT,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_capital_allocation": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Capital Allocation",
+                    )
+                }
+            ),
+        )
+
+        with authenticated_grant_admin_client.session_transaction() as sess:
+            sess["question"] = AddContextToComponentSessionModel(
+                data_type=QuestionDataType.TEXT_SINGLE_LINE,
+                component_form_data={
+                    "text": "Test question text",
+                    "name": "Test question name",
+                    "hint": "Test question hint",
+                    "add_context": "text",
+                },
+            ).model_dump(mode="json")
+
+        response = authenticated_grant_admin_client.get(
+            url_for(
+                "deliver_grant_funding.select_context_source_data_set",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                form_id=form.id,
+            )
+        )
+        assert response.status_code == 200
+
+        soup = BeautifulSoup(response.data, "html.parser")
+        assert "Select uploaded data set" in soup.text
+        assert data_source.name in soup.text
+        assert data_source_2.name in soup.text
+        assert data_source_3.name not in soup.text
+
+    def test_get_shows_text_when_no_data_sets(self, authenticated_grant_admin_client, factories):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant)
+        form = factories.form.create(collection=report)
+
+        with authenticated_grant_admin_client.session_transaction() as sess:
+            sess["question"] = AddContextToComponentSessionModel(
+                data_type=QuestionDataType.TEXT_SINGLE_LINE,
+                component_form_data={
+                    "text": "Test question text",
+                    "name": "Test question name",
+                    "hint": "Test question hint",
+                    "add_context": "text",
+                },
+            ).model_dump(mode="json")
+
+        response = authenticated_grant_admin_client.get(
+            url_for(
+                "deliver_grant_funding.select_context_source_data_set",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                form_id=form.id,
+            )
+        )
+        assert response.status_code == 200
+
+        soup = BeautifulSoup(response.data, "html.parser")
+        assert "Select uploaded data set" in soup.text
+        assert "There are no data sets to reference in this collection" in soup.text
+
+    def test_post_redirects_to_select_data_set_column_and_updates_session(
+        self, authenticated_grant_admin_client, factories
+    ):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant)
+        form = factories.form.create(collection=report)
+        data_source = factories.data_source.create(
+            grant=authenticated_grant_admin_client.grant,
+            collection=report,
+            name="Test data set",
+            type=DataSourceType.GRANT_RECIPIENT,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_capital_allocation": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Capital Allocation",
+                    )
+                }
+            ),
+        )
+
+        with authenticated_grant_admin_client.session_transaction() as sess:
+            sess["question"] = AddContextToComponentSessionModel(
+                data_type=QuestionDataType.TEXT_SINGLE_LINE,
+                component_form_data={
+                    "text": "Test question text",
+                    "name": "Test question name",
+                    "hint": "Test question hint",
+                    "add_context": "text",
+                },
+            ).model_dump(mode="json")
+
+        response = authenticated_grant_admin_client.post(
+            url_for(
+                "deliver_grant_funding.select_context_source_data_set",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                form_id=form.id,
+            ),
+            data={"data_set": data_source.id},
+            follow_redirects=False,
+        )
+        assert response.status_code == 302
+        assert response.location == (
+            f"/deliver/grant/{authenticated_grant_admin_client.grant.id}/section/"
+            f"{form.id}/add-context/data-set/{data_source.id}/select-column"
+        )
+
+        with authenticated_grant_admin_client.session_transaction() as sess:
+            question_data = sess.get("question")
+            assert question_data is not None
+
+
 class TestEditQuestion:
     def test_404(self, authenticated_grant_admin_client):
         response = authenticated_grant_admin_client.get(

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -5909,7 +5909,7 @@ class TestEditQuestionCondition:
             assert "The question" in soup.text
             assert "What is your email?" in soup.text
 
-            assert "Depends on the answer to" in soup.text
+            assert "Depends on" in soup.text
             assert "Do you like cheese?" in soup.text
 
             yes_radio = soup.find("input", {"type": "radio", "value": "Yes"})

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -73,7 +73,7 @@ from app.deliver_grant_funding.forms import (
     SetUpReportForm,
 )
 from app.deliver_grant_funding.routes.reports import (
-    _determine_return_url_and_update_session_after_choosing_referenced_question_for_expression,
+    _determine_return_url_and_update_session_after_choosing_reference_for_expression,
 )
 from app.deliver_grant_funding.session_models import (
     AddConditionDependsOnSessionModel,
@@ -3947,6 +3947,573 @@ class TestSelectContextSourceDataSet:
         with authenticated_grant_admin_client.session_transaction() as sess:
             question_data = sess.get("question")
             assert question_data is not None
+
+
+class TestSelectContextSourceDataSetColumn:
+    @pytest.mark.parametrize(
+        "client_fixture, can_access",
+        (
+            ("authenticated_grant_member_client", False),
+            ("authenticated_grant_admin_client", True),
+        ),
+    )
+    def test_get(self, request, client_fixture, can_access, factories, db_session):
+        client = request.getfixturevalue(client_fixture)
+        report = factories.collection.create(grant=client.grant)
+        form = factories.form.create(collection=report)
+        data_set = factories.data_source.create(
+            grant=client.grant,
+            collection=report,
+            name="Test data set",
+            type=DataSourceType.GRANT_RECIPIENT,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_capital_allocation": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Capital Allocation",
+                    )
+                }
+            ),
+        )
+
+        with client.session_transaction() as sess:
+            sess["question"] = AddContextToComponentSessionModel(
+                data_type=QuestionDataType.TEXT_SINGLE_LINE,
+                component_form_data={
+                    "text": "Test question text",
+                    "name": "Test question name",
+                    "hint": "Test question hint",
+                    "add_context": "text",
+                },
+            ).model_dump(mode="json")
+
+        response = client.get(
+            url_for(
+                "deliver_grant_funding.select_context_source_data_set_column",
+                grant_id=client.grant.id,
+                form_id=form.id,
+                data_set_id=data_set.id,
+            )
+        )
+
+        if not can_access:
+            assert response.status_code == 403
+        else:
+            assert response.status_code == 200
+
+    def test_get_404_if_other_collection_data_set(self, authenticated_grant_admin_client, factories):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant)
+        form = factories.form.create(collection=report)
+
+        report_2 = factories.collection.create(grant=authenticated_grant_admin_client.grant)
+        data_set_2 = factories.data_source.create(
+            grant=authenticated_grant_admin_client.grant,
+            collection=report_2,
+            name="Different collection data set",
+            type=DataSourceType.GRANT_RECIPIENT,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_capital_allocation": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Capital Allocation",
+                    )
+                }
+            ),
+        )
+
+        with authenticated_grant_admin_client.session_transaction() as sess:
+            sess["question"] = AddContextToComponentSessionModel(
+                data_type=QuestionDataType.TEXT_SINGLE_LINE,
+                component_form_data={
+                    "text": "Test question text",
+                    "name": "Test question name",
+                    "hint": "Test question hint",
+                    "add_context": "text",
+                },
+            ).model_dump(mode="json")
+
+        response = authenticated_grant_admin_client.get(
+            url_for(
+                "deliver_grant_funding.select_context_source_data_set_column",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                form_id=form.id,
+                data_set_id=data_set_2.id,
+            )
+        )
+        assert response.status_code == 404
+
+    def test_get_fails_with_empty_session(self, authenticated_grant_admin_client, factories):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant)
+        form = factories.form.create(collection=report)
+        data_set = factories.data_source.create(
+            grant=authenticated_grant_admin_client.grant,
+            collection=report,
+            name="Test data set",
+            type=DataSourceType.GRANT_RECIPIENT,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_capital_allocation": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Capital Allocation",
+                    )
+                }
+            ),
+        )
+
+        response = authenticated_grant_admin_client.get(
+            url_for(
+                "deliver_grant_funding.select_context_source_data_set_column",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                form_id=form.id,
+                data_set_id=data_set.id,
+            )
+        )
+        assert response.status_code == 400
+
+    def test_get_shows_available_data_set_columns(self, authenticated_grant_admin_client, factories):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant)
+        form = factories.form.create(collection=report)
+        data_set = factories.data_source.create(
+            grant=authenticated_grant_admin_client.grant,
+            collection=report,
+            name="Test data set",
+            type=DataSourceType.GRANT_RECIPIENT,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_capital_allocation": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Capital Allocation",
+                    ),
+                    "c_revenue_allocation": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Revenue Allocation",
+                    ),
+                    "c_description": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.TEXT_SINGLE_LINE,
+                        presentation_options=QuestionPresentationOptions(),
+                        data_options=QuestionDataOptions(),
+                        original_column_name="Description",
+                    ),
+                }
+            ),
+        )
+
+        with authenticated_grant_admin_client.session_transaction() as sess:
+            sess["question"] = AddContextToComponentSessionModel(
+                data_type=QuestionDataType.TEXT_SINGLE_LINE,
+                component_form_data={
+                    "text": "Test question text",
+                    "name": "Test question name",
+                    "hint": "Test question hint",
+                    "add_context": "text",
+                },
+            ).model_dump(mode="json")
+
+        response = authenticated_grant_admin_client.get(
+            url_for(
+                "deliver_grant_funding.select_context_source_data_set_column",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                form_id=form.id,
+                data_set_id=data_set.id,
+            )
+        )
+        assert response.status_code == 200
+
+        soup = BeautifulSoup(response.data, "html.parser")
+        assert f"Select column in {data_set.name} data set" in soup.text
+        assert "Capital Allocation" in soup.text
+        assert "Revenue Allocation" in soup.text
+        assert "Description" in soup.text
+
+    def test_post_with_component_session_model_new_question_redirects_and_updates_session(
+        self, authenticated_grant_admin_client, factories
+    ):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant)
+        form = factories.form.create(collection=report)
+        data_set = factories.data_source.create(
+            grant=authenticated_grant_admin_client.grant,
+            collection=report,
+            name="Test data set",
+            type=DataSourceType.GRANT_RECIPIENT,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_capital_allocation": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Capital Allocation",
+                    )
+                }
+            ),
+        )
+
+        with authenticated_grant_admin_client.session_transaction() as sess:
+            sess["question"] = AddContextToComponentSessionModel(
+                data_type=QuestionDataType.TEXT_SINGLE_LINE,
+                component_form_data={
+                    "text": "Test question text",
+                    "name": "Test question name",
+                    "hint": "Test question hint",
+                    "add_context": "text",
+                },
+            ).model_dump(mode="json")
+
+        response = authenticated_grant_admin_client.post(
+            url_for(
+                "deliver_grant_funding.select_context_source_data_set_column",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                form_id=form.id,
+                data_set_id=data_set.id,
+            ),
+            data={"column": next(iter(data_set.schema.root))},
+            follow_redirects=False,
+        )
+        assert response.status_code == 302
+        assert response.location == (
+            f"/deliver/grant/{authenticated_grant_admin_client.grant.id}/section/"
+            f"{form.id}/questions/add?question_data_type=TEXT_SINGLE_LINE"
+        )
+        with authenticated_grant_admin_client.session_transaction() as sess:
+            question_data = sess.get("question")
+            assert question_data is not None
+            expected_reference = ExpressionReference.from_data_source_column(data_set, "c_capital_allocation")
+            assert question_data["component_form_data"]["text"] == f"Test question text {expected_reference.wrapped}"
+
+    def test_post_with_component_session_model_existing_question_redirects_and_updates_session(
+        self, authenticated_grant_admin_client, factories
+    ):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant)
+        form = factories.form.create(collection=report)
+        question = factories.question.create(form=form)
+        data_set = factories.data_source.create(
+            grant=authenticated_grant_admin_client.grant,
+            collection=report,
+            name="Test data set",
+            type=DataSourceType.GRANT_RECIPIENT,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_capital_allocation": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Capital Allocation",
+                    )
+                }
+            ),
+        )
+
+        with authenticated_grant_admin_client.session_transaction() as sess:
+            sess["question"] = AddContextToComponentSessionModel(
+                data_type=QuestionDataType.TEXT_SINGLE_LINE,
+                component_form_data={
+                    "text": "Test question text",
+                    "name": "Test question name",
+                    "hint": "Test question hint",
+                    "add_context": "text",
+                },
+                component_id=question.id,
+            ).model_dump(mode="json")
+
+        response = authenticated_grant_admin_client.post(
+            url_for(
+                "deliver_grant_funding.select_context_source_data_set_column",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                form_id=form.id,
+                data_set_id=data_set.id,
+            ),
+            data={"column": next(iter(data_set.schema.root))},
+            follow_redirects=False,
+        )
+        assert response.status_code == 302
+        assert response.location == (
+            f"/deliver/grant/{authenticated_grant_admin_client.grant.id}/question/{question.id}"
+        )
+        with authenticated_grant_admin_client.session_transaction() as sess:
+            question_data = sess.get("question")
+            assert question_data is not None
+            expected_reference = ExpressionReference.from_data_source_column(data_set, "c_capital_allocation")
+            assert question_data["component_form_data"]["text"] == f"Test question text {expected_reference.wrapped}"
+
+    def test_post_with_guidance_session_model_redirects_and_updates_session(
+        self, authenticated_grant_admin_client, factories
+    ):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant)
+        form = factories.form.create(collection=report)
+        question = factories.question.create(form=form)
+        data_set = factories.data_source.create(
+            grant=authenticated_grant_admin_client.grant,
+            collection=report,
+            name="Test data set",
+            type=DataSourceType.GRANT_RECIPIENT,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_capital_allocation": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Capital Allocation",
+                    )
+                }
+            ),
+        )
+
+        with authenticated_grant_admin_client.session_transaction() as sess:
+            sess["question"] = AddContextToComponentGuidanceSessionModel(
+                component_form_data={
+                    "add_context": "guidance_body",
+                    "guidance_body": "Some guidance text",
+                    "guidance_heading": "Guidance header",
+                    "preview": False,
+                },
+                component_id=question.id,
+                is_add_another_guidance=False,
+            ).model_dump(mode="json")
+
+        response = authenticated_grant_admin_client.post(
+            url_for(
+                "deliver_grant_funding.select_context_source_data_set_column",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                form_id=form.id,
+                data_set_id=data_set.id,
+            ),
+            data={"column": next(iter(data_set.schema.root))},
+            follow_redirects=False,
+        )
+        assert response.status_code == 302
+        assert response.location == (
+            f"/deliver/grant/{authenticated_grant_admin_client.grant.id}/question/{question.id}/guidance"
+        )
+        with authenticated_grant_admin_client.session_transaction() as sess:
+            question_data = sess.get("question")
+            assert question_data is not None
+            expected_reference = ExpressionReference.from_data_source_column(data_set, "c_capital_allocation")
+            assert (
+                question_data["component_form_data"]["guidance_body"]
+                == f"Some guidance text {expected_reference.wrapped}"
+            )
+
+    def test_post_with_expressions_session_model_redirects_and_updates_session(
+        self, authenticated_grant_admin_client, factories
+    ):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant)
+        form = factories.form.create(collection=report)
+        question = factories.question.create(form=form)
+        data_set = factories.data_source.create(
+            grant=authenticated_grant_admin_client.grant,
+            collection=report,
+            name="Test data set",
+            type=DataSourceType.GRANT_RECIPIENT,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_capital_allocation": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Capital Allocation",
+                    )
+                }
+            ),
+        )
+
+        with authenticated_grant_admin_client.session_transaction() as sess:
+            sess["question"] = AddContextToExpressionsModel(
+                field=ExpressionType.VALIDATION,
+                managed_expression_name=ManagedExpressionsEnum.GREATER_THAN,
+                expression_form_data={
+                    "type": "Greater than",
+                    "greater_than_value": None,
+                    "greater_than_expression": "",
+                    "greater_than_inclusive": False,
+                    "add_context": "greater_than_expression",
+                },
+                component_id=question.id,
+            ).model_dump(mode="json")
+
+        response = authenticated_grant_admin_client.post(
+            url_for(
+                "deliver_grant_funding.select_context_source_data_set_column",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                form_id=form.id,
+                data_set_id=data_set.id,
+            ),
+            data={"column": next(iter(data_set.schema.root))},
+            follow_redirects=False,
+        )
+        assert response.status_code == 302
+        assert response.location == (
+            f"/deliver/grant/{authenticated_grant_admin_client.grant.id}/question/{question.id}/add-validation"
+        )
+        with authenticated_grant_admin_client.session_transaction() as sess:
+            question_data = sess.get("question")
+            assert question_data is not None
+            expected_reference = ExpressionReference.from_data_source_column(data_set, "c_capital_allocation")
+            assert question_data["expression_form_data"]["greater_than_expression"] == expected_reference.wrapped
+
+    def test_post_with_custom_validation_expressions_session_model_redirects_and_updates_session(
+        self, authenticated_grant_admin_client, factories
+    ):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant)
+        form = factories.form.create(collection=report)
+        question = factories.question.create(form=form)
+        data_set = factories.data_source.create(
+            grant=authenticated_grant_admin_client.grant,
+            collection=report,
+            name="Test data set",
+            type=DataSourceType.GRANT_RECIPIENT,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_capital_allocation": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Capital Allocation",
+                    )
+                }
+            ),
+        )
+
+        with authenticated_grant_admin_client.session_transaction() as sess:
+            sess["question"] = AddContextToExpressionsModel(
+                field=ExpressionType.VALIDATION,
+                managed_expression_name=None,
+                expression_form_data={
+                    "custom_expression": "some existing text",
+                    "add_context": "custom_expression",
+                },
+                component_id=question.id,
+                is_custom=True,
+            ).model_dump(mode="json")
+
+        response = authenticated_grant_admin_client.post(
+            url_for(
+                "deliver_grant_funding.select_context_source_data_set_column",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                form_id=form.id,
+                data_set_id=data_set.id,
+            ),
+            data={"column": next(iter(data_set.schema.root))},
+            follow_redirects=False,
+        )
+        assert response.status_code == 302
+        assert response.location == (
+            f"/deliver/grant/{authenticated_grant_admin_client.grant.id}/question/{question.id}/add-validation/custom"
+        )
+        with authenticated_grant_admin_client.session_transaction() as sess:
+            question_data = sess.get("question")
+            assert question_data is not None
+            expected_reference = ExpressionReference.from_data_source_column(data_set, "c_capital_allocation")
+            assert (
+                question_data["expression_form_data"]["custom_expression"]
+                == f"some existing text {expected_reference.wrapped}"
+            )
+
+    def test_post_with_calculated_condition_expressions_session_model_redirects_and_updates_session(
+        self, authenticated_grant_admin_client, factories
+    ):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant)
+        form = factories.form.create(collection=report)
+        question = factories.question.create(form=form)
+        data_set = factories.data_source.create(
+            grant=authenticated_grant_admin_client.grant,
+            collection=report,
+            name="Test data set",
+            type=DataSourceType.GRANT_RECIPIENT,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_capital_allocation": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Capital Allocation",
+                    )
+                }
+            ),
+        )
+
+        with authenticated_grant_admin_client.session_transaction() as sess:
+            sess["question"] = AddContextToExpressionsModel(
+                field=ExpressionType.CONDITION,
+                managed_expression_name=None,
+                expression_form_data={
+                    "custom_expression": "some existing text",
+                    "add_context": "custom_expression",
+                },
+                component_id=question.id,
+                is_custom=True,
+            ).model_dump(mode="json")
+
+        response = authenticated_grant_admin_client.post(
+            url_for(
+                "deliver_grant_funding.select_context_source_data_set_column",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                form_id=form.id,
+                data_set_id=data_set.id,
+            ),
+            data={"column": next(iter(data_set.schema.root))},
+            follow_redirects=False,
+        )
+        assert response.status_code == 302
+        assert response.location == (
+            f"/deliver/grant/{authenticated_grant_admin_client.grant.id}/question/{question.id}/add-calculated-condition"
+        )
+        with authenticated_grant_admin_client.session_transaction() as sess:
+            question_data = sess.get("question")
+            assert question_data is not None
+            expected_reference = ExpressionReference.from_data_source_column(data_set, "c_capital_allocation")
+            assert (
+                question_data["expression_form_data"]["custom_expression"]
+                == f"some existing text {expected_reference.wrapped}"
+            )
+
+    def test_post_with_condition_depends_on_session_model_raises_not_implemented(
+        self, authenticated_grant_admin_client, factories
+    ):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant)
+        form = factories.form.create(collection=report)
+        question = factories.question.create(form=form)
+        data_set = factories.data_source.create(
+            grant=authenticated_grant_admin_client.grant,
+            collection=report,
+            name="Test data set",
+            type=DataSourceType.GRANT_RECIPIENT,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_capital_allocation": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Capital Allocation",
+                    )
+                }
+            ),
+        )
+
+        with authenticated_grant_admin_client.session_transaction() as sess:
+            sess["question"] = AddConditionDependsOnSessionModel(
+                component_id=question.id,
+            ).model_dump(mode="json")
+
+        with pytest.raises(NotImplementedError):
+            authenticated_grant_admin_client.post(
+                url_for(
+                    "deliver_grant_funding.select_context_source_data_set_column",
+                    grant_id=authenticated_grant_admin_client.grant.id,
+                    form_id=form.id,
+                    data_set_id=data_set.id,
+                ),
+                data={"column": next(iter(data_set.schema.root))},
+                follow_redirects=False,
+            )
 
 
 class TestEditQuestion:
@@ -11061,7 +11628,7 @@ class TestChangeGroupDisplayOptionsBlockedByValidations:
         assert reloaded.presentation_options.show_questions_on_the_same_page is True
 
 
-class TestDetermineReturnUrlExpressionReferencedQuestion:
+class TestDetermineReturnUrlExpressionReference:
     def test_update_target_field_replace(self, factories):
         question = factories.question.create()
         add_context_data = AddContextToExpressionsModel(
@@ -11075,8 +11642,8 @@ class TestDetermineReturnUrlExpressionReferencedQuestion:
             depends_on_question_id=uuid.uuid4(),
         )
 
-        _determine_return_url_and_update_session_after_choosing_referenced_question_for_expression(
-            uuid.uuid4(), add_context_data, question
+        _determine_return_url_and_update_session_after_choosing_reference_for_expression(
+            uuid.uuid4(), add_context_data, ExpressionReference.from_question(question)
         )
 
         assert add_context_data.expression_form_data["test_field"] == f"(({question.safe_qid}))"
@@ -11088,13 +11655,13 @@ class TestDetermineReturnUrlExpressionReferencedQuestion:
             component_id=question.id,
             managed_expression_name=None,
             expression_form_data={
-                "test_field": "start + ",
+                "test_field": "start +",
                 "add_context": "test_field",
             },
         )
 
-        _determine_return_url_and_update_session_after_choosing_referenced_question_for_expression(
-            uuid.uuid4(), add_context_data, question
+        _determine_return_url_and_update_session_after_choosing_reference_for_expression(
+            uuid.uuid4(), add_context_data, ExpressionReference.from_question(question)
         )
 
         assert add_context_data.expression_form_data["test_field"] == f"start + (({question.safe_qid}))"
@@ -11112,8 +11679,8 @@ class TestDetermineReturnUrlExpressionReferencedQuestion:
             depends_on_question_id=uuid.uuid4(),
         )
 
-        result = _determine_return_url_and_update_session_after_choosing_referenced_question_for_expression(
-            uuid.uuid4(), add_context_data, question
+        result = _determine_return_url_and_update_session_after_choosing_reference_for_expression(
+            uuid.uuid4(), add_context_data, ExpressionReference.from_question(question)
         )
         assert result == AnyStringMatching(
             "^/deliver/grant/[a-z0-9-]{36}/question/[a-z0-9-]{36}/add-condition/[a-z0-9-]{36}"
@@ -11133,8 +11700,8 @@ class TestDetermineReturnUrlExpressionReferencedQuestion:
             expression_id=uuid.uuid4(),
         )
 
-        result = _determine_return_url_and_update_session_after_choosing_referenced_question_for_expression(
-            uuid.uuid4(), add_context_data, question
+        result = _determine_return_url_and_update_session_after_choosing_reference_for_expression(
+            uuid.uuid4(), add_context_data, ExpressionReference.from_question(question)
         )
         assert result == AnyStringMatching("^/deliver/grant/[a-z0-9-]{36}/condition/[a-z0-9-]{36}")
 
@@ -11150,8 +11717,8 @@ class TestDetermineReturnUrlExpressionReferencedQuestion:
             },
         )
 
-        result = _determine_return_url_and_update_session_after_choosing_referenced_question_for_expression(
-            uuid.uuid4(), add_context_data, question
+        result = _determine_return_url_and_update_session_after_choosing_reference_for_expression(
+            uuid.uuid4(), add_context_data, ExpressionReference.from_question(question)
         )
         assert result == AnyStringMatching(
             "^/deliver/grant/[a-z0-9-]{36}/question/[a-z0-9-]{36}/add-calculated-condition"
@@ -11170,7 +11737,7 @@ class TestDetermineReturnUrlExpressionReferencedQuestion:
             expression_id=uuid.uuid4(),
         )
 
-        result = _determine_return_url_and_update_session_after_choosing_referenced_question_for_expression(
-            uuid.uuid4(), add_context_data, question
+        result = _determine_return_url_and_update_session_after_choosing_reference_for_expression(
+            uuid.uuid4(), add_context_data, ExpressionReference.from_question(question)
         )
         assert result == AnyStringMatching("^/deliver/grant/[a-z0-9-]{36}/calculated-condition/[a-z0-9-]{36}")

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -4509,7 +4509,7 @@ class TestSelectContextSourceDataSetColumn:
                 == f"some existing text {expected_reference.wrapped}"
             )
 
-    def test_post_with_condition_depends_on_session_model_raises_not_implemented(
+    def test_post_with_condition_depends_on_session_model_redirects_and_updates_session(
         self, authenticated_grant_admin_client, factories
     ):
         report = factories.collection.create(grant=authenticated_grant_admin_client.grant)
@@ -4518,7 +4518,7 @@ class TestSelectContextSourceDataSetColumn:
         data_set = factories.data_source.create(
             grant=authenticated_grant_admin_client.grant,
             collection=report,
-            name="Test data set",
+            name="Allocations",
             type=DataSourceType.GRANT_RECIPIENT,
             schema=DataSourceSchema.model_validate(
                 {
@@ -4537,17 +4537,30 @@ class TestSelectContextSourceDataSetColumn:
                 component_id=question.id,
             ).model_dump(mode="json")
 
-        with pytest.raises(NotImplementedError):
-            authenticated_grant_admin_client.post(
-                url_for(
-                    "deliver_grant_funding.select_context_source_data_set_column",
-                    grant_id=authenticated_grant_admin_client.grant.id,
-                    form_id=form.id,
-                    data_set_id=data_set.id,
-                ),
-                data={"column": next(iter(data_set.schema.root))},
-                follow_redirects=False,
-            )
+        response = authenticated_grant_admin_client.post(
+            url_for(
+                "deliver_grant_funding.select_context_source_data_set_column",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                form_id=form.id,
+                data_set_id=data_set.id,
+            ),
+            data={"column": next(iter(data_set.schema.root))},
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 302
+        assert response.location == AnyStringMatching(
+            "^/deliver/grant/[a-z0-9-]{36}/question/[a-z0-9-]{36}/add-condition/d_[0-9a-f]{32}.c_capital_allocation"
+        )
+        with authenticated_grant_admin_client.session_transaction() as sess:
+            assert sess.get("question") is None
+
+        # Additional request to follow the response through to the final destination and confirm the data set
+        # is being referenced
+        follow_response = authenticated_grant_admin_client.get(response.location)
+        assert follow_response.status_code == 200
+        soup = BeautifulSoup(follow_response.data, "html.parser")
+        assert "Capital Allocation from Allocations data set" in soup.text
 
 
 class TestEditQuestion:
@@ -5636,6 +5649,68 @@ class TestAddQuestionCondition:
         assert expression.type_ == ExpressionType.CONDITION
         assert expression.managed_name == "Yes"
         assert expression.managed.referenced_question.id == depends_on_question.id
+
+    def test_post_for_data_set(self, authenticated_grant_admin_client, factories, db_session):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant, name="Test Report")
+        db_form = factories.form.create(collection=report, title="Organisation information")
+        target_question = factories.question.create(
+            form=db_form,
+            text="How much cheese do you eat a month?",
+            name="total cheese eaten",
+            data_type=QuestionDataType.NUMBER,
+        )
+        data_set = factories.data_source.create(
+            grant=authenticated_grant_admin_client.grant,
+            collection=report,
+            name="Test data set",
+            type=DataSourceType.GRANT_RECIPIENT,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_capital_allocation": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Capital Allocation",
+                    )
+                }
+            ),
+        )
+
+        reference = ExpressionReference.from_data_source_column(data_set, "c_capital_allocation")
+
+        ConditionForm = build_managed_expression_form(ExpressionType.CONDITION, reference)
+        form = ConditionForm(
+            data={
+                "type": "Greater than",
+                "greater_than_value": 100,
+                "greater_than_expression": "",
+                "greater_than_inclusive": False,
+            }
+        )
+
+        response = authenticated_grant_admin_client.post(
+            url_for(
+                "deliver_grant_funding.add_question_condition",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                component_id=target_question.id,
+                subject_reference=reference,
+            ),
+            data=get_form_data(form),
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 302
+        assert response.location == AnyStringMatching(
+            rf"/deliver/grant/{authenticated_grant_admin_client.grant.id}/question/{target_question.id}"
+        )
+
+        assert len(target_question.expressions) == 1
+        expression = target_question.expressions[0]
+        assert expression.type_ == ExpressionType.CONDITION
+        assert expression.managed.subject_reference == reference
+        assert len(expression.component_references) == 1
+        assert expression.component_references[0].depends_on_data_source_id == data_set.id
+        assert expression.component_references[0].depends_on_column_name == "c_capital_allocation"
 
     def test_post_duplicate_condition(self, authenticated_grant_admin_client, factories, db_session):
         report = factories.collection.create(grant=authenticated_grant_admin_client.grant, name="Test Report")

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -3493,6 +3493,63 @@ class TestSelectContextSourceQuestion:
         assert reference_question.text in soup.text
         assert depends_on_question.text not in soup.text and skipped_question.text not in soup.text
 
+    def test_get_lists_questions_before_component_id_when_subject_reference_is_data_set_column(
+        self, authenticated_grant_admin_client, factories
+    ):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant)
+        form = factories.form.create(collection=report)
+        reference_question = factories.question.create(form=form, data_type=QuestionDataType.NUMBER)
+        target_question = factories.question.create(form=form, data_type=QuestionDataType.TEXT_SINGLE_LINE)
+        skipped_question = factories.question.create(form=form, data_type=QuestionDataType.NUMBER)
+        data_set = factories.data_source.create(
+            grant=authenticated_grant_admin_client.grant,
+            collection=report,
+            name="Test data set",
+            type=DataSourceType.GRANT_RECIPIENT,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_capital_allocation": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Capital Allocation",
+                    )
+                }
+            ),
+        )
+        data_set_reference = ExpressionReference.from_data_source_column(data_set, "c_capital_allocation")
+
+        with authenticated_grant_admin_client.session_transaction() as sess:
+            sess["question"] = AddContextToExpressionsModel(
+                field=ExpressionType.CONDITION,
+                managed_expression_name=ManagedExpressionsEnum.GREATER_THAN,
+                expression_form_data={
+                    "type": "Greater than",
+                    "greater_than_value": None,
+                    "greater_than_inclusive": True,
+                    "add_context": "greater_than_expression",
+                },
+                component_id=target_question.id,
+                subject_reference=data_set_reference,
+                data_source=ExpressionContext.ContextSources.SECTION,
+                collection_id=form.collection_id,
+                form_id=form.id,
+            ).model_dump(mode="json")
+
+        response = authenticated_grant_admin_client.get(
+            url_for(
+                "deliver_grant_funding.select_context_source_question",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                form_id=form.id,
+            )
+        )
+        assert response.status_code == 200
+
+        soup = BeautifulSoup(response.data, "html.parser")
+        assert reference_question.text in soup.text
+        assert skipped_question.text not in soup.text
+        assert target_question.text not in soup.text
+
     def test_get_back_link_points_to_select_context_source_when_same_section(
         self, authenticated_grant_admin_client, factories
     ):

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -3299,13 +3299,15 @@ class TestSelectContextSourceSection:
         question = factories.question.create(form=form_2, text="Question 1")
         question_2 = factories.question.create(form=form_3, text="Question 2")
 
+        subject_reference = ExpressionReference.from_question(question)
+
         with authenticated_grant_admin_client.session_transaction() as sess:
             sess["question"] = AddContextToExpressionsModel(
                 data_source=ExpressionContext.ContextSources.SECTION,
                 collection_id=form.collection_id,
                 form_id=None,
                 component_id=question_2.id,
-                depends_on_question_id=question.id,
+                subject_reference=subject_reference,
                 field=ExpressionType.CONDITION,
                 managed_expression_name=ManagedExpressionsEnum.ANY_OF,
                 expression_form_data={},
@@ -3471,7 +3473,7 @@ class TestSelectContextSourceQuestion:
                     "add_context": "greater_than_expression",
                 },
                 component_id=target_question.id,
-                depends_on_question_id=depends_on_question.id,
+                subject_reference=ExpressionReference.from_question(depends_on_question),
                 data_source=ExpressionContext.ContextSources.SECTION,
                 collection_id=form.collection_id,
                 form_id=form.id,
@@ -3591,7 +3593,7 @@ class TestSelectContextSourceQuestion:
                 grant_id=authenticated_grant_admin_client.grant.id,
                 form_id=form.id,
             ),
-            data={"question": str(question.id)},
+            data={"question": ExpressionReference.from_question(question)},
             follow_redirects=False,
         )
         assert response.status_code == 302
@@ -3630,7 +3632,7 @@ class TestSelectContextSourceQuestion:
                 grant_id=authenticated_grant_admin_client.grant.id,
                 form_id=form.id,
             ),
-            data={"question": str(referenced_question.id)},
+            data={"question": ExpressionReference.from_question(referenced_question)},
             follow_redirects=False,
         )
         assert response.status_code == 302
@@ -3690,8 +3692,8 @@ class TestSelectContextSourceQuestion:
                 data_source=ExpressionContext.ContextSources.SECTION,
                 collection_id=form.collection_id,
                 form_id=form.id,
-                depends_on_question_id=depends_on_question.id
-                if expression_type is ExpressionType.CONDITION and not existing_expression
+                subject_reference=ExpressionReference.from_question(depends_on_question)
+                if (expression_type is ExpressionType.CONDITION and not existing_expression)
                 else None,
                 expression_id=expression_id,
             ).model_dump(mode="json")
@@ -3702,7 +3704,7 @@ class TestSelectContextSourceQuestion:
                 grant_id=authenticated_grant_admin_client.grant.id,
                 form_id=form.id,
             ),
-            data={"question": str(reference_data_question.id)},
+            data={"question": ExpressionReference.from_question(reference_data_question)},
             follow_redirects=False,
         )
         assert response.status_code == 302
@@ -3723,7 +3725,7 @@ class TestSelectContextSourceQuestion:
             else:
                 assert response.location == AnyStringMatching(
                     rf"/deliver/grant/{authenticated_grant_admin_client.grant.id}/question/"
-                    + rf"{target_question.id}/add-condition/{depends_on_question.id}"
+                    + rf"{target_question.id}/add-condition/{ExpressionReference.from_question(depends_on_question)}"
                 )
         else:
             if existing_expression:
@@ -3734,6 +3736,38 @@ class TestSelectContextSourceQuestion:
                 assert response.location == AnyStringMatching(
                     rf"/deliver/grant/{authenticated_grant_admin_client.grant.id}/question/{target_question.id}/add-validation"
                 )
+
+    def test_post_redirects_to_add_condition_and_clears_session(self, authenticated_grant_admin_client, factories):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant)
+        form = factories.form.create(collection=report)
+        referenced_question = factories.question.create(form=form)
+        question = factories.question.create(form=form)
+
+        with authenticated_grant_admin_client.session_transaction() as sess:
+            sess["question"] = AddConditionDependsOnSessionModel(
+                field="condition_depends_on",
+                component_id=question.id,
+                data_source=ExpressionContext.ContextSources.SECTION,
+                collection_id=form.collection_id,
+                form_id=form.id,
+            ).model_dump(mode="json")
+
+        response = authenticated_grant_admin_client.post(
+            url_for(
+                "deliver_grant_funding.select_context_source_question",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                form_id=form.id,
+            ),
+            data={"question": ExpressionReference.from_question(referenced_question)},
+            follow_redirects=False,
+        )
+        assert response.status_code == 302
+        assert response.location == AnyStringMatching(
+            rf"/deliver/grant/{authenticated_grant_admin_client.grant.id}/question/{question.id}/add-condition/{ExpressionReference.from_question(referenced_question)}"
+        )
+
+        with authenticated_grant_admin_client.session_transaction() as sess:
+            assert sess.get("question") is None
 
 
 class TestSelectContextSourceDataSet:
@@ -5442,12 +5476,13 @@ class TestEditCalculatedCondition:
 
 class TestAddQuestionCondition:
     def test_404(self, authenticated_grant_admin_client):
+        reference = ExpressionReference(f"q_{uuid.uuid4().hex}")
         response = authenticated_grant_admin_client.get(
             url_for(
                 "deliver_grant_funding.add_question_condition",
                 grant_id=uuid.uuid4(),
                 component_id=uuid.uuid4(),
-                depends_on_question_id=uuid.uuid4(),
+                subject_reference=reference,
             )
         )
         assert response.status_code == 404
@@ -5489,7 +5524,7 @@ class TestAddQuestionCondition:
                 "deliver_grant_funding.add_question_condition",
                 grant_id=client.grant.id,
                 component_id=target_question.id,
-                depends_on_question_id=depends_on_question.id,
+                subject_reference=ExpressionReference.from_question(depends_on_question),
             )
         )
 
@@ -5503,7 +5538,7 @@ class TestAddQuestionCondition:
                 "deliver_grant_funding.add_question_condition",
                 grant_id=client.grant.id,
                 component_id=group.id,
-                depends_on_question_id=depends_on_question.id,
+                subject_reference=ExpressionReference.from_question(depends_on_question),
             )
         )
 
@@ -5523,6 +5558,7 @@ class TestAddQuestionCondition:
             hint="Please select yes or no",
             data_type=QuestionDataType.YES_NO,
         )
+        reference = ExpressionReference.from_question(depends_on_question)
 
         target_question = factories.question.create(
             form=db_form,
@@ -5534,9 +5570,7 @@ class TestAddQuestionCondition:
 
         assert len(target_question.expressions) == 0
 
-        ConditionForm = build_managed_expression_form(
-            ExpressionType.CONDITION, ExpressionReference.from_question(depends_on_question)
-        )
+        ConditionForm = build_managed_expression_form(ExpressionType.CONDITION, reference)
         form = ConditionForm(data={"type": "Yes"})
 
         response = authenticated_grant_admin_client.post(
@@ -5544,7 +5578,7 @@ class TestAddQuestionCondition:
                 "deliver_grant_funding.add_question_condition",
                 grant_id=authenticated_grant_admin_client.grant.id,
                 component_id=target_question.id,
-                depends_on_question_id=depends_on_question.id,
+                subject_reference=reference,
             ),
             data=get_form_data(form),
             follow_redirects=False,
@@ -5572,14 +5606,13 @@ class TestAddQuestionCondition:
             hint="Please select yes or no",
             data_type=QuestionDataType.YES_NO,
         )
+        reference = ExpressionReference.from_question(depends_on_question)
 
         target_group = factories.group.create(form=db_form)
 
         assert len(target_group.expressions) == 0
 
-        ConditionForm = build_managed_expression_form(
-            ExpressionType.CONDITION, ExpressionReference.from_question(depends_on_question)
-        )
+        ConditionForm = build_managed_expression_form(ExpressionType.CONDITION, reference)
         form = ConditionForm(data={"type": "Yes"})
 
         response = authenticated_grant_admin_client.post(
@@ -5587,7 +5620,7 @@ class TestAddQuestionCondition:
                 "deliver_grant_funding.add_question_condition",
                 grant_id=authenticated_grant_admin_client.grant.id,
                 component_id=target_group.id,
-                depends_on_question_id=depends_on_question.id,
+                subject_reference=reference,
             ),
             data=get_form_data(form),
             follow_redirects=False,
@@ -5615,6 +5648,7 @@ class TestAddQuestionCondition:
             hint="Please select yes or no",
             data_type=QuestionDataType.YES_NO,
         )
+        reference = ExpressionReference.from_question(depends_on_question)
 
         target_question = factories.question.create(
             form=db_form,
@@ -5631,9 +5665,7 @@ class TestAddQuestionCondition:
         interfaces.collections.add_component_condition(target_question, interfaces.user.get_current_user(), expression)
         db_session.commit()
 
-        ConditionForm = build_managed_expression_form(
-            ExpressionType.CONDITION, ExpressionReference.from_question(depends_on_question)
-        )
+        ConditionForm = build_managed_expression_form(ExpressionType.CONDITION, reference)
         form = ConditionForm(data={"type": "Yes"})
 
         response = authenticated_grant_admin_client.post(
@@ -5641,7 +5673,7 @@ class TestAddQuestionCondition:
                 "deliver_grant_funding.add_question_condition",
                 grant_id=authenticated_grant_admin_client.grant.id,
                 component_id=target_question.id,
-                depends_on_question_id=depends_on_question.id,
+                subject_reference=reference,
             ),
             data=get_form_data(form),
             follow_redirects=False,
@@ -5663,6 +5695,7 @@ class TestAddQuestionCondition:
             name="total cheese eaten",
             data_type=QuestionDataType.NUMBER,
         )
+        reference = ExpressionReference.from_question(depends_on_question)
 
         target_question = factories.question.create(
             form=db_form,
@@ -5673,9 +5706,7 @@ class TestAddQuestionCondition:
 
         assert len(target_question.expressions) == 0
 
-        ConditionForm = build_managed_expression_form(
-            ExpressionType.CONDITION, ExpressionReference.from_question(depends_on_question)
-        )
+        ConditionForm = build_managed_expression_form(ExpressionType.CONDITION, reference)
         form = ConditionForm(
             data={
                 "type": "Greater than",
@@ -5691,7 +5722,7 @@ class TestAddQuestionCondition:
                 "deliver_grant_funding.add_question_condition",
                 grant_id=authenticated_grant_admin_client.grant.id,
                 component_id=target_question.id,
-                depends_on_question_id=depends_on_question.id,
+                subject_reference=reference,
             ),
             data=get_form_data(form, submit=""),
             follow_redirects=False,
@@ -5715,6 +5746,7 @@ class TestAddQuestionCondition:
         reference_data_question = factories.question.create(form=db_form, data_type=QuestionDataType.NUMBER)
         depends_on_question = factories.question.create(form=db_form, data_type=QuestionDataType.NUMBER)
         target_question = factories.question.create(form=db_form, data_type=QuestionDataType.TEXT_MULTI_LINE)
+        reference = ExpressionReference.from_question(depends_on_question)
 
         session_data = AddContextToExpressionsModel(
             field=ExpressionType.CONDITION,
@@ -5726,15 +5758,13 @@ class TestAddQuestionCondition:
                 "greater_than_inclusive": True,
             },
             component_id=target_question.id,
-            depends_on_question_id=depends_on_question.id,
+            subject_reference=ExpressionReference.from_question(depends_on_question),
         )
 
         with authenticated_grant_admin_client.session_transaction() as session:
             session["question"] = session_data.model_dump(mode="json")
 
-        ConditionForm = build_managed_expression_form(
-            ExpressionType.CONDITION, ExpressionReference.from_question(depends_on_question)
-        )
+        ConditionForm = build_managed_expression_form(ExpressionType.CONDITION, reference)
         form = ConditionForm(
             data={
                 "type": "Greater than",
@@ -5750,7 +5780,7 @@ class TestAddQuestionCondition:
                 "deliver_grant_funding.add_question_condition",
                 grant_id=authenticated_grant_admin_client.grant.id,
                 component_id=target_question.id,
-                depends_on_question_id=depends_on_question.id,
+                subject_reference=reference,
             ),
             data=get_form_data(form, submit=""),
             follow_redirects=False,
@@ -5763,7 +5793,7 @@ class TestAddQuestionCondition:
                 "deliver_grant_funding.add_question_condition",
                 grant_id=authenticated_grant_admin_client.grant.id,
                 component_id=target_question.id,
-                depends_on_question_id=depends_on_question.id,
+                subject_reference=reference,
             )
         )
         assert len(target_question.expressions) == 0
@@ -5793,6 +5823,7 @@ class TestAddQuestionCondition:
             name="total cheese eaten",
             data_type=QuestionDataType.NUMBER,
         )
+        reference = ExpressionReference.from_question(depends_on_question)
 
         target_question = factories.question.create(
             form=db_form,
@@ -5801,9 +5832,7 @@ class TestAddQuestionCondition:
             data_type=QuestionDataType.TEXT_MULTI_LINE,
         )
 
-        ConditionForm = build_managed_expression_form(
-            ExpressionType.CONDITION, ExpressionReference.from_question(depends_on_question)
-        )
+        ConditionForm = build_managed_expression_form(ExpressionType.CONDITION, reference)
         form = ConditionForm(
             data={
                 "type": "Greater than",
@@ -5818,7 +5847,7 @@ class TestAddQuestionCondition:
             managed_expression_name=ManagedExpressionsEnum.GREATER_THAN,
             expression_form_data=form.data,
             component_id=target_question.id,
-            depends_on_question_id=depends_on_question.id,
+            subject_reference=reference,
             value_dependent_question_id=reference_data_question.id,
         )
 
@@ -5830,7 +5859,7 @@ class TestAddQuestionCondition:
                 "deliver_grant_funding.add_question_condition",
                 grant_id=authenticated_grant_admin_client.grant.id,
                 component_id=target_question.id,
-                depends_on_question_id=depends_on_question.id,
+                subject_reference=reference,
             ),
             data=get_form_data(form),
             follow_redirects=False,
@@ -6344,7 +6373,7 @@ class TestEditQuestionCondition:
             expression_id=expression_id,
             expression_form_data=form.data,
             component_id=target_question.id,
-            depends_on_question_id=depends_on_question.id,
+            subject_reference=ExpressionReference.from_question(depends_on_question),
             value_dependent_question_id=reference_data_question.id,
         )
 
@@ -11639,7 +11668,7 @@ class TestDetermineReturnUrlExpressionReference:
                 "test_field": "start",
                 "add_context": "test_field",
             },
-            depends_on_question_id=uuid.uuid4(),
+            subject_reference=ExpressionReference.from_question(question),
         )
 
         _determine_return_url_and_update_session_after_choosing_reference_for_expression(
@@ -11676,14 +11705,14 @@ class TestDetermineReturnUrlExpressionReference:
                 "test_field": "start + ",
                 "add_context": "test_field",
             },
-            depends_on_question_id=uuid.uuid4(),
+            subject_reference=ExpressionReference.from_question(question),
         )
 
         result = _determine_return_url_and_update_session_after_choosing_reference_for_expression(
             uuid.uuid4(), add_context_data, ExpressionReference.from_question(question)
         )
         assert result == AnyStringMatching(
-            "^/deliver/grant/[a-z0-9-]{36}/question/[a-z0-9-]{36}/add-condition/[a-z0-9-]{36}"
+            "^/deliver/grant/[a-z0-9-]{36}/question/[a-z0-9-]{36}/add-condition/q_[0-9a-f]{32}"
         )
 
     def test_return_url_existing_non_calculated_condition(self, factories):
@@ -11696,7 +11725,7 @@ class TestDetermineReturnUrlExpressionReference:
                 "test_field": "start + ",
                 "add_context": "test_field",
             },
-            depends_on_question_id=uuid.uuid4(),
+            subject_reference=ExpressionReference.from_question(question),
             expression_id=uuid.uuid4(),
         )
 

--- a/tests/unit/deliver_grant_funding/test_forms.py
+++ b/tests/unit/deliver_grant_funding/test_forms.py
@@ -8,10 +8,14 @@ from werkzeug.datastructures import MultiDict
 from wtforms import ValidationError
 
 from app.common.data.types import (
+    DataSourceSchema,
+    DataSourceSchemaColumn,
+    DataSourceType,
     ExpressionType,
     ManagedExpressionsEnum,
     MaximumFileSize,
     NumberTypeEnum,
+    QuestionDataOptions,
     QuestionDataType,
     QuestionPresentationOptions,
     RoleEnum,
@@ -334,6 +338,7 @@ class TestSelectDataSourceQuestionForm:
         form = SelectDataSourceQuestionForm(
             form=questions[2].form,
             interpolate=SubmissionHelper.get_interpolator(collection=questions[2].form.collection),
+            subject_reference=None,
             current_component=questions[2],
             expression_type=None,
             managed_expression_name=None,
@@ -360,6 +365,7 @@ class TestSelectDataSourceQuestionForm:
         form = SelectDataSourceQuestionForm(
             form=questions[2].form,
             interpolate=SubmissionHelper.get_interpolator(collection=questions[2].form.collection),
+            subject_reference=None,
             current_component=questions[2],
             expression_type=None,
             managed_expression_name=None,
@@ -377,6 +383,7 @@ class TestSelectDataSourceQuestionForm:
         form = SelectDataSourceQuestionForm(
             form=questions[2].form,
             interpolate=SubmissionHelper.get_interpolator(collection=questions[2].form.collection),
+            subject_reference=None,
             current_component=questions[2],
             expression_type=None,
             managed_expression_name=None,
@@ -400,6 +407,7 @@ class TestSelectDataSourceQuestionForm:
         form = SelectDataSourceQuestionForm(
             form=text_question.form,
             interpolate=SubmissionHelper.get_interpolator(collection=text_question.form.collection),
+            subject_reference=None,
             current_component=integer_question,
             expression_type=None,
             managed_expression_name=None,
@@ -430,6 +438,7 @@ class TestSelectDataSourceQuestionForm:
         form = SelectDataSourceQuestionForm(
             form=multi_line_question.form,
             interpolate=SubmissionHelper.get_interpolator(collection=multi_line_question.form.collection),
+            subject_reference=None,
             current_component=integer_questions[2],
             expression_type=ExpressionType.CONDITION,
             managed_expression_name=ManagedExpressionsEnum.GREATER_THAN,
@@ -463,6 +472,7 @@ class TestSelectDataSourceQuestionForm:
         form = SelectDataSourceQuestionForm(
             form=group.form,
             interpolate=SubmissionHelper.get_interpolator(collection=group.form.collection),
+            subject_reference=None,
             current_component=integer_q4,
             expression_type=ExpressionType.CONDITION,
             managed_expression_name=ManagedExpressionsEnum.GREATER_THAN,
@@ -498,7 +508,104 @@ class TestSelectDataSourceQuestionForm:
         form = SelectDataSourceQuestionForm(
             form=group.form,
             interpolate=SubmissionHelper.get_interpolator(collection=group.form.collection),
+            subject_reference=None,
             current_component=text_q4,
+            expression_type=ExpressionType.CONDITION,
+            managed_expression_name=None,
+        )
+
+        assert len(form.question.choices) == 3
+        assert {q[0] for q in form.question.choices} == {
+            "",
+            ExpressionReference.from_question(integer_q1),
+            ExpressionReference.from_question(integer_q2),
+        }
+
+    def test_managed_condition_with_question_subject_reference(self, app, factories, mocker):
+        integer_q1 = factories.question.build(data_type=QuestionDataType.NUMBER)
+        integer_q2 = factories.question.build(form=integer_q1.form, data_type=QuestionDataType.NUMBER)
+        multi_line_q = factories.question.build(form=integer_q1.form, data_type=QuestionDataType.YES_NO)
+        text_question = factories.question.build(form=integer_q1.form, data_type=QuestionDataType.TEXT_MULTI_LINE)
+
+        group = factories.group.build(
+            form=integer_q1.form, presentation_options=QuestionPresentationOptions(show_questions_on_the_same_page=True)
+        )
+        integer_q3 = factories.question.build(form=integer_q1.form, parent=group, data_type=QuestionDataType.NUMBER)
+        text_q4 = factories.question.build(
+            form=integer_q1.form, parent=group, data_type=QuestionDataType.TEXT_SINGLE_LINE
+        )
+
+        all_questions = [integer_q1, multi_line_q, integer_q2, text_question, integer_q3, text_q4]
+
+        subject_reference = ExpressionReference.from_question(integer_q3)
+
+        # TODO[FSPT-1255]: don't love these being mocked; move to an integration test instead?
+        mocker.patch.object(group.form, "cached_questions", all_questions)
+        mocker.patch.object(group.form, "cached_all_components", [group] + all_questions)
+        mocker.patch.object(ExpressionReference, "question", new_callable=mock.PropertyMock, return_value=integer_q3)
+
+        form = SelectDataSourceQuestionForm(
+            form=group.form,
+            interpolate=SubmissionHelper.get_interpolator(collection=group.form.collection),
+            subject_reference=subject_reference,
+            current_component=text_q4,
+            expression_type=ExpressionType.CONDITION,
+            managed_expression_name=None,
+        )
+
+        assert len(form.question.choices) == 3
+        assert {q[0] for q in form.question.choices} == {
+            "",
+            ExpressionReference.from_question(integer_q1),
+            ExpressionReference.from_question(integer_q2),
+        }
+
+    def test_managed_condition_with_data_set_subject_reference(self, app, factories, mocker):
+        integer_q1 = factories.question.build(data_type=QuestionDataType.NUMBER)
+        integer_q2 = factories.question.build(form=integer_q1.form, data_type=QuestionDataType.NUMBER)
+        multi_line_q = factories.question.build(form=integer_q1.form, data_type=QuestionDataType.YES_NO)
+        text_question = factories.question.build(form=integer_q1.form, data_type=QuestionDataType.TEXT_MULTI_LINE)
+
+        group = factories.group.build(
+            form=integer_q1.form, presentation_options=QuestionPresentationOptions(show_questions_on_the_same_page=True)
+        )
+        integer_q3 = factories.question.build(form=integer_q1.form, parent=group, data_type=QuestionDataType.NUMBER)
+        text_q4 = factories.question.build(
+            form=integer_q1.form, parent=group, data_type=QuestionDataType.TEXT_SINGLE_LINE
+        )
+
+        data_set_column = DataSourceSchemaColumn(
+            data_type=QuestionDataType.NUMBER,
+            presentation_options=QuestionPresentationOptions(),
+            data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+            original_column_name="Capital Allocation",
+        )
+
+        data_set = factories.data_source.build(
+            grant=integer_q1.form.collection.grant,
+            collection=integer_q1.form.collection,
+            name="Test data set",
+            type=DataSourceType.GRANT_RECIPIENT,
+            schema=DataSourceSchema.model_validate({"c_capital_allocation": data_set_column}),
+        )
+
+        all_questions = [integer_q1, multi_line_q, integer_q2, text_question, integer_q3, text_q4]
+
+        subject_reference = ExpressionReference.from_data_source_column(data_set, "c_capital_allocation")
+
+        # TODO[FSPT-1255]: don't love these being mocked; move to an integration test instead?
+        mocker.patch.object(group.form, "cached_questions", all_questions)
+        mocker.patch.object(group.form, "cached_all_components", [group] + all_questions)
+        mocker.patch.object(ExpressionReference, "question", new_callable=mock.PropertyMock, return_value=None)
+        mocker.patch.object(
+            ExpressionReference, "data_source_column", new_callable=mock.PropertyMock, return_value=data_set_column
+        )
+
+        form = SelectDataSourceQuestionForm(
+            form=group.form,
+            interpolate=SubmissionHelper.get_interpolator(collection=group.form.collection),
+            subject_reference=subject_reference,
+            current_component=text_question,
             expression_type=ExpressionType.CONDITION,
             managed_expression_name=None,
         )

--- a/tests/unit/deliver_grant_funding/test_forms.py
+++ b/tests/unit/deliver_grant_funding/test_forms.py
@@ -16,6 +16,7 @@ from app.common.data.types import (
     QuestionPresentationOptions,
     RoleEnum,
 )
+from app.common.expressions.references import ExpressionReference
 from app.common.filters import format_thousands
 from app.common.helpers.collections import SubmissionHelper
 from app.deliver_grant_funding.admin.forms import PlatformAdminCreateCertifiersForm
@@ -340,7 +341,11 @@ class TestSelectDataSourceQuestionForm:
 
         assert len(form.question.choices) == 3
         # '' is the default "no answer" choice
-        assert {q[0] for q in form.question.choices} == {"", str(questions[0].id), str(questions[1].id)}
+        assert {q[0] for q in form.question.choices} == {
+            "",
+            ExpressionReference.from_question(questions[0]),
+            ExpressionReference.from_question(questions[1]),
+        }
 
     def test_questions_in_a_same_page_group_excluded(self, app, factories, mocker):
         group = factories.group.build(
@@ -362,7 +367,11 @@ class TestSelectDataSourceQuestionForm:
 
         assert len(form.question.choices) == 3
         # '' is the default "no answer" choice
-        assert {q[0] for q in form.question.choices} == {"", str(questions[0].id), str(questions[1].id)}
+        assert {q[0] for q in form.question.choices} == {
+            "",
+            ExpressionReference.from_question(questions[0]),
+            ExpressionReference.from_question(questions[1]),
+        }
 
         group.presentation_options.show_questions_on_the_same_page = True
         form = SelectDataSourceQuestionForm(
@@ -400,9 +409,9 @@ class TestSelectDataSourceQuestionForm:
         # '' is the default "no answer" choice
         assert {q[0] for q in form.question.choices} == {
             "",
-            str(text_question.id),
-            str(yes_no_question.id),
-            str(date_question.id),
+            str(ExpressionReference.from_question(text_question)),
+            str(ExpressionReference.from_question(yes_no_question)),
+            str(ExpressionReference.from_question(date_question)),
         }
 
     def test_managed_expression_excludes_mismatched_data_types(self, app, factories, mocker):
@@ -430,8 +439,8 @@ class TestSelectDataSourceQuestionForm:
         # '' is the default "no answer" choice
         assert {q[0] for q in form.question.choices} == {
             "",
-            str(integer_questions[0].id),
-            str(integer_questions[1].id),
+            ExpressionReference.from_question(integer_questions[0]),
+            ExpressionReference.from_question(integer_questions[1]),
         }
 
     def test_excludes_same_page_groups_and_unregistered_data_types(self, app, factories, mocker):
@@ -460,7 +469,11 @@ class TestSelectDataSourceQuestionForm:
         )
 
         assert len(form.question.choices) == 3
-        assert {q[0] for q in form.question.choices} == {"", str(integer_q1.id), str(integer_q2.id)}
+        assert {q[0] for q in form.question.choices} == {
+            "",
+            ExpressionReference.from_question(integer_q1),
+            ExpressionReference.from_question(integer_q2),
+        }
 
     def test_calculated_condition_excludes_unregistered_data_types(self, app, factories, mocker):
         integer_q1 = factories.question.build(data_type=QuestionDataType.NUMBER)
@@ -493,8 +506,8 @@ class TestSelectDataSourceQuestionForm:
         assert len(form.question.choices) == 3
         assert {q[0] for q in form.question.choices} == {
             "",
-            str(integer_q1.id),
-            str(integer_q2.id),
+            ExpressionReference.from_question(integer_q1),
+            ExpressionReference.from_question(integer_q2),
         }
 
 

--- a/tests/unit/test_all_routes_access.py
+++ b/tests/unit/test_all_routes_access.py
@@ -58,6 +58,8 @@ routes_with_expected_grant_admin_only_access = [
     "deliver_grant_funding.select_context_source_collection",
     "deliver_grant_funding.select_context_source_section",
     "deliver_grant_funding.select_context_source_question",
+    "deliver_grant_funding.select_context_source_data_set",
+    "deliver_grant_funding.select_context_source_data_set_column",
     "deliver_grant_funding.edit_question",
     "deliver_grant_funding.manage_guidance",
     "deliver_grant_funding.manage_add_another_guidance",


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-1147

## 📝 Description
With the ability to upload data sets (still feature flagged but can be done) we need to allow form designers to reference those data sets in forms in all the usual places - question text, hint text, guidance, managed expressions and custom expressions.

Most of these were straightforward but we realised recently that managed expressions (specifically managed conditions) expected a referenced question to be the component against which the expression would evaluate. Sam did some work to refactor this and introduced the ExpressionReference which could be either a question or a data set column, and so data set referencing can now be plugged in and used in the first step of setting up a managed condition, with a few other small refactors to enable this and make the behaviour consistent through the UI flow for all managed conditions.


## 📸 Show the thing (screenshots, gifs)
<img width="1050" height="1268" alt="2026-04-27 12 10 05" src="https://github.com/user-attachments/assets/ca2242a1-b23d-4627-ba04-4c78d09ac3bb" />


## 🧪 Testing
In a report with an uploaded grant recipient level data set, step through the UI and insert a reference in all the places listed above. You should see:
- the reference correctly inserted/interpolated
- the data set reference in DB expression and component reference tables
- you shouldn't be able to delete a data set that has a reference

## 📋 Developer Checklist

### Review Readiness
- [X] PR title and description provide sufficient context for reviewers
- [X] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- [X] No N+1 query problems introduced
- [X] Any new DB queries include appropriate where clauses based on the user's permissions

### Testing
- [X] I have tested this change and it meets the acceptance criteria for the ticket
- [X] I need the reviewer(s) to pull and run this change locally
- [X] New (non-developer) functionality has appropriate unit and integration tests
- ~[ ] End-to-end tests have been updated (if applicable)~
- [X] Edge cases and error conditions are tested

## 📚 Additional Notes
The 'select context source data set' view and form currently show all data sets for the given collection, but our referencing only works for Grant Recipient level data sets. This is intentional, as part of the work to remove the feature flag from the data set upload journey will involve restricting the uploads to only Grant Recipient level.

Filtering the data sets/columns to be referenced to just number columns when the reference is for a managed/custom expression is done in a follow up PR: https://github.com/communitiesuk/funding-service/pull/1573
