### PR TITLE
Remove existing component self-refernces

### DIFF
--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-054_allow_public_sign_up
+055_delete_self_component_refs

--- a/app/common/data/migrations/versions/055_delete_self_component_refs.py
+++ b/app/common/data/migrations/versions/055_delete_self_component_refs.py
@@ -1,0 +1,22 @@
+"""delete self component refs
+
+Revision ID: 055_delete_self_component_refs
+Revises: 054_allow_public_sign_up
+Create Date: 2026-04-09 14:06:37.697095
+
+"""
+
+from alembic import op
+
+revision = "055_delete_self_component_refs"
+down_revision = "054_allow_public_sign_up"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("DELETE FROM component_reference WHERE component_id = depends_on_component_id")
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
To merge after: https://github.com/communitiesuk/funding-service/pull/1534

Split this into a separate DB migration to be deployed separate from the code change to ensure that all existing self-references are caught.

Otherwise our deployment pipeline would run the migration while old code is still running, and that old code could create new self-refs that then linger around.

## 🧪 Testing
<!-- Describe how you've tested this change, and how a reviewer can test it -->

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- [x] No N+1 query problems introduced
- [x] Any new DB queries include appropriate where clauses based on the user's permissions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [-] I need the reviewer(s) to pull and run this change locally
- [-] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested