### PR TITLE
BAU Firm up remove add another entry integrity checks

### DIFF
--- a/app/access_grant_funding/routes/runner.py
+++ b/app/access_grant_funding/routes/runner.py
@@ -232,6 +232,7 @@ def ask_a_question(
     action: str | None = None,
 ) -> ResponseReturnValue:
     source = request.args.get("source")
+    check_entries = request.args.get("check_entries")
     grant_recipient = interfaces.grant_recipients.get_grant_recipient(grant_id, organisation_id)
 
     runner = AGFFormRunner.load(
@@ -242,6 +243,7 @@ def ask_a_question(
         grant_recipient_id=grant_recipient.id,
         is_removing=action == "remove",
         is_clearing=action == "clear",
+        check_entries=int(check_entries) if check_entries else None,
     )
 
     if not runner.validate_can_show_question_page():

--- a/app/access_grant_funding/routes/runner.py
+++ b/app/access_grant_funding/routes/runner.py
@@ -232,7 +232,7 @@ def ask_a_question(
     action: str | None = None,
 ) -> ResponseReturnValue:
     source = request.args.get("source")
-    check_entries = request.args.get("check_entries")
+    check_entries = request.args.get("check_entries", type=int)
     grant_recipient = interfaces.grant_recipients.get_grant_recipient(grant_id, organisation_id)
 
     runner = AGFFormRunner.load(
@@ -243,7 +243,7 @@ def ask_a_question(
         grant_recipient_id=grant_recipient.id,
         is_removing=action == "remove",
         is_clearing=action == "clear",
-        check_entries=int(check_entries) if check_entries else None,
+        check_entries=check_entries,
     )
 
     if not runner.validate_can_show_question_page():

--- a/app/common/collections/runner.py
+++ b/app/common/collections/runner.py
@@ -64,6 +64,7 @@ class FormRunner:
         add_another_index: int | None = None,
         is_removing: bool = False,
         is_clearing: bool = False,
+        check_entries: int | None = None,
     ):
         if question and form:
             raise ValueError("Expected only one of question or form")
@@ -75,6 +76,7 @@ class FormRunner:
         self.linked_question = question
         self.is_removing = is_removing
         self.is_clearing = is_clearing
+        self.check_entries = check_entries
 
         self._valid: bool | None = None
 
@@ -168,6 +170,7 @@ class FormRunner:
         grant_recipient_id: UUID | None = None,
         is_removing: bool = False,
         is_clearing: bool = False,
+        check_entries: int | None = None,
     ) -> FormRunner:
         if question_id and form_id:
             raise ValueError("Expected only one of question_id or form_id")
@@ -213,6 +216,7 @@ class FormRunner:
             add_another_index=add_another_index,
             is_removing=is_removing,
             is_clearing=is_clearing,
+            check_entries=check_entries,
         )
 
         if form_runner.submission.in_immutable_state:
@@ -284,6 +288,13 @@ class FormRunner:
         if self.is_clearing and self.linked_question:
             if self.confirm_remove_form.validate_on_submit():
                 if self.confirm_remove_form.confirm_remove.data == "yes":
+                    if self.check_entries and self.component.add_another_container:
+                        if self.check_entries != self.submission.get_count_for_add_another(
+                            self.component.add_another_container
+                        ):
+                            # the number of entries has changed since we loaded the page
+                            # return to the add another summary page with a no-op
+                            return True
                     self.submission.remove_answer_for_question(
                         question_id=self.linked_question.id, add_another_index=self.add_another_index
                     )
@@ -386,14 +397,18 @@ class FormRunner:
         add_another_index: int | None = None,
         action: str | None = None,
     ) -> str:
+        check_entries = None
+        if (
+            action == "remove"
+            and self.add_another_summary_context
+            and self.component
+            and self.component.add_another_container
+        ):
+            check_entries = self.submission.get_count_for_add_another(self.component.add_another_container)
+
         # todo: resolve type hinting issues w/ circular dependencies and bringing in class for instance check
         return self.url_map[state](
-            self,
-            question or self.component,
-            form or self.form,
-            source,
-            add_another_index,
-            action,
+            self, question or self.component, form or self.form, source, add_another_index, action, check_entries
         )
 
     @property
@@ -497,6 +512,13 @@ class FormRunner:
         if self._valid:
             if self.component.is_question and not self.can_edit_question(self.component):  # type: ignore[arg-type]
                 self._valid = False
+
+        if self._valid:
+            if self.check_entries is not None and self.component.add_another_container:
+                if self.check_entries != self.submission.get_count_for_add_another(
+                    self.component.add_another_container
+                ):
+                    self._valid = False
 
         return self._valid
 
@@ -606,70 +628,84 @@ def add_another_suffix(heading: str, add_another_index: int) -> str:
 
 class DGFFormRunner(FormRunner):
     url_map: ClassVar[TRunnerUrlMap] = {
-        FormRunnerState.QUESTION: lambda runner, question, _form, source, add_another_index, action: url_for(
-            "deliver_grant_funding.ask_a_question",
-            grant_id=runner.submission.grant.id,
-            submission_id=runner.submission.id,
-            question_id=question.id if question else None,
-            source=source,
-            add_another_index=add_another_index,
-            action=action if action else None,
+        FormRunnerState.QUESTION: (
+            lambda runner, question, _form, source, add_another_index, action, check_entries: url_for(
+                "deliver_grant_funding.ask_a_question",
+                grant_id=runner.submission.grant.id,
+                submission_id=runner.submission.id,
+                question_id=question.id if question else None,
+                source=source,
+                add_another_index=add_another_index,
+                action=action if action else None,
+                check_entries=check_entries,
+            ),
         ),
-        FormRunnerState.TASKLIST: lambda runner, _question, _form, _source, _add_another_index, _action: url_for(
-            "deliver_grant_funding.submission_tasklist",
-            grant_id=runner.submission.grant.id,
-            submission_id=runner.submission.id,
-            form_id=runner.form.id if runner.form else None,
+        FormRunnerState.TASKLIST: (
+            lambda runner, _question, _form, _source, _add_another_index, _action, _check_entries: url_for(
+                "deliver_grant_funding.submission_tasklist",
+                grant_id=runner.submission.grant.id,
+                submission_id=runner.submission.id,
+                form_id=runner.form.id if runner.form else None,
+            ),
         ),
-        FormRunnerState.CHECK_YOUR_ANSWERS: lambda runner, _question, form, source, _add_another_index, _action: (
-            url_for(
+        FormRunnerState.CHECK_YOUR_ANSWERS: (
+            lambda runner, _question, form, source, _add_another_index, _action, _check_entries: url_for(
                 "deliver_grant_funding.check_your_answers",
                 grant_id=runner.submission.grant.id,
                 submission_id=runner.submission.id,
                 form_id=form.id if form else runner.form.id if runner.form else None,
                 source=source,
-            )
+            ),
         ),
-        FormRunnerState.VIEW_REPORT_PAGE: lambda runner, _question, _form, source, _add_another_index, _action: url_for(
-            "deliver_grant_funding.view_submission",
-            grant_id=runner.submission.grant.id,
-            submission_id=runner.submission.id,
+        FormRunnerState.VIEW_REPORT_PAGE: (
+            lambda runner, _question, _form, source, _add_another_index, _action, _check_entries: url_for(
+                "deliver_grant_funding.view_submission",
+                grant_id=runner.submission.grant.id,
+                submission_id=runner.submission.id,
+            ),
         ),
     }
 
 
 class AGFFormRunner(FormRunner):
     url_map: ClassVar[TRunnerUrlMap] = {
-        FormRunnerState.QUESTION: lambda runner, question, _form, source, add_another_index, action: url_for(
-            "access_grant_funding.ask_a_question",
-            organisation_id=runner.submission.submission.grant_recipient.organisation.id,
-            grant_id=runner.submission.submission.grant_recipient.grant.id,
-            submission_id=runner.submission.id,
-            question_id=question.id if question else None,
-            source=source,
-            add_another_index=add_another_index,
-            action=action if action else None,
+        FormRunnerState.QUESTION: (
+            lambda runner, question, _form, source, add_another_index, action, check_entries: url_for(
+                "access_grant_funding.ask_a_question",
+                organisation_id=runner.submission.submission.grant_recipient.organisation.id,
+                grant_id=runner.submission.submission.grant_recipient.grant.id,
+                submission_id=runner.submission.id,
+                question_id=question.id if question else None,
+                source=source,
+                add_another_index=add_another_index,
+                action=action if action else None,
+                check_entries=check_entries,
+            ),
         ),
-        FormRunnerState.TASKLIST: lambda runner, _question, _form, _source, _add_another_index, _action: url_for(
-            "access_grant_funding.tasklist",
-            organisation_id=runner.submission.submission.grant_recipient.organisation.id,
-            grant_id=runner.submission.submission.grant_recipient.grant.id,
-            submission_id=runner.submission.id,
+        FormRunnerState.TASKLIST: (
+            lambda runner, _question, _form, _source, _add_another_index, _action, _check_entries: url_for(
+                "access_grant_funding.tasklist",
+                organisation_id=runner.submission.submission.grant_recipient.organisation.id,
+                grant_id=runner.submission.submission.grant_recipient.grant.id,
+                submission_id=runner.submission.id,
+            ),
         ),
-        FormRunnerState.CHECK_YOUR_ANSWERS: lambda runner, _question, form, source, _add_another_index, _action: (
-            url_for(
+        FormRunnerState.CHECK_YOUR_ANSWERS: (
+            lambda runner, _question, form, source, _add_another_index, _action, _check_entries: url_for(
                 "access_grant_funding.check_your_answers",
                 organisation_id=runner.submission.submission.grant_recipient.organisation.id,
                 grant_id=runner.submission.submission.grant_recipient.grant.id,
                 submission_id=runner.submission.id,
                 section_id=form.id if form else runner.form.id if runner.form else None,
                 source=source,
-            )
+            ),
         ),
-        FormRunnerState.VIEW_REPORT_PAGE: lambda runner, _question, _form, source, _add_another_index, _action: url_for(
-            "access_grant_funding.view_locked_report",
-            organisation_id=runner.submission.submission.grant_recipient.organisation.id,
-            grant_id=runner.submission.grant.id,
-            submission_id=runner.submission.id,
+        FormRunnerState.VIEW_REPORT_PAGE: (
+            lambda runner, _question, _form, source, _add_another_index, _action, _check_entries: url_for(
+                "access_grant_funding.view_locked_report",
+                organisation_id=runner.submission.submission.grant_recipient.organisation.id,
+                grant_id=runner.submission.grant.id,
+                submission_id=runner.submission.id,
+            ),
         ),
     }

--- a/app/common/collections/runner.py
+++ b/app/common/collections/runner.py
@@ -288,13 +288,6 @@ class FormRunner:
         if self.is_clearing and self.linked_question:
             if self.confirm_remove_form.validate_on_submit():
                 if self.confirm_remove_form.confirm_remove.data == "yes":
-                    if self.check_entries and self.component.add_another_container:
-                        if self.check_entries != self.submission.get_count_for_add_another(
-                            self.component.add_another_container
-                        ):
-                            # the number of entries has changed since we loaded the page
-                            # return to the add another summary page with a no-op
-                            return True
                     self.submission.remove_answer_for_question(
                         question_id=self.linked_question.id, add_another_index=self.add_another_index
                     )
@@ -331,6 +324,13 @@ class FormRunner:
         if self.is_removing:
             if self.confirm_remove_form.validate_on_submit():
                 if self.confirm_remove_form.confirm_remove.data == "yes":
+                    if self.check_entries is not None and self.component.add_another_container:
+                        if self.check_entries != self.submission.get_count_for_add_another(
+                            self.component.add_another_container
+                        ):
+                            # the number of entries has changed since we loaded the page
+                            # return to the add another summary page with a no-op
+                            return True
                     self.submission.remove_entry_for_add_another(
                         add_another_container=cast("Group", self.component.add_another_container),
                         add_another_index=self.add_another_index,
@@ -514,7 +514,7 @@ class FormRunner:
                 self._valid = False
 
         if self._valid:
-            if self.check_entries is not None and self.component.add_another_container:
+            if self.is_removing and self.check_entries is not None and self.component.add_another_container:
                 if self.check_entries != self.submission.get_count_for_add_another(
                     self.component.add_another_container
                 ):

--- a/app/common/collections/runner.py
+++ b/app/common/collections/runner.py
@@ -638,7 +638,7 @@ class DGFFormRunner(FormRunner):
                 add_another_index=add_another_index,
                 action=action if action else None,
                 check_entries=check_entries,
-            ),
+            )
         ),
         FormRunnerState.TASKLIST: (
             lambda runner, _question, _form, _source, _add_another_index, _action, _check_entries: url_for(
@@ -646,7 +646,7 @@ class DGFFormRunner(FormRunner):
                 grant_id=runner.submission.grant.id,
                 submission_id=runner.submission.id,
                 form_id=runner.form.id if runner.form else None,
-            ),
+            )
         ),
         FormRunnerState.CHECK_YOUR_ANSWERS: (
             lambda runner, _question, form, source, _add_another_index, _action, _check_entries: url_for(
@@ -655,14 +655,14 @@ class DGFFormRunner(FormRunner):
                 submission_id=runner.submission.id,
                 form_id=form.id if form else runner.form.id if runner.form else None,
                 source=source,
-            ),
+            )
         ),
         FormRunnerState.VIEW_REPORT_PAGE: (
             lambda runner, _question, _form, source, _add_another_index, _action, _check_entries: url_for(
                 "deliver_grant_funding.view_submission",
                 grant_id=runner.submission.grant.id,
                 submission_id=runner.submission.id,
-            ),
+            )
         ),
     }
 
@@ -680,7 +680,7 @@ class AGFFormRunner(FormRunner):
                 add_another_index=add_another_index,
                 action=action if action else None,
                 check_entries=check_entries,
-            ),
+            )
         ),
         FormRunnerState.TASKLIST: (
             lambda runner, _question, _form, _source, _add_another_index, _action, _check_entries: url_for(
@@ -688,7 +688,7 @@ class AGFFormRunner(FormRunner):
                 organisation_id=runner.submission.submission.grant_recipient.organisation.id,
                 grant_id=runner.submission.submission.grant_recipient.grant.id,
                 submission_id=runner.submission.id,
-            ),
+            )
         ),
         FormRunnerState.CHECK_YOUR_ANSWERS: (
             lambda runner, _question, form, source, _add_another_index, _action, _check_entries: url_for(
@@ -698,7 +698,7 @@ class AGFFormRunner(FormRunner):
                 submission_id=runner.submission.id,
                 section_id=form.id if form else runner.form.id if runner.form else None,
                 source=source,
-            ),
+            )
         ),
         FormRunnerState.VIEW_REPORT_PAGE: (
             lambda runner, _question, _form, source, _add_another_index, _action, _check_entries: url_for(
@@ -706,6 +706,6 @@ class AGFFormRunner(FormRunner):
                 organisation_id=runner.submission.submission.grant_recipient.organisation.id,
                 grant_id=runner.submission.grant.id,
                 submission_id=runner.submission.id,
-            ),
+            )
         ),
     }

