### PR TITLE
Add e2e test coverage for group validation on number questions

### DIFF
--- a/tests/e2e/dataclasses.py
+++ b/tests/e2e/dataclasses.py
@@ -38,6 +38,7 @@ class QuestionResponse:
     answer: str | list[str]
     error_message: str | None = None
     check_your_answers_text: str | None = None
+    expect_group_validation_error: bool = False
 
 
 @dataclasses.dataclass

--- a/tests/e2e/dataclasses.py
+++ b/tests/e2e/dataclasses.py
@@ -87,5 +87,6 @@ class QuestionGroupDict(TypedDict):
     display_options: GroupDisplayOptions
     guidance: NotRequired[GuidanceText]
     condition: NotRequired[E2EManagedExpression]
+    validation: NotRequired[E2EManagedExpression]
     questions: list[QuestionDict]
     add_another: NotRequired[bool]

--- a/tests/e2e/deliver_grant_funding/reports_pages.py
+++ b/tests/e2e/deliver_grant_funding/reports_pages.py
@@ -891,6 +891,57 @@ class CreateCustomExpressionPage(ReportsBasePage):
         return edit_question_page
 
 
+class AddGroupValidationPage(ReportsBasePage):
+    add_validation_button: Locator
+
+    def __init__(
+        self, page: Page, domain: str, grant_name: str, report_name: str, section_name: str, group_name: str
+    ) -> None:
+        super().__init__(
+            page,
+            domain,
+            grant_name=grant_name,
+            heading=page.get_by_role("heading", name="Create a group validation"),
+        )
+        self.report_name = report_name
+        self.section_name = section_name
+        self.group_name = group_name
+        self.add_validation_button = self.page.get_by_role("button", name="Add group validation")
+
+        self.custom_expression_textarea = get_context_aware_textbox_locator_by_name(page, "Calculation")
+        self.add_data_to_expression_button = self.page.get_by_role("button", name="Reference data for calculation")
+
+        self.custom_message_textarea = get_context_aware_textbox_locator_by_name(page, name="Error message")
+        self.add_data_to_message_button = self.page.get_by_role("button", name="Reference data for error message")
+
+    def configure_custom_expression(
+        self, expression: str, expression_references: dict[str, DataReferenceConfig]
+    ) -> None:
+        wait_for_context_aware_textarea_to_be_ready(self.page, "custom_expression")
+        _fill_custom_field(
+            self, self.custom_expression_textarea, self.add_data_to_expression_button, expression, expression_references
+        )
+
+    def configure_custom_message(self, expression: str, message_references: dict[str, DataReferenceConfig]) -> None:
+        wait_for_context_aware_textarea_to_be_ready(self.page, "custom_message")
+        _fill_custom_field(
+            self, self.custom_message_textarea, self.add_data_to_message_button, expression, message_references
+        )
+
+    def click_create_group_validation_expression(self) -> "EditQuestionGroupPage":
+        self.add_validation_button.click()
+        edit_question_group_page = EditQuestionGroupPage(
+            self.page,
+            self.domain,
+            grant_name=self.grant_name,
+            report_name=self.report_name,
+            section_name=self.section_name,
+            group_name=self.group_name,
+        )
+        expect(edit_question_group_page.heading).to_be_visible()
+        return edit_question_group_page
+
+
 class CreateCalculatedConditionPage(ReportsBasePage):
     add_condition_button: Locator
 
@@ -1773,6 +1824,22 @@ class EditQuestionGroupPage(ReportsBasePage):
         self.change_display_options_link = self.page.get_by_role("link", name="Change")
         self.change_guidance_link = self.page.get_by_role("link", name="Change  page heading")
         self.add_question_group_button = self.page.get_by_role("link", name="Add a question group", exact=True)
+        self.add_validation_button = self.page.get_by_role("button", name="Add validation").or_(
+            self.page.get_by_role("button", name="Add more validation")
+        )
+
+    def click_add_validation(self) -> AddGroupValidationPage:
+        self.add_validation_button.click()
+        add_group_validation_page = AddGroupValidationPage(
+            self.page,
+            self.domain,
+            grant_name=self.grant_name,
+            report_name=self.report_name,
+            section_name=self.section_name,
+            group_name=self.group_name,
+        )
+        expect(add_group_validation_page.heading).to_be_visible()
+        return add_group_validation_page
 
     def click_section_breadcrumb(self) -> ManageSectionPage:
         self.section_breadcrumb.click()

--- a/tests/e2e/deliver_grant_funding/reports_pages.py
+++ b/tests/e2e/deliver_grant_funding/reports_pages.py
@@ -1456,11 +1456,15 @@ class RunnerQuestionPage(ReportsBasePage):
         self.question_name = question_name
         self.continue_button = page.get_by_role("button", name="Continue")
 
-    def respond_to_question(self, question_type: QuestionDataType, question_text: str, answer: str) -> None:
+    def respond_to_question(self, question_type: QuestionDataType, question_text: str, answer: str | list[str]) -> None:
         if question_type == QuestionDataType.CHECKBOXES:
             for choice in answer:
                 self.page.get_by_role("checkbox", name=choice).click()
-        elif question_type == QuestionDataType.YES_NO or question_type == QuestionDataType.RADIOS:
+        elif (
+            question_type == QuestionDataType.YES_NO
+            or question_type == QuestionDataType.RADIOS
+            and isinstance(answer, str)
+        ):
             # once we start having multiple of these on a page - enjoy the refactor =]
             accessible_autocomplete = self.page.query_selector("[data-accessible-autocomplete]")
             if accessible_autocomplete:
@@ -1471,10 +1475,10 @@ class RunnerQuestionPage(ReportsBasePage):
                 expect(self.page.locator("[class='autocomplete__wrapper']")).to_be_attached()
                 element = self.page.get_by_role("combobox")
                 element.click()
-                element.fill(answer)
+                element.fill(answer)  # ty:ignore[invalid-argument-type]
                 element.press("Enter")
             else:
-                self.page.get_by_role("radio", name=answer).click()
+                self.page.get_by_role("radio", name=answer).click()  # ty:ignore[invalid-argument-type]
         elif question_type == QuestionDataType.DATE:
             approx_date = len(answer) == 2
             date_to_enter = (
@@ -1490,7 +1494,7 @@ class RunnerQuestionPage(ReportsBasePage):
         elif question_type == QuestionDataType.FILE_UPLOAD:
             self.page.locator("input[type='file']").set_input_files("./tests/fixtures/e2e-test-file.txt")
         else:
-            self.page.get_by_role("textbox", name=question_text).fill(answer)
+            self.page.get_by_role("textbox", name=question_text).fill(answer)  # ty:ignore[invalid-argument-type]
 
     def click_continue(
         self,

--- a/tests/e2e/deliver_grant_funding/reports_pages.py
+++ b/tests/e2e/deliver_grant_funding/reports_pages.py
@@ -1457,44 +1457,46 @@ class RunnerQuestionPage(ReportsBasePage):
         self.continue_button = page.get_by_role("button", name="Continue")
 
     def respond_to_question(self, question_type: QuestionDataType, question_text: str, answer: str | list[str]) -> None:
-        if question_type == QuestionDataType.CHECKBOXES:
-            for choice in answer:
-                self.page.get_by_role("checkbox", name=choice).click()
-        elif (
-            question_type == QuestionDataType.YES_NO
-            or question_type == QuestionDataType.RADIOS
-            and isinstance(answer, str)
-        ):
-            # once we start having multiple of these on a page - enjoy the refactor =]
-            accessible_autocomplete = self.page.query_selector("[data-accessible-autocomplete]")
-            if accessible_autocomplete:
-                # there is a few ms of delay during the call to "enhanceSelectElement" which allows the select
-                # being progressively enhanced to be selected before its complete as playwright will act immediately
-                # on the role being available - this causes the test to fail particularly when there is network latency.
-                # Wait for the full input + options to be loaded before using it
-                expect(self.page.locator("[class='autocomplete__wrapper']")).to_be_attached()
-                element = self.page.get_by_role("combobox")
-                element.click()
-                element.fill(answer)  # ty:ignore[invalid-argument-type]
-                element.press("Enter")
+        if isinstance(answer, list):
+            if question_type == QuestionDataType.CHECKBOXES:
+                for choice in answer:
+                    self.page.get_by_role("checkbox", name=choice).click()
+            elif question_type == QuestionDataType.DATE:
+                approx_date = len(answer) == 2
+                date_to_enter = (
+                    datetime.date(*[int(a) for a in answer])
+                    if not approx_date
+                    else datetime.date(int(answer[0]), int(answer[1]), 1)
+                )
+                ReportsBasePage.fill_in_date_fields(
+                    self.page.get_by_role("group", name=question_text),
+                    date_to_enter,
+                    approx_date=approx_date,
+                )
             else:
-                self.page.get_by_role("radio", name=answer).click()  # ty:ignore[invalid-argument-type]
-        elif question_type == QuestionDataType.DATE:
-            approx_date = len(answer) == 2
-            date_to_enter = (
-                datetime.date(*[int(a) for a in answer])
-                if not approx_date
-                else datetime.date(int(answer[0]), int(answer[1]), 1)
-            )
-            ReportsBasePage.fill_in_date_fields(
-                self.page.get_by_role("group", name=question_text),
-                date_to_enter,
-                approx_date=approx_date,
-            )
-        elif question_type == QuestionDataType.FILE_UPLOAD:
-            self.page.locator("input[type='file']").set_input_files("./tests/fixtures/e2e-test-file.txt")
+                raise ValueError(f"respond_to_question got a list of answers, but question type was {question_type}")
         else:
-            self.page.get_by_role("textbox", name=question_text).fill(answer)  # ty:ignore[invalid-argument-type]
+            if question_type in [QuestionDataType.YES_NO, QuestionDataType.RADIOS]:
+                # once we start having multiple of these on a page - enjoy the refactor =]
+                accessible_autocomplete = self.page.query_selector("[data-accessible-autocomplete]")
+                if accessible_autocomplete:
+                    # there is a few ms of delay during the call to "enhanceSelectElement" which allows the select
+                    # being progressively enhanced to be selected before its complete as playwright will act immediately
+                    # on the role being available - this causes the test to fail particularly when there is network
+                    # latency.
+                    # Wait for the full input + options to be loaded before using it
+                    expect(self.page.locator("[class='autocomplete__wrapper']")).to_be_attached()
+                    element = self.page.get_by_role("combobox")
+                    element.click()
+                    element.fill(answer)
+                    element.press("Enter")
+                else:
+                    self.page.get_by_role("radio", name=answer).click()
+
+            elif question_type == QuestionDataType.FILE_UPLOAD:
+                self.page.locator("input[type='file']").set_input_files("./tests/fixtures/e2e-test-file.txt")
+            else:
+                self.page.get_by_role("textbox", name=question_text).fill(answer)
 
     def click_continue(
         self,

--- a/tests/e2e/deliver_grant_funding/test_create_preview_collection.py
+++ b/tests/e2e/deliver_grant_funding/test_create_preview_collection.py
@@ -155,6 +155,71 @@ section_1_questions_with_groups_to_test: dict[str, TQuestionToTest] = {
         "display_text": "Enter another single line of text",
         "answers": [QuestionResponse("E2E question text single line second answer")],
     },
+    "question-group-number-validation": {
+        "type": "group",
+        "text": "Number questions with group validation",
+        "display_options": GroupDisplayOptions.ALL_QUESTIONS_ON_SAME_PAGE,
+        "condition": E2EManagedExpression(
+            conditional_on=DataReferenceConfig(
+                data_source=ExpressionContext.ContextSources.SECTION,
+                question_text="Do you want to show question groups?",
+            ),
+            evaluatable_expression=IsYes(subject_reference="q_00000000000000000000000000001234"),
+        ),
+        "validation": E2EManagedExpression(
+            evaluatable_expression=CustomExpression(
+                custom_expression="((ref1)) + ((ref2)) + ((ref3)) <= ((ref4))",
+                custom_message="The total of the three amounts must not exceed the allowed amount",
+            ),
+            expression_references={
+                "ref1": DataReferenceConfig(
+                    data_source=ExpressionContext.ContextSources.SECTION,
+                    question_text="First number amount",
+                ),
+                "ref2": DataReferenceConfig(
+                    data_source=ExpressionContext.ContextSources.SECTION,
+                    question_text="Second number amount",
+                ),
+                "ref3": DataReferenceConfig(
+                    data_source=ExpressionContext.ContextSources.SECTION,
+                    question_text="Third number amount",
+                ),
+                "ref4": DataReferenceConfig(
+                    data_source=ExpressionContext.ContextSources.SECTION,
+                    question_text="What number do you want to see in another section?",
+                ),
+            },
+        ),
+        "questions": [
+            {
+                "type": QuestionDataType.NUMBER,
+                "text": "First number amount",
+                "display_text": "First number amount",
+                "options": QuestionPresentationOptions(),
+                "data_options": QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                "answers": [
+                    QuestionResponse("40", "The total of the three amounts must not exceed the allowed amount"),
+                    QuestionResponse("30"),
+                ],
+            },
+            {
+                "type": QuestionDataType.NUMBER,
+                "text": "Second number amount",
+                "display_text": "Second number amount",
+                "options": QuestionPresentationOptions(),
+                "data_options": QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                "answers": [QuestionResponse("40"), QuestionResponse("30")],
+            },
+            {
+                "type": QuestionDataType.NUMBER,
+                "text": "Third number amount",
+                "display_text": "Third number amount",
+                "options": QuestionPresentationOptions(),
+                "data_options": QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                "answers": [QuestionResponse("40"), QuestionResponse("30")],
+            },
+        ],
+    },
     "question-group-one-per-page": {
         "type": "group",
         "text": "One question per page group",
@@ -670,6 +735,8 @@ def create_question_or_group(
                 parent_group_name=question_definition["text"],
                 parent_add_another=question_definition.get("add_another", False),
             )
+        if question_definition.get("validation") is not None:
+            add_group_validation(edit_question_group_page, question_definition["validation"])
         if parent_group_name:
             edit_question_group_page.click_parent_group_breadcrumb()
         else:
@@ -800,6 +867,20 @@ def add_question_guidance(
         add_guidance_page.click_save_guidance_button(edit_question_page)
 
 
+def add_group_validation(
+    edit_question_group_page: EditQuestionGroupPage,
+    validation: E2EManagedExpression,
+) -> None:
+    add_validation_page = edit_question_group_page.click_add_validation()
+    add_validation_page.configure_custom_expression(
+        validation.evaluatable_expression.custom_expression, validation.expression_references
+    )
+    add_validation_page.configure_custom_message(
+        validation.evaluatable_expression.custom_message, validation.expression_references
+    )
+    add_validation_page.click_create_group_validation_expression()
+
+
 def add_validation(
     edit_question_page: EditQuestionPage,
     validation: E2EManagedExpression,
@@ -859,30 +940,58 @@ def complete_question_group(
 ):
     if group_to_test.get("guidance") is not None:
         assert_question_visibility(question_page, group_to_test)
-    for nested_question in group_to_test["questions"]:
-        if group_to_test.get("guidance") is None:
-            question_page = RunnerQuestionPage(
-                tasklist_page.page,
-                tasklist_page.domain,
-                grant_name,
-                nested_question["text"],
-                is_in_a_same_page_group=group_to_test["display_options"]
-                == GroupDisplayOptions.ALL_QUESTIONS_ON_SAME_PAGE,
-            )
-            assert_question_visibility(question_page, nested_question)
-        if nested_question["type"] == "group":
-            complete_question_group(question_page, tasklist_page, grant_name, nested_question)
-        else:
-            for question_response in nested_question["answers"]:
+
+    if group_to_test["display_options"] == GroupDisplayOptions.ALL_QUESTIONS_ON_SAME_PAGE:
+        answer_count = max(len(q["answers"]) for q in group_to_test["questions"])
+
+        for answer_idx in range(answer_count):
+            for nested_question in group_to_test["questions"]:
+                if group_to_test.get("guidance") is None:
+                    question_page = RunnerQuestionPage(
+                        tasklist_page.page,
+                        tasklist_page.domain,
+                        grant_name,
+                        nested_question["text"],
+                        is_in_a_same_page_group=True,
+                    )
+                    assert_question_visibility(question_page, nested_question)
                 question_page.respond_to_question(
                     question_type=nested_question["type"],
                     question_text=nested_question["display_text"],
-                    answer=question_response.answer,
+                    answer=nested_question["answers"][answer_idx].answer,
                 )
-        if group_to_test["display_options"] == GroupDisplayOptions.ONE_QUESTION_PER_PAGE:
             question_page.click_continue()
-    if group_to_test["display_options"] == GroupDisplayOptions.ALL_QUESTIONS_ON_SAME_PAGE:
-        question_page.click_continue()
+            error_message = next(
+                (
+                    q["answers"][answer_idx].error_message
+                    for q in group_to_test["questions"]
+                    if q["answers"][answer_idx].error_message
+                ),
+                None,
+            )
+            if error_message:
+                expect(question_page.page.get_by_text(error_message)).to_be_visible()
+    else:
+        for nested_question in group_to_test["questions"]:
+            if group_to_test.get("guidance") is None:
+                question_page = RunnerQuestionPage(
+                    tasklist_page.page,
+                    tasklist_page.domain,
+                    grant_name,
+                    nested_question["text"],
+                    is_in_a_same_page_group=False,
+                )
+                assert_question_visibility(question_page, nested_question)
+            if nested_question["type"] == "group":
+                complete_question_group(question_page, tasklist_page, grant_name, nested_question)
+            else:
+                for question_response in nested_question["answers"]:
+                    question_page.respond_to_question(
+                        question_type=nested_question["type"],
+                        question_text=nested_question["display_text"],
+                        answer=question_response.answer,
+                    )
+            question_page.click_continue()
 
 
 def complete_task(

--- a/tests/e2e/deliver_grant_funding/test_create_preview_collection.py
+++ b/tests/e2e/deliver_grant_funding/test_create_preview_collection.py
@@ -948,6 +948,7 @@ def answer_questions_and_check_for_expected_errors(
     questions_on_this_page: list[QuestionDict],
     question_page: RunnerQuestionPage,
     group_validation_error: str | None = None,
+    same_page_group: bool = False,
 ):
     for question in questions_on_this_page:
         question_page = RunnerQuestionPage(
@@ -955,7 +956,7 @@ def answer_questions_and_check_for_expected_errors(
             question_page.domain,
             question_page.grant_name,
             question["text"],
-            is_in_a_same_page_group=len(questions_on_this_page) > 1,
+            is_in_a_same_page_group=same_page_group,
         )
         assert_question_visibility(question_page, question)
 
@@ -964,6 +965,9 @@ def answer_questions_and_check_for_expected_errors(
         expect_errors = False
         current_responses: list[QuestionResponse] = []
         for question in questions_on_this_page:
+            if "This question should not be shown" in question["display_text"]:
+                continue
+
             # If this question doesn't have as many answers as other questions in the group, just use its last answer
             response = (
                 question["answers"][answer_idx]
@@ -1001,6 +1005,7 @@ def complete_question_group(
             group_to_test["validation"].evaluatable_expression.custom_message
             if group_to_test.get("validation") is not None
             else None,
+            same_page_group=True,
         )
 
     else:
@@ -1030,20 +1035,7 @@ def complete_task(
         if question_to_test["type"] == "group":
             complete_question_group(question_page, tasklist_page, grant_name, question_to_test)
         else:
-            assert_question_visibility(question_page, question_to_test)
-            for question_response in question_to_test["answers"]:
-                if "This question should not be shown" not in question_to_test["display_text"]:
-                    question_page.respond_to_question(
-                        question_type=question_to_test["type"],
-                        question_text=question_to_test["display_text"],
-                        answer=question_response.answer,
-                    )
-                    question_page.click_continue()
-
-                    if question_response.error_message:
-                        expect(
-                            question_page.page.get_by_role("link", name=question_response.error_message)
-                        ).to_be_visible()
+            answer_questions_and_check_for_expected_errors([cast(QuestionDict, question_to_test)], question_page, None)
 
 
 def task_check_your_answers(

--- a/tests/e2e/deliver_grant_funding/test_create_preview_collection.py
+++ b/tests/e2e/deliver_grant_funding/test_create_preview_collection.py
@@ -198,7 +198,9 @@ section_1_questions_with_groups_to_test: dict[str, TQuestionToTest] = {
                 "options": QuestionPresentationOptions(),
                 "data_options": QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
                 "answers": [
-                    QuestionResponse("40", "The total of the three amounts must not exceed the allowed amount"),
+                    QuestionResponse(
+                        "40", "Check your answer for First number amount (40)", expect_group_validation_error=True
+                    ),
                     QuestionResponse("30"),
                 ],
             },
@@ -208,7 +210,12 @@ section_1_questions_with_groups_to_test: dict[str, TQuestionToTest] = {
                 "display_text": "Second number amount",
                 "options": QuestionPresentationOptions(),
                 "data_options": QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                "answers": [QuestionResponse("40"), QuestionResponse("30")],
+                "answers": [
+                    QuestionResponse(
+                        "56", "Check your answer for Second number amount (56)", expect_group_validation_error=True
+                    ),
+                    QuestionResponse("30"),
+                ],
             },
             {
                 "type": QuestionDataType.NUMBER,
@@ -216,7 +223,12 @@ section_1_questions_with_groups_to_test: dict[str, TQuestionToTest] = {
                 "display_text": "Third number amount",
                 "options": QuestionPresentationOptions(),
                 "data_options": QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                "answers": [QuestionResponse("40"), QuestionResponse("30")],
+                "answers": [
+                    QuestionResponse(
+                        "45", "Check your answer for Third number amount (45)", expect_group_validation_error=True
+                    ),
+                    QuestionResponse("30"),
+                ],
             },
         ],
     },
@@ -932,66 +944,75 @@ def add_condition(
         add_condition_page.click_add_condition(edit_question_page)
 
 
+def answer_questions_and_check_for_expected_errors(
+    questions_on_this_page: list[QuestionDict],
+    question_page: RunnerQuestionPage,
+    group_validation_error: str | None = None,
+):
+    for question in questions_on_this_page:
+        question_page = RunnerQuestionPage(
+            question_page.page,
+            question_page.domain,
+            question_page.grant_name,
+            question["text"],
+            is_in_a_same_page_group=len(questions_on_this_page) > 1,
+        )
+        assert_question_visibility(question_page, question)
+
+    max_answers = max(len(q["answers"]) for q in questions_on_this_page)
+    for answer_idx in range(max_answers):
+        expect_errors = False
+        current_responses: list[QuestionResponse] = []
+        for question in questions_on_this_page:
+            # If this question doesn't have as many answers as other questions in the group, just use its last answer
+            response = (
+                question["answers"][answer_idx]
+                if answer_idx < len(question["answers"])
+                else question["answers"][len(question["answers"]) - 1]
+            )
+            current_responses.append(response)
+            if response.error_message or response.expect_group_validation_error:
+                expect_errors = True
+            question_page.respond_to_question(question["type"], question["text"], response.answer)
+        question_page.click_continue()
+        if expect_errors:
+            for response in current_responses:
+                if response.error_message is not None:
+                    expect(question_page.page.get_by_role("link", name=response.error_message)).to_be_visible()
+                if response.expect_group_validation_error and group_validation_error is not None:
+                    expect(question_page.page.get_by_text(group_validation_error)).to_be_visible()
+
+
 def complete_question_group(
     question_page: RunnerQuestionPage,
     tasklist_page: RunnerTasklistPage,
     grant_name: str,
     group_to_test: TQuestionToTest,
 ):
-    if group_to_test.get("guidance") is not None:
-        assert_question_visibility(question_page, group_to_test)
 
     if group_to_test["display_options"] == GroupDisplayOptions.ALL_QUESTIONS_ON_SAME_PAGE:
-        answer_count = max(len(q["answers"]) for q in group_to_test["questions"])
+        if group_to_test.get("guidance") is not None:
+            # Just checks the guidance for this group is visible
+            assert_question_visibility(question_page, group_to_test)
 
-        for answer_idx in range(answer_count):
-            for nested_question in group_to_test["questions"]:
-                if group_to_test.get("guidance") is None:
-                    question_page = RunnerQuestionPage(
-                        tasklist_page.page,
-                        tasklist_page.domain,
-                        grant_name,
-                        nested_question["text"],
-                        is_in_a_same_page_group=True,
-                    )
-                    assert_question_visibility(question_page, nested_question)
-                question_page.respond_to_question(
-                    question_type=nested_question["type"],
-                    question_text=nested_question["display_text"],
-                    answer=nested_question["answers"][answer_idx].answer,
-                )
-            question_page.click_continue()
-            error_message = next(
-                (
-                    q["answers"][answer_idx].error_message
-                    for q in group_to_test["questions"]
-                    if q["answers"][answer_idx].error_message
-                ),
-                None,
-            )
-            if error_message:
-                expect(question_page.page.get_by_text(error_message)).to_be_visible()
+        answer_questions_and_check_for_expected_errors(
+            group_to_test["questions"],
+            question_page,
+            group_to_test["validation"].evaluatable_expression.custom_message
+            if group_to_test.get("validation") is not None
+            else None,
+        )
+
     else:
         for nested_question in group_to_test["questions"]:
-            if group_to_test.get("guidance") is None:
-                question_page = RunnerQuestionPage(
-                    tasklist_page.page,
-                    tasklist_page.domain,
-                    grant_name,
-                    nested_question["text"],
-                    is_in_a_same_page_group=False,
-                )
-                assert_question_visibility(question_page, nested_question)
             if nested_question["type"] == "group":
                 complete_question_group(question_page, tasklist_page, grant_name, nested_question)
             else:
-                for question_response in nested_question["answers"]:
-                    question_page.respond_to_question(
-                        question_type=nested_question["type"],
-                        question_text=nested_question["display_text"],
-                        answer=question_response.answer,
-                    )
-            question_page.click_continue()
+                answer_questions_and_check_for_expected_errors(
+                    [nested_question],
+                    question_page,
+                    None,
+                )
 
 
 def complete_task(


### PR DESCRIPTION
## 🎫 Ticket
[FSPT-1202](https://mhclgdigital.atlassian.net/browse/FSPT-1202)

## 📝 Description
Adds config to the e2e tests to create a new group containing number questions, and add calculated group validation to check they add up to less than a previous answer.

## 📸 Show the thing (screenshots, gifs)

### After
<img width="703" height="844" alt="Screenshot 2026-04-22 at 10 47 56" src="https://github.com/user-attachments/assets/a205afdd-dd96-496b-b279-33173b938cac" />


## 🧪 Testing
Run the e2e tests



[FSPT-1202]: https://mhclgdigital.atlassian.net/browse/FSPT-1202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