### PR TITLE
Export grants to s3

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -133,6 +133,7 @@ class _SharedConfig(_BaseConfig):
     AWS_S3_BUCKET_NAME: str
     SUBMISSION_FILES_PREFIX: str = "uploaded-submission-files"
     REFERENCE_FILES_PREFIX: str = "data-set-uploads"
+    GRANT_EXPORT_FILES_PREFIX: str = "grant-exports"
 
     # Basic auth
     BASIC_AUTH_ENABLED: bool = False

--- a/app/developers/commands.py
+++ b/app/developers/commands.py
@@ -3,6 +3,7 @@ import hashlib
 import json
 import uuid
 from collections import defaultdict
+from io import BytesIO
 from pathlib import Path
 from typing import Any, TextIO, TypedDict, cast
 from uuid import UUID
@@ -12,7 +13,7 @@ from flask import current_app
 from pydantic import BaseModel as PydanticBaseModel
 from sqlalchemy import delete, inspect, or_, select
 from sqlalchemy.exc import NoResultFound
-from werkzeug.datastructures import MultiDict
+from werkzeug.datastructures import FileStorage, MultiDict
 
 from app.common.collections.forms import build_question_form
 from app.common.data.base import BaseModel
@@ -62,7 +63,7 @@ from app.common.expressions import ExpressionContext
 from app.common.helpers.collections import SubmissionHelper
 from app.common.utils import slugify
 from app.developers import developers_blueprint
-from app.extensions import db
+from app.extensions import db, s3_service
 
 export_path = Path.cwd() / "app" / "developers" / "data" / "grants.json"
 
@@ -173,17 +174,38 @@ def _import_organisations_and_handle_org_ids(export_data: ExportData) -> ExportD
 
 @developers_blueprint.cli.command("export-grants", help="Export configured grants to consistently seed environments")
 @click.argument("grant_ids", nargs=-1, type=click.UUID)
-@click.option("--output", type=click.Choice(["file", "stdout"]), default="file")
-def export_grants(grant_ids: list[uuid.UUID], output: str) -> None:  # noqa: C901
+@click.option("--output", type=click.Choice(["file", "stdout", "s3"]), default="file")
+@click.option("--s3-key", help="S3 object key to upload to. Required when --output=s3.")
+@click.option(
+    "--exclude-users/--no-exclude-users",
+    default=None,
+    help="Replace all user associations when exporting with a single placeholder user. Forced on for production.",
+)
+def export_grants(  # noqa: C901
+    grant_ids: list[uuid.UUID], output: str, s3_key: str | None, exclude_users: bool | None
+) -> None:
     from faker import Faker
 
-    if not export_path.exists():
-        raise RuntimeError(
-            f"Could not find the exported data at {export_path}. "
-            f"Make sure you're running this command from the root of the repository."
-        )
+    if current_app.config["IS_PRODUCTION"]:
+        if exclude_users is False:
+            click.echo("Warning: --no-exclude-users is ignored in production; user data will be stripped.")
+        exclude_users = True
+    else:
+        exclude_users = bool(exclude_users)
+
+    if output == "s3":
+        if not s3_key:
+            raise click.ClickException("--s3-key is required when --output=s3")
+        required_prefix = current_app.config["GRANT_EXPORT_FILES_PREFIX"].rstrip("/") + "/"
+        if not s3_key.startswith(required_prefix):
+            raise click.ClickException(f"--s3-key must start with {required_prefix!r}")
 
     if len(grant_ids) == 0:
+        if not export_path.exists():
+            raise click.ClickException(
+                f"Could not find the exported data at {export_path}. "
+                f"Make sure you're running this command from the root of the repository."
+            )
         with open(export_path) as infile:
             previous_export_data = json.load(infile)
         grant_ids = [uuid.UUID(grant_data["grant"]["id"]) for grant_data in previous_export_data["grants"]]
@@ -248,31 +270,45 @@ def export_grants(grant_ids: list[uuid.UUID], output: str) -> None:  # noqa: C90
         for user in grant.grant_team_users:
             users.add(user)
 
-    org_ids = {org["id"] for org in export_data["organisations"]}
-    for user in users:
-        if user.id in [u["id"] for u in export_data["users"]]:
-            continue
+    if exclude_users:
+        placeholder_user = User(
+            id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
+            email="placeholder@communities.test.gov.localhost",
+            name="Placeholder User",
+        )
 
-        user_data = to_dict(user)
+        for user in users:
+            export_data = __replace_id(export_data, str(user.id), str(placeholder_user.id))
 
-        # Anonymise the user, but in a consistent way
-        if user.email not in USERS_NOT_TO_ANONYMISE:
-            faker = Faker()
-            faker.seed_instance(int(hashlib.md5(str(user_data["id"]).encode()).hexdigest(), 16))
-            first_name = faker.first_name()
-            last_name = faker.last_name()
-            user_data["email"] = f"{first_name.lower()}.{last_name.lower()}@test.communities.gov.uk"
-            user_data["name"] = f"{first_name} {last_name}"
+        export_data["users"] = [to_dict(placeholder_user)]
+        export_data["user_roles"] = []
 
-        export_data["users"].append(user_data)
-
-        for role in user.roles:
-            if (role.organisation_id and role.organisation_id not in org_ids) or (
-                role.grant_id and role.grant_id not in grant_ids
-            ):
+    else:
+        org_ids = {org["id"] for org in export_data["organisations"]}
+        for user in users:
+            if user.id in [u["id"] for u in export_data["users"]]:
                 continue
 
-            export_data["user_roles"].append(to_dict(role))
+            user_data = to_dict(user)
+
+            # Anonymise the user, but in a consistent way.
+            if user.email not in USERS_NOT_TO_ANONYMISE:
+                faker = Faker()
+                faker.seed_instance(int(hashlib.md5(str(user_data["id"]).encode()).hexdigest(), 16))
+                first_name = faker.first_name()
+                last_name = faker.last_name()
+                user_data["email"] = f"{first_name.lower()}.{last_name.lower()}@test.communities.gov.uk"
+                user_data["name"] = f"{first_name} {last_name}"
+
+            export_data["users"].append(user_data)
+
+            for role in user.roles:
+                if (role.organisation_id and role.organisation_id not in org_ids) or (
+                    role.grant_id and role.grant_id not in grant_ids
+                ):
+                    continue
+
+                export_data["user_roles"].append(to_dict(role))
 
     _sort_export_data_in_place(export_data)
     export_data = _handle_org_ids_for_export(export_data)
@@ -291,6 +327,17 @@ def export_grants(grant_ids: list[uuid.UUID], output: str) -> None:  # noqa: C90
             click.echo(export_json)
             click.echo("\n\n\n")
             click.echo(f"Written {len(grants)} grants to stdout")
+
+        case "s3":
+            assert s3_key is not None
+            buf = FileStorage(
+                stream=BytesIO(export_json.encode("utf-8")),
+                filename=s3_key,
+                content_type="application/json",
+            )
+            s3_service.upload_file(buf, key=s3_key)
+            bucket = current_app.config["AWS_S3_BUCKET_NAME"]
+            click.echo(f"Written {len(grants)} grants to s3://{bucket}/{s3_key}")
 
 
 @developers_blueprint.cli.command("seed-grants", help="Load exported grants into the database")

--- a/app/developers/commands.py
+++ b/app/developers/commands.py
@@ -295,6 +295,9 @@ def export_grants(grant_ids: list[uuid.UUID], output: str) -> None:  # noqa: C90
 
 @developers_blueprint.cli.command("seed-grants", help="Load exported grants into the database")
 def seed_grants() -> None:  # noqa: C901
+    if current_app.config["IS_PRODUCTION"]:
+        raise click.ClickException("seed-grants must not be run in production; it deletes and recreates grants.")
+
     with open(export_path) as infile:
         raw_export_json = infile.read()
         export_data: ExportData = json.loads(raw_export_json)

--- a/tests/integration/developers/test_commands.py
+++ b/tests/integration/developers/test_commands.py
@@ -1,5 +1,6 @@
 import io
 
+import click
 import pytest
 from sqlalchemy import select
 
@@ -12,15 +13,22 @@ from app.common.data.types import (
     TasklistSectionStatusEnum,
 )
 from app.common.helpers.collections import SubmissionHelper
-from app.developers.commands import create_multi_submissions
+from app.developers.commands import create_multi_submissions, seed_grants
 from app.extensions import db
 from tests.models import FactoryAnswer
 
+
+def _unwrap(command):
+    fn = command.callback
+    while hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+    return fn
+
+
 # Unwrap Flask's with_appcontext / click.pass_context wrappers so we can call
 # the function directly within the test's existing app context and DB session.
-_create_multi_submissions = create_multi_submissions.callback
-while hasattr(_create_multi_submissions, "__wrapped__"):
-    _create_multi_submissions = _create_multi_submissions.__wrapped__
+_create_multi_submissions = _unwrap(create_multi_submissions)
+_seed_grants = _unwrap(seed_grants)
 
 
 def _make_csv(rows: list[tuple[str, str]]) -> io.StringIO:
@@ -399,3 +407,10 @@ class TestCreateMultiSubmissions:
         helper = SubmissionHelper(submission)
         assert helper.cached_get_all_questions_are_answered_for_form(question.form).all_answered is True
         assert helper.get_status_for_form(question.form) != TasklistSectionStatusEnum.COMPLETED
+
+
+class TestSeedGrants:
+    def test_refuses_to_run_in_production(self, app, monkeypatch):
+        monkeypatch.setitem(app.config, "IS_PRODUCTION", True)
+        with pytest.raises(click.ClickException, match="must not be run in production"):
+            _seed_grants()

--- a/tests/integration/developers/test_commands.py
+++ b/tests/integration/developers/test_commands.py
@@ -1,4 +1,5 @@
 import io
+import json
 
 import click
 import pytest
@@ -13,7 +14,7 @@ from app.common.data.types import (
     TasklistSectionStatusEnum,
 )
 from app.common.helpers.collections import SubmissionHelper
-from app.developers.commands import create_multi_submissions, seed_grants
+from app.developers.commands import create_multi_submissions, export_grants, seed_grants
 from app.extensions import db
 from tests.models import FactoryAnswer
 
@@ -28,6 +29,7 @@ def _unwrap(command):
 # Unwrap Flask's with_appcontext / click.pass_context wrappers so we can call
 # the function directly within the test's existing app context and DB session.
 _create_multi_submissions = _unwrap(create_multi_submissions)
+_export_grants = _unwrap(export_grants)
 _seed_grants = _unwrap(seed_grants)
 
 
@@ -407,6 +409,84 @@ class TestCreateMultiSubmissions:
         helper = SubmissionHelper(submission)
         assert helper.cached_get_all_questions_are_answered_for_form(question.form).all_answered is True
         assert helper.get_status_for_form(question.form) != TasklistSectionStatusEnum.COMPLETED
+
+
+def _extract_stdout_json(captured_out: str) -> dict:
+    start = captured_out.index("{")
+    end = captured_out.rindex("}") + 1
+    return json.loads(captured_out[start:end])
+
+
+class TestExportGrants:
+    def test_exclude_users_collapses_to_placeholder(self, db_session, factories, capsys):
+        question = factories.question.create(data_type=QuestionDataType.TEXT_SINGLE_LINE)
+        grant = question.form.collection.grant
+
+        _export_grants(grant_ids=[grant.id], output="stdout", s3_key=None, exclude_users=True)
+
+        payload = _extract_stdout_json(capsys.readouterr().out)
+
+        assert payload["users"] == [
+            {
+                "id": "00000000-0000-0000-0000-000000000001",
+                "email": "placeholder@communities.test.gov.localhost",
+                "name": "Placeholder User",
+            }
+        ]
+        assert payload["user_roles"] == []
+
+        grant_data = payload["grants"][0]
+        assert grant_data["collections"][0]["created_by_id"] == "00000000-0000-0000-0000-000000000001"
+
+    def test_production_forces_exclude_users_and_warns_on_opt_out(
+        self, app, monkeypatch, db_session, factories, capsys
+    ):
+        question = factories.question.create(data_type=QuestionDataType.TEXT_SINGLE_LINE)
+        grant = question.form.collection.grant
+        monkeypatch.setitem(app.config, "IS_PRODUCTION", True)
+
+        _export_grants(grant_ids=[grant.id], output="stdout", s3_key=None, exclude_users=False)
+
+        captured = capsys.readouterr().out
+        assert "--no-exclude-users is ignored in production" in captured
+
+        payload = _extract_stdout_json(captured)
+        assert [u["id"] for u in payload["users"]] == ["00000000-0000-0000-0000-000000000001"]
+        assert payload["grants"][0]["collections"][0]["created_by_id"] == "00000000-0000-0000-0000-000000000001"
+
+    def test_s3_output_uploads_export(self, db_session, factories, mock_s3_service_calls):
+        question = factories.question.create(data_type=QuestionDataType.TEXT_SINGLE_LINE)
+        grant = question.form.collection.grant
+
+        _export_grants(
+            grant_ids=[grant.id],
+            output="s3",
+            s3_key="grant-exports/test-export.json",
+            exclude_users=True,
+        )
+
+        assert len(mock_s3_service_calls.upload_file_calls) == 1
+        call = mock_s3_service_calls.upload_file_calls[0]
+        uploaded_file = call.args[0]
+        assert call.kwargs["key"] == "grant-exports/test-export.json"
+        uploaded_file.stream.seek(0)
+        payload = json.loads(uploaded_file.stream.read().decode("utf-8"))
+        assert [u["id"] for u in payload["users"]] == ["00000000-0000-0000-0000-000000000001"]
+        assert payload["grants"][0]["grant"]["id"] == str(grant.id)
+
+    def test_s3_output_requires_key(self, db_session, factories):
+        question = factories.question.create(data_type=QuestionDataType.TEXT_SINGLE_LINE)
+        grant = question.form.collection.grant
+
+        with pytest.raises(click.ClickException, match="--s3-key is required"):
+            _export_grants(grant_ids=[grant.id], output="s3", s3_key=None, exclude_users=True)
+
+    def test_s3_output_rejects_key_outside_prefix(self, db_session, factories):
+        question = factories.question.create(data_type=QuestionDataType.TEXT_SINGLE_LINE)
+        grant = question.form.collection.grant
+
+        with pytest.raises(click.ClickException, match="must start with 'grant-exports/'"):
+            _export_grants(grant_ids=[grant.id], output="s3", s3_key="exports/test.json", exclude_users=True)
 
 
 class TestSeedGrants:


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
Allow exporting grants/reports from a deployed environment to s3, anonymously, so that we can import their config locally for review and testing.

Corresponding terraform PR: https://github.com/communitiesuk/funding-service-terraform/pull/93

I've deployed this to dev and run an export successfully.

## 🧪 Testing
<!-- Describe how you've tested this change, and how a reviewer can test it -->

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested