### PR TITLE
BAU Line up CPU and memory between infra and deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -116,8 +116,8 @@ jobs:
           access-role-arn: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/${{ inputs.environment }}-funding-service-app-runner-build-role
           region: eu-west-2
           port: 8080
-          cpu: 1
-          memory: 2
+          cpu: 2
+          memory: 4
           wait-for-service-stability-seconds: 600
 
   e2e_tests:


### PR DESCRIPTION
The deploy action for AppRunner updates the service with the new image every time we release - IIRC as we depend on an external action there was no way to not include the CPU/ memory configuration when updating the service. If we don't include values it will override whatever was provisioned with defaults.

As we've increased this in the infra lets bump what the deploy script sets - we'll look to avoid this discrepancy when working with ECS.