### PR TITLE
Data set component references

### DIFF
--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -756,7 +756,7 @@ def get_component_by_id(component_id: UUID) -> Component:
 
 
 class FlashableException(Protocol):
-    def as_flash_context(self) -> dict[str, str | bool]: ...
+    def as_flash_context(self) -> dict[str, Any]: ...
 
 
 class DependencyOrderException(WTFormRenderableException, FlashableException):
@@ -847,6 +847,34 @@ class IncompatibleDataTypeException(WTFormRenderableException):
             "question_text": self.question.text,
             "depends_on_question_id": str(self.depends_on_question.id),
             "depends_on_question_text": self.depends_on_question.text,
+        }
+
+
+class DataSourceHasReferencesException(Exception, FlashableException):
+    def __init__(
+        self,
+        message: str,
+        data_source_id: uuid.UUID,
+        data_source_name: str,
+        grant_id: uuid.UUID,
+        referenced_columns: set[str],
+        references: list[dict[str, Any]],
+    ):
+        super().__init__(message)
+        self.message = message
+        self.data_source_id = data_source_id
+        self.data_source_name = data_source_name
+        self.grant_id = grant_id
+        self.referenced_columns = referenced_columns
+        self.references = references
+
+    def as_flash_context(self) -> dict[str, Any]:
+        return {
+            "message": self.message,
+            "data_source_name": self.data_source_name,
+            "grant_id": str(self.grant_id),
+            "referenced_columns": sorted(self.referenced_columns),
+            "references": sorted(self.references, key=lambda r: (r["component_text"], r["reference_type"])),
         }
 
 
@@ -1122,6 +1150,49 @@ def raise_if_data_source_item_reference_dependency(
             data_source_item_dependency_map=data_source_item_dependency_map,
         )
     return None
+
+
+def raise_if_data_source_has_references(data_source: DataSource) -> Never | None:
+    references = list(data_source.depended_on_by_columns)
+    if not references:
+        return None
+
+    seen_keys: set[tuple[UUID, str]] = set()
+    references_for_flash: list[dict[str, Any]] = []
+    for ref in references:
+        if ref.component is None:
+            continue
+        if ref.expression is not None:
+            reference_type = "Validation" if ref.expression.type_ == ExpressionType.VALIDATION else "Condition"
+        else:
+            reference_type = "Group" if ref.component.is_group else "Question"
+
+        key = (ref.component.id, reference_type)
+        if key in seen_keys:
+            continue
+        seen_keys.add(key)
+        references_for_flash.append(
+            {
+                "component_id": str(ref.component.id),
+                "component_text": ref.component.text or "",
+                "is_group": ref.component.is_group,
+                "reference_type": reference_type,
+            }
+        )
+
+    if data_source.grant_id is None:
+        # Should not happen for non-CUSTOM data sources (see check constraint on DataSource), so we treat this
+        # as a programmer error rather than trying to build a half-broken flash message.
+        raise RuntimeError(f"DataSource {data_source.id} has references but no grant_id")
+
+    raise DataSourceHasReferencesException(
+        "You cannot delete this data set because it's being referenced in the form. You need to remove references in:",
+        data_source_id=data_source.id,
+        data_source_name=data_source.name or "",
+        grant_id=data_source.grant_id,
+        referenced_columns={ref.depends_on_column_name or "" for ref in references},
+        references=references_for_flash,
+    )
 
 
 class AddAnotherDependencyException(WTFormRenderableException, FlashableException):

--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -1090,6 +1090,7 @@ def raise_if_group_questions_depend_on_each_other(group: Group) -> Never | None:
         .all()
     )
     if component_reference:
+        assert component_reference[0].depends_on_component
         raise DependencyOrderException(
             f"Group {group.id} cannot be set to same page because {component_reference[0].component.id} "
             f"depends on {component_reference[0].depends_on_component.id}",

--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -1653,6 +1653,7 @@ def _validate_and_sync_expression_references(expression: Expression) -> None:  #
         if expr_impl.referenced_question != expression.question:  # ty:ignore[unresolved-attribute]
             referenced_questions.add(expr_impl.referenced_question)  # ty:ignore[unresolved-attribute]
 
+    referenced_columns: set[tuple[UUID, str]] = set()
     for field in expr_impl.reference_aware_fields:
         field_value = getattr(expr_impl, field)
         if not field_value:
@@ -1670,12 +1671,17 @@ def _validate_and_sync_expression_references(expression: Expression) -> None:  #
                 question_to_test=expr_impl.referenced_question if expression.is_managed else None,  # ty:ignore[unresolved-attribute]
             )
 
-            # TODO: Add data_source wrangling for creating component references
-            question_id = SafeQidMixin.safe_qid_to_id(valid_reference)
-            if not question_id:
+            if question_id := SafeQidMixin.safe_qid_to_id(valid_reference):
+                referenced_question = get_question_by_id(question_id)
+                referenced_questions.add(referenced_question)
                 continue
-            referenced_question = get_question_by_id(question_id)
-            referenced_questions.add(referenced_question)
+
+            data_source_id, column_name = SafeDidMixin.safe_ds_ref_to_id_and_column_name(valid_reference)
+            if data_source_id and column_name:
+                referenced_columns.add((data_source_id, column_name))
+                continue
+
+            raise ValueError(f"Unhandled reference '{valid_reference}' in component '{expression.question_id}'")
 
     for referenced_question in referenced_questions:
         if referenced_question == expression.question:
@@ -1684,6 +1690,16 @@ def _validate_and_sync_expression_references(expression: Expression) -> None:  #
             component=expression.question,
             expression=expression,
             depends_on_component=referenced_question,
+        )
+        db.session.add(cr)
+        references.append(cr)
+
+    for data_source_id, column_name in referenced_columns:
+        cr = ComponentReference(
+            component=expression.question,
+            expression=expression,
+            depends_on_data_source_id=data_source_id,
+            depends_on_column_name=column_name,
         )
         db.session.add(cr)
         references.append(cr)
@@ -1735,6 +1751,9 @@ def _validate_and_sync_component_references(component: Component, expression_con
             data_source_id, column_name = SafeDidMixin.safe_ds_ref_to_id_and_column_name(reference)
             if data_source_id and column_name:
                 column_refs_to_set_up.add((data_source_id, column_name))
+                continue
+
+            raise ValueError(f"Unhandled reference '{reference}' in component '{component.id}'")
 
     for component_id, depends_on_component_id in component_refs_to_set_up:
         if component_id == depends_on_component_id:

--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -1588,7 +1588,14 @@ def _validate_reference(  # noqa:C901
                 "than once",
             )
     elif data_source_id:
-        db.session.get_one(DataSource, data_source_id)
+        data_source = db.session.get_one(DataSource, data_source_id)
+        if not data_source.schema or _column_name not in data_source.schema.root:
+            raise InvalidReferenceInExpression(
+                f"Column {_column_name} does not exist on data source {data_source_id}",
+                field_name=field_name_for_error_message,
+                bad_reference=wrapped_reference,
+                form_error_message=f"You cannot use {wrapped_reference} because it does not exist",
+            )
 
     else:
         # TODO implement this once we can reference other things, eg. data uploads
@@ -1701,7 +1708,8 @@ def _validate_and_sync_component_references(component: Component, expression_con
     for expression in component.expressions:
         _validate_and_sync_expression_references(expression)
 
-    references_to_set_up: set[tuple[UUID, UUID]] = set()
+    component_refs_to_set_up: set[tuple[UUID, UUID]] = set()
+    column_refs_to_set_up: set[tuple[UUID, str]] = set()
     field_names = ["text", "hint", "guidance_body", "add_another_guidance_body"]
     for field_name in field_names:
         value = getattr(component, field_name)
@@ -1721,15 +1729,26 @@ def _validate_and_sync_component_references(component: Component, expression_con
 
             if question_id := SafeQidMixin.safe_qid_to_id(reference):
                 question = db.session.get_one(Question, question_id)
+                component_refs_to_set_up.add((component.id, question.id))
+                continue
 
-                references_to_set_up.add((component.id, question.id))
+            data_source_id, column_name = SafeDidMixin.safe_ds_ref_to_id_and_column_name(reference)
+            if data_source_id and column_name:
+                column_refs_to_set_up.add((data_source_id, column_name))
 
-            # TODO: Add data_source wrangling for creating component references
-
-    for component_id, depends_on_component_id in references_to_set_up:
+    for component_id, depends_on_component_id in component_refs_to_set_up:
         if component_id == depends_on_component_id:
             continue
         db.session.add(ComponentReference(component_id=component_id, depends_on_component_id=depends_on_component_id))
+
+    for data_source_id, column_name in column_refs_to_set_up:
+        db.session.add(
+            ComponentReference(
+                component_id=component.id,
+                depends_on_data_source_id=data_source_id,
+                depends_on_column_name=column_name,
+            )
+        )
 
 
 @flush_and_rollback_on_exceptions(coerce_exceptions=[(IntegrityError, DuplicateValueError)])

--- a/app/common/data/interfaces/data_sets.py
+++ b/app/common/data/interfaces/data_sets.py
@@ -5,6 +5,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import selectinload
 
+from app.common.data.interfaces.collections import raise_if_data_source_has_references
 from app.common.data.interfaces.exceptions import DuplicateDataSourceItemError, flush_and_rollback_on_exceptions
 from app.common.data.models import DataSource, DataSourceItem, DataSourceOrganisationItem
 from app.common.data.models_user import User
@@ -187,7 +188,8 @@ def create_uploaded_data_source(
 
 @flush_and_rollback_on_exceptions
 def delete_data_source(data_source: DataSource) -> None:
-    # TODO: Add guardrails against deleting datasource where it's been used in a reference
+    raise_if_data_source_has_references(data_source)
+
     if data_source.file_metadata and data_source.file_metadata.s3_key:
         s3_service.delete_file(data_source.file_metadata.s3_key)
 

--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-055_delete_self_component_refs
+056_component_ref_column_deps

--- a/app/common/data/migrations/versions/056_component_ref_column_deps.py
+++ b/app/common/data/migrations/versions/056_component_ref_column_deps.py
@@ -1,0 +1,54 @@
+"""component reference supports data source columns
+
+Revision ID: 056_component_ref_column_deps
+Revises: 055_delete_self_component_refs
+Create Date: 2026-04-14 15:49:00.608338
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "056_component_ref_column_deps"
+down_revision = "055_delete_self_component_refs"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("component_reference", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("depends_on_data_source_id", sa.Uuid(), nullable=True))
+        batch_op.add_column(sa.Column("depends_on_column_name", sa.String(), nullable=True))
+        batch_op.alter_column("depends_on_component_id", existing_type=sa.UUID(), nullable=True)
+        batch_op.create_foreign_key(
+            batch_op.f("fk_component_reference_depends_on_data_source_id_data_source"),
+            "data_source",
+            ["depends_on_data_source_id"],
+            ["id"],
+            ondelete="RESTRICT",
+        )
+        batch_op.create_check_constraint(
+            "ck_component_reference_component_xor_data_source",
+            "(depends_on_component_id IS NOT NULL) != (depends_on_data_source_id IS NOT NULL)",
+        )
+        batch_op.create_check_constraint(
+            "ck_component_reference_item_requires_component",
+            "depends_on_data_source_item_id IS NULL OR depends_on_component_id IS NOT NULL",
+        )
+        batch_op.create_check_constraint(
+            "ck_component_reference_data_source_requires_column",
+            "(depends_on_data_source_id IS NULL) = (depends_on_column_name IS NULL)",
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("component_reference", schema=None) as batch_op:
+        batch_op.drop_constraint("ck_component_reference_data_source_requires_column", type_="check")
+        batch_op.drop_constraint("ck_component_reference_item_requires_component", type_="check")
+        batch_op.drop_constraint("ck_component_reference_component_xor_data_source", type_="check")
+        batch_op.drop_constraint(
+            batch_op.f("fk_component_reference_depends_on_data_source_id_data_source"), type_="foreignkey"
+        )
+        batch_op.alter_column("depends_on_component_id", existing_type=sa.UUID(), nullable=False)
+        batch_op.drop_column("depends_on_column_name")
+        batch_op.drop_column("depends_on_data_source_id")

--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -1050,6 +1050,14 @@ class DataSource(BaseModel, SafeDidMixin):
         cascade="all, delete-orphan",
     )
 
+    depended_on_by_columns: Mapped[list[ComponentReference]] = relationship(
+        "ComponentReference",
+        back_populates="depends_on_data_source",
+        # explicitly disable cascading deletes so that ComponentReference can protect the DataSource
+        passive_deletes="all",
+        foreign_keys="ComponentReference.depends_on_data_source_id",
+    )
+
     def get_filtered_organisation_item(self, organisation_external_id: str) -> DataSourceOrganisationItem | None:
         if not self.organisation_items:
             return None
@@ -1226,7 +1234,8 @@ class DataSourceOrganisationItem(BaseModel):
 
 
 class ComponentReference(BaseModel):
-    """A table to track when components (and their expressions) create a dependency upon another component.
+    """A table to track when components (and their expressions) create a dependency upon another component
+    or an uploaded reference-dataset column.
 
     As of creating this table, the common examples are:
 
@@ -1235,6 +1244,10 @@ class ComponentReference(BaseModel):
 
     q2 has text that shows the answer to q1:
       => ComponentReference(component_id=q2.id, expression_id=None, depends_on_component_id=q1.id)
+
+    q2 has text that shows a column value from an uploaded reference dataset d1:
+      => ComponentReference(component_id=q2.id, expression_id=None,
+                            depends_on_data_source_id=d1.id, depends_on_column_name="c_allocation")
     """
 
     __tablename__ = "component_reference"
@@ -1247,22 +1260,54 @@ class ComponentReference(BaseModel):
     expression_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("expression.id"))
     expression: Mapped[Expression | None] = relationship("Expression")
 
-    depends_on_component_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("component.id"))
-    depends_on_component: Mapped[Component] = relationship(
+    depends_on_component_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("component.id"))
+    depends_on_component: Mapped[Component | None] = relationship(
         "Component", foreign_keys=[depends_on_component_id], back_populates="depended_on_by"
     )
 
+    # NOTE: When pointing at a CUSTOM data source item, we also store `depends_on_component_id` - maybe we shouldn't?
+    #       When we add STATIC data sources, it would be nice for CUSTOM+STATIC to be treated the same in terms of
+    #       component references?
     depends_on_data_source_item_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("data_source_item.id"))
     depends_on_data_source_item: Mapped[DataSourceItem | None] = relationship("DataSourceItem")
 
-    # Mirror columns from the referenced component for ordering the Component.component_references relationship
-    _sort_form_id: Mapped[uuid.UUID] = column_property(
+    depends_on_data_source_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("data_source.id", ondelete="RESTRICT")
+    )
+    depends_on_data_source: Mapped[DataSource | None] = relationship(
+        "DataSource", back_populates="depended_on_by_columns"
+    )
+    # NOTE: should we store dataset columns in a separate table so we can link to specific FKs here for more in-depth
+    #       integrity checks?
+    depends_on_column_name: Mapped[str | None]
+
+    __table_args__ = (
+        # A reference points at exactly one target kind: either a component (optionally paired with a
+        # specific data-source item for CUSTOM radio choices), or a data-source column.
+        CheckConstraint(
+            "(depends_on_component_id IS NOT NULL) != (depends_on_data_source_id IS NOT NULL)",
+            name="ck_component_reference_component_xor_data_source",
+        ),
+        CheckConstraint(
+            "depends_on_data_source_item_id IS NULL OR depends_on_component_id IS NOT NULL",
+            name="ck_component_reference_item_requires_component",
+        ),
+        CheckConstraint(
+            "(depends_on_data_source_id IS NULL) = (depends_on_column_name IS NULL)",
+            name="ck_component_reference_data_source_requires_column",
+        ),
+    )
+
+    # Mirror columns from the referenced component for ordering the Component.component_references relationship.
+    # Column-level references (depends_on_data_source_id set) leave these NULL — they don't participate in
+    # form ordering.
+    _sort_form_id: Mapped[uuid.UUID | None] = column_property(
         select(Component.form_id).where(Component.id == foreign(depends_on_component_id)).scalar_subquery()
     )
     _sort_parent_id: Mapped[uuid.UUID | None] = column_property(
         select(Component.parent_id).where(Component.id == foreign(depends_on_component_id)).scalar_subquery()
     )
-    _sort_order: Mapped[int] = column_property(
+    _sort_order: Mapped[int | None] = column_property(
         select(Component.order).where(Component.id == foreign(depends_on_component_id)).scalar_subquery()
     )
 

--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -517,6 +517,9 @@ class SubmissionHelper:
         for component in form.cached_all_components:
             for ref in component.owned_component_references:
                 depends_on = ref.depends_on_component
+                if depends_on is None:
+                    # Data-source column references don't depend on a component, so they can't hold a form back.
+                    continue
                 if depends_on.form_id != form.id:
                     if depends_on.is_question:
                         answer = self.cached_get_answer_for_question(depends_on.id)
@@ -616,6 +619,9 @@ class SubmissionHelper:
 
         for ref in component.owned_component_references:
             depends_on = ref.depends_on_component
+            if depends_on is None:
+                # Data-source column references are always available — they can't gate visibility.
+                continue
             if depends_on.id == component.id:
                 continue
             if not depends_on.is_question:

--- a/app/deliver_grant_funding/routes/reports.py
+++ b/app/deliver_grant_funding/routes/reports.py
@@ -20,6 +20,7 @@ from app.common.data import interfaces
 from app.common.data.interfaces.collections import (
     AddAnotherDependencyException,
     AddAnotherNotValidException,
+    DataSourceHasReferencesException,
     DataSourceItemReferenceDependencyException,
     DependencyOrderException,
     GroupContainsAddAnotherException,
@@ -47,6 +48,7 @@ from app.common.data.interfaces.collections import (
     move_component_up,
     move_form_down,
     move_form_up,
+    raise_if_data_source_has_references,
     raise_if_nested_group_creation_not_valid_here,
     raise_if_question_has_any_dependencies,
     remove_question_expression,
@@ -3548,12 +3550,25 @@ def view_data_source(grant_id: UUID, report_id: UUID, data_source_id: UUID) -> R
                     data_source_id=data_source_id,
                 )
             )
-        if delete_wtform.validate_on_submit():
-            name = data_source.name
-            delete_data_source(data_source)
-            flash(Markup(f"'{escape(name)}' data set has been deleted."))
+        try:
+            raise_if_data_source_has_references(data_source)
+
+            if delete_wtform.validate_on_submit():
+                name = data_source.name
+                delete_data_source(data_source)
+                flash(Markup(f"'{escape(name)}' data set has been deleted."))
+                return redirect(
+                    url_for("deliver_grant_funding.list_report_data_sets", grant_id=grant_id, report_id=report_id)
+                )
+        except DataSourceHasReferencesException as e:
+            flash(e.as_flash_context(), FlashMessageType.DATA_SOURCE_REFERENCE_ERROR.value)  # type: ignore[arg-type]
             return redirect(
-                url_for("deliver_grant_funding.list_report_data_sets", grant_id=grant_id, report_id=report_id)
+                url_for(
+                    "deliver_grant_funding.view_data_source",
+                    grant_id=grant_id,
+                    report_id=report_id,
+                    data_source_id=data_source_id,
+                )
             )
 
     return render_template(
@@ -3563,6 +3578,7 @@ def view_data_source(grant_id: UUID, report_id: UUID, data_source_id: UUID) -> R
         data_source=data_source,
         delete_form=delete_wtform,
         grant_recipient_name_by_external_id=grant_recipient_name_by_external_id,
+        interpolate=SubmissionHelper.get_interpolator(collection=report),
     )
 
 

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/data_sets/view_data_set.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/data_sets/view_data_set.html
@@ -15,6 +15,28 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      {% with flashes = get_flashed_messages(category_filter=[enum.flash_message_type.DATA_SOURCE_REFERENCE_ERROR.value]) %}
+        {% for flash in flashes %}
+          {% set reference_error_html %}
+            <p class="govuk-body govuk-!-font-weight-bold">{{ flash.message }}</p>
+            {% for ref in flash.references %}
+              {% set component_link = url_for("deliver_grant_funding.edit_question", grant_id=flash.grant_id, question_id=ref.component_id) if not ref.is_group else url_for("deliver_grant_funding.list_group_questions", grant_id=flash.grant_id, group_id=ref.component_id) %}
+              <p class="govuk-body govuk-!-font-weight-bold">
+                <a class="govuk-notification-banner__link" href="{{ component_link }}">{{ interpolate(ref.component_text) }} ({{ ref.reference_type }})</a>
+              </p>
+            {% endfor %}
+          {% endset %}
+          {{
+            govukNotificationBanner(params={
+              "role": "alert",
+              "titleText": "Error",
+              "classes": "app-notification-banner--destructive",
+              "html": reference_error_html,
+            })
+          }}
+        {% endfor %}
+      {% endwith %}
+
       {% if delete_form and authorisation_helper.can_edit_collection(current_user, report.id) %}
         {% set banner_html %}
           <p class="govuk-body govuk-!-font-weight-bold">Are you sure you want to delete this data set?</p>

--- a/app/types.py
+++ b/app/types.py
@@ -17,6 +17,7 @@ class FlashMessageType(StrEnum):
     DEPENDENCY_ORDER_ERROR = "dependency_order_error"
     SECTION_DEPENDENCY_ORDER_ERROR = "section_dependency_order_error"
     DATA_SOURCE_ITEM_DEPENDENCY_ERROR = "data_source_item_dependency_error"
+    DATA_SOURCE_REFERENCE_ERROR = "data_source_reference_error"
     SUBMISSION_TESTING_COMPLETE = "submission_testing_complete"
     QUESTION_CREATED = "question_created"
     NESTED_GROUP_ERROR = "nested_group_error"

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -84,6 +84,9 @@ from app.common.data.types import (
     CollectionStatusEnum,
     CollectionType,
     ConditionsOperator,
+    DataSourceSchema,
+    DataSourceSchemaColumn,
+    DataSourceType,
     ExpressionType,
     GrantStatusEnum,
     ManagedExpressionsEnum,
@@ -4405,6 +4408,123 @@ class TestValidateAndSyncComponentReferences:
                 ExpressionContext.build_expression_context(
                     collection=referenced_question.form.collection, mode="interpolation"
                 ),
+            )
+
+    def test_creates_reference_for_data_source_column_in_text(self, db_session, factories):
+        grant = factories.grant.create()
+        collection = factories.collection.create(grant=grant)
+        data_source = factories.data_source.create(
+            name="Budget data",
+            grant=grant,
+            collection=collection,
+            type=DataSourceType.GRANT_RECIPIENT,
+            items=None,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_allocation": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(prefix="£"),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Allocation",
+                    )
+                }
+            ),
+        )
+        form = factories.form.create(collection=collection)
+        question = factories.question.create(form=form)
+
+        question.text = f"Your allocation is (({data_source.safe_did}.c_allocation))"
+
+        _validate_and_sync_component_references(
+            question,
+            ExpressionContext.build_expression_context(collection=collection, mode="interpolation"),
+        )
+        db_session.flush()
+
+        refs = db_session.query(ComponentReference).filter_by(component=question).all()
+        assert len(refs) == 1
+        assert refs[0].depends_on_component is None
+        assert refs[0].depends_on_data_source == data_source
+        assert refs[0].depends_on_column_name == "c_allocation"
+
+    def test_regenerates_column_references_after_edit(self, db_session, factories):
+        grant = factories.grant.create()
+        collection = factories.collection.create(grant=grant)
+        data_source = factories.data_source.create(
+            name="Budget data",
+            grant=grant,
+            collection=collection,
+            type=DataSourceType.GRANT_RECIPIENT,
+            items=None,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_allocation": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(prefix="£"),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Allocation",
+                    ),
+                    "c_theme": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.TEXT_SINGLE_LINE,
+                        presentation_options=QuestionPresentationOptions(),
+                        data_options=QuestionDataOptions(),
+                        original_column_name="Theme",
+                    ),
+                }
+            ),
+        )
+        form = factories.form.create(collection=collection)
+        question = factories.question.create(form=form)
+
+        question.text = f"Allocation: (({data_source.safe_did}.c_allocation))"
+        _validate_and_sync_component_references(
+            question,
+            ExpressionContext.build_expression_context(collection=collection, mode="interpolation"),
+        )
+        db_session.flush()
+
+        refs = db_session.query(ComponentReference).filter_by(component=question).all()
+        assert {ref.depends_on_column_name for ref in refs} == {"c_allocation"}
+
+        question.text = f"Theme: (({data_source.safe_did}.c_theme))"
+        _validate_and_sync_component_references(
+            question,
+            ExpressionContext.build_expression_context(collection=collection, mode="interpolation"),
+        )
+        db_session.flush()
+
+        refs = db_session.query(ComponentReference).filter_by(component=question).all()
+        assert {ref.depends_on_column_name for ref in refs} == {"c_theme"}
+
+    def test_rejects_reference_to_unknown_column(self, db_session, factories):
+        grant = factories.grant.create()
+        collection = factories.collection.create(grant=grant)
+        data_source = factories.data_source.create(
+            name="Budget data",
+            grant=grant,
+            collection=collection,
+            type=DataSourceType.GRANT_RECIPIENT,
+            items=None,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_allocation": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(prefix="£"),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Allocation",
+                    ),
+                }
+            ),
+        )
+        form = factories.form.create(collection=collection)
+        question = factories.question.create(form=form)
+
+        question.text = f"(({data_source.safe_did}.c_nonexistent))"
+
+        with pytest.raises(InvalidReferenceInExpression):
+            _validate_and_sync_component_references(
+                question,
+                ExpressionContext.build_expression_context(collection=collection, mode="interpolation"),
             )
 
 

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -4157,6 +4157,200 @@ class TestValidateAndSyncExpressionReferences:
         assert all(ref.expression == expression for ref in expression.component_references)
         assert all(ref.depends_on_component in {q0, q1, q2} for ref in expression.component_references)
 
+    def test_creates_column_reference_for_reference_aware_field(self, db_session, factories):
+        user = factories.user.create()
+        grant = factories.grant.create()
+        collection = factories.collection.create(grant=grant)
+        data_source = factories.data_source.create(
+            name="Budget data",
+            grant=grant,
+            collection=collection,
+            type=DataSourceType.GRANT_RECIPIENT,
+            items=None,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_threshold": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(prefix="£"),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Threshold",
+                    ),
+                }
+            ),
+        )
+        form = factories.form.create(collection=collection)
+        question = factories.question.create(form=form, data_type=QuestionDataType.NUMBER)
+
+        expression = Expression.from_evaluatable_expression(
+            GreaterThan(
+                question_id=question.id,
+                minimum_value=None,
+                minimum_expression=f"(({data_source.safe_did}.c_threshold))",
+            ),
+            ExpressionType.VALIDATION,
+            user,
+        )
+        question.expressions.append(expression)
+        db_session.add(expression)
+        db_session.flush()
+
+        _validate_and_sync_expression_references(expression)
+        db_session.flush()
+
+        assert len(expression.component_references) == 1
+        ref = expression.component_references[0]
+        assert ref.component == question
+        assert ref.expression == expression
+        assert ref.depends_on_component is None
+        assert ref.depends_on_data_source == data_source
+        assert ref.depends_on_column_name == "c_threshold"
+
+    def test_creates_column_references_for_both_between_bounds(self, db_session, factories):
+        user = factories.user.create()
+        grant = factories.grant.create()
+        collection = factories.collection.create(grant=grant)
+        data_source = factories.data_source.create(
+            name="Budget data",
+            grant=grant,
+            collection=collection,
+            type=DataSourceType.GRANT_RECIPIENT,
+            items=None,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_min": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(prefix="£"),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Min",
+                    ),
+                    "c_max": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(prefix="£"),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Max",
+                    ),
+                }
+            ),
+        )
+        form = factories.form.create(collection=collection)
+        question = factories.question.create(form=form, data_type=QuestionDataType.NUMBER)
+
+        expression = Expression.from_evaluatable_expression(
+            Between(
+                question_id=question.id,
+                minimum_value=None,
+                minimum_expression=f"(({data_source.safe_did}.c_min))",
+                maximum_value=None,
+                maximum_expression=f"(({data_source.safe_did}.c_max))",
+            ),
+            ExpressionType.VALIDATION,
+            user,
+        )
+        question.expressions.append(expression)
+        db_session.add(expression)
+        db_session.flush()
+
+        _validate_and_sync_expression_references(expression)
+        db_session.flush()
+
+        assert {ref.depends_on_column_name for ref in expression.component_references} == {"c_min", "c_max"}
+        assert all(ref.depends_on_data_source == data_source for ref in expression.component_references)
+        assert all(ref.expression == expression for ref in expression.component_references)
+
+    def test_mixes_question_and_column_references_in_one_field(self, db_session, factories):
+        user = factories.user.create()
+        grant = factories.grant.create()
+        collection = factories.collection.create(grant=grant)
+        data_source = factories.data_source.create(
+            name="Budget data",
+            grant=grant,
+            collection=collection,
+            type=DataSourceType.GRANT_RECIPIENT,
+            items=None,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_min": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(prefix="£"),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Min",
+                    ),
+                    "c_max": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(prefix="£"),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Max",
+                    ),
+                }
+            ),
+        )
+        form = factories.form.create(collection=collection)
+        min_question = factories.question.create(form=form, data_type=QuestionDataType.NUMBER)
+        target_question = factories.question.create(form=form, data_type=QuestionDataType.NUMBER)
+
+        expression = Expression.from_evaluatable_expression(
+            Between(
+                question_id=target_question.id,
+                minimum_value=None,
+                minimum_expression=f"(({min_question.safe_qid}))",
+                maximum_value=None,
+                maximum_expression=f"(({data_source.safe_did}.c_max))",
+            ),
+            ExpressionType.VALIDATION,
+            user,
+        )
+        target_question.expressions.append(expression)
+        db_session.add(expression)
+        db_session.flush()
+
+        _validate_and_sync_expression_references(expression)
+        db_session.flush()
+
+        component_refs = [ref for ref in expression.component_references if ref.depends_on_component_id]
+        column_refs = [ref for ref in expression.component_references if ref.depends_on_data_source_id]
+        assert {ref.depends_on_component for ref in component_refs} == {min_question}
+        assert {ref.depends_on_column_name for ref in column_refs} == {"c_max"}
+
+    def test_rejects_column_reference_to_missing_column(self, db_session, factories):
+        user = factories.user.create()
+        grant = factories.grant.create()
+        collection = factories.collection.create(grant=grant)
+        data_source = factories.data_source.create(
+            name="Budget data",
+            grant=grant,
+            collection=collection,
+            type=DataSourceType.GRANT_RECIPIENT,
+            items=None,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_threshold": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(prefix="£"),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Threshold",
+                    ),
+                }
+            ),
+        )
+        form = factories.form.create(collection=collection)
+        question = factories.question.create(form=form, data_type=QuestionDataType.NUMBER)
+
+        expression = Expression.from_evaluatable_expression(
+            GreaterThan(
+                question_id=question.id,
+                minimum_value=None,
+                minimum_expression=f"(({data_source.safe_did}.c_missing))",
+            ),
+            ExpressionType.VALIDATION,
+            user,
+        )
+        question.expressions.append(expression)
+        db_session.add(expression)
+        db_session.flush()
+
+        with pytest.raises(InvalidReferenceInExpression):
+            _validate_and_sync_expression_references(expression)
+
 
 class TestValidateAndSyncComponentReferences:
     def test_creates_references_for_supported_fields(self, db_session, factories):

--- a/tests/integration/common/data/interfaces/test_data_sets.py
+++ b/tests/integration/common/data/interfaces/test_data_sets.py
@@ -6,19 +6,28 @@ from sqlalchemy import func, select
 from sqlalchemy.orm.exc import NoResultFound
 
 from app.common.collections.types import DecimalAnswer, IntegerAnswer, TextSingleLineAnswer
+from app.common.data.interfaces.collections import (
+    DataSourceHasReferencesException,
+    _validate_and_sync_component_references,
+)
 from app.common.data.interfaces.data_sets import (
     create_uploaded_data_source,
     delete_data_source,
     get_data_source,
 )
 from app.common.data.interfaces.exceptions import DuplicateDataSourceItemError
-from app.common.data.models import DataSource, DataSourceItem, DataSourceOrganisationItem
+from app.common.data.models import ComponentReference, DataSource, DataSourceItem, DataSourceOrganisationItem
 from app.common.data.types import (
     DataSourceFileMetadata,
+    DataSourceSchema,
+    DataSourceSchemaColumn,
     DataSourceType,
     NumberTypeEnum,
+    QuestionDataOptions,
     QuestionDataType,
+    QuestionPresentationOptions,
 )
+from app.common.expressions import ExpressionContext
 from app.constants import DATA_SET_EXTERNAL_ID_COLUMN_HEADER, DATA_SET_GRANT_RECIPIENT_COLUMN_HEADER
 from app.deliver_grant_funding.session_models import DataSetColumnMapping
 
@@ -836,6 +845,91 @@ class TestDeleteDataSource:
         assert db_session.scalar(select(func.count()).select_from(DataSourceOrganisationItem)) == 1
         assert db_session.get(DataSourceOrganisationItem, org_item_1.id) is None
         assert db_session.get(DataSourceOrganisationItem, org_item_2.id) is not None
+
+    def test_delete_blocked_when_column_is_referenced(self, db_session, factories, mock_s3_service_calls):
+        grant = factories.grant.create()
+        collection = factories.collection.create(grant=grant)
+        data_source = factories.data_source.create(
+            name="Budget data",
+            grant=grant,
+            collection=collection,
+            type=DataSourceType.GRANT_RECIPIENT,
+            items=None,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_allocation": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(prefix="£"),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Allocation",
+                    )
+                }
+            ),
+        )
+        form = factories.form.create(collection=collection)
+        question = factories.question.create(
+            form=form,
+            text=f"Your allocation is (({data_source.safe_did}.c_allocation))",
+        )
+        _validate_and_sync_component_references(
+            question,
+            ExpressionContext.build_expression_context(collection=collection, mode="interpolation"),
+        )
+        db_session.flush()
+
+        with pytest.raises(DataSourceHasReferencesException) as e:
+            delete_data_source(data_source)
+
+        assert e.value.data_source_id == data_source.id
+        assert e.value.data_source_name == "Budget data"
+        assert e.value.referenced_columns == {"c_allocation"}
+        assert db_session.get(DataSource, data_source.id) is not None
+        assert mock_s3_service_calls.delete_file_calls == []
+
+    def test_delete_allowed_after_references_removed(self, db_session, factories, mock_s3_service_calls):
+        grant = factories.grant.create()
+        collection = factories.collection.create(grant=grant)
+        data_source = factories.data_source.create(
+            name="Budget data",
+            grant=grant,
+            collection=collection,
+            type=DataSourceType.GRANT_RECIPIENT,
+            items=None,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_allocation": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(prefix="£"),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Allocation",
+                    )
+                }
+            ),
+        )
+        form = factories.form.create(collection=collection)
+        question = factories.question.create(
+            form=form,
+            text=f"Your allocation is (({data_source.safe_did}.c_allocation))",
+        )
+        _validate_and_sync_component_references(
+            question,
+            ExpressionContext.build_expression_context(collection=collection, mode="interpolation"),
+        )
+        db_session.flush()
+
+        question.text = "Static text with no reference"
+        _validate_and_sync_component_references(
+            question,
+            ExpressionContext.build_expression_context(collection=collection, mode="interpolation"),
+        )
+        db_session.flush()
+
+        assert db_session.query(ComponentReference).count() == 0
+
+        delete_data_source(data_source)
+        db_session.flush()
+
+        assert db_session.get(DataSource, data_source.id) is None
 
 
 class TestDataSourceOrganisationItemDataProperty:

