### PR TITLE
BAU - adding caption to heading on grant recipient admin pages

### DIFF
--- a/app/deliver_grant_funding/templates/deliver_grant_funding/admin/add-bulk-data-providers.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/admin/add-bulk-data-providers.html
@@ -18,7 +18,10 @@
         {{ govukErrorSummary(wtforms_errors(form)) }}
       {% endif %}
 
-      <h1 class="govuk-heading-l">Set up grant recipient data providers</h1>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l">{{ grant.name }} - {{ collection.name }}</span>
+        Set up grant recipient data providers
+      </h1>
 
       <p class="govuk-body">They will be able to log in and submit reports as the selected grant recipient.</p>
       <p class="govuk-body">Users created this way will not receive any notification email.</p>

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/admin/add-individual-data-provider.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/admin/add-individual-data-provider.html
@@ -18,7 +18,10 @@
         {{ govukErrorSummary(wtforms_errors(form)) }}
       {% endif %}
 
-      <h1 class="govuk-heading-l">Add a grant recipient data provider</h1>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l">{{ grant.name }} - {{ collection.name }}</span>
+        Add a grant recipient data provider
+      </h1>
       <p class="govuk-body">Add a new data provider who will be able to log in and submit reports as the selected grant recipient.</p>
     </div>
   </div>

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/admin/set-up-grant-recipients.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/admin/set-up-grant-recipients.html
@@ -17,7 +17,7 @@
         {{ govukErrorSummary(wtforms_errors(form)) }}
       {% endif %}
 
-      <h1 class="govuk-heading-l">Set up grant recipients</h1>
+      <h1 class="govuk-heading-l"><span class="govuk-caption-l">{{ grant.name }}</span>Set up grant recipients</h1>
 
       <p class="govuk-body">Set up grant recipients by selecting all of the organisations that have been awarded funding through the grant. They will be able to see and submit monitoring reports for the grant.</p>
 

--- a/tests/integration/deliver_grant_funding/admin/test_views.py
+++ b/tests/integration/deliver_grant_funding/admin/test_views.py
@@ -1946,7 +1946,7 @@ class TestSetupGrantRecipients:
         assert response.status_code == 200
 
         soup = BeautifulSoup(response.data, "html.parser")
-        assert get_h1_text(soup) == "Set up grant recipients"
+        assert "Set up grant recipients" in get_h1_text(soup)
 
         select_element = soup.find("select", {"id": "recipients"})
         assert select_element is not None
@@ -2183,7 +2183,7 @@ class TestAddIndividualDataProviders:
         assert response.status_code == 200
 
         soup = BeautifulSoup(response.data, "html.parser")
-        assert get_h1_text(soup) == "Add a grant recipient data provider"
+        assert "Add a grant recipient data provider" in get_h1_text(soup)
 
         assert soup.find("select", {"id": "grant_recipient"}) is not None
         assert soup.find("input", {"id": "full_name"}) is not None
@@ -2421,7 +2421,7 @@ class TestAddBulkDataProviders:
         assert response.status_code == 200
 
         soup = BeautifulSoup(response.data, "html.parser")
-        assert get_h1_text(soup) == "Set up grant recipient data providers"
+        assert "Set up grant recipient data providers" in get_h1_text(soup)
 
         assert soup.find("textarea", {"id": "users_data"}) is not None
 


### PR DESCRIPTION
## 📝 Description
Adding the grant name and report name as a caption on the heading of a couple of admin pages so that when adding grant recipients, you get some reassurance you are adding them to the right grant.

Also means that if you tick 'send report is ready to complete email', you know which report they are getting a link to.

## 📸 Show the thing (screenshots, gifs)

### Before
<img width="695" height="260" alt="Screenshot 2026-04-20 at 12 51 28" src="https://github.com/user-attachments/assets/7feda429-86e8-448e-88ce-5142abbfa5dc" />

### After
<img width="683" height="279" alt="Screenshot 2026-04-20 at 12 51 11" src="https://github.com/user-attachments/assets/710cb85e-9b92-463c-a40c-445b9fe3a5f1" />

