### PR TITLE
FSPT-1147: Filter data sets during referencing flow

### DIFF
--- a/app/deliver_grant_funding/forms.py
+++ b/app/deliver_grant_funding/forms.py
@@ -715,11 +715,21 @@ class SelectDataSourceDataSetForm(FlaskForm):
         self,
         collection: Collection,
         *args: Any,
+        number_columns_only: bool = False,
         **kwargs: Any,
     ):
         super().__init__(*args, **kwargs)
+        self.number_columns_only = number_columns_only
 
-        self.data_set.choices = [(d.id, cast(str, d.name)) for d in collection.data_sources]
+        data_sources = collection.data_sources
+        if number_columns_only:
+            data_sources = [
+                d
+                for d in data_sources
+                if d.schema and any(col.data_type == QuestionDataType.NUMBER for col in d.schema.root.values())
+            ]
+
+        self.data_set.choices = [(d.id, cast(str, d.name)) for d in data_sources]
 
 
 class SelectDataSourceDataSetColumnForm(FlaskForm):
@@ -734,17 +744,27 @@ class SelectDataSourceDataSetColumnForm(FlaskForm):
         self,
         data_set: DataSource,
         *args: Any,
+        number_columns_only: bool = False,
         **kwargs: Any,
     ):
         super().__init__(*args, **kwargs)
+        self.number_columns_only = number_columns_only
 
         assert data_set.schema is not None
 
         self.column.label.text = f"Select column in {data_set.name} data set"
 
+        columns = data_set.schema.root.items()
+        if number_columns_only:
+            columns = [
+                (safe_column_id, column_schema)
+                for safe_column_id, column_schema in columns
+                if column_schema.data_type == QuestionDataType.NUMBER
+            ]
+
         self.column.choices = [
             (safe_column_id, uppercase_first(column_schema.original_column_name) or "")
-            for safe_column_id, column_schema in data_set.schema.root.items()
+            for safe_column_id, column_schema in columns
         ]
 
 

--- a/app/deliver_grant_funding/routes/reports.py
+++ b/app/deliver_grant_funding/routes/reports.py
@@ -1515,7 +1515,12 @@ def select_context_source_data_set(grant_id: UUID, form_id: UUID) -> ResponseRet
     if not add_context_data:
         return abort(400)
 
-    wtform = SelectDataSourceDataSetForm(collection=db_form.collection, data=request.args)
+    number_columns_only = isinstance(
+        add_context_data, (AddConditionDependsOnSessionModel, AddContextToExpressionsModel)
+    )
+    wtform = SelectDataSourceDataSetForm(
+        collection=db_form.collection, data=request.args, number_columns_only=number_columns_only
+    )
 
     if wtform.validate_on_submit():
         reference_data_set = get_data_source(uuid.UUID(wtform.data_set.data))
@@ -1554,7 +1559,10 @@ def select_context_source_data_set_column(grant_id: UUID, form_id: UUID, data_se
     if not add_context_data:
         return abort(400)
 
-    wtform = SelectDataSourceDataSetColumnForm(data_set=data_set)
+    number_columns_only = isinstance(
+        add_context_data, (AddConditionDependsOnSessionModel, AddContextToExpressionsModel)
+    )
+    wtform = SelectDataSourceDataSetColumnForm(data_set=data_set, number_columns_only=number_columns_only)
 
     if wtform.validate_on_submit():
         safe_column_id = wtform.column.data

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/select_context_source_data_set.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/select_context_source_data_set.html
@@ -44,6 +44,7 @@
           {{ form.data_set.label.text }}
         </h1>
         <p class="govuk-body">There are no data sets to reference in this collection.</p>
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ cancel_url }}">Cancel</a>
       {% endif %}
     </div>
   </div>

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/select_context_source_data_set_column.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/select_context_source_data_set_column.html
@@ -25,18 +25,27 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-l">Question {{ heading_caption }}</span>
+      {% if form.column.choices | length > 0 %}
+        <span class="govuk-caption-l">Question {{ heading_caption }}</span>
 
-      <form method="post" novalidate>
-        {{ form.csrf_token }}
-        {{ form.column(params={"fieldset": {"legend": {"text": form.column.label.text, "isPageHeading": true, "classes": "govuk-fieldset__legend--l"} } }) }}
+        <form method="post" novalidate>
+          {{ form.csrf_token }}
+          {{ form.column(params={"fieldset": {"legend": {"text": form.column.label.text, "isPageHeading": true, "classes": "govuk-fieldset__legend--l"} } }) }}
 
-        <span class="govuk-button-group">
-          {{ form.submit(params={"text": "Select column"}) }}
+          <span class="govuk-button-group">
+            {{ form.submit(params={"text": "Select column"}) }}
 
-          <a class="govuk-link govuk-link--no-visited-state" href="{{ cancel_url }}">Cancel</a>
-        </span>
-      </form>
+            <a class="govuk-link govuk-link--no-visited-state" href="{{ cancel_url }}">Cancel</a>
+          </span>
+        </form>
+      {% else %}
+        <h1 class="govuk-heading-l">
+          <span class="govuk-caption-l">Question {{ heading_caption }}</span>
+          {{ form.column.label.text }}
+        </h1>
+        <p class="govuk-body">You cannot reference this data set because there are no columns with numbers.</p>
+        <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="{{ cancel_url }}">Cancel</a></p>
+      {% endif %}
     </div>
   </div>
 {% endblock content %}

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -4008,6 +4008,23 @@ class TestSelectContextSourceDataSet:
 
         data_source_3 = factories.data_source.create(
             grant=authenticated_grant_admin_client.grant,
+            collection=report,
+            name="Data set with just text column should still show",
+            type=DataSourceType.GRANT_RECIPIENT,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_description": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.TEXT_SINGLE_LINE,
+                        presentation_options=QuestionPresentationOptions(),
+                        data_options=QuestionDataOptions(),
+                        original_column_name="Description",
+                    )
+                }
+            ),
+        )
+
+        data_source_4 = factories.data_source.create(
+            grant=authenticated_grant_admin_client.grant,
             collection=report_2,
             name="Data set that shouldn't be shown",
             type=DataSourceType.GRANT_RECIPIENT,
@@ -4032,6 +4049,191 @@ class TestSelectContextSourceDataSet:
                     "hint": "Test question hint",
                     "add_context": "text",
                 },
+            ).model_dump(mode="json")
+
+        response = authenticated_grant_admin_client.get(
+            url_for(
+                "deliver_grant_funding.select_context_source_data_set",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                form_id=form.id,
+            )
+        )
+        assert response.status_code == 200
+
+        soup = BeautifulSoup(response.data, "html.parser")
+        assert "Select uploaded data set" in soup.text
+        assert data_source.name in soup.text
+        assert data_source_2.name in soup.text
+        assert data_source_3.name in soup.text
+        assert data_source_4.name not in soup.text
+
+    def test_get_shows_only_data_sets_with_number_columns_when_expression_reference(
+        self, authenticated_grant_admin_client, factories
+    ):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant)
+        report_2 = factories.collection.create(grant=authenticated_grant_admin_client.grant)
+        form = factories.form.create(collection=report)
+        question = factories.question.create(form=form, data_type=QuestionDataType.NUMBER)
+
+        data_source = factories.data_source.create(
+            grant=authenticated_grant_admin_client.grant,
+            collection=report,
+            name="Test data set",
+            type=DataSourceType.GRANT_RECIPIENT,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_capital_allocation": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Capital Allocation",
+                    )
+                }
+            ),
+        )
+
+        data_source_2 = factories.data_source.create(
+            grant=authenticated_grant_admin_client.grant,
+            collection=report,
+            name="Second data set",
+            type=DataSourceType.GRANT_RECIPIENT,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_capital_allocation": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Capital Allocation",
+                    )
+                }
+            ),
+        )
+
+        data_source_3 = factories.data_source.create(
+            grant=authenticated_grant_admin_client.grant,
+            collection=report,
+            name="Data set with just text column",
+            type=DataSourceType.GRANT_RECIPIENT,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_description": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.TEXT_SINGLE_LINE,
+                        presentation_options=QuestionPresentationOptions(),
+                        data_options=QuestionDataOptions(),
+                        original_column_name="Description",
+                    )
+                }
+            ),
+        )
+
+        data_source_4 = factories.data_source.create(
+            grant=authenticated_grant_admin_client.grant,
+            collection=report_2,
+            name="Data set that shouldn't be shown",
+            type=DataSourceType.GRANT_RECIPIENT,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_capital_allocation": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Capital Allocation",
+                    )
+                }
+            ),
+        )
+
+        with authenticated_grant_admin_client.session_transaction() as sess:
+            sess["question"] = AddContextToExpressionsModel(
+                field=ExpressionType.VALIDATION,
+                managed_expression_name=ManagedExpressionsEnum.GREATER_THAN,
+                expression_form_data={
+                    "type": "Greater than",
+                    "greater_than_value": None,
+                    "greater_than_expression": "",
+                    "greater_than_inclusive": False,
+                    "add_context": "greater_than_expression",
+                },
+                component_id=question.id,
+            ).model_dump(mode="json")
+
+        response = authenticated_grant_admin_client.get(
+            url_for(
+                "deliver_grant_funding.select_context_source_data_set",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                form_id=form.id,
+            )
+        )
+        assert response.status_code == 200
+
+        soup = BeautifulSoup(response.data, "html.parser")
+        assert "Select uploaded data set" in soup.text
+        assert data_source.name in soup.text
+        assert data_source_2.name in soup.text
+        assert data_source_3.name not in soup.text
+        assert data_source_4.name not in soup.text
+
+    def test_get_shows_only_data_sets_with_number_columns_when_condition_depends_on_reference(
+        self, authenticated_grant_admin_client, factories
+    ):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant)
+        form = factories.form.create(collection=report)
+        question = factories.question.create(form=form, data_type=QuestionDataType.NUMBER)
+
+        data_source = factories.data_source.create(
+            grant=authenticated_grant_admin_client.grant,
+            collection=report,
+            name="Test data set",
+            type=DataSourceType.GRANT_RECIPIENT,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_capital_allocation": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Capital Allocation",
+                    )
+                }
+            ),
+        )
+
+        data_source_2 = factories.data_source.create(
+            grant=authenticated_grant_admin_client.grant,
+            collection=report,
+            name="Second data set",
+            type=DataSourceType.GRANT_RECIPIENT,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_capital_allocation": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Capital Allocation",
+                    )
+                }
+            ),
+        )
+
+        data_source_3 = factories.data_source.create(
+            grant=authenticated_grant_admin_client.grant,
+            collection=report,
+            name="Data set with just text column",
+            type=DataSourceType.GRANT_RECIPIENT,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_description": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.TEXT_SINGLE_LINE,
+                        presentation_options=QuestionPresentationOptions(),
+                        data_options=QuestionDataOptions(),
+                        original_column_name="Description",
+                    )
+                }
+            ),
+        )
+
+        with authenticated_grant_admin_client.session_transaction() as sess:
+            sess["question"] = AddConditionDependsOnSessionModel(
+                component_id=question.id,
             ).model_dump(mode="json")
 
         response = authenticated_grant_admin_client.get(
@@ -4076,6 +4278,7 @@ class TestSelectContextSourceDataSet:
         soup = BeautifulSoup(response.data, "html.parser")
         assert "Select uploaded data set" in soup.text
         assert "There are no data sets to reference in this collection" in soup.text
+        assert page_has_link(soup, "Cancel")
 
     def test_post_redirects_to_select_data_set_column_and_updates_session(
         self, authenticated_grant_admin_client, factories
@@ -4315,6 +4518,175 @@ class TestSelectContextSourceDataSetColumn:
         assert "Capital Allocation" in soup.text
         assert "Revenue Allocation" in soup.text
         assert "Description" in soup.text
+
+    def test_get_shows_only_number_columns_when_expression(self, authenticated_grant_admin_client, factories):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant)
+        form = factories.form.create(collection=report)
+        question = factories.question.create(form=form, data_type=QuestionDataType.NUMBER)
+        data_set = factories.data_source.create(
+            grant=authenticated_grant_admin_client.grant,
+            collection=report,
+            name="Test data set",
+            type=DataSourceType.GRANT_RECIPIENT,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_capital_allocation": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Capital Allocation",
+                    ),
+                    "c_revenue_allocation": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Revenue Allocation",
+                    ),
+                    "c_description": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.TEXT_SINGLE_LINE,
+                        presentation_options=QuestionPresentationOptions(),
+                        data_options=QuestionDataOptions(),
+                        original_column_name="Description",
+                    ),
+                }
+            ),
+        )
+
+        with authenticated_grant_admin_client.session_transaction() as sess:
+            sess["question"] = AddContextToExpressionsModel(
+                field=ExpressionType.VALIDATION,
+                managed_expression_name=ManagedExpressionsEnum.GREATER_THAN,
+                expression_form_data={
+                    "type": "Greater than",
+                    "greater_than_value": None,
+                    "greater_than_expression": "",
+                    "greater_than_inclusive": False,
+                    "add_context": "greater_than_expression",
+                },
+                component_id=question.id,
+            ).model_dump(mode="json")
+
+        response = authenticated_grant_admin_client.get(
+            url_for(
+                "deliver_grant_funding.select_context_source_data_set_column",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                form_id=form.id,
+                data_set_id=data_set.id,
+            )
+        )
+        assert response.status_code == 200
+
+        soup = BeautifulSoup(response.data, "html.parser")
+        assert f"Select column in {data_set.name} data set" in soup.text
+        assert "Capital Allocation" in soup.text
+        assert "Revenue Allocation" in soup.text
+        assert "Description" not in soup.text
+
+    def test_get_shows_only_number_columns_when_condition_depends_on_reference(
+        self, authenticated_grant_admin_client, factories
+    ):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant)
+        form = factories.form.create(collection=report)
+        question = factories.question.create(form=form, data_type=QuestionDataType.NUMBER)
+        data_set = factories.data_source.create(
+            grant=authenticated_grant_admin_client.grant,
+            collection=report,
+            name="Test data set",
+            type=DataSourceType.GRANT_RECIPIENT,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_capital_allocation": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Capital Allocation",
+                    ),
+                    "c_revenue_allocation": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Revenue Allocation",
+                    ),
+                    "c_description": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.TEXT_SINGLE_LINE,
+                        presentation_options=QuestionPresentationOptions(),
+                        data_options=QuestionDataOptions(),
+                        original_column_name="Description",
+                    ),
+                }
+            ),
+        )
+
+        with authenticated_grant_admin_client.session_transaction() as sess:
+            sess["question"] = AddConditionDependsOnSessionModel(
+                component_id=question.id,
+            ).model_dump(mode="json")
+
+        response = authenticated_grant_admin_client.get(
+            url_for(
+                "deliver_grant_funding.select_context_source_data_set_column",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                form_id=form.id,
+                data_set_id=data_set.id,
+            )
+        )
+        assert response.status_code == 200
+
+        soup = BeautifulSoup(response.data, "html.parser")
+        assert f"Select column in {data_set.name} data set" in soup.text
+        assert "Capital Allocation" in soup.text
+        assert "Revenue Allocation" in soup.text
+        assert "Description" not in soup.text
+
+    def test_get_shows_text_when_data_set_has_no_number_columns(self, authenticated_grant_admin_client, factories):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant)
+        form = factories.form.create(collection=report)
+        question = factories.question.create(form=form, data_type=QuestionDataType.NUMBER)
+        data_set = factories.data_source.create(
+            grant=authenticated_grant_admin_client.grant,
+            collection=report,
+            name="Test data set",
+            type=DataSourceType.GRANT_RECIPIENT,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_description": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.TEXT_SINGLE_LINE,
+                        presentation_options=QuestionPresentationOptions(),
+                        data_options=QuestionDataOptions(),
+                        original_column_name="Description",
+                    ),
+                }
+            ),
+        )
+
+        with authenticated_grant_admin_client.session_transaction() as sess:
+            sess["question"] = AddContextToExpressionsModel(
+                field=ExpressionType.VALIDATION,
+                managed_expression_name=ManagedExpressionsEnum.GREATER_THAN,
+                expression_form_data={
+                    "type": "Greater than",
+                    "greater_than_value": None,
+                    "greater_than_expression": "",
+                    "greater_than_inclusive": False,
+                    "add_context": "greater_than_expression",
+                },
+                component_id=question.id,
+            ).model_dump(mode="json")
+
+        response = authenticated_grant_admin_client.get(
+            url_for(
+                "deliver_grant_funding.select_context_source_data_set_column",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                form_id=form.id,
+                data_set_id=data_set.id,
+            )
+        )
+        assert response.status_code == 200
+
+        soup = BeautifulSoup(response.data, "html.parser")
+        assert f"Select column in {data_set.name} data set" in soup.text
+        assert "You cannot reference this data set because there are no columns with numbers" in soup.text
+        assert page_has_link(soup, "Cancel")
 
     def test_post_with_component_session_model_new_question_redirects_and_updates_session(
         self, authenticated_grant_admin_client, factories


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-1147

## 📝 Description
During the referencing flow, we might need to filter out certain data set or data set columns in certain circumstances, eg. if the referencing flow started in a condition or validation then we should only show data sets that have number columns on the select data set page and should only show number columns on the select data set column page.

This is to prevent errors should someone accidentally insert a reference to a text column in a validation or condition and the expression engine would try to evaluate something like `2 < some_text_value`.

Because we now filter out column choices, we also need some copy should someone tweak the URL and try to reference columns for a data set which wouldn't have number columns while in an expression reference flow.

## 📸 Show the thing (screenshots, gifs)
<!-- Include screenshots for UI changes, new features, or visual modifications -->
<!-- Use "Before" and "After" sections if showing changes to existing functionality -->

### Before
<!-- Screenshot or description of previous state -->

### After
<!-- Screenshot or description of new state -->

## 🧪 Testing
<!-- Describe how you've tested this change, and how a reviewer can test it -->

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [ ] PR title and description provide sufficient context for reviewers
- [ ] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- [ ] No N+1 query problems introduced
- [ ] Any new DB queries include appropriate where clauses based on the user's permissions

### Testing
- [ ] I have tested this change and it meets the acceptance criteria for the ticket
- [ ] I need the reviewer(s) to pull and run this change locally
- [ ] New (non-developer) functionality has appropriate unit and integration tests
- [ ] End-to-end tests have been updated (if applicable)
- [ ] Edge cases and error conditions are tested

## 📚 Additional Notes
<!-- Any additional context, concerns, or considerations for reviewers -->