--- a/tests/integration/common/data/test_models.py
+++ b/tests/integration/common/data/test_models.py
@@ -739,6 +739,97 @@ class TestComponentReferenceModel:
 
         assert db_session.query(ComponentReference).count() == 0
 
+    def test_column_reference_round_trips(self, factories, db_session):
+        grant = factories.grant.create()
+        collection = factories.collection.create(grant=grant)
+        data_source = factories.data_source.create(
+            name="Budget data", grant=grant, collection=collection, type=DataSourceType.GRANT_RECIPIENT, items=None
+        )
+        question = factories.question.create(form__collection=collection)
+
+        cr = ComponentReference(
+            component=question,
+            depends_on_data_source=data_source,
+            depends_on_column_name="c_allocation",
+        )
+        db_session.add(cr)
+        db_session.commit()
+
+        loaded = db_session.get(ComponentReference, cr.id)
+        assert loaded is not None
+        assert loaded.depends_on_component_id is None
+        assert loaded.depends_on_data_source == data_source
+        assert loaded.depends_on_column_name == "c_allocation"
+        assert data_source.depended_on_by_columns == [loaded]
+
+    def test_reference_with_no_target_is_rejected(self, factories, db_session):
+        question = factories.question.create()
+
+        with pytest.raises(IntegrityError):
+            db_session.add(ComponentReference(component=question))
+            db_session.commit()
+
+    def test_reference_with_both_component_and_data_source_is_rejected(self, factories, db_session):
+        grant = factories.grant.create()
+        collection = factories.collection.create(grant=grant)
+        data_source = factories.data_source.create(
+            name="Budget data", grant=grant, collection=collection, type=DataSourceType.GRANT_RECIPIENT, items=None
+        )
+        q1 = factories.question.create(form__collection=collection)
+        q2 = factories.question.create(form=q1.form)
+
+        with pytest.raises(IntegrityError):
+            db_session.add(
+                ComponentReference(
+                    component=q2,
+                    depends_on_component=q1,
+                    depends_on_data_source=data_source,
+                    depends_on_column_name="c_allocation",
+                )
+            )
+            db_session.commit()
+
+    def test_data_source_reference_without_column_name_is_rejected(self, factories, db_session):
+        grant = factories.grant.create()
+        collection = factories.collection.create(grant=grant)
+        data_source = factories.data_source.create(
+            name="Budget data", grant=grant, collection=collection, type=DataSourceType.GRANT_RECIPIENT, items=None
+        )
+        question = factories.question.create(form__collection=collection)
+
+        with pytest.raises(IntegrityError):
+            db_session.add(ComponentReference(component=question, depends_on_data_source=data_source))
+            db_session.commit()
+
+    def test_column_name_without_data_source_reference_is_rejected(self, factories, db_session):
+        question = factories.question.create()
+
+        with pytest.raises(IntegrityError):
+            db_session.add(ComponentReference(component=question, depends_on_column_name="c_allocation"))
+            db_session.commit()
+
+    def test_deleting_a_data_source_with_a_column_reference_is_blocked(self, factories, db_session):
+        grant = factories.grant.create()
+        collection = factories.collection.create(grant=grant)
+        data_source = factories.data_source.create(
+            name="Budget data", grant=grant, collection=collection, type=DataSourceType.GRANT_RECIPIENT, items=None
+        )
+        question = factories.question.create(form__collection=collection)
+        db_session.add(
+            ComponentReference(
+                component=question,
+                depends_on_data_source=data_source,
+                depends_on_column_name="c_allocation",
+            )
+        )
+        db_session.commit()
+
+        with pytest.raises(IntegrityError) as e:
+            db_session.delete(data_source)
+            db_session.commit()
+
+        assert isinstance(e.value.__cause__, ForeignKeyViolation)
+
 
 class TestDataSourceModel:
     def test_filtering_organisation_items(self, factories):

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -9354,6 +9354,202 @@ class TestViewDataSource:
         assert db_session.get(DataSource, data_source.id) is None
         assert db_session.scalar(select(func.count()).select_from(DataSourceOrganisationItem)) == 0
 
