### PR TITLE
Preparatory refactors: managed expression subject references

### DIFF
--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -61,11 +61,11 @@ from app.common.expressions import (
     ExpressionContext,
 )
 from app.common.expressions.managed import BaseDataSourceManagedExpression
+from app.common.expressions.references import DataSourceReference, ExpressionReference
 from app.common.forms.helpers import (
     components_in_valid_add_another_combination,
 )
 from app.common.helpers.submission_events import DeclinedByCertifierKwargs, SubmissionEventHelper
-from app.common.safe_ids import SafeDidMixin, SafeQidMixin
 from app.common.utils import slugify
 from app.extensions import db
 from app.metrics import MetricAttributeName, MetricEventName, emit_metric_count
@@ -1494,10 +1494,10 @@ def get_referenced_data_source_items_by_managed_expression(
 
 def _find_all_references_in_expression(
     value: str,
-) -> list[str]:
-    references = list()
+) -> list[ExpressionReference]:
+    references: list[ExpressionReference] = []
     for match in INTERPOLATE_REGEX.finditer(value):
-        references.append(match.group(0))
+        references.append(ExpressionReference.from_wrapped(match.group(0)))
     return references
 
 
@@ -1516,23 +1516,24 @@ def components_in_same_group_and_on_same_page(component1: Component, component2:
 
 # TODO separate out more checks into little functions
 def _validate_reference(  # noqa:C901
-    wrapped_reference: str,
+    reference: ExpressionReference,
     attached_to_component: Component | None,
     expression_context: ExpressionContext,
     expression_type: ExpressionType | None,  # None if it's not an expression, eg. guidance text
     field_name_for_error_message: str,
     question_to_test: Question | None,
-) -> str:
-    unwrapped_ref = wrapped_reference.strip("() ")
+) -> ExpressionReference:
+    wrapped_reference = reference.wrapped
+    unwrapped_reference = reference.unwrapped
 
-    if not unwrapped_ref:
+    if not unwrapped_reference:
         raise InvalidReferenceInExpression(
             f"You cannot use {wrapped_reference} because it does not exist",
             field_name=field_name_for_error_message,
             bad_reference=wrapped_reference,
             form_error_message=f"You cannot use {wrapped_reference} because it does not exist",
         )
-    if ALLOWED_INTERPOLATION_REGEX.search(unwrapped_ref) is not None:
+    if ALLOWED_INTERPOLATION_REGEX.search(unwrapped_reference) is not None:
         raise InvalidReferenceInExpression(
             f"Reference is not valid: {wrapped_reference}",
             field_name=field_name_for_error_message,
@@ -1544,7 +1545,7 @@ def _validate_reference(  # noqa:C901
         raise NotImplementedError("Cannot handle un-attached references yet")
 
     # Check the reference is valid in this expression context
-    if not expression_context.is_valid_reference(unwrapped_ref):
+    if not expression_context.is_valid_reference(unwrapped_reference):
         raise InvalidReferenceInExpression(
             f"You cannot use {wrapped_reference} because it does not exist",
             field_name=field_name_for_error_message,
@@ -1552,14 +1553,7 @@ def _validate_reference(  # noqa:C901
             form_error_message=f"You cannot use {wrapped_reference} because it does not exist",
         )
 
-    question_id = SafeQidMixin.safe_qid_to_id(unwrapped_ref)
-
-    # If it's a data source, we check this below in the elif
-    data_source_id, _column_name = SafeDidMixin.safe_ds_ref_to_id_and_column_name(unwrapped_ref)
-
-    if question_id:
-        referenced_question = db.session.get_one(Question, question_id)
-
+    if referenced_question := reference.question:
         # for validation, the question being validated (ie attached to) needs to have the same data type as the question
         # being referenced. Groups have no data_type so this check is skipped for group-level validations.
         if (
@@ -1658,11 +1652,14 @@ def _validate_reference(  # noqa:C901
                 form_error_message=f"You cannot reference {referenced_question.name} because it can be answered more "
                 "than once",
             )
-    elif data_source_id:
-        data_source = db.session.get_one(DataSource, data_source_id)
-        if not data_source.schema or _column_name not in data_source.schema.root:
+    elif data_source_reference := reference.data_source_reference:
+        data_source_column = reference.data_source_column
+        if not data_source_column:
             raise InvalidReferenceInExpression(
-                f"Column {_column_name} does not exist on data source {data_source_id}",
+                (
+                    f"Column {data_source_reference.column_name} does not exist "
+                    f"on data source {data_source_reference.data_source_id}"
+                ),
                 field_name=field_name_for_error_message,
                 bad_reference=wrapped_reference,
                 form_error_message=f"You cannot use {wrapped_reference} because it does not exist",
@@ -1673,7 +1670,7 @@ def _validate_reference(  # noqa:C901
         raise NotImplementedError(
             f"Reference is not a valid question ID: {wrapped_reference}",
         )
-    return unwrapped_ref
+    return reference
 
 
 def _validate_and_sync_expression_references(expression: Expression) -> None:  # noqa:C901
@@ -1683,14 +1680,15 @@ def _validate_and_sync_expression_references(expression: Expression) -> None:  #
         expr_impl = expression.custom
 
     referenced_questions = set()
-    references: list[ComponentReference] = []
+    component_references: list[ComponentReference] = []
+    data_source_references: set[DataSourceReference] = set()
 
     if isinstance(expr_impl, BaseDataSourceManagedExpression):
         referenced_data_source_items = get_referenced_data_source_items_by_managed_expression(
             managed_expression=expr_impl
         )
 
-        # TODO: Support data sources that are independent of components(questions), eg when ee have platform-level
+        # TODO: Support data sources that are independent of components(questions), eg when we have platform-level
         #       data sources.
         for referenced_data_source_item in referenced_data_source_items:
             cr = ComponentReference(
@@ -1702,12 +1700,12 @@ def _validate_and_sync_expression_references(expression: Expression) -> None:  #
                 depends_on_data_source_item=referenced_data_source_item,
             )
             db.session.add(cr)
-            references.append(cr)
+            component_references.append(cr)
     elif expression.is_managed:
         if expression.type_ == ExpressionType.CONDITION:
             # validate the referenced question - the one that is compared against the expression
-            valid_reference = _validate_reference(
-                wrapped_reference=f"(({expr_impl.referenced_question.safe_qid}))",  # ty:ignore[unresolved-attribute]
+            _validate_reference(
+                reference=ExpressionReference.from_question(expr_impl.referenced_question),  # ty:ignore[unresolved-attribute]
                 attached_to_component=expression.question,
                 expression_context=ExpressionContext.build_expression_context(
                     expression.question.form.collection, "interpolation", None, None
@@ -1724,15 +1722,20 @@ def _validate_and_sync_expression_references(expression: Expression) -> None:  #
         if expr_impl.referenced_question != expression.question:  # ty:ignore[unresolved-attribute]
             referenced_questions.add(expr_impl.referenced_question)  # ty:ignore[unresolved-attribute]
 
-    referenced_columns: set[tuple[UUID, str]] = set()
     for field in expr_impl.reference_aware_fields:
         field_value = getattr(expr_impl, field)
         if not field_value:
             continue
-        unvalidated_references = set(_find_all_references_in_expression(field_value))
-        for wrapped_reference in unvalidated_references:
+        # An ExpressionReference-typed field is itself a single reference; a plain str field is
+        # free text that may contain zero or more ((…)) references to scan out.
+        references = (
+            [field_value]
+            if isinstance(field_value, ExpressionReference)
+            else list(set(_find_all_references_in_expression(field_value)))
+        )
+        for reference in references:
             valid_reference = _validate_reference(
-                wrapped_reference=wrapped_reference,
+                reference=reference,
                 attached_to_component=expression.question,
                 expression_context=ExpressionContext.build_expression_context(
                     expression.question.form.collection, "interpolation", None, None
@@ -1742,14 +1745,12 @@ def _validate_and_sync_expression_references(expression: Expression) -> None:  #
                 question_to_test=expr_impl.referenced_question if expression.is_managed else None,  # ty:ignore[unresolved-attribute]
             )
 
-            if question_id := SafeQidMixin.safe_qid_to_id(valid_reference):
-                referenced_question = get_question_by_id(question_id)
+            if referenced_question := valid_reference.question:
                 referenced_questions.add(referenced_question)
                 continue
 
-            data_source_id, column_name = SafeDidMixin.safe_ds_ref_to_id_and_column_name(valid_reference)
-            if data_source_id and column_name:
-                referenced_columns.add((data_source_id, column_name))
+            if data_source_reference := valid_reference.data_source_reference:
+                data_source_references.add(data_source_reference)
                 continue
 
             raise ValueError(f"Unhandled reference '{valid_reference}' in component '{expression.question_id}'")
@@ -1763,19 +1764,19 @@ def _validate_and_sync_expression_references(expression: Expression) -> None:  #
             depends_on_component=referenced_question,
         )
         db.session.add(cr)
-        references.append(cr)
+        component_references.append(cr)
 
-    for data_source_id, column_name in referenced_columns:
+    for data_source_reference in data_source_references:
         cr = ComponentReference(
             component=expression.question,
             expression=expression,
-            depends_on_data_source_id=data_source_id,
-            depends_on_column_name=column_name,
+            depends_on_data_source_id=data_source_reference.data_source_id,
+            depends_on_column_name=data_source_reference.column_name,
         )
         db.session.add(cr)
-        references.append(cr)
+        component_references.append(cr)
 
-    expression.component_references = references
+    expression.component_references = component_references
 
 
 def _validate_and_sync_component_references(component: Component, expression_context: ExpressionContext) -> None:  # noqa: C901
@@ -1796,7 +1797,7 @@ def _validate_and_sync_component_references(component: Component, expression_con
         _validate_and_sync_expression_references(expression)
 
     component_refs_to_set_up: set[tuple[UUID, UUID]] = set()
-    column_refs_to_set_up: set[tuple[UUID, str]] = set()
+    data_source_refs_to_set_up: set[DataSourceReference] = set()
     field_names = ["text", "hint", "guidance_body", "add_another_guidance_body"]
     for field_name in field_names:
         value = getattr(component, field_name)
@@ -1804,9 +1805,9 @@ def _validate_and_sync_component_references(component: Component, expression_con
             continue
 
         unvalidated_references = set(_find_all_references_in_expression(value))
-        for wrapped_reference in unvalidated_references:
-            reference = _validate_reference(
-                wrapped_reference=wrapped_reference,
+        for unvalidated_reference in unvalidated_references:
+            validated_reference = _validate_reference(
+                reference=unvalidated_reference,
                 attached_to_component=component,
                 expression_context=expression_context,
                 expression_type=None,
@@ -1814,29 +1815,29 @@ def _validate_and_sync_component_references(component: Component, expression_con
                 question_to_test=None,
             )
 
-            if question_id := SafeQidMixin.safe_qid_to_id(reference):
+            # TODO: make a match statement for clearer unhandled case
+            if question_id := validated_reference.question_id:
                 question = db.session.get_one(Question, question_id)
                 component_refs_to_set_up.add((component.id, question.id))
                 continue
 
-            data_source_id, column_name = SafeDidMixin.safe_ds_ref_to_id_and_column_name(reference)
-            if data_source_id and column_name:
-                column_refs_to_set_up.add((data_source_id, column_name))
+            if data_source_reference := validated_reference.data_source_reference:
+                data_source_refs_to_set_up.add(data_source_reference)
                 continue
 
-            raise ValueError(f"Unhandled reference '{reference}' in component '{component.id}'")
+            raise ValueError(f"Unhandled reference '{validated_reference}' in component '{component.id}'")
 
     for component_id, depends_on_component_id in component_refs_to_set_up:
         if component_id == depends_on_component_id:
             continue
         db.session.add(ComponentReference(component_id=component_id, depends_on_component_id=depends_on_component_id))
 
-    for data_source_id, column_name in column_refs_to_set_up:
+    for data_source_reference in data_source_refs_to_set_up:
         db.session.add(
             ComponentReference(
                 component_id=component.id,
-                depends_on_data_source_id=data_source_id,
-                depends_on_column_name=column_name,
+                depends_on_data_source_id=data_source_reference.data_source_id,
+                depends_on_column_name=data_source_reference.column_name,
             )
         )
 

--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -1483,6 +1483,9 @@ def add_submission_event(
 def get_referenced_data_source_items_by_managed_expression(
     managed_expression: BaseDataSourceManagedExpression,
 ) -> Sequence[DataSourceItem]:
+    # TODO[FSPT-1284]: handle not a `referenced_question` here explicitly? Probably just throw an error because
+    #                  data source managed expressions might legitimately only ever be able to reference other questions
+    #                  rather than anything in expression context (eg uplaoded data sets)?
     referenced_data_source_items = db.session.scalars(
         select(DataSourceItem).where(
             DataSourceItem.data_source == managed_expression.referenced_question.data_source,

--- a/app/common/expressions/__init__.py
+++ b/app/common/expressions/__init__.py
@@ -9,12 +9,12 @@ from uuid import UUID
 
 import simpleeval
 from markupsafe import Markup, escape
-from pydantic import BaseModel
+from pydantic import BaseModel, computed_field, model_validator
 
 from app.common.data.submission_data_manager import SubmissionDataManager
 from app.common.data.types import ExpressionType, ManagedExpressionsEnum
 from app.common.exceptions import WTFormRenderableException
-from app.common.safe_ids import SafeQidMixin
+from app.common.expressions.references import ExpressionReference
 from app.types import NOT_PROVIDED
 
 if TYPE_CHECKING:
@@ -115,12 +115,45 @@ class InvalidEvaluationResult(
         )
 
 
-class EvaluatableExpression(BaseModel, SafeQidMixin):
+class EvaluatableExpression(BaseModel):
     # Defining this as a ClassVar allows direct access from the class and excludes it from pydantic instance
     name: ClassVar[ManagedExpressionsEnum | Literal["CUSTOM"]]
-    question_id: UUID | None = None
+    subject_reference: ExpressionReference | None = None
 
     _key: ManagedExpressionsEnum | None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _accept_legacy_question_id(cls, data: Any) -> Any:
+        """Accept inputs that still use the pre-rename ``question_id: UUID`` key.
+
+        Legacy JSONB rows in ``Expression.context`` and legacy construction sites that pass
+        ``question_id=<uuid>`` are rewritten here to ``subject_reference=<q_hex>``. Keep
+        until the next deploy has backfilled every row and the dual-write shim below has been
+        removed.
+        """
+        if isinstance(data, dict) and "question_id" in data and "subject_reference" not in data:
+            data = dict(data)
+            question_id = data.pop("question_id")
+            if question_id is not None:
+                question_uuid = UUID(str(question_id)) if not isinstance(question_id, UUID) else question_id
+                # Hack together the safe qid - this will be removed in the next PR
+                data["subject_reference"] = f"q_{question_uuid.hex}"
+        return data
+
+    @computed_field
+    @property
+    def question_id(self) -> UUID | None:
+        """Dual-write shim: emit the pre-rename ``question_id`` key on every ``model_dump()``.
+
+        This keeps JSONB blobs written by the new code backwards-compatible with code that still
+        expects the old key shape, and keeps the ``uq_type_condition_unique_question`` index
+        (which uses ``context ->> 'question_id'``) populated while both code versions coexist.
+        Remove once the follow-up deploy has swapped the index to ``subject_reference``.
+        """
+        if self.subject_reference is None:
+            return None
+        return self.subject_reference.question_id
 
     @property
     @abc.abstractmethod

--- a/app/common/expressions/custom.py
+++ b/app/common/expressions/custom.py
@@ -11,7 +11,6 @@ if TYPE_CHECKING:
 
 class CustomExpression(EvaluatableExpression):
     name: ClassVar[Literal["CUSTOM"]] = "CUSTOM"
-    question_id: None = None
     _key: None = None
     expression_name: str | None = None
     custom_expression: str

--- a/app/common/expressions/forms.py
+++ b/app/common/expressions/forms.py
@@ -101,7 +101,7 @@ class _ManagedExpressionForm(FlaskForm):
 
 def build_managed_expression_form(
     type_: ExpressionType,
-    referenced_question: Question,
+    referenced_question: Question,  # TODO[FSPT-1284]: make this the ExpressionReference?
     expression: Expression | None = None,
     show_calculated_validation_option: bool = False,
 ) -> type[_ManagedExpressionForm] | None:

--- a/app/common/expressions/forms.py
+++ b/app/common/expressions/forms.py
@@ -245,15 +245,15 @@ def _validate_custom_syntax(  # noqa:C901
     try:
         unvalidated_references = _find_all_references_in_expression(statement)
         for ref in unvalidated_references:
-            unwrapped_ref = _validate_reference(
-                wrapped_reference=ref,
+            validated_ref = _validate_reference(
+                reference=ref,
                 attached_to_component=component,
                 expression_context=interpolation_context,
                 expression_type=expression_type,
                 field_name_for_error_message=field_name,
                 question_to_test=None,
             )
-            validated_references.append(unwrapped_ref)
+            validated_references.append(validated_ref)
 
         if not validate_with_evaluation:
             # No further validation needed for custom error message

--- a/app/common/expressions/managed.py
+++ b/app/common/expressions/managed.py
@@ -30,6 +30,7 @@ from wtforms.validators import DataRequired, InputRequired, Optional, ReadOnly, 
 
 from app.common.data.types import ManagedExpressionsEnum, QuestionDataType
 from app.common.expressions import EvaluatableExpression
+from app.common.expressions.references import ExpressionReference
 from app.common.expressions.registry import lookup_managed_expression, register_managed_expression
 from app.common.filters import format_date_approximate, format_date_short
 from app.common.forms.fields import DecimalWithCommasField, MHCLGApproximateDateInput
@@ -216,7 +217,7 @@ class GreaterThan(ManagedExpression):
 
     question_id: UUID
     minimum_value: int | Decimal | None
-    minimum_expression: str | None = None
+    minimum_expression: ExpressionReference | None = None
     inclusive: bool = False
 
     @property
@@ -227,7 +228,7 @@ class GreaterThan(ManagedExpression):
     def message(self) -> str:
         return (
             f"The answer must be greater than {'or equal to ' if self.inclusive else ''}"
-            + f"{self.minimum_expression if self.minimum_expression else self.minimum_value}"
+            + f"{self.minimum_expression.wrapped if self.minimum_expression else self.minimum_value}"
         )
 
     @property
@@ -235,7 +236,7 @@ class GreaterThan(ManagedExpression):
         min_value_for_stmt = f"Decimal('{self.minimum_value}')"
         return (
             f"{self.safe_qid} >{'=' if self.inclusive else ''} "
-            + f"{self.minimum_expression if self.minimum_expression else min_value_for_stmt}"
+            + f"{self.minimum_expression.unwrapped if self.minimum_expression else min_value_for_stmt}"
         )
 
     @property
@@ -244,9 +245,8 @@ class GreaterThan(ManagedExpression):
 
     @property
     def expression_referenced_question_ids(self) -> list[UUID]:
-        if self.minimum_expression:
-            if question_id := self.safe_qid_to_id(self.minimum_expression.strip("() ")):
-                return [question_id]
+        if self.minimum_expression and (question_id := self.minimum_expression.question_id):
+            return [question_id]
         return []
 
     @staticmethod
@@ -266,7 +266,9 @@ class GreaterThan(ManagedExpression):
             ),
             "greater_than_expression": StringField(
                 "Minimum value",
-                default=expression.context.get("minimum_expression") or "" if expression else "",  # type: ignore[arg-type]
+                default=ExpressionReference(str(minimum_expression)).wrapped
+                if expression and (minimum_expression := expression.context.get("minimum_expression"))
+                else "",
                 widget=GovTextArea(),
             ),
             "greater_than_inclusive": BooleanField(
@@ -322,7 +324,7 @@ class LessThan(ManagedExpression):
 
     question_id: UUID
     maximum_value: int | Decimal | None
-    maximum_expression: str | None = None
+    maximum_expression: ExpressionReference | None = None
     inclusive: bool = False
 
     @property
@@ -333,21 +335,21 @@ class LessThan(ManagedExpression):
     def message(self) -> str:
         return (
             f"The answer must be less than {'or equal to ' if self.inclusive else ''}"
-            + f"{self.maximum_expression if self.maximum_expression else self.maximum_value}"
+            + f"{self.maximum_expression.wrapped if self.maximum_expression else self.maximum_value}"
         )
 
     @property
     def statement(self) -> str:
         max_value_for_stmt = f"Decimal('{self.maximum_value}')"
         return (
-            f"{self.safe_qid} <{'=' if self.inclusive else ''}"
-            + f"{self.maximum_expression if self.maximum_expression else max_value_for_stmt}"
+            f"{self.safe_qid} <{'=' if self.inclusive else ''} "
+            + f"{self.maximum_expression.unwrapped if self.maximum_expression else max_value_for_stmt}"
         )
 
     @property
     def expression_referenced_question_ids(self) -> list[UUID]:
         if self.maximum_expression:
-            if question_id := self.safe_qid_to_id(self.maximum_expression.strip("() ")):
+            if question_id := self.maximum_expression.question_id:
                 return [question_id]
         return []
 
@@ -369,7 +371,9 @@ class LessThan(ManagedExpression):
             ),
             "less_than_expression": StringField(
                 "Maximum value",
-                default=expression.context.get("maximum_expression") or "" if expression else "",  # type: ignore[arg-type]
+                default=ExpressionReference(str(maximum_expression)).wrapped
+                if expression and (maximum_expression := expression.context.get("maximum_expression"))
+                else "",
                 widget=GovTextArea(),
             ),
             "less_than_inclusive": BooleanField(
@@ -423,10 +427,10 @@ class Between(ManagedExpression):
 
     question_id: UUID
     minimum_value: int | Decimal | None
-    minimum_expression: str | None = None
+    minimum_expression: ExpressionReference | None = None
     minimum_inclusive: bool = False
     maximum_value: int | Decimal | None
-    maximum_expression: str | None = None
+    maximum_expression: ExpressionReference | None = None
     maximum_inclusive: bool = False
 
     @property
@@ -437,9 +441,9 @@ class Between(ManagedExpression):
     def message(self) -> str:
         return (
             "The answer must be between "
-            + f"{self.minimum_expression if self.minimum_expression else self.minimum_value}"
+            + f"{self.minimum_expression.wrapped if self.minimum_expression else self.minimum_value}"
             + f"{' (inclusive)' if self.minimum_inclusive else ' (exclusive)'} and "
-            + f"{self.maximum_expression if self.maximum_expression else self.maximum_value}"
+            + f"{self.maximum_expression.wrapped if self.maximum_expression else self.maximum_value}"
             + f"{' (inclusive)' if self.maximum_inclusive else ' (exclusive)'}"
         )
 
@@ -448,24 +452,22 @@ class Between(ManagedExpression):
         max_value_for_stmt = f"Decimal('{self.maximum_value}')"
         min_value_for_stmt = f"Decimal('{self.minimum_value}')"
         return (
-            f"{self.minimum_expression if self.minimum_expression else min_value_for_stmt} "
+            f"{self.minimum_expression.unwrapped if self.minimum_expression else min_value_for_stmt} "
             f"<{'=' if self.minimum_inclusive else ''} "
             f"{self.safe_qid} "
             f"<{'=' if self.maximum_inclusive else ''} "
-            f"{self.maximum_expression if self.maximum_expression else max_value_for_stmt}"
+            f"{self.maximum_expression.unwrapped if self.maximum_expression else max_value_for_stmt}"
         )
 
     @property
     def expression_referenced_question_ids(self) -> list[UUID]:
         referenced_ids = []
 
-        if self.minimum_expression:
-            if question_id := self.safe_qid_to_id(self.minimum_expression.strip("() ")):
-                referenced_ids.append(question_id)
+        if self.minimum_expression and (question_id := self.minimum_expression.question_id):
+            referenced_ids.append(question_id)
 
-        if self.maximum_expression:
-            if question_id := self.safe_qid_to_id(self.maximum_expression.strip("() ")):
-                referenced_ids.append(question_id)
+        if self.maximum_expression and (question_id := self.maximum_expression.question_id):
+            referenced_ids.append(question_id)
 
         return referenced_ids
 
@@ -487,7 +489,9 @@ class Between(ManagedExpression):
             ),
             "between_bottom_of_range_expression": StringField(
                 "Minimum value",
-                default=expression.context.get("minimum_expression") or "" if expression else "",  # type: ignore[arg-type]
+                default=ExpressionReference(str(minimum_expression)).wrapped
+                if expression and (minimum_expression := expression.context.get("minimum_expression"))
+                else "",
                 widget=GovTextArea(),
             ),
             "between_bottom_inclusive": BooleanField(
@@ -506,7 +510,9 @@ class Between(ManagedExpression):
             ),
             "between_top_of_range_expression": StringField(
                 "Maximum value",
-                default=expression.context.get("maximum_expression") or "" if expression else "",  # type: ignore[arg-type]
+                default=ExpressionReference(str(maximum_expression)).wrapped
+                if expression and (maximum_expression := expression.context.get("maximum_expression"))
+                else "",
                 widget=GovTextArea(),
             ),
             "between_top_inclusive": BooleanField(
@@ -788,7 +794,7 @@ class IsBefore(ManagedExpression):
 
     question_id: UUID
     latest_value: datetime.date | None
-    latest_expression: str | None = None
+    latest_expression: ExpressionReference | None = None
     inclusive: bool = False
 
     @property
@@ -804,7 +810,7 @@ class IsBefore(ManagedExpression):
                 else format_date_approximate(self.latest_value)
             )
         return f"The answer must be {'on or ' if self.inclusive else ''}before " + (
-            self.latest_expression if self.latest_expression else formatted_latest_value
+            self.latest_expression.wrapped if self.latest_expression else formatted_latest_value
         )
 
     @property
@@ -812,7 +818,7 @@ class IsBefore(ManagedExpression):
         if not self.latest_expression:
             assert self.latest_value
         date_expression = (
-            self.latest_expression
+            self.latest_expression.unwrapped
             if self.latest_expression
             else f"date({self.latest_value.year}, {self.latest_value.month}, {self.latest_value.day})"  # type: ignore[union-attr]
         )
@@ -820,9 +826,8 @@ class IsBefore(ManagedExpression):
 
     @property
     def expression_referenced_question_ids(self) -> list[UUID]:
-        if self.latest_expression:
-            if question_id := self.safe_qid_to_id(self.latest_expression.strip("() ")):
-                return [question_id]
+        if self.latest_expression and (question_id := self.latest_expression.question_id):
+            return [question_id]
         return []
 
     @property
@@ -845,7 +850,9 @@ class IsBefore(ManagedExpression):
             ),
             "latest_expression": StringField(
                 "Latest date",
-                default=cast(str, expression.context.get("latest_expression") or "" if expression else ""),
+                default=ExpressionReference(str(latest_expression)).wrapped
+                if expression and (latest_expression := expression.context.get("latest_expression"))
+                else "",
                 widget=GovTextArea(),
             ),
             "latest_inclusive": BooleanField(
@@ -908,7 +915,7 @@ class IsAfter(ManagedExpression):
 
     question_id: UUID
     earliest_value: datetime.date | None
-    earliest_expression: str | None = None
+    earliest_expression: ExpressionReference | None = None
     inclusive: bool = False
 
     @property
@@ -924,13 +931,13 @@ class IsAfter(ManagedExpression):
                 else format_date_approximate(self.earliest_value)
             )
         return f"The answer must be {'on or ' if self.inclusive else ''}after " + (
-            self.earliest_expression if self.earliest_expression else formatted_earliest_value
+            self.earliest_expression.wrapped if self.earliest_expression else formatted_earliest_value
         )
 
     @property
     def statement(self) -> str:
         date_expression = (
-            self.earliest_expression
+            self.earliest_expression.unwrapped
             if self.earliest_expression
             else f"date({self.earliest_value.year}, {self.earliest_value.month}, {self.earliest_value.day})"  # type: ignore[union-attr]
         )
@@ -938,9 +945,8 @@ class IsAfter(ManagedExpression):
 
     @property
     def expression_referenced_question_ids(self) -> list[UUID]:
-        if self.earliest_expression:
-            if question_id := self.safe_qid_to_id(self.earliest_expression.strip("() ")):
-                return [question_id]
+        if self.earliest_expression and (question_id := self.earliest_expression.question_id):
+            return [question_id]
         return []
 
     @property
@@ -963,7 +969,9 @@ class IsAfter(ManagedExpression):
             ),
             "earliest_expression": StringField(
                 "Earliest date",
-                default=cast(str, expression.context.get("earliest_expression") or "" if expression else ""),
+                default=ExpressionReference(str(earliest_expression)).wrapped
+                if expression and (earliest_expression := expression.context.get("earliest_expression"))
+                else "",
                 widget=GovTextArea(),
             ),
             "earliest_inclusive": BooleanField(
@@ -1026,10 +1034,10 @@ class BetweenDates(ManagedExpression):
 
     question_id: UUID
     earliest_value: datetime.date | None
-    earliest_expression: str | None = None
+    earliest_expression: ExpressionReference | None = None
     earliest_inclusive: bool = False
     latest_value: datetime.date | None
-    latest_expression: str | None = None
+    latest_expression: ExpressionReference | None = None
     latest_inclusive: bool = False
 
     @property
@@ -1052,26 +1060,26 @@ class BetweenDates(ManagedExpression):
             )
         return (
             "The answer must be between "
-            + (self.earliest_expression if self.earliest_expression else formatted_earliest_value)
+            + (self.earliest_expression.wrapped if self.earliest_expression else formatted_earliest_value)
             + f"{' (inclusive)' if self.earliest_inclusive else ' (exclusive)'} and "
-            + (self.latest_expression if self.latest_expression else formatted_latest_value)
+            + (self.latest_expression.wrapped if self.latest_expression else formatted_latest_value)
             + f"{' (inclusive)' if self.latest_inclusive else ' (exclusive)'}"
         )
 
     @property
     def statement(self) -> str:
         earliest_date_expression = (
-            self.earliest_expression
+            self.earliest_expression.unwrapped
             if self.earliest_expression
             else f"date({self.earliest_value.year}, {self.earliest_value.month}, {self.earliest_value.day})"  # type: ignore[union-attr]
         )
         latest_date_expression = (
-            self.latest_expression
+            self.latest_expression.unwrapped
             if self.latest_expression
             else f"date({self.latest_value.year}, {self.latest_value.month}, {self.latest_value.day})"  # type: ignore[union-attr]
         )
         return (
-            earliest_date_expression
+            f"{earliest_date_expression} "
             + f"<{'=' if self.earliest_inclusive else ''} "
             + f"{self.safe_qid} "
             + f"<{'=' if self.latest_inclusive else ''} "
@@ -1082,13 +1090,11 @@ class BetweenDates(ManagedExpression):
     def expression_referenced_question_ids(self) -> list[UUID]:
         referenced_ids = []
 
-        if self.earliest_expression:
-            if question_id := self.safe_qid_to_id(self.earliest_expression.strip("() ")):
-                referenced_ids.append(question_id)
+        if self.earliest_expression and (question_id := self.earliest_expression.question_id):
+            referenced_ids.append(question_id)
 
-        if self.latest_expression:
-            if question_id := self.safe_qid_to_id(self.latest_expression.strip("() ")):
-                referenced_ids.append(question_id)
+        if self.latest_expression and (question_id := self.latest_expression.question_id):
+            referenced_ids.append(question_id)
 
         return referenced_ids
 
@@ -1112,7 +1118,9 @@ class BetweenDates(ManagedExpression):
             ),
             "between_bottom_of_range_expression": StringField(
                 "Earliest date",
-                default=expression.context.get("earliest_expression") or "" if expression else "",  # type: ignore[arg-type]
+                default=ExpressionReference(str(earliest_expression)).wrapped
+                if expression and (earliest_expression := expression.context.get("earliest_expression"))
+                else "",
                 widget=GovTextArea(),
             ),
             "between_bottom_inclusive": BooleanField(
@@ -1133,7 +1141,9 @@ class BetweenDates(ManagedExpression):
             ),
             "between_top_of_range_expression": StringField(
                 "Latest date",
-                default=expression.context.get("latest_expression") or "" if expression else "",  # type: ignore[arg-type]
+                default=ExpressionReference(str(latest_expression)).wrapped
+                if expression and (latest_expression := expression.context.get("latest_expression"))
+                else "",
                 widget=GovTextArea(),
             ),
             "between_top_inclusive": BooleanField(

--- a/app/common/expressions/managed.py
+++ b/app/common/expressions/managed.py
@@ -44,7 +44,12 @@ if TYPE_CHECKING:
 
 class ManagedExpression(EvaluatableExpression):
     name: ClassVar[ManagedExpressionsEnum]
-    question_id: UUID
+
+    # This is the 'center' of the managed expression:
+    # For managed conditions, the value that should be compared against
+    # For managed validations, the question that is to be validated
+    subject_reference: ExpressionReference
+
     supported_condition_data_types: ClassVar[set[QuestionDataType]]
     supported_validator_data_types: ClassVar[set[QuestionDataType]]
     managed_expression_form_template: ClassVar[str | None]
@@ -73,13 +78,19 @@ class ManagedExpression(EvaluatableExpression):
 
     @property
     def referenced_question(self) -> Question:
-        # todo: split up the collections interface to let us sensibly reason about whats importing what
-        from app.common.data.interfaces.collections import get_question_by_id
-
-        # todo: this will do a database query per expression on the question - for now we'd anticipate
+        # todo: this might do a database query per expression on the question - for now we'd anticipate
         #       questions only have one or two managed expressions but in the future we should probably
         #       optimise this to fetch the full schema once and then re-use that throughout these helpers
-        return get_question_by_id(self.question_id)
+
+        # TODO[FSPT-1284]: we need to remove this and - probably - just point at the `subject_reference` here instead?
+        #                  That will need a helper to identify what the data type is for the reference; used by
+        #                  `build_managed_expression_form` in order to limit what can be selected to compare against
+        if not (question := self.subject_reference.question):
+            raise ValueError(
+                f"ManagedExpression.referenced_question called on {self!r} whose subject_reference "
+                f"is not a question reference"
+            )
+        return question
 
     @property
     def expression_referenced_question_ids(self) -> list[UUID]:
@@ -182,7 +193,7 @@ class ManagedExpression(EvaluatableExpression):
         Eg:
             def build_from_form(form: "_ManagedExpressionForm", question: "Question") -> "GreaterThan":
                 return GreaterThan(
-                    question_id=question.id,
+                    subject_reference=ExpressionReference.from_question(question),
                     minimum_value=form.greater_than_value.data,
                     inclusive=form.greater_than_inclusive.data,
                 )
@@ -215,7 +226,6 @@ class GreaterThan(ManagedExpression):
 
     _key: ManagedExpressionsEnum = name
 
-    question_id: UUID
     minimum_value: int | Decimal | None
     minimum_expression: ExpressionReference | None = None
     inclusive: bool = False
@@ -235,7 +245,7 @@ class GreaterThan(ManagedExpression):
     def statement(self) -> str:
         min_value_for_stmt = f"Decimal('{self.minimum_value}')"
         return (
-            f"{self.safe_qid} >{'=' if self.inclusive else ''} "
+            f"{self.subject_reference.unwrapped} >{'=' if self.inclusive else ''} "
             + f"{self.minimum_expression.unwrapped if self.minimum_expression else min_value_for_stmt}"
         )
 
@@ -300,7 +310,7 @@ class GreaterThan(ManagedExpression):
         form: _ManagedExpressionForm, question: Question, expression: TOptional[Expression] = None
     ) -> GreaterThan:
         return GreaterThan(
-            question_id=question.id,
+            subject_reference=ExpressionReference.from_question(question),
             minimum_value=form.greater_than_value.data if not form.greater_than_expression.data else None,  # ty: ignore[unresolved-attribute]
             minimum_expression=form.greater_than_expression.data if form.greater_than_expression.data else None,  # ty: ignore[unresolved-attribute]
             inclusive=form.greater_than_inclusive.data,  # ty: ignore[unresolved-attribute]
@@ -322,7 +332,6 @@ class LessThan(ManagedExpression):
 
     _key: ManagedExpressionsEnum = name
 
-    question_id: UUID
     maximum_value: int | Decimal | None
     maximum_expression: ExpressionReference | None = None
     inclusive: bool = False
@@ -342,7 +351,7 @@ class LessThan(ManagedExpression):
     def statement(self) -> str:
         max_value_for_stmt = f"Decimal('{self.maximum_value}')"
         return (
-            f"{self.safe_qid} <{'=' if self.inclusive else ''} "
+            f"{self.subject_reference.unwrapped} <{'=' if self.inclusive else ''} "
             + f"{self.maximum_expression.unwrapped if self.maximum_expression else max_value_for_stmt}"
         )
 
@@ -403,7 +412,7 @@ class LessThan(ManagedExpression):
     @staticmethod
     def build_from_form(form: _ManagedExpressionForm, question: Question) -> LessThan:
         return LessThan(
-            question_id=question.id,
+            subject_reference=ExpressionReference.from_question(question),
             maximum_value=form.less_than_value.data if not form.less_than_expression.data else None,  # ty: ignore[unresolved-attribute]
             maximum_expression=form.less_than_expression.data if form.less_than_expression.data else None,  # ty: ignore[unresolved-attribute]
             inclusive=form.less_than_inclusive.data,  # ty: ignore[unresolved-attribute]
@@ -425,7 +434,6 @@ class Between(ManagedExpression):
 
     _key: ManagedExpressionsEnum = name
 
-    question_id: UUID
     minimum_value: int | Decimal | None
     minimum_expression: ExpressionReference | None = None
     minimum_inclusive: bool = False
@@ -454,7 +462,7 @@ class Between(ManagedExpression):
         return (
             f"{self.minimum_expression.unwrapped if self.minimum_expression else min_value_for_stmt} "
             f"<{'=' if self.minimum_inclusive else ''} "
-            f"{self.safe_qid} "
+            f"{self.subject_reference.unwrapped} "
             f"<{'=' if self.maximum_inclusive else ''} "
             f"{self.maximum_expression.unwrapped if self.maximum_expression else max_value_for_stmt}"
         )
@@ -556,7 +564,7 @@ class Between(ManagedExpression):
     @staticmethod
     def build_from_form(form: _ManagedExpressionForm, question: Question) -> Between:
         return Between(
-            question_id=question.id,
+            subject_reference=ExpressionReference.from_question(question),
             minimum_value=form.between_bottom_of_range.data  # ty: ignore[unresolved-attribute]
             if not form.between_bottom_of_range_expression.data  # ty: ignore[unresolved-attribute]
             else None,
@@ -592,7 +600,6 @@ class AnyOf(BaseDataSourceManagedExpression):
 
     _key: ManagedExpressionsEnum = name
 
-    question_id: UUID
     items: list[TRadioItem]
 
     @property
@@ -609,7 +616,7 @@ class AnyOf(BaseDataSourceManagedExpression):
     @property
     def statement(self) -> str:
         item_keys = {str(item["key"]) for item in self.items}
-        return f"{self.safe_qid} in {item_keys}"
+        return f"{self.subject_reference.unwrapped} in {item_keys}"
 
     @staticmethod
     def get_form_fields(referenced_question: Question, expression: TOptional[Expression] = None) -> dict[str, Field]:
@@ -641,7 +648,7 @@ class AnyOf(BaseDataSourceManagedExpression):
 
         items = [TRadioItem(key=key, label=item_labels[key]) for key in form.any_of.data]  # ty: ignore[unresolved-attribute]
         return AnyOf(
-            question_id=question.id,
+            subject_reference=ExpressionReference.from_question(question),
             items=items,
         )
 
@@ -659,8 +666,6 @@ class IsYes(ManagedExpression):
 
     _key: ManagedExpressionsEnum = name
 
-    question_id: UUID
-
     @property
     def description(self) -> str:
         return "is yes"
@@ -671,7 +676,7 @@ class IsYes(ManagedExpression):
 
     @property
     def statement(self) -> str:
-        return f"{self.safe_qid} is True"
+        return f"{self.subject_reference.unwrapped} is True"
 
     @staticmethod
     def get_form_fields(referenced_question: Question, expression: TOptional[Expression] = None) -> dict[str, Field]:
@@ -683,7 +688,7 @@ class IsYes(ManagedExpression):
 
     @staticmethod
     def build_from_form(form: _ManagedExpressionForm, question: Question) -> IsYes:
-        return IsYes(question_id=question.id)
+        return IsYes(subject_reference=ExpressionReference.from_question(question))
 
 
 @register_managed_expression
@@ -695,8 +700,6 @@ class IsNo(ManagedExpression):
 
     _key: ManagedExpressionsEnum = name
 
-    question_id: UUID
-
     @property
     def description(self) -> str:
         return "is no"
@@ -707,7 +710,7 @@ class IsNo(ManagedExpression):
 
     @property
     def statement(self) -> str:
-        return f"{self.safe_qid} is False"
+        return f"{self.subject_reference.unwrapped} is False"
 
     @staticmethod
     def get_form_fields(referenced_question: Question, expression: TOptional[Expression] = None) -> dict[str, Field]:
@@ -719,7 +722,7 @@ class IsNo(ManagedExpression):
 
     @staticmethod
     def build_from_form(form: _ManagedExpressionForm, question: Question) -> IsNo:
-        return IsNo(question_id=question.id)
+        return IsNo(subject_reference=ExpressionReference.from_question(question))
 
 
 @register_managed_expression
@@ -731,7 +734,6 @@ class Specifically(BaseDataSourceManagedExpression):
 
     _key: ManagedExpressionsEnum = name
 
-    question_id: UUID
     item: TRadioItem
 
     @property
@@ -745,7 +747,7 @@ class Specifically(BaseDataSourceManagedExpression):
     @property
     def statement(self) -> str:
         # TODO: This a bit fragile - another reason for referencing a data source item?
-        return f"{self.item['key']!r} in {self.safe_qid}"
+        return f"{self.item['key']!r} in {self.subject_reference.unwrapped}"
 
     @staticmethod
     def get_form_fields(referenced_question: Question, expression: TOptional[Expression] = None) -> dict[str, Field]:
@@ -774,7 +776,7 @@ class Specifically(BaseDataSourceManagedExpression):
         item_labels = {item.key: item.label for item in question.data_source.items}
         selected_key = form.specifically.data  # ty: ignore[unresolved-attribute]
         item: TRadioItem = {"key": selected_key, "label": item_labels[selected_key]}
-        return Specifically(question_id=question.id, item=item)
+        return Specifically(subject_reference=ExpressionReference.from_question(question), item=item)
 
     @property
     def referenced_data_source_items(self) -> list[TRadioItem]:
@@ -792,7 +794,6 @@ class IsBefore(ManagedExpression):
 
     _key: ManagedExpressionsEnum = name
 
-    question_id: UUID
     latest_value: datetime.date | None
     latest_expression: ExpressionReference | None = None
     inclusive: bool = False
@@ -822,7 +823,7 @@ class IsBefore(ManagedExpression):
             if self.latest_expression
             else f"date({self.latest_value.year}, {self.latest_value.month}, {self.latest_value.day})"  # type: ignore[union-attr]
         )
-        return f"{self.safe_qid} <{'=' if self.inclusive else ''} {date_expression}"
+        return f"{self.subject_reference.unwrapped} <{'=' if self.inclusive else ''} {date_expression}"
 
     @property
     def expression_referenced_question_ids(self) -> list[UUID]:
@@ -882,7 +883,7 @@ class IsBefore(ManagedExpression):
     @staticmethod
     def build_from_form(form: _ManagedExpressionForm, question: Question) -> IsBefore:
         return IsBefore(
-            question_id=question.id,
+            subject_reference=ExpressionReference.from_question(question),
             latest_value=form.latest_value.data if not form.latest_expression.data else None,  # ty: ignore[unresolved-attribute]
             latest_expression=form.latest_expression.data if form.latest_expression.data else None,  # ty: ignore[unresolved-attribute]
             inclusive=form.latest_inclusive.data,  # ty: ignore[unresolved-attribute]
@@ -913,7 +914,6 @@ class IsAfter(ManagedExpression):
 
     _key: ManagedExpressionsEnum = name
 
-    question_id: UUID
     earliest_value: datetime.date | None
     earliest_expression: ExpressionReference | None = None
     inclusive: bool = False
@@ -941,7 +941,7 @@ class IsAfter(ManagedExpression):
             if self.earliest_expression
             else f"date({self.earliest_value.year}, {self.earliest_value.month}, {self.earliest_value.day})"  # type: ignore[union-attr]
         )
-        return f"{self.safe_qid} >{'=' if self.inclusive else ''} {date_expression}"
+        return f"{self.subject_reference.unwrapped} >{'=' if self.inclusive else ''} {date_expression}"
 
     @property
     def expression_referenced_question_ids(self) -> list[UUID]:
@@ -1001,7 +1001,7 @@ class IsAfter(ManagedExpression):
     @staticmethod
     def build_from_form(form: _ManagedExpressionForm, question: Question) -> IsAfter:
         return IsAfter(
-            question_id=question.id,
+            subject_reference=ExpressionReference.from_question(question),
             earliest_value=form.earliest_value.data if not form.earliest_expression.data else None,  # ty: ignore[unresolved-attribute]
             earliest_expression=form.earliest_expression.data if form.earliest_expression.data else None,  # ty: ignore[unresolved-attribute]
             inclusive=form.earliest_inclusive.data,  # ty: ignore[unresolved-attribute]
@@ -1032,7 +1032,6 @@ class BetweenDates(ManagedExpression):
 
     _key: ManagedExpressionsEnum = name
 
-    question_id: UUID
     earliest_value: datetime.date | None
     earliest_expression: ExpressionReference | None = None
     earliest_inclusive: bool = False
@@ -1081,7 +1080,7 @@ class BetweenDates(ManagedExpression):
         return (
             f"{earliest_date_expression} "
             + f"<{'=' if self.earliest_inclusive else ''} "
-            + f"{self.safe_qid} "
+            + f"{self.subject_reference.unwrapped} "
             + f"<{'=' if self.latest_inclusive else ''} "
             + latest_date_expression
         )
@@ -1187,7 +1186,7 @@ class BetweenDates(ManagedExpression):
     @staticmethod
     def build_from_form(form: _ManagedExpressionForm, question: Question) -> BetweenDates:
         return BetweenDates(
-            question_id=question.id,
+            subject_reference=ExpressionReference.from_question(question),
             earliest_value=form.between_bottom_of_range.data  # ty: ignore[unresolved-attribute]
             if not form.between_bottom_of_range_expression.data  # ty: ignore[unresolved-attribute]
             else None,
@@ -1230,8 +1229,6 @@ class UKPostcode(ManagedExpression):
 
     _key: ManagedExpressionsEnum = name
 
-    question_id: UUID
-
     @property
     def description(self) -> str:
         return "Must be a UK postcode"
@@ -1242,7 +1239,7 @@ class UKPostcode(ManagedExpression):
 
     @property
     def statement(self) -> str:
-        return f"uk_postcode_match({self.safe_qid})"
+        return f"uk_postcode_match({self.subject_reference.unwrapped})"
 
     @property
     def required_functions(self) -> dict[str, Callable[[Any], Any] | type[Any]]:
@@ -1265,7 +1262,7 @@ class UKPostcode(ManagedExpression):
 
     @staticmethod
     def build_from_form(form: _ManagedExpressionForm, question: Question) -> UKPostcode:
-        return UKPostcode(question_id=question.id)
+        return UKPostcode(subject_reference=ExpressionReference.from_question(question))
 
 
 def get_managed_expression(expression: Expression) -> ManagedExpression:

--- a/app/common/expressions/references.py
+++ b/app/common/expressions/references.py
@@ -1,0 +1,168 @@
+from collections import namedtuple
+from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
+from pydantic import GetCoreSchemaHandler
+from pydantic_core import CoreSchema, core_schema
+from sqlalchemy.exc import NoResultFound
+
+from app.common.safe_ids import SafeDidMixin, SafeQidMixin
+
+if TYPE_CHECKING:
+    from app.common.data.models import DataSource, Question
+    from app.common.data.types import DataSourceSchemaColumn, QuestionDataType
+
+
+def _try_unwrap(text: str) -> str | None:
+    """If ``text`` is a single ``((reference))`` token, return the inner reference; else None."""
+    from app.common.expressions import INTERPOLATE_REGEX
+
+    match = INTERPOLATE_REGEX.fullmatch(text.strip())
+    if not match:
+        return None
+    return match.group(1).strip()
+
+
+DataSourceReference = namedtuple("DataSourceReference", ("data_source_id", "column_name"))
+
+
+class ExpressionReference(str):
+    """A reference to a datapoint available within an ExpressionContext.
+
+    Stored form is unwrapped: e.g. ``q_<hex>`` for a question answer, or
+    ``d_<hex>.<column_name>`` for a data source column value.
+
+    This class owns the parsing/formatting logic for references so that the
+    rest of the codebase can pass a typed value around instead of juggling
+    bare strings. Instances inherit from ``str`` so they serialise naturally
+    through Pydantic/JSON and compare equal to the underlying unwrapped
+    reference string.
+    """
+
+    def __new__(cls, value: str) -> ExpressionReference:
+        if (unwrapped := _try_unwrap(value)) is not None:
+            # Allow passing already-wrapped references for backwards compatibility.
+            value = unwrapped
+        value = value.strip()
+        return super().__new__(cls, value)
+
+    @classmethod
+    def from_wrapped(cls, text: str) -> ExpressionReference:
+        unwrapped = _try_unwrap(text)
+        if unwrapped is None:
+            raise ValueError(f"Expected a wrapped reference like ((ref)); got {text!r}")
+        # TODO: This should raise InvalidReferenceInExpression if an empty string?
+        return cls(unwrapped)
+
+    @classmethod
+    def from_question(cls, question: Question) -> ExpressionReference:
+        return cls(question.safe_qid)
+
+    @classmethod
+    def from_data_source_column(cls, data_source: DataSource, column_name: str) -> ExpressionReference:
+        return cls(f"{data_source.safe_did}.{column_name}")
+
+    @property
+    def unwrapped(self) -> str:
+        return str(self)
+
+    @property
+    def wrapped(self) -> str:
+        return f"(({self.unwrapped}))"
+
+    @property
+    def question_id(self) -> UUID | None:
+        """If this reference refers to a question, return the question's UUID; otherwise None.
+
+        This does not check that the referenced question exists in any DB/context —
+        it only inspects the shape of the reference string.
+        """
+        try:
+            return SafeQidMixin.safe_qid_to_id(self.unwrapped)
+        except ValueError:
+            return None
+
+    @property
+    def data_source_reference(self) -> DataSourceReference | None:
+        """If this reference refers to a data source column, return ``(data_source_id, column_name)``;
+        otherwise None.
+
+        As with `question_id`, this only inspects the shape of the reference string.
+        """
+        try:
+            data_source_id, column_name = SafeDidMixin.safe_ds_ref_to_id_and_column_name(self.unwrapped)
+        except ValueError:
+            return None
+        if data_source_id is None or column_name is None:
+            return None
+        return DataSourceReference(data_source_id, column_name)
+
+    @property
+    def question(self) -> Question | None:
+        from app.common.data.interfaces.collections import get_question_by_id
+
+        question_id = self.question_id
+        if not question_id:
+            return None
+
+        try:
+            return get_question_by_id(question_id)
+        except NoResultFound:
+            return None
+
+    @property
+    def data_source_column(self) -> DataSourceSchemaColumn | None:
+        from app.common.data.interfaces.data_sets import get_data_source
+
+        ds_ref = self.data_source_reference
+        if not ds_ref:
+            return None
+
+        try:
+            data_source = get_data_source(ds_ref.data_source_id) if ds_ref else None
+        except NoResultFound:
+            data_source = None
+
+        if not data_source:
+            return None
+
+        schema = data_source.schema
+        if not schema:
+            return None
+
+        return schema.root.get(ds_ref.column_name)
+
+    @property
+    def data_type(self) -> QuestionDataType:
+        """Resolve this reference to the data type of the value it points at.
+
+        Returns the referenced Question's data_type for question refs, or the data source
+        column's data_type for column refs.
+
+        Called by `build_managed_expression_form` to pick the set of managed expressions
+        applicable to a subject without caring whether that subject is a question or a
+        data source column.
+        """
+        if question := self.question:
+            return question.data_type
+
+        if column := self.data_source_column:
+            return column.data_type
+
+        raise ValueError(f"Can't resolve ExpressionReference {self!r} to a specific data type; unknown reference shape")
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, source_type: Any, handler: GetCoreSchemaHandler) -> CoreSchema:
+        def _from_str(value: str) -> ExpressionReference:
+            if isinstance(value, cls):
+                return value
+            # Be lenient about wrapped input from the Pydantic deserialisation path —
+            # existing stored JSONB contains wrapped references like "((q_xxx))" and
+            # form submissions also arrive wrapped. Canonicalise to unwrapped here.
+            return cls(value)
+
+        return core_schema.no_info_after_validator_function(
+            _from_str,
+            core_schema.str_schema(),
+            serialization=core_schema.plain_serializer_function_ser_schema(str),
+        )

--- a/app/deliver_grant_funding/routes/reports.py
+++ b/app/deliver_grant_funding/routes/reports.py
@@ -97,6 +97,7 @@ from app.common.expressions.forms import (
     _ManagedExpressionForm,
     build_managed_expression_form,
 )
+from app.common.expressions.references import ExpressionReference
 from app.common.expressions.registry import get_managed_validators_by_data_type, lookup_managed_expression
 from app.common.forms import GenericConfirmDeletionForm, GenericSubmitForm
 from app.common.helpers.collections import AllSubmissionsHelper, SubmissionHelper
@@ -1498,10 +1499,11 @@ def _determine_return_url_and_update_session_after_choosing_referenced_question_
 ) -> str:
     if add_context_data and isinstance(add_context_data, AddContextToExpressionsModel):
         target_field = add_context_data.expression_form_data["add_context"]
+        reference = ExpressionReference.from_question(referenced_question)
         if add_context_data.managed_expression_name is None:
-            add_context_data.expression_form_data[target_field] += f"(({referenced_question.safe_qid}))"
+            add_context_data.expression_form_data[target_field] += reference.wrapped
         else:
-            add_context_data.expression_form_data[target_field] = f"(({referenced_question.safe_qid}))"
+            add_context_data.expression_form_data[target_field] = reference.wrapped
 
     if add_context_data.field == ExpressionType.CONDITION:
         if not add_context_data.expression_id:
@@ -1647,7 +1649,8 @@ def select_context_source_question(grant_id: UUID, form_id: UUID) -> ResponseRet
 
                 if add_context_data and isinstance(add_context_data, AddContextToComponentSessionModel):
                     target_field = add_context_data.component_form_data["add_context"]
-                    add_context_data.component_form_data[target_field] += f" (({referenced_question.safe_qid}))"
+                    reference = ExpressionReference.from_question(referenced_question)
+                    add_context_data.component_form_data[target_field] += " " + reference.wrapped
 
             case AddContextToComponentGuidanceSessionModel():
                 return_url = (
@@ -1665,7 +1668,8 @@ def select_context_source_question(grant_id: UUID, form_id: UUID) -> ResponseRet
                 )
                 if add_context_data and isinstance(add_context_data, AddContextToComponentGuidanceSessionModel):
                     target_field = add_context_data.component_form_data["add_context"]
-                    add_context_data.component_form_data[target_field] += f" (({referenced_question.safe_qid}))"
+                    reference = ExpressionReference.from_question(referenced_question)
+                    add_context_data.component_form_data[target_field] += " " + reference.wrapped
 
             case AddContextToExpressionsModel():
                 return_url = _determine_return_url_and_update_session_after_choosing_referenced_question_for_expression(

--- a/app/developers/commands.py
+++ b/app/developers/commands.py
@@ -3,7 +3,8 @@ import hashlib
 import json
 import uuid
 from collections import defaultdict
-from io import BytesIO
+from difflib import SequenceMatcher
+from io import BytesIO, StringIO
 from pathlib import Path
 from typing import Any, TextIO, TypedDict, cast
 from uuid import UUID
@@ -800,3 +801,99 @@ def create_multi_submissions(  # noqa: C901
         click.echo(f"\nDone. Created {created} submissions, skipped {skipped}.")
     else:
         click.echo(f"\nDry run complete. Would create {created} submissions, would skip {skipped}.")
+
+
+def _render_char_diff(stored: str, generated: str) -> tuple[str, str]:
+    matcher = SequenceMatcher(a=stored, b=generated, autojunk=False)
+    stored_out: list[str] = []
+    generated_out: list[str] = []
+    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+        if tag == "equal":
+            stored_out.append(stored[i1:i2])
+            generated_out.append(generated[j1:j2])
+            continue
+        if i1 != i2:
+            stored_out.append(click.style(stored[i1:i2], fg="red", bold=True))
+        if j1 != j2:
+            generated_out.append(click.style(generated[j1:j2], fg="green", bold=True))
+    return "".join(stored_out), "".join(generated_out)
+
+
+@developers_blueprint.cli.command(
+    "check-managed-statements",
+    help="Diff each managed expression's stored statement against one regenerated from its ManagedExpression.",
+)
+@click.option("--output", type=click.Choice(["stdout", "s3"]), default="stdout")
+@click.option("--s3-key", help="S3 object key to upload the report to. Required when --output=s3.")
+@click.option(
+    "--force-colour",
+    is_flag=True,
+    default=False,
+    help="Force ANSI colour codes in output even when stdout is not a TTY (e.g. ECS/CloudWatch, S3).",
+)
+@click.pass_context
+def check_managed_statements(ctx: click.Context, output: str, s3_key: str | None, force_colour: bool) -> None:
+    if force_colour:
+        ctx.color = True
+
+    if output == "s3" and not s3_key:
+        raise click.ClickException("--s3-key is required when --output=s3")
+
+    buf: StringIO | None = StringIO() if output == "s3" else None
+
+    def emit(line: str = "") -> None:
+        click.echo(line)
+        if buf is not None:
+            click.echo(line, file=buf)
+
+    expressions = (
+        db.session.query(Expression)
+        .where(Expression.managed_name.isnot(None))
+        .order_by(Expression.managed_name, Expression.id)
+        .all()
+    )
+
+    mismatches = 0
+    errors = 0
+    for expression in expressions:
+        assert expression.managed_name is not None
+        header = f"expression {expression.id} ({expression.managed_name.value}) on component {expression.question_id}"
+
+        try:
+            generated = expression.managed.statement
+        except Exception as exc:
+            errors += 1
+            emit(f"{header}:")
+            emit(f"  stored:    {expression.statement}")
+            emit(f"  {click.style('could not regenerate: ' + type(exc).__name__ + ': ' + str(exc), fg='yellow')}")
+            emit()
+            continue
+
+        stored = expression.statement
+        if stored == generated:
+            continue
+
+        mismatches += 1
+        stored_coloured, generated_coloured = _render_char_diff(stored, generated)
+        emit(f"{header}:")
+        emit(f"  - {stored_coloured}")
+        emit(f"  + {generated_coloured}")
+        emit()
+
+    emit(
+        f"Checked {len(expressions)} managed expressions; {mismatches} mismatch(es), {errors} reconstruction error(s)."
+    )
+
+    if buf is not None:
+        assert s3_key is not None
+        file_storage = FileStorage(
+            stream=BytesIO(buf.getvalue().encode("utf-8")),
+            filename=s3_key,
+            content_type="text/plain; charset=utf-8",
+        )
+        s3_service.upload_file(file_storage, key=s3_key)
+        bucket = current_app.config["AWS_S3_BUCKET_NAME"]
+        click.echo(f"Report uploaded to s3://{bucket}/{s3_key}")
+
+    if mismatches or errors:
+        raise click.exceptions.Exit(1)

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -102,6 +102,7 @@ from app.common.data.types import (
 from app.common.expressions import ExpressionContext
 from app.common.expressions.custom import CustomExpression
 from app.common.expressions.managed import AnyOf, Between, GreaterThan, LessThan, Specifically
+from app.common.expressions.references import ExpressionReference
 from app.common.forms.helpers import components_in_valid_add_another_combination
 from app.metrics import MetricEventName
 from tests.models import FactoryAnswer
@@ -4894,7 +4895,7 @@ class TestValidateReference:
 
         assert (
             _validate_reference(
-                wrapped_reference=f"(({q1.safe_qid}))",
+                reference=ExpressionReference(q1.safe_qid),
                 attached_to_component=q2,
                 expression_context=expression_context,
                 expression_type=ExpressionType.VALIDATION,
@@ -4905,7 +4906,7 @@ class TestValidateReference:
         )
         assert (
             _validate_reference(
-                wrapped_reference=f"(({q1.safe_qid}))",
+                reference=ExpressionReference(q1.safe_qid),
                 attached_to_component=q2,
                 expression_context=expression_context,
                 expression_type=ExpressionType.CONDITION,
@@ -4920,7 +4921,7 @@ class TestValidateReference:
         g = factories.group.create(form=q1.form, add_another=True)
         assert (
             _validate_reference(
-                wrapped_reference=f"(({q1.safe_qid}))",
+                reference=ExpressionReference(q1.safe_qid),
                 attached_to_component=g,
                 expression_context=ExpressionContext.build_expression_context(
                     q1.form.collection, "interpolation", None, None
@@ -4938,7 +4939,7 @@ class TestValidateReference:
         q2 = factories.question.create(form=q1.form)
         with pytest.raises(DependencyOrderException):
             _validate_reference(
-                wrapped_reference=f"(({q2.safe_qid}))",
+                reference=ExpressionReference(q2.safe_qid),
                 attached_to_component=g,
                 expression_context=ExpressionContext.build_expression_context(
                     q1.form.collection, "interpolation", None, None
@@ -4950,7 +4951,7 @@ class TestValidateReference:
         g1_q1 = factories.question.create(parent=g)
         with pytest.raises(DependencyOrderException):
             _validate_reference(
-                wrapped_reference=f"(({g1_q1.safe_qid}))",
+                reference=ExpressionReference(g1_q1.safe_qid),
                 attached_to_component=g,
                 expression_context=ExpressionContext.build_expression_context(
                     q1.form.collection, "interpolation", None, None
@@ -4968,7 +4969,7 @@ class TestValidateReference:
 
         with pytest.raises(DependencyOrderException):
             _validate_reference(
-                wrapped_reference=f"(({q2.safe_qid}))",
+                reference=ExpressionReference(q2.safe_qid),
                 attached_to_component=q2,
                 expression_context=expression_context,
                 expression_type=ExpressionType.VALIDATION,
@@ -4977,7 +4978,7 @@ class TestValidateReference:
             )
         with pytest.raises(DependencyOrderException):
             _validate_reference(
-                wrapped_reference=f"(({q2.safe_qid}))",
+                reference=ExpressionReference(q2.safe_qid),
                 attached_to_component=q2,
                 expression_context=expression_context,
                 expression_type=ExpressionType.CONDITION,
@@ -4993,7 +4994,7 @@ class TestValidateReference:
 
         assert (
             _validate_reference(
-                wrapped_reference=f"(({q2.safe_qid}))",
+                reference=ExpressionReference(q2.safe_qid),
                 attached_to_component=q2,
                 expression_context=expression_context,
                 expression_type=ExpressionType.VALIDATION,
@@ -5014,7 +5015,7 @@ class TestValidateReference:
 
         assert (
             _validate_reference(
-                wrapped_reference=f"(({q1.safe_qid}))",
+                reference=ExpressionReference(q1.safe_qid),
                 attached_to_component=q1,
                 expression_context=expression_context,
                 expression_type=ExpressionType.VALIDATION,
@@ -5030,7 +5031,7 @@ class TestValidateReference:
         context = ExpressionContext.build_expression_context(form.collection, mode="interpolation")
         with pytest.raises(DependencyOrderException) as e:
             _validate_reference(
-                wrapped_reference=f"(({q3.safe_qid}))",
+                reference=ExpressionReference(q3.safe_qid),
                 attached_to_component=q2,
                 expression_context=context,
                 expression_type=ExpressionType.VALIDATION,
@@ -5047,7 +5048,7 @@ class TestValidateReference:
         context = ExpressionContext.build_expression_context(form.collection, mode="interpolation")
         with pytest.raises(DependencyOrderException) as e:
             _validate_reference(
-                wrapped_reference=f"(({q3.safe_qid}))",
+                reference=ExpressionReference(q3.safe_qid),
                 attached_to_component=q2,
                 expression_context=context,
                 expression_type=ExpressionType.CONDITION,
@@ -5060,7 +5061,7 @@ class TestValidateReference:
 
         with pytest.raises(DependencyOrderException) as e:
             _validate_reference(
-                wrapped_reference=f"(({q1.safe_qid}))",
+                reference=ExpressionReference(q1.safe_qid),
                 attached_to_component=q2,
                 expression_context=context,
                 expression_type=ExpressionType.CONDITION,
@@ -5077,7 +5078,7 @@ class TestValidateReference:
         context = ExpressionContext.build_expression_context(form.collection, mode="interpolation")
         with pytest.raises(InvalidReferenceInExpression) as e:
             _validate_reference(
-                wrapped_reference="((q_bad_ref))",
+                reference=ExpressionReference("q_bad_ref"),
                 attached_to_component=q2,
                 expression_context=context,
                 expression_type=ExpressionType.VALIDATION,
@@ -5095,7 +5096,7 @@ class TestValidateReference:
         context = ExpressionContext.build_expression_context(form.collection, mode="interpolation")
         with pytest.raises(IncompatibleDataTypeException) as e:
             _validate_reference(
-                wrapped_reference=f"(({q1.safe_qid}))",
+                reference=ExpressionReference(q1.safe_qid),
                 attached_to_component=q2,
                 expression_context=context,
                 expression_type=ExpressionType.VALIDATION,
@@ -5118,7 +5119,7 @@ class TestValidateReference:
 
         with pytest.raises(AddAnotherDependencyException):
             _validate_reference(
-                wrapped_reference=f"(({g1_q1.safe_qid}))",
+                reference=ExpressionReference(g1_q1.safe_qid),
                 attached_to_component=q1,
                 expression_context=expression_context,
                 expression_type=ExpressionType.VALIDATION,
@@ -5127,7 +5128,7 @@ class TestValidateReference:
             )
         with pytest.raises(AddAnotherDependencyException):
             _validate_reference(
-                wrapped_reference=f"(({g1_q1.safe_qid}))",
+                reference=ExpressionReference(g1_q1.safe_qid),
                 attached_to_component=q1,
                 expression_context=expression_context,
                 expression_type=None,
@@ -5137,7 +5138,7 @@ class TestValidateReference:
 
         with pytest.raises(AddAnotherDependencyException):
             _validate_reference(
-                wrapped_reference=f"(({q1.safe_qid}))",
+                reference=ExpressionReference(q1.safe_qid),
                 attached_to_component=q2,
                 expression_context=expression_context,
                 expression_type=ExpressionType.VALIDATION,
@@ -5147,7 +5148,7 @@ class TestValidateReference:
 
         with pytest.raises(DependencyOrderException):
             _validate_reference(
-                wrapped_reference=f"(({g1_q2.safe_qid}))",
+                reference=ExpressionReference(g1_q2.safe_qid),
                 attached_to_component=g1_q1,
                 expression_context=expression_context,
                 expression_type=ExpressionType.VALIDATION,
@@ -5157,7 +5158,7 @@ class TestValidateReference:
 
         with pytest.raises(AddAnotherDependencyException):
             _validate_reference(
-                wrapped_reference=f"(({g1_q2.safe_qid}))",
+                reference=ExpressionReference(g1_q2.safe_qid),
                 attached_to_component=q2,
                 expression_context=expression_context,
                 expression_type=ExpressionType.CONDITION,
@@ -5175,7 +5176,7 @@ class TestValidateReference:
         expression_context = ExpressionContext.build_expression_context(form.collection, "interpolation", None, None)
 
         _validate_reference(
-            wrapped_reference=f"(({q1.safe_qid}))",
+            reference=ExpressionReference(q1.safe_qid),
             attached_to_component=g1_q1,
             expression_context=expression_context,
             expression_type=ExpressionType.VALIDATION,
@@ -5184,7 +5185,7 @@ class TestValidateReference:
         )
 
         _validate_reference(
-            wrapped_reference=f"(({g1_q1.safe_qid}))",
+            reference=ExpressionReference(g1_q1.safe_qid),
             attached_to_component=g1_q2,
             expression_context=expression_context,
             expression_type=ExpressionType.CONDITION,
@@ -5204,7 +5205,7 @@ class TestValidateReference:
         with pytest.raises(InvalidReferenceInExpression):
             assert (
                 _validate_reference(
-                    wrapped_reference=f"(({q1.safe_qid}))",
+                    reference=ExpressionReference(q1.safe_qid),
                     attached_to_component=q2,
                     expression_context=expression_context,
                     expression_type=ExpressionType.VALIDATION,

--- a/tests/integration/common/expressions/test_managed.py
+++ b/tests/integration/common/expressions/test_managed.py
@@ -116,7 +116,7 @@ class TestGreaterThanExpression:
         expr = GreaterThan(question_id=uuid.uuid4(), minimum_value=minimum_value, inclusive=inclusive)
         expression = Expression.from_evaluatable_expression(expr, ExpressionType.VALIDATION, user)
         expression.context = {
-            expr.safe_qid: answer,
+            expr.subject_reference.unwrapped: answer,
             "minimum_value": expr.minimum_value,
             "inclusive": expr.inclusive,
             "question_id": expr.question_id,
@@ -199,7 +199,7 @@ class TestLessThanExpression:
         expr = LessThan(question_id=uuid.uuid4(), maximum_value=maximum_value, inclusive=inclusive)
         expression = Expression.from_evaluatable_expression(expr, ExpressionType.VALIDATION, user)
         expression.context = {
-            expr.safe_qid: answer,
+            expr.subject_reference.unwrapped: answer,
             "maximum_value": expr.maximum_value,
             "question_id": expr.question_id,
         }
@@ -297,7 +297,7 @@ class TestBetweenExpression:
         )
         expression = Expression.from_evaluatable_expression(expr, ExpressionType.VALIDATION, factories.user.build())
         expression.context = {
-            expr.safe_qid: answer,
+            expr.subject_reference.unwrapped: answer,
             "maximum_value": expr.maximum_value,
             "minimum_value": expr.maximum_value,
             "minimum_inclusive": expr.minimum_inclusive,
@@ -400,7 +400,10 @@ class TestAnyOfExpression:
     )
     def test_evaluate(self, items: list[TRadioItem], answer: str, expected_result: bool):
         expr = AnyOf(question_id=uuid.uuid4(), items=items)
-        assert evaluate(Expression(statement=expr.statement, context={expr.safe_qid: answer})) is expected_result
+        assert (
+            evaluate(Expression(statement=expr.statement, context={expr.subject_reference.unwrapped: answer}))
+            is expected_result
+        )
 
 
 class TestIsYesExpression:
@@ -413,7 +416,10 @@ class TestIsYesExpression:
     )
     def test_evaluate(self, answer: str, expected_result: bool):
         expr = IsYes(question_id=uuid.uuid4())
-        assert evaluate(Expression(statement=expr.statement, context={expr.safe_qid: answer})) is expected_result
+        assert (
+            evaluate(Expression(statement=expr.statement, context={expr.subject_reference.unwrapped: answer}))
+            is expected_result
+        )
 
 
 class TestIsNoExpression:
@@ -426,7 +432,10 @@ class TestIsNoExpression:
     )
     def test_evaluate(self, answer: str, expected_result: bool):
         expr = IsNo(question_id=uuid.uuid4())
-        assert evaluate(Expression(statement=expr.statement, context={expr.safe_qid: answer})) is expected_result
+        assert (
+            evaluate(Expression(statement=expr.statement, context={expr.subject_reference.unwrapped: answer}))
+            is expected_result
+        )
 
 
 class TestSpecificallyExpression:
@@ -445,7 +454,10 @@ class TestSpecificallyExpression:
     )
     def test_evaluate(self, item: TRadioItem, answers: set[str], expected_result: bool):
         expr = Specifically(question_id=uuid.uuid4(), item=item)
-        assert evaluate(Expression(statement=expr.statement, context={expr.safe_qid: answers})) is expected_result
+        assert (
+            evaluate(Expression(statement=expr.statement, context={expr.subject_reference.unwrapped: answers}))
+            is expected_result
+        )
 
 
 class TestIsBeforeExpression:
@@ -464,7 +476,11 @@ class TestIsBeforeExpression:
         user = factories.user.create()
         expr = IsBefore(question_id=uuid.uuid4(), latest_value=self.maximum_value, inclusive=inclusive)
         expression = Expression.from_evaluatable_expression(expr, ExpressionType.CONDITION, user)
-        expression.context = {expr.safe_qid: answer, "latest_value": expr.latest_value, "question_id": expr.question_id}
+        expression.context = {
+            expr.subject_reference.unwrapped: answer,
+            "latest_value": expr.latest_value,
+            "question_id": expr.question_id,
+        }
         assert evaluate(expression) is expected_result
 
     @pytest.mark.parametrize(
@@ -542,7 +558,7 @@ class TestIsAfterExpression:
         expr = IsAfter(question_id=uuid.uuid4(), earliest_value=self.min_value, inclusive=inclusive)
         expression = Expression.from_evaluatable_expression(expr, ExpressionType.CONDITION, user)
         expression.context = {
-            expr.safe_qid: answer,
+            expr.subject_reference.unwrapped: answer,
             "earliest_value": expr.earliest_value,
             "question_id": expr.question_id,
         }
@@ -639,7 +655,7 @@ class TestIsBetweenDatesExpression:
         )
         expression = Expression.from_evaluatable_expression(expr, ExpressionType.CONDITION, user)
         expression.context = {
-            expr.safe_qid: answer,
+            expr.subject_reference.unwrapped: answer,
             "earliest_value": expr.earliest_value,
             "latest_value": expr.latest_value,
             "earliest_inclusive": expr.earliest_inclusive,
@@ -759,7 +775,7 @@ class TestUKPostcodeExpression:
         user = factories.user.create()
         expr = UKPostcode(question_id=uuid.uuid4())
         expression = Expression.from_evaluatable_expression(expr, ExpressionType.CONDITION, user)
-        expression.context = {expr.safe_qid: answer, "question_id": expr.question_id}
+        expression.context = {expr.subject_reference.unwrapped: answer, "question_id": expr.question_id}
         assert evaluate(expression) is expected_result
 
 
@@ -790,6 +806,7 @@ class TestCustomExpression:
         assert from_db.custom.custom_message == expr.custom_message
         assert from_db.context == {
             "question_id": None,
+            "subject_reference": None,
             "custom_expression": "(({question_id})) > 5",
             "custom_message": "Failed validation",
             "expression_name": "my short name",

--- a/tests/integration/common/expressions/test_references.py
+++ b/tests/integration/common/expressions/test_references.py
@@ -1,0 +1,131 @@
+from uuid import uuid4
+
+import pytest
+
+from app.common.data.types import (
+    DataSourceSchema,
+    DataSourceSchemaColumn,
+    DataSourceType,
+    NumberTypeEnum,
+    QuestionDataOptions,
+    QuestionDataType,
+    QuestionPresentationOptions,
+)
+from app.common.expressions.references import ExpressionReference
+
+
+class TestExpressionReference:
+    class TestQuestion:
+        def test_question_exists(self, factories):
+            q = factories.question.create()
+
+            reference = ExpressionReference(q.safe_qid)
+            assert reference.question == q
+
+        def test_question_does_not_exist(self):
+            reference = ExpressionReference(f"q_{uuid4().hex}")
+            assert reference.question is None
+
+        def test_question_is_none_for_non_question_reference(self):
+            reference = ExpressionReference(f"d_{uuid4().hex}.c_col")
+            assert reference.question is None
+
+    class TestDataSourceColumn:
+        def test_data_source_exists(self, factories):
+            collection = factories.collection.create()
+            allocation_column = DataSourceSchemaColumn(
+                data_type=QuestionDataType.NUMBER,
+                presentation_options=QuestionPresentationOptions(prefix="£"),
+                data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                original_column_name="Allocation",
+            )
+            data_source = factories.data_source.create(
+                grant=collection.grant,
+                collection=collection,
+                type=DataSourceType.GRANT_RECIPIENT,
+                items=None,
+                schema=DataSourceSchema.model_validate({"c_allocation": allocation_column}),
+            )
+
+            reference = ExpressionReference(f"{data_source.safe_did}.c_allocation")
+            assert reference.data_source_column == allocation_column
+
+        def test_data_source_does_not_exist(self):
+            reference = ExpressionReference(f"d_{uuid4().hex}.c_col")
+            assert reference.data_source_column is None
+
+        def test_data_source_is_none_for_non_data_source_reference(self):
+            reference = ExpressionReference(f"q_{uuid4().hex}")
+            assert reference.data_source_column is None
+
+    class TestGetDataType:
+        def test_raises_none_for_question_reference_to_missing_question(self):
+            reference = ExpressionReference(f"q_{uuid4().hex}")
+
+            with pytest.raises(ValueError):
+                _ = reference.data_type
+
+        def test_returns_data_type_for_question_reference(self, factories):
+            question = factories.question.create(data_type=QuestionDataType.NUMBER)
+            reference = ExpressionReference.from_question(question)
+
+            assert reference.data_type == QuestionDataType.NUMBER
+
+        def test_returns_data_type_for_data_source_column_reference(self, factories):
+            grant = factories.grant.create()
+            collection = factories.collection.create(grant=grant)
+            data_source = factories.data_source.create(
+                grant=grant,
+                collection=collection,
+                type=DataSourceType.GRANT_RECIPIENT,
+                items=None,
+                schema=DataSourceSchema.model_validate(
+                    {
+                        "c_threshold": DataSourceSchemaColumn(
+                            data_type=QuestionDataType.NUMBER,
+                            presentation_options=QuestionPresentationOptions(prefix="£"),
+                            data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                            original_column_name="Threshold",
+                        ),
+                    }
+                ),
+            )
+            reference = ExpressionReference.from_data_source_column(data_source, "c_threshold")
+
+            assert reference.data_type == QuestionDataType.NUMBER
+
+        def test_raises_for_data_source_column_that_does_not_exist(self, factories):
+            grant = factories.grant.create()
+            collection = factories.collection.create(grant=grant)
+            data_source = factories.data_source.create(
+                grant=grant,
+                collection=collection,
+                type=DataSourceType.GRANT_RECIPIENT,
+                items=None,
+                schema=DataSourceSchema.model_validate(
+                    {
+                        "c_threshold": DataSourceSchemaColumn(
+                            data_type=QuestionDataType.NUMBER,
+                            presentation_options=QuestionPresentationOptions(),
+                            data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                            original_column_name="Threshold",
+                        ),
+                    }
+                ),
+            )
+            reference = ExpressionReference.from_data_source_column(data_source, "c_missing")
+
+            with pytest.raises(ValueError):
+                _ = reference.data_type
+
+        def test_raises_for_reference_to_missing_data_source(self):
+            reference = ExpressionReference(f"d_{uuid4().hex}.c_col")
+
+            with pytest.raises(ValueError):
+                _ = reference.data_type
+
+        def test_raises_for_unknown_reference_shape(self):
+            reference = ExpressionReference("something_else")
+
+            with pytest.raises(ValueError):
+                _ = reference.data_type

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -5516,7 +5516,7 @@ class TestEditQuestionCondition:
         assert expression.type_ == ExpressionType.CONDITION
         assert expression.managed_name == "Is after"
         assert expression.managed.referenced_question.id == depends_on_question.id
-        assert expression.statement == f"{depends_on_question.safe_qid} > (({reference_data_question.safe_qid}))"
+        assert expression.statement == f"{depends_on_question.safe_qid} > {reference_data_question.safe_qid}"
 
         with authenticated_grant_admin_client.session_transaction() as session:
             assert "question" not in session
@@ -6280,7 +6280,7 @@ class TestEditQuestionValidation:
         assert expression.type_ == ExpressionType.VALIDATION
         assert expression.managed_name == "Less than"
         assert expression.managed.referenced_question.id == target_question.id
-        assert expression.statement == f"{target_question.safe_qid} <=(({reference_data_question.safe_qid}))"
+        assert expression.statement == f"{target_question.safe_qid} <= {reference_data_question.safe_qid}"
 
         with authenticated_grant_admin_client.session_transaction() as session:
             assert "question" not in session

--- a/tests/models.py
+++ b/tests/models.py
@@ -294,7 +294,9 @@ class _CollectionFactory(SQLAlchemyModelFactory):
             text="What size pack of teabags do you usually buy?",
             expressions=[
                 Expression.from_evaluatable_expression(
-                    GreaterThan(question_id=q1.id, minimum_value=30), ExpressionType.CONDITION, _UserFactory.create()
+                    GreaterThan(question_id=q1.id, minimum_value=30),  # ty:ignore[missing-argument, unknown-argument]
+                    ExpressionType.CONDITION,
+                    _UserFactory.create(),
                 )
             ],
         )
@@ -359,7 +361,9 @@ class _CollectionFactory(SQLAlchemyModelFactory):
             text="Do you buy teabags in bulk?",
             expressions=[
                 Expression.from_evaluatable_expression(
-                    GreaterThan(question_id=q1.id, minimum_value=30), ExpressionType.CONDITION, _UserFactory.create()
+                    GreaterThan(question_id=q1.id, minimum_value=30),  # ty:ignore[missing-argument, unknown-argument]
+                    ExpressionType.CONDITION,
+                    _UserFactory.create(),
                 )
             ],
         )
@@ -383,13 +387,13 @@ class _CollectionFactory(SQLAlchemyModelFactory):
             expressions=[
                 Expression.from_evaluatable_expression(
                     AnyOf(
-                        question_id=q4.id,
+                        question_id=q4.id,  # ty:ignore[unknown-argument]
                         items=[
                             cast(
                                 TRadioItem, {"key": q4.data_source.items[0].key, "label": q4.data_source.items[0].label}
                             )
                         ],
-                    ),
+                    ),  # ty:ignore[missing-argument]
                     ExpressionType.CONDITION,
                     _UserFactory.create(),
                 )
@@ -409,11 +413,11 @@ class _CollectionFactory(SQLAlchemyModelFactory):
             expressions=[
                 Expression.from_evaluatable_expression(
                     Specifically(
-                        question_id=q4.id,
+                        question_id=q4.id,  # ty:ignore[unknown-argument]
                         item=cast(
                             TRadioItem, {"key": q4.data_source.items[0].key, "label": q4.data_source.items[0].label}
                         ),
-                    ),
+                    ),  # ty:ignore[missing-argument]
                     ExpressionType.CONDITION,
                     _UserFactory.create(),
                 )

--- a/tests/unit/common/data/interfaces/test_collections.py
+++ b/tests/unit/common/data/interfaces/test_collections.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 
 from app.common.data.interfaces.collections import _find_all_references_in_expression
+from app.common.expressions.references import ExpressionReference
 
 
 class TestReferenceValidation:
@@ -15,4 +16,6 @@ class TestReferenceValidation:
         ids=lambda case: case["pattern"],
     )
     def test_find_references_in_expression_shared_fixtures(self, case):
-        assert _find_all_references_in_expression(case["pattern"]) == case["references"]
+        assert _find_all_references_in_expression(case["pattern"]) == [
+            ExpressionReference(ref).unwrapped for ref in case["references"]
+        ]

--- a/tests/unit/common/expressions/test_forms.py
+++ b/tests/unit/common/expressions/test_forms.py
@@ -98,7 +98,8 @@ class TestBuildManagedExpressionForm:
         assert expression.minimum_expression is None
         assert expression.minimum_inclusive is False
         assert expression.maximum_value is None
-        assert expression.maximum_expression == f"(({referenced_question.safe_qid}))"
+        assert expression.maximum_expression == referenced_question.safe_qid
+        assert expression.maximum_expression.wrapped == f"(({referenced_question.safe_qid}))"
         assert expression.maximum_inclusive is True
 
     def test_can_build_a_managed_expression_with_valid_reference_data__date(self, factories):
@@ -127,5 +128,6 @@ class TestBuildManagedExpressionForm:
         assert expression.earliest_expression is None
         assert expression.earliest_inclusive is False
         assert expression.latest_value is None
-        assert expression.latest_expression == f"(({referenced_question.safe_qid}))"
+        assert expression.latest_expression == referenced_question.safe_qid
+        assert expression.latest_expression.wrapped == f"(({referenced_question.safe_qid}))"
         assert expression.latest_inclusive is True

--- a/tests/unit/common/expressions/test_references.py
+++ b/tests/unit/common/expressions/test_references.py
@@ -1,0 +1,116 @@
+import pytest
+from pydantic import BaseModel
+
+from app.common.data.types import (
+    DataSourceSchema,
+    DataSourceSchemaColumn,
+    DataSourceType,
+    NumberTypeEnum,
+    QuestionDataOptions,
+    QuestionDataType,
+    QuestionPresentationOptions,
+)
+from app.common.expressions.references import (
+    DataSourceReference,
+    ExpressionReference,
+)
+
+
+class TestExpressionReference:
+    class TestConstruction:
+        def test_direct_construction_stores_unwrapped(self):
+            reference = ExpressionReference("q_abc123")
+            assert reference == "q_abc123"
+            assert reference.unwrapped == "q_abc123"
+            assert reference.wrapped == "((q_abc123))"
+
+        def test_direct_construction_allows_wrapped_input(self):
+            ref = ExpressionReference("(( q_abc123 ))")
+            assert ref == "q_abc123"
+            assert ref.unwrapped == "q_abc123"
+            assert ref.wrapped == "((q_abc123))"
+
+        def test_from_wrapped_strips_parens(self):
+            reference = ExpressionReference.from_wrapped("(( q_abc123 ))")
+            assert reference == "q_abc123"
+
+        def test_from_wrapped_tolerates_whitespace(self):
+            reference = ExpressionReference.from_wrapped("  ((  q_abc123  ))  ")
+            assert reference == "q_abc123"
+
+        def test_from_wrapped_rejects_unwrapped_input(self):
+            with pytest.raises(ValueError, match="Expected a wrapped reference"):
+                ExpressionReference.from_wrapped("q_abc123")
+
+        def test_from_wrapped_rejects_triple_paren_input(self):
+            with pytest.raises(ValueError, match="Expected a wrapped reference"):
+                ExpressionReference.from_wrapped("(((q_abc123)))")
+
+    class TestDecomposition:
+        def test_question_reference_decomposes_to_question_id(self, factories):
+            question = factories.question.build()
+            reference = ExpressionReference.from_question(question)
+            assert reference.question_id == question.id
+            assert reference.data_source_reference is None
+
+        def test_data_source_reference_decomposes_to_ds_ref(self, factories):
+            collection = factories.collection.build()
+            allocation_column = DataSourceSchemaColumn(
+                data_type=QuestionDataType.NUMBER,
+                presentation_options=QuestionPresentationOptions(prefix="£"),
+                data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                original_column_name="Allocation",
+            )
+            data_source = factories.data_source.build(
+                grant=collection.grant,
+                collection=collection,
+                type=DataSourceType.GRANT_RECIPIENT,
+                items=None,
+                schema=DataSourceSchema.model_validate({"c_allocation": allocation_column}),
+            )
+
+            reference = ExpressionReference.from_data_source_column(data_source, "c_allocation")
+            assert reference.data_source_reference == DataSourceReference(data_source.id, "c_allocation")
+            assert reference.question_id is None
+
+        def test_unknown_shape_decomposes_to_nothing(self):
+            reference = ExpressionReference("something_else")
+            assert reference.question_id is None
+            assert reference.data_source_reference is None
+
+    class TestPydantic:
+        def test_round_trips_through_pydantic_model(self):
+            class Container(BaseModel):
+                ref: ExpressionReference | None = None
+
+            container = Container(ref=ExpressionReference("q_abc"))
+            dumped = container.model_dump()
+            assert dumped == {"ref": "q_abc"}
+
+            restored = Container.model_validate(dumped)
+            assert isinstance(restored.ref, ExpressionReference)
+            assert restored.ref == "q_abc"
+
+        def test_accepts_plain_string_on_validation(self):
+            class Container(BaseModel):
+                ref: ExpressionReference
+
+            restored = Container.model_validate({"ref": "q_abc"})
+            assert isinstance(restored.ref, ExpressionReference)
+            assert restored.ref == "q_abc"
+
+        def test_accepts_wrapped_string_on_validation_for_backwards_compat(self):
+            class Container(BaseModel):
+                ref: ExpressionReference
+
+            restored = Container.model_validate({"ref": "((q_abc))"})
+            assert isinstance(restored.ref, ExpressionReference)
+            assert restored.ref == "q_abc"
+            assert restored.ref.wrapped == "((q_abc))"
+
+        def test_json_serialisation_is_plain_string(self):
+            class Container(BaseModel):
+                ref: ExpressionReference
+
+            container = Container(ref=ExpressionReference("d_xyz.c_col"))
+            assert container.model_dump_json() == '{"ref":"d_xyz.c_col"}'


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-1284

## 📝 Description
This is a backwards-compatible set of refactors to managed expressions that starts moving us away from expecting them to be centred around a `Question` and towards allowing them to reference any piece of data in the expression context.

This introduces a slim `ExpressionReference` type that is essentially just a string. This is used when we are passing around a reference to a datapoint in expression context to help enforce typing through the codebase and provide a single place for working out if a datapoint refers to a question, a data source, or (future) something else. It also has helpers for getting "wrapped" and "unwrapped" references (with/without the `(( ))` we use for interpolation). This should help stop that implementation detail from leaking across the codebase.

Note for the future: I think we should also add something like an ExpressionStatement, which would be used for representing entire statements like `d_123.c_allocation >= q_123 + q_234` and then have helpers for extracting all of the references from it.

After this patch, managed expressions will work with both `question_id`s directly (current state of the world), but also start working with the new `subject_reference` - which can be any context datapoint. Future PRs in this stack will migrate us to `subject_reference` and clean up the old `question_id` limitation.

## 🧪 Testing
This should be a fully-backwards-compatible zero-downtime deploy. After this is merged, any new managed expressions or edited managed expressions should start writing a `subject_reference` into the `context` column of the `expression` table. Future PRs will backfill that key into all rows and then start reading those values instead of `question_id`.

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested