### PR TITLE
Strip the legacy question_id key from expression context

### DIFF
--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-057_swap_depends_on_ref_idx
+058_drop_legacy_question_id

--- a/app/common/data/migrations/versions/058_drop_legacy_question_id.py
+++ b/app/common/data/migrations/versions/058_drop_legacy_question_id.py
@@ -1,0 +1,22 @@
+"""Strip the legacy question_id key from every Expression.context JSONB blob.
+
+Revision ID: 058_drop_legacy_question_id
+Revises: 057_swap_depends_on_ref_idx
+Create Date: 2026-04-16 16:13:00.494020
+"""
+
+from alembic import op
+
+revision = "058_drop_legacy_question_id"
+down_revision = "057_swap_depends_on_ref_idx"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("UPDATE expression SET context = context - 'question_id' WHERE context ? 'question_id'")
+
+
+def downgrade() -> None:
+    # No going back!
+    pass


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-1284

## 📝 Description
After merging and deploying https://github.com/communitiesuk/funding-service/pull/1552 all the way to prod, we can merge this to clean up any lingering `question_id`s in expression contexts which are no longer used/needed.

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [-] I need the reviewer(s) to pull and run this change locally
- [-] New (non-developer) functionality has appropriate unit and integration tests
- [x] End-to-end tests have been updated (if applicable)
- [x] Edge cases and error conditions are tested