+    def test_delete_blocked_when_column_is_referenced_shows_flash_before_confirmation(
+        self, authenticated_grant_admin_client, factories, db_session, mock_s3_service_calls
+    ):
+        grant = authenticated_grant_admin_client.grant
+        report = factories.collection.create(grant=grant)
+        data_source = factories.data_source.create(
+            name="Budget data",
+            grant=grant,
+            collection=report,
+            type=DataSourceType.GRANT_RECIPIENT,
+            items=None,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_allocation": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(prefix="£"),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Allocation",
+                    ),
+                }
+            ),
+        )
+        form = factories.form.create(collection=report)
+        question = factories.question.create(
+            form=form,
+            text=f"Your allocation is (({data_source.safe_did}.c_allocation))",
+        )
+
+        response = authenticated_grant_admin_client.get(
+            url_for(
+                "deliver_grant_funding.view_data_source",
+                grant_id=grant.id,
+                report_id=report.id,
+                data_source_id=data_source.id,
+                delete="",
+            ),
+            follow_redirects=True,
+        )
+
+        assert response.status_code == 200
+        assert db_session.get(DataSource, data_source.id) is not None
+        assert mock_s3_service_calls.delete_file_calls == []
+        soup = BeautifulSoup(response.data, "html.parser")
+        banner = page_has_flash(
+            soup,
+            "You cannot delete this data set because it's being referenced in the form. "
+            "You need to remove references in:",
+        )
+        assert banner is not None
+        # The confirmation banner must NOT be rendered when the deletion has already been blocked.
+        assert "Are you sure you want to delete this data set?" not in soup.text
+        links = banner.select(".govuk-notification-banner__link")
+        assert len(links) == 1
+        assert links[0]["href"] == url_for(
+            "deliver_grant_funding.edit_question", grant_id=grant.id, question_id=question.id
+        )
+        assert "Your allocation is" in links[0].text
+        assert "(Question)" in links[0].text
+
+    def test_delete_blocked_links_to_group_when_reference_is_on_a_group(
+        self, authenticated_grant_admin_client, factories, db_session, mock_s3_service_calls
+    ):
+        grant = authenticated_grant_admin_client.grant
+        report = factories.collection.create(grant=grant)
+        data_source = factories.data_source.create(
+            name="Budget data",
+            grant=grant,
+            collection=report,
+            type=DataSourceType.GRANT_RECIPIENT,
+            items=None,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_allocation": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(prefix="£"),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Allocation",
+                    ),
+                }
+            ),
+        )
+        form = factories.form.create(collection=report)
+        group = factories.group.create(form=form, text=f"Allocation overview (({data_source.safe_did}.c_allocation))")
+
+        response = authenticated_grant_admin_client.get(
+            url_for(
+                "deliver_grant_funding.view_data_source",
+                grant_id=grant.id,
+                report_id=report.id,
+                data_source_id=data_source.id,
+                delete="",
+            ),
+            follow_redirects=True,
+        )
+
+        assert response.status_code == 200
+        soup = BeautifulSoup(response.data, "html.parser")
+        banner = page_has_flash(soup, "You cannot delete this data set")
+        assert banner is not None
+        links = banner.select(".govuk-notification-banner__link")
+        assert len(links) == 1
+        assert links[0]["href"] == url_for(
+            "deliver_grant_funding.list_group_questions", grant_id=grant.id, group_id=group.id
+        )
+        assert "(Group)" in links[0].text
+
+    def test_delete_blocked_labels_validation_and_question_refs_separately(
+        self, authenticated_grant_admin_client, factories, db_session, mock_s3_service_calls
+    ):
+        grant = authenticated_grant_admin_client.grant
+        user = factories.user.create()
+        report = factories.collection.create(grant=grant)
+        data_source = factories.data_source.create(
+            name="Budget data",
+            grant=grant,
+            collection=report,
+            type=DataSourceType.GRANT_RECIPIENT,
+            items=None,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_allocation": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(prefix="£"),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Allocation",
+                    ),
+                }
+            ),
+        )
+        form = factories.form.create(collection=report)
+        question_id = uuid.uuid4()
+        factories.question.create(
+            id=question_id,
+            form=form,
+            data_type=QuestionDataType.NUMBER,
+            text=f"How much did you spend? (({data_source.safe_did}.c_allocation))",
+            expressions=[
+                Expression.from_evaluatable_expression(
+                    GreaterThan(
+                        question_id=question_id,
+                        minimum_value=None,
+                        minimum_expression=f"(({data_source.safe_did}.c_allocation))",
+                    ),
+                    ExpressionType.VALIDATION,
+                    user,
+                ),
+            ],
+        )
+
+        response = authenticated_grant_admin_client.get(
+            url_for(
+                "deliver_grant_funding.view_data_source",
+                grant_id=grant.id,
+                report_id=report.id,
+                data_source_id=data_source.id,
+                delete="",
+            ),
+            follow_redirects=True,
+        )
+
+        assert response.status_code == 200
+        soup = BeautifulSoup(response.data, "html.parser")
+        banner = page_has_flash(soup, "You cannot delete this data set")
+        assert banner is not None
+        link_texts = [link.text.strip() for link in banner.select(".govuk-notification-banner__link")]
+        assert any("(Question)" in t for t in link_texts)
+        assert any("(Validation)" in t for t in link_texts)
+
+    def test_delete_shows_confirmation_banner_when_data_set_has_no_references(
+        self, authenticated_grant_admin_client, factories
+    ):
+        grant = authenticated_grant_admin_client.grant
+        report = factories.collection.create(grant=grant)
+        data_source = factories.data_source.create(
+            name="Budget data",
+            grant=grant,
+            collection=report,
+            type=DataSourceType.GRANT_RECIPIENT,
+            items=None,
+        )
+
+        response = authenticated_grant_admin_client.get(
+            url_for(
+                "deliver_grant_funding.view_data_source",
+                grant_id=grant.id,
+                report_id=report.id,
+                data_source_id=data_source.id,
+                delete="",
+            )
+        )
+
+        assert response.status_code == 200
+        soup = BeautifulSoup(response.data, "html.parser")
+        assert "Are you sure you want to delete this data set?" in soup.text
+        assert page_has_flash(soup, "You cannot delete this data set") is None
+
 
 class TestDownloadDataSourceCsv:
     def test_404(self, authenticated_grant_member_client):

--- a/tests/unit/common/helpers/test_collections.py
+++ b/tests/unit/common/helpers/test_collections.py
@@ -790,6 +790,16 @@ class TestSubmissionHelper:
 
             assert helper.is_component_visible(q1, helper.cached_evaluation_context) is True
 
+        def test_is_component_visible_ignores_data_source_column_references(self, factories):
+            q1 = factories.question.build()
+            q1.owned_component_references = [
+                ComponentReference(component=q1, depends_on_data_source_id=uuid.uuid4(), depends_on_column_name="c_x")
+            ]
+            submission = factories.submission.build(collection=q1.form.collection)
+            helper = SubmissionHelper(submission)
+
+            assert helper.is_component_visible(q1, helper.cached_evaluation_context) is True
+
         def test_any_operator_with_hidden_referenced_question(self, factories):
             """Scenario: Q1 yes/no, Q2 yes/no (show if Q1=yes), Q3 text (show if Q1=no OR Q2=yes).
 
@@ -1131,6 +1141,20 @@ class TestSubmissionHelper:
             helper = SubmissionHelper(submission)
             result = helper.get_referenced_forms_with_unanswered_references(form_b)
             assert result == [form_a]
+
+        def test_ignores_data_source_column_references(self, factories):
+            collection = factories.collection.build()
+            form_a = factories.form.build(collection=collection, order=0)
+            form_b = factories.form.build(collection=collection, order=1)
+            factories.question.build(form=form_a)
+            q_b = factories.question.build(form=form_b)
+            q_b.owned_component_references = [
+                ComponentReference(component=q_b, depends_on_data_source_id=uuid.uuid4(), depends_on_column_name="c_x"),
+            ]
+            submission = factories.submission.build(collection=collection)
+
+            helper = SubmissionHelper(submission)
+            assert helper.get_referenced_forms_with_unanswered_references(form_b) == []
 
         def test_returns_sorted_by_form_order(self, factories):
             collection = factories.collection.build()


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-1147

## 📝 Description
Refactors to component references to allow us to start recording when components/expressions/etc are using data from uploaded data sets. When used, we use the new references to prevent data sets from being deleted, which would break forms.

This PR does not deal with creating component references for any existing data set references. We _probably_ can get away with doing this - all existing references will be in active forms that can't be edited. But we could be thorough and do a followup PR to generate/sync missing component references.

## 🧪 Testing
<!-- Describe how you've tested this change, and how a reviewer can test it -->

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested