### PR TITLE
Bugfix: Fix submission status with not needed form

### DIFF
--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -338,14 +338,19 @@ class SubmissionHelper:
         submission_state = self.events.submission_state
 
         form_statuses = {self.get_status_for_form(form) for form in self.collection.forms}
-        if {TasklistSectionStatusEnum.COMPLETED} == form_statuses and submission_state.is_submitted:
+        all_forms_completed_or_not_needed = form_statuses <= {
+            TasklistSectionStatusEnum.COMPLETED,
+            TasklistSectionStatusEnum.NOT_NEEDED,
+        }
+
+        if all_forms_completed_or_not_needed and submission_state.is_submitted:
             return SubmissionStatusEnum.SUBMITTED
         elif self.collection_helper.is_closed:
             return SubmissionStatusEnum.NOT_SUBMITTED
-        elif {TasklistSectionStatusEnum.COMPLETED} == form_statuses and submission_state.is_awaiting_sign_off:
+        elif all_forms_completed_or_not_needed and submission_state.is_awaiting_sign_off:
             return SubmissionStatusEnum.AWAITING_SIGN_OFF
         elif (
-            form_statuses <= {TasklistSectionStatusEnum.COMPLETED, TasklistSectionStatusEnum.NOT_NEEDED}
+            all_forms_completed_or_not_needed
             and (
                 self.is_preview
                 or not self.submission.collection.requires_certification

--- a/tests/integration/common/helpers/test_collections.py
+++ b/tests/integration/common/helpers/test_collections.py
@@ -38,7 +38,7 @@ from app.common.data.types import (
 )
 from app.common.exceptions import SubmissionAnswerConflict
 from app.common.expressions import ExpressionContext
-from app.common.expressions.managed import GreaterThan
+from app.common.expressions.managed import GreaterThan, IsYes
 from app.common.expressions.references import ExpressionReference
 from app.common.helpers.collections import (
     AllSubmissionsHelper,
@@ -1026,6 +1026,56 @@ class TestSubmissionHelper:
         ):
             submission_submitted.collection.status = CollectionStatusEnum.CLOSED
             helper = SubmissionHelper(submission_submitted)
+
+            assert helper.status == SubmissionStatusEnum.SUBMITTED
+
+        def test_submission_status_with_not_needed_forms(self, db_session, factories, mock_notification_service_calls):
+            org = factories.organisation.create()
+            grant = factories.grant.create()
+            gr = factories.grant_recipient.create(organisation=org, grant=grant)
+            collection = factories.collection.create(
+                grant=grant,
+                reporting_period_start_date=date(2025, 1, 1),
+                reporting_period_end_date=date(2025, 3, 31),
+                requires_certification=False,
+            )
+
+            question = factories.question.create(form__collection=collection, data_type=QuestionDataType.YES_NO)
+            form_two = factories.form.create(collection=collection)
+            factories.question.create(
+                form=form_two,
+                expressions=[
+                    Expression.from_evaluatable_expression(
+                        IsYes(subject_reference=ExpressionReference.from_question(question)),
+                        ExpressionType.CONDITION,
+                        collection.created_by,
+                    )
+                ],
+            )
+
+            form_three = factories.form.create(collection=collection)
+            question_three = factories.question.create(form=form_three)
+
+            submission = factories.submission.create(
+                collection=question.form.collection,
+                grant_recipient=gr,
+                answers=[
+                    FactoryAnswer(question, YesNoAnswer(False)),
+                    FactoryAnswer(question_three, TextSingleLineAnswer("Hello")),
+                ],
+            )
+
+            helper = SubmissionHelper(submission)
+            helper.toggle_form_completed(question.form, submission.created_by, True)
+            helper.toggle_form_completed(form_three, submission.created_by, True)
+
+            assert helper.get_status_for_form(question.form) == TasklistSectionStatusEnum.COMPLETED
+            assert helper.get_status_for_form(form_two) == TasklistSectionStatusEnum.NOT_NEEDED
+            assert helper.get_status_for_form(form_three) == TasklistSectionStatusEnum.COMPLETED
+
+            assert helper.status == SubmissionStatusEnum.READY_TO_SUBMIT
+
+            helper.submit(submission.created_by)
 
             assert helper.status == SubmissionStatusEnum.SUBMITTED
 


### PR DESCRIPTION
## 🎫 Ticket
Bugfix

## 📝 Description
A user raised a support ticket that they successfully submitted their report but the report was still showing as 'in progress'.

On investigation we found that they had successfully submitted their report but that the submission status calculation was incorrect - one of the sections in the form was marked as NOT_NEEDED but the status calculation wasn't taking this into account and was expecting all sections to be completed. This led to a successful submission but what the user saw was 'In Progress' and they were seemingly stuck in a loop.

This fix makes sure the submission status calculation takes into account NOT_NEEDED sections correctly.