### PR TITLE
FIX Don't raise when adding the same add another expression context

### DIFF
--- a/app/common/expressions/__init__.py
+++ b/app/common/expressions/__init__.py
@@ -208,9 +208,6 @@ class ExpressionContext(ChainMap[str, Any]):
         Creates a new `ExpressionContext` with `add_another_context` set to the provided `add_another_context`, and the
         other contexts set to the same values as this context
         """
-        if self._add_another_context:
-            raise ValueError("add_another_context is already set on this ExpressionContext")
-
         if not component.add_another_container:
             raise ValueError("add_another_context can only be set for add another components")
 
@@ -228,6 +225,12 @@ class ExpressionContext(ChainMap[str, Any]):
             if answer is not None:
                 add_another_context[question.safe_qid] = (
                     answer.get_value_for_evaluation() if mode == "evaluation" else answer.get_value_for_interpolation()
+                )
+
+        if self._add_another_context:
+            if self._add_another_context != add_another_context:
+                raise ValueError(
+                    "overriding with different add_another_context where it is already set on this ExpressionContext"
                 )
 
         return ExpressionContext(

--- a/tests/integration/common/expressions/test_init.py
+++ b/tests/integration/common/expressions/test_init.py
@@ -806,15 +806,48 @@ class TestExtendingWithAddAnotherContext:
             == context
         )
 
-    def test_extending_with_existing_context(self, factories):
+    def test_extending_with_different_add_another_context(self, factories):
         component = factories.question.create(add_another=True)
-        submission = factories.submission.create(collection=component.form.collection)
-        ex = ExpressionContext(submission_data={"a": [1, 2, 3], "b": 1, "c": 1}, add_another_context={"a": 1})
-        with pytest.raises(ValueError) as e:
+        submission = factories.submission.create(
+            collection=component.form.collection,
+            answers=[
+                FactoryAnswer(component, TextSingleLineAnswer("1"), add_another_index=0),
+                FactoryAnswer(component, TextSingleLineAnswer("2"), add_another_index=1),
+                FactoryAnswer(component, TextSingleLineAnswer("3"), add_another_index=2),
+            ],
+        )
+        submission_helper = SubmissionHelper(submission)
+        ex = submission_helper.cached_evaluation_context
+        with pytest.raises(
+            ValueError,
+            match="overriding with different add_another_context",
+        ):
             ex.with_add_another_context(
-                component, data_manager=SubmissionHelper(submission).submission.data_manager, add_another_index=0
+                component, data_manager=submission_helper.submission.data_manager, add_another_index=0
+            ).with_add_another_context(
+                component, data_manager=submission_helper.submission.data_manager, add_another_index=1
             )
-        assert str(e.value) == "add_another_context is already set on this ExpressionContext"
+
+    def test_extending_with_same_add_another_context(self, factories):
+        component = factories.question.create(add_another=True)
+        submission = factories.submission.create(
+            collection=component.form.collection,
+            answers=[
+                FactoryAnswer(component, TextSingleLineAnswer("1"), add_another_index=0),
+                FactoryAnswer(component, TextSingleLineAnswer("2"), add_another_index=1),
+                FactoryAnswer(component, TextSingleLineAnswer("3"), add_another_index=2),
+            ],
+        )
+
+        submission_helper = SubmissionHelper(submission)
+        ex = submission_helper.cached_evaluation_context
+
+        # adding the same add another context should not raise
+        ex.with_add_another_context(
+            component, data_manager=submission_helper.submission.data_manager, add_another_index=0
+        ).with_add_another_context(
+            component, data_manager=submission_helper.submission.data_manager, add_another_index=0
+        )
 
     def test_extending_with_non_add_another_component(self, factories):
         component = factories.question.create(add_another=False)


### PR DESCRIPTION
While checking component and component reference visibility, `_get_component_visibility_state_internal` sets up evaluation contexts and calls itself.

When there is a combination of an add another group and nested group with a condition (on a previous question in the section) the combination of checks + building contexts will end up creating an evaluation context and trying to add the add another context on top (for a second time).

This is sub-optimal as its checking visibility where it already has before (walking back up the nested group) but isn't technically a problem.

This patches the integrity check to make sure you're not creating an invalid evalutation context to allow the same add another context to be set however it does not address the very complicated and error prone approach to recursively checking visibility.

We have an additional proposed patch that moves condition checking to a directed graph which ensures checks and context are only built and evaluated once - this should be merged very shortly following.