--- a/app/common/data/types.py
+++ b/app/common/data/types.py
@@ -205,6 +205,7 @@ TRunnerUrlMapCallable = Callable[
         Optional["FormRunnerState"],
         Optional[int],
         Optional[str],
+        Optional[int],
     ],
     str,
 ]

--- a/app/deliver_grant_funding/routes/runner.py
+++ b/app/deliver_grant_funding/routes/runner.py
@@ -73,7 +73,7 @@ def ask_a_question(
     action: str | None = None,
 ) -> ResponseReturnValue:
     source = request.args.get("source")
-    check_entries = request.args.get("check_entries")
+    check_entries = request.args.get("check_entries", type=int)
     runner = DGFFormRunner.load(
         submission_id=submission_id,
         question_id=question_id,
@@ -81,7 +81,7 @@ def ask_a_question(
         add_another_index=add_another_index,
         is_removing=action == "remove",
         is_clearing=action == "clear",
-        check_entries=int(check_entries) if check_entries else None,
+        check_entries=check_entries,
     )
 
     if not runner.validate_can_show_question_page():

--- a/app/deliver_grant_funding/routes/runner.py
+++ b/app/deliver_grant_funding/routes/runner.py
@@ -73,6 +73,7 @@ def ask_a_question(
     action: str | None = None,
 ) -> ResponseReturnValue:
     source = request.args.get("source")
+    check_entries = request.args.get("check_entries")
     runner = DGFFormRunner.load(
         submission_id=submission_id,
         question_id=question_id,
@@ -80,6 +81,7 @@ def ask_a_question(
         add_another_index=add_another_index,
         is_removing=action == "remove",
         is_clearing=action == "clear",
+        check_entries=int(check_entries) if check_entries else None,
     )
 
     if not runner.validate_can_show_question_page():

--- a/tests/integration/access_grant_funding/routes/test_runner.py
+++ b/tests/integration/access_grant_funding/routes/test_runner.py
@@ -2361,3 +2361,79 @@ class TestRemoveAddAnotherEntry:
 
         assert submission.data_manager.get_count_for_add_another(group) == 2
         assert submission.data_manager.get(q1, add_another_index=0) == TextSingleLineAnswer("Entry 1")
+
+    def test_post_remove_add_another_entry_with_matching_check_entries(
+        self, authenticated_grant_recipient_data_provider_client, factories
+    ):
+        grant_recipient = authenticated_grant_recipient_data_provider_client.grant_recipient
+        group = factories.group.create(
+            add_another=True, name="Test groups", text="Test groups", form__collection__grant=grant_recipient.grant
+        )
+        q1 = factories.question.create(form=group.form, parent=group)
+        submission = factories.submission.create(
+            collection=group.form.collection,
+            grant_recipient=grant_recipient,
+            mode=SubmissionModeEnum.LIVE,
+            answers=[
+                FactoryAnswer(q1, TextSingleLineAnswer("Entry 1"), add_another_index=0),
+                FactoryAnswer(q1, TextSingleLineAnswer("Entry 2"), add_another_index=1),
+                FactoryAnswer(q1, TextSingleLineAnswer("Entry 3"), add_another_index=2),
+            ],
+        )
+
+        response = authenticated_grant_recipient_data_provider_client.post(
+            url_for(
+                "access_grant_funding.ask_a_question",
+                organisation_id=grant_recipient.organisation.id,
+                grant_id=grant_recipient.grant.id,
+                submission_id=submission.id,
+                question_id=q1.id,
+                add_another_index=0,
+                action="remove",
+                check_entries=3,
+            ),
+            data={"confirm_remove": "yes"},
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 302
+        assert submission.data_manager.get_count_for_add_another(group) == 2
+        assert submission.data_manager.get(q1, add_another_index=0) == TextSingleLineAnswer("Entry 2")
+
+    def test_post_remove_add_another_entry_with_mismatched_check_entries_redirects(
+        self, authenticated_grant_recipient_data_provider_client, factories
+    ):
+        grant_recipient = authenticated_grant_recipient_data_provider_client.grant_recipient
+        group = factories.group.create(
+            add_another=True, name="Test groups", text="Test groups", form__collection__grant=grant_recipient.grant
+        )
+        q1 = factories.question.create(form=group.form, parent=group)
+        submission = factories.submission.create(
+            collection=group.form.collection,
+            grant_recipient=grant_recipient,
+            mode=SubmissionModeEnum.LIVE,
+            answers=[
+                FactoryAnswer(q1, TextSingleLineAnswer("Entry 1"), add_another_index=0),
+                FactoryAnswer(q1, TextSingleLineAnswer("Entry 2"), add_another_index=1),
+            ],
+        )
+
+        response = authenticated_grant_recipient_data_provider_client.post(
+            url_for(
+                "access_grant_funding.ask_a_question",
+                organisation_id=grant_recipient.organisation.id,
+                grant_id=grant_recipient.grant.id,
+                submission_id=submission.id,
+                question_id=q1.id,
+                add_another_index=0,
+                action="remove",
+                check_entries=3,
+            ),
+            data={"confirm_remove": "yes"},
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 302
+
+        # no entries are removed
+        assert submission.data_manager.get_count_for_add_another(group) == 2

--- a/tests/integration/deliver_grant_funding/routes/test_runner.py
+++ b/tests/integration/deliver_grant_funding/routes/test_runner.py
@@ -1497,3 +1497,75 @@ class TestRemoveAddAnotherEntry:
 
         assert submission.data_manager.get_count_for_add_another(group) == 2
         assert submission.data_manager.get(q1, add_another_index=0) == TextSingleLineAnswer("Entry 1")
+
+    def test_post_remove_add_another_entry_with_matching_check_entries(
+        self, authenticated_grant_admin_client, factories
+    ):
+        grant = authenticated_grant_admin_client.grant
+        group = factories.group.create(
+            add_another=True, name="Test groups", text="Test groups", form__collection__grant=grant
+        )
+        q1 = factories.question.create(form=group.form, parent=group)
+        submission = factories.submission.create(
+            collection=group.form.collection,
+            created_by=authenticated_grant_admin_client.user,
+            answers=[
+                FactoryAnswer(q1, TextSingleLineAnswer("Entry 1"), add_another_index=0),
+                FactoryAnswer(q1, TextSingleLineAnswer("Entry 2"), add_another_index=1),
+                FactoryAnswer(q1, TextSingleLineAnswer("Entry 3"), add_another_index=2),
+            ],
+        )
+
+        response = authenticated_grant_admin_client.post(
+            url_for(
+                "deliver_grant_funding.ask_a_question",
+                grant_id=grant.id,
+                submission_id=submission.id,
+                question_id=q1.id,
+                add_another_index=0,
+                action="remove",
+                check_entries=3,
+            ),
+            data={"confirm_remove": "yes"},
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 302
+        assert submission.data_manager.get_count_for_add_another(group) == 2
+        assert submission.data_manager.get(q1, add_another_index=0) == TextSingleLineAnswer("Entry 2")
+
+    def test_post_remove_add_another_entry_with_mismatched_check_entries_redirects(
+        self, authenticated_grant_admin_client, factories
+    ):
+        grant = authenticated_grant_admin_client.grant
+        group = factories.group.create(
+            add_another=True, name="Test groups", text="Test groups", form__collection__grant=grant
+        )
+        q1 = factories.question.create(form=group.form, parent=group)
+        submission = factories.submission.create(
+            collection=group.form.collection,
+            created_by=authenticated_grant_admin_client.user,
+            answers=[
+                FactoryAnswer(q1, TextSingleLineAnswer("Entry 1"), add_another_index=0),
+                FactoryAnswer(q1, TextSingleLineAnswer("Entry 2"), add_another_index=1),
+            ],
+        )
+
+        response = authenticated_grant_admin_client.post(
+            url_for(
+                "deliver_grant_funding.ask_a_question",
+                grant_id=grant.id,
+                submission_id=submission.id,
+                question_id=q1.id,
+                add_another_index=0,
+                action="remove",
+                check_entries=3,
+            ),
+            data={"confirm_remove": "yes"},
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 302
+
+        # no entries are removed
+        assert submission.data_manager.get_count_for_add_another(group) == 2

--- a/tests/unit/common/collections/test_runner.py
+++ b/tests/unit/common/collections/test_runner.py
@@ -133,22 +133,24 @@ class TestFormRunner:
         runner = MappedFormRunner(submission=helper, question=question, source=None)
         url = runner.to_url(FormRunnerState.QUESTION, source=FormRunnerState.TASKLIST)
         assert url == "mock_question_url"
-        question_mock.assert_called_once_with(runner, question, question.form, FormRunnerState.TASKLIST, None, None)
+        question_mock.assert_called_once_with(
+            runner, question, question.form, FormRunnerState.TASKLIST, None, None, None
+        )
 
         question_mock.reset_mock()
         runner.to_url(FormRunnerState.QUESTION, question=second_question)
-        question_mock.assert_called_once_with(runner, second_question, question.form, None, None, None)
+        question_mock.assert_called_once_with(runner, second_question, question.form, None, None, None, None)
 
         tasklist_url = runner.to_url(FormRunnerState.TASKLIST)
         assert tasklist_url == "mock_tasklist_url"
-        tasklist_mock.assert_called_once_with(runner, question, question.form, None, None, None)
+        tasklist_mock.assert_called_once_with(runner, question, question.form, None, None, None, None)
 
         check_answers_url = runner.to_url(FormRunnerState.CHECK_YOUR_ANSWERS)
         assert check_answers_url == "mock_check_answers_url"
-        check_answers_mock.assert_called_once_with(runner, question, question.form, None, None, None)
+        check_answers_mock.assert_called_once_with(runner, question, question.form, None, None, None, None)
         check_answers_mock.reset_mock()
         runner.to_url(FormRunnerState.CHECK_YOUR_ANSWERS, form=second_form)
-        check_answers_mock.assert_called_once_with(runner, question, second_form, None, None, None)
+        check_answers_mock.assert_called_once_with(runner, question, second_form, None, None, None, None)
 
     def test_next_url(self, factories, app):
         question = factories.question.build()
@@ -156,7 +158,7 @@ class TestFormRunner:
         submission = factories.submission.build(collection=question.form.collection)
         helper = SubmissionHelper(submission)
 
-        question_mock = Mock(side_effect=lambda r, q, f, s, i, rm: f"mock_question_url_{str(q.id)}")
+        question_mock = Mock(side_effect=lambda r, q, f, s, i, rm, ce: f"mock_question_url_{str(q.id)}")
         check_your_answers_mock = Mock(return_value="mock_check_answers_url")
 
         class MappedFormRunner(FormRunner):
@@ -187,7 +189,7 @@ class TestFormRunner:
         )
         helper = SubmissionHelper(submission)
 
-        question_mock = Mock(side_effect=lambda r, q, f, s, i, rm: f"mock_question_url_{str(q.id)}")
+        question_mock = Mock(side_effect=lambda r, q, f, s, i, rm, ce: f"mock_question_url_{str(q.id)}")
         check_your_answers_mock = Mock(return_value="mock_check_answers_url")
 
         class MappedFormRunner(FormRunner):
@@ -220,7 +222,7 @@ class TestFormRunner:
         )
         helper = SubmissionHelper(submission)
 
-        question_mock = Mock(side_effect=lambda r, q, f, s, i, rm: f"mock_question_url_{str(q.id)}")
+        question_mock = Mock(side_effect=lambda r, q, f, s, i, rm, ce: f"mock_question_url_{str(q.id)}")
 
         class MappedFormRunner(FormRunner):
             url_map = {
@@ -236,7 +238,7 @@ class TestFormRunner:
         submission = factories.submission.build(collection=question.form.collection)
         helper = SubmissionHelper(submission)
 
-        question_mock = Mock(side_effect=lambda r, q, f, s, i, rm: f"mock_question_url_{str(q.id)}")
+        question_mock = Mock(side_effect=lambda r, q, f, s, i, rm, ce: f"mock_question_url_{str(q.id)}")
         tasklist_mock = Mock(return_value="mock_tasklist_url")
 
         class MappedFormRunner(FormRunner):
@@ -262,7 +264,7 @@ class TestFormRunner:
         submission = factories.submission.build(collection=group.form.collection)
         helper = SubmissionHelper(submission)
 
-        question_mock = Mock(side_effect=lambda r, q, f, s, i, rm: f"mock_question_url_{str(q.id)}")
+        question_mock = Mock(side_effect=lambda r, q, f, s, i, rm, ce: f"mock_question_url_{str(q.id)}")
         check_your_answers_mock = Mock(return_value="mock_check_answers_url")
 
         class MappedFormRunner(FormRunner):
@@ -290,7 +292,7 @@ class TestFormRunner:
         )
         helper = SubmissionHelper(submission)
 
-        question_mock = Mock(side_effect=lambda r, q, f, s, i, rm: f"mock_question_url_{str(q.id)}")
+        question_mock = Mock(side_effect=lambda r, q, f, s, i, rm, ce: f"mock_question_url_{str(q.id)}")
 
         class MappedFormRunner(FormRunner):
             url_map = {


### PR DESCRIPTION
Adds `check_entries` property to the form runner when removing an add
another entry. This is an optional check just to make sure that there
are the same number of entires as when we originally clicked through to
remove.

This should address some edge cases we've seen through errors where the
user presses back in the browser and attempts to re-remove entries. If
there multiple entries it should also avoid accidentally removing.

Any additional properties on the form runner library are completely
unmanagable, at this stage it needs to be split up into smaller pages so
that each of the interface methods can define what it cares about and
how to calulate valid states, where to go next, etc. - as it is there
are far too many things to check to make sure you're in the right
context.