### PR TITLE
Make context aware editor handle parens inside references

### DIFF
--- a/app/assets/components/context-aware-editor/highlighting.js
+++ b/app/assets/components/context-aware-editor/highlighting.js
@@ -1,7 +1,7 @@
 // Reference highlighting functionality
 // Refactored from reference-overlay to work as part of combined editor
 
-const REFERENCE_REGEX = /\(\([^)]+\)\)/g;
+const REFERENCE_REGEX = /\(\((?!\()((?:[^()]|\([^()]*\))*)\)\)/g;
 
 const parseReferences = (text, mappings = null) => {
     const references = [];
@@ -439,4 +439,4 @@ const parseReferenceMappings = (mappingData) => {
     return { mappings, reverseMappings };
 };
 
-export { createHighlighting, parseReferenceMappings };
+export { createHighlighting, parseReferenceMappings, parseReferences };

--- a/app/assets/components/context-aware-editor/highlighting.test.js
+++ b/app/assets/components/context-aware-editor/highlighting.test.js
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { parseReferences } from "./highlighting.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixturePath = path.resolve(
+    __dirname,
+    "../../../../tests/fixtures/reference-regex-validation.json",
+);
+const cases = JSON.parse(readFileSync(fixturePath, "utf8"))["test_cases"];
+
+describe("parseReferences (shared fixtures)", () => {
+    test.each(cases)("$pattern", ({ pattern, references }) => {
+        const matches = parseReferences(pattern).map((ref) => ref.match);
+        expect(matches).toEqual(references);
+    });
+});

--- a/app/common/expressions/__init__.py
+++ b/app/common/expressions/__init__.py
@@ -22,11 +22,17 @@ if TYPE_CHECKING:
     from app.common.helpers.collections import SubmissionHelper
     from app.deliver_grant_funding.session_models import AddContextToExpressionsModel
 
-INTERPOLATE_REGEX = re.compile(r"\(\(([^\(]+?)\)\)")
+# This is tested by `test_find_references_in_expression_shared_fixtures` - look there for test cases
+INTERPOLATE_REGEX = re.compile(r"\(\((?!\()((?:[^()]|\([^()]*\))*)\)\)")
+
 # If any interpolation references contain characters other than alphanumeric, full stops or underscores,
 # then we'll hard stop that for now. As of this implementation, only single variable references are allowed.
 # We expect to want complex expressions in the future, but are hard limiting that for now as a specific
 # product/tech edge case restriction.
+# This is stricter than we allow for INTERPOLATE_REGEX, which allows anything that the frontend JS regex allows
+#    (which works for highlighting human-readable labels which may contain other characters like arrows or parens).
+#    Once those are accepted and normalised to ExpressionContext references, everything should only be dot-notated
+#    python-variable-like names.
 ALLOWED_INTERPOLATION_REGEX = re.compile(r"[^A-Za-z0-9_.]")
 
 

--- a/tests/fixtures/reference-regex-validation.json
+++ b/tests/fixtures/reference-regex-validation.json
@@ -1,0 +1,50 @@
+{
+    "comment": "This file is used to hold a set of test cases that run against both JavaScript (highlighting.test.js) and Python (unit/common/data/interfaces/test_collections.py).",
+    "test_cases": [
+        {
+            "pattern": "Text with no references",
+            "references": []
+        },
+        {
+            "pattern": "Text with a ((reference))",
+            "references": [
+                "((reference))"
+            ]
+        },
+        {
+            "pattern": "Text with a partial ((reference)",
+            "references": []
+        },
+        {
+            "pattern": "Text with a ((reference)) and ((another reference))",
+            "references": [
+                "((reference))",
+                "((another reference))"
+            ]
+        },
+        {
+            "pattern": "Text with a (( spaced reference ))",
+            "references": [
+                "(( spaced reference ))"
+            ]
+        },
+        {
+            "pattern": "Text with some (( reference(s) ))",
+            "references": [
+                "(( reference(s) ))"
+            ]
+        },
+        {
+            "pattern": "Text with some literal parens around the (((reference)))",
+            "references": [
+                "((reference))"
+            ]
+        },
+        {
+            "pattern": "Text with some literal parens around maybe plural (((reference(s))))",
+            "references": [
+                "((reference(s)))"
+            ]
+        }
+    ]
+}

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -15,7 +15,6 @@ from app.common.data.interfaces.collections import (
     IncompatibleDataTypeException,
     NestedGroupDisplayTypeSamePageException,
     NestedGroupException,
-    _find_all_references_in_expression,
     _validate_and_sync_component_references,
     _validate_and_sync_expression_references,
     _validate_reference,
@@ -3704,23 +3703,6 @@ class TestDeleteCollectionSubmissions:
 
 
 class TestReferenceValidation:
-    @pytest.mark.parametrize(
-        "expression, expected_references",
-        [
-            ("((q1)) + ((q2))", ["((q1))", "((q2))"]),
-            ("((q1)) + 5", ["((q1))"]),
-            ("5 + 10", list()),
-            ("((q1)) + ((q2)) + ((q3))", ["((q1))", "((q2))", "((q3))"]),
-            ("((q1)) + ((q2)) + ((q1))", ["((q1))", "((q2))", "((q1))"]),
-            ["((q1)) + (not a ref)", ["((q1))"]],
-            ["((q1)) + (not a ref))", ["((q1))"]],
-            ["((q1)) + ((not a ref)", ["((q1))"]],
-        ],
-    )
-    def test_find_references_in_expression(self, expression, expected_references):
-        references = _find_all_references_in_expression(expression)
-        assert references == expected_references
-
     def test_components_in_same_group_and_on_same_page(self, factories):
         group = factories.group.create(
             presentation_options=QuestionPresentationOptions(show_questions_on_the_same_page=True)

--- a/tests/unit/common/data/interfaces/test_collections.py
+++ b/tests/unit/common/data/interfaces/test_collections.py
@@ -1,0 +1,18 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from app.common.data.interfaces.collections import _find_all_references_in_expression
+
+
+class TestReferenceValidation:
+    @pytest.mark.parametrize(
+        "case",
+        json.loads((Path(__file__).parents[4] / "fixtures" / "reference-regex-validation.json").read_text())[
+            "test_cases"
+        ],
+        ids=lambda case: case["pattern"],
+    )
+    def test_find_references_in_expression_shared_fixtures(self, case):
+        assert _find_all_references_in_expression(case["pattern"]) == case["references"]


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
Our simplistic regexes for finding/extracting 'references' in strings were not working if those included parens, which was broken in two places:

- the frontend JS on our context-aware editors that maps human-readable labels to our internal reference format.

- the backend invalid reference detection

If a section had a name with parens in, eg `Report -> Risk(s) -> Risk name` then the frontend JS would not map this correctly to an internal reference like `((q_123))`. It would instead pass the raw label to the backend.

The backend _should_ have caught this and flagged it as an invalid/unknown reference, but we have the same regex on the Python side which was also failing to recognise this as a correct reference, so it just skipped over it entirely.

These two regexes need to stay in sync and detect the same references in the same way. We tie these together with a shared test data file that is tied to some new JS and Python tests, which should mean they are known to find the same set of references.

This also fixes one other nasty edge case we had where you couldn't wrap a reference in parens without adding spaces, which made some things like weird, eg we had an error message that would have to render like `You cannot spend more than your allocation ( £100,000 )`.

Now we can remove the spacing and have it like `You cannot spend more than your allocation (£100,000)`

## 📸 Show the thing (screenshots, gifs)

| State | Before | After |
|---|---|---|
| valid parens reference | <img width="350" height="350" alt="2026-04-17 12 47 45" src="https://github.com/user-attachments/assets/80ad8196-a21a-45ed-a310-58856937c0ba" /> | <img width="350" height="350" alt="2026-04-17 12 48 49" src="https://github.com/user-attachments/assets/6b5e4e81-6f90-43a0-a969-6c605b607826" /> |
| invalid parens reference | <img width="350" height="350" alt="2026-04-17 12 53 23" src="https://github.com/user-attachments/assets/8c0af161-a7a6-4d55-80c0-471eb839060a" /> | <img width="350" height="350" alt="2026-04-17 12 52 43" src="https://github.com/user-attachments/assets/19c47fd6-875a-4060-bed6-b6482b23f3cd" /> |



## 🧪 Testing
<!-- Describe how you've tested this change, and how a reviewer can test it -->

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [-] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested