### PR TITLE
Add filter for uppercasing first word of a phrase

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -51,7 +51,7 @@ from app.common.filters import (
     to_ordinal,
 )
 from app.common.helpers.collections import SubmissionAuthorisationError
-from app.common.utils import comma_join_items
+from app.common.utils import comma_join_items, uppercase_first
 from app.config import get_settings
 from app.constants import DATA_SET_EXTERNAL_ID_COLUMN_HEADER, DATA_SET_GRANT_RECIPIENT_COLUMN_HEADER
 from app.extensions import (
@@ -274,6 +274,7 @@ def create_app() -> Flask:  # noqa: C901
         return str(current_app.config["FLASK_ENV"].value)
 
     app.jinja_env.filters["comma_join_items"] = comma_join_items
+    app.jinja_env.filters["uppercase_first"] = uppercase_first
 
     @app.context_processor
     def _jinja_template_context() -> dict[str, Any]:

--- a/app/access_grant_funding/templates/access_grant_funding/submission_list.html
+++ b/app/access_grant_funding/templates/access_grant_funding/submission_list.html
@@ -65,7 +65,7 @@
           {% endset %}
           {%
             do rows.append([
-              {"text": submission_helper.submission_name},
+              {"text": submission_helper.submission_name },
               {"html": submission_status_html},
               {"html": action_html}
             ])
@@ -78,7 +78,7 @@
           govukTable(params={
                   "firstCellIsHeader": false,
                   "head":[
-                    {"text": (collection.submission_name_question.name[0]|upper + collection.submission_name_question.name[1:])},
+                    {"text": (collection.submission_name_question.name | uppercase_first )},
                     {"text": "Status"},
                     {"html": actions_html}
                   ],

--- a/app/common/utils.py
+++ b/app/common/utils.py
@@ -40,3 +40,10 @@ def comma_join_items(items: Sequence[Any], join_word: str = "and") -> str:
         return f"{items[0]} {join_word} {items[1]}"
 
     return f"{', '.join(items[:-1])} {join_word} {items[-1]}"
+
+
+def uppercase_first(text: str | None) -> str | None:
+    if not text:
+        return text
+
+    return text[0].upper() + text[1:]

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_submissions.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_submissions.html
@@ -143,7 +143,7 @@
           govukTable({
             "captionClasses": "govuk-table__caption--m",
             "head": [
-              { "text": (report.submission_name_question.name[0]|upper + report.submission_name_question.name[1:]) if report.submission_name_question else "Submission", "classes": "govuk-!-width-one-third" },
+              { "text": (report.submission_name_question.name | uppercase_first) if report.submission_name_question else "Submission", "classes": "govuk-!-width-one-third" },
               { "text": "Grant recipient" },
               { "text": "Status" },
               { "text": "Last updated" }

--- a/tests/unit/common/test_utils.py
+++ b/tests/unit/common/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from app.common.utils import comma_join_items, slugify
+from app.common.utils import comma_join_items, slugify, uppercase_first
 
 
 @pytest.mark.parametrize(
@@ -41,3 +41,19 @@ def test_slugify(test_string, expected_result):
 )
 def test_comma_join_items(items, join_word, expected):
     assert comma_join_items(items, join_word=join_word) == expected
+
+
+@pytest.mark.parametrize(
+    "phrase, expected_phrase",
+    (
+        ("hello", "Hello"),
+        ("hello world", "Hello world"),
+        ("hello WORLD", "Hello WORLD"),
+        ("Hello world", "Hello world"),
+        ("123 world", "123 world"),
+        ("@ oh no", "@ oh no"),
+        (None, None),
+    ),
+)
+def test_uppercase_first(phrase, expected_phrase):
+    assert uppercase_first(phrase) == expected_phrase


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
This is so we can display phrases/fragments and still have them render grammatically correct if we're not inserting them into the middle of a sentence.
