### PR TITLE
Order grant recipients by organisation name consistently

### DIFF
--- a/app/common/data/interfaces/grant_recipients.py
+++ b/app/common/data/interfaces/grant_recipients.py
@@ -30,6 +30,8 @@ def get_grant_recipients(
     if with_organisations:
         stmt = stmt.options(selectinload(GrantRecipient.organisation))
 
+    stmt = stmt.join(Organisation, GrantRecipient.organisation_id == Organisation.id).order_by(Organisation.name)
+
     return db.session.scalars(stmt).unique().all()
 
 

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_details.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_details.html
@@ -98,7 +98,7 @@
         {% endset %}
         {% do tableRows.append([{"html": noGrantRecipientsHtml, "colspan": 2}]) %}
       {% else %}
-        {% for grant_recipient in grant_recipients | sort(attribute="organisation.name") %}
+        {% for grant_recipient in grant_recipients %}
           {% set userDetails %}
             <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-0">Can edit and submit reports:</p>
             {% if grant_recipient.data_providers %}


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
Consistently sort grant recipients by organisation name so that the list of grant recipients in Deliver will be ordered the same as the list in the admin panels.