### PR TITLE
FSPT-1269 - Calculations content review

### DIFF
--- a/app/common/collections/forms.py
+++ b/app/common/collections/forms.py
@@ -73,7 +73,7 @@ class ErrorListEntry:
 
     @property
     def error_message(self) -> str:
-        return f"Check your answer for {self.question.name}"
+        return f"Check {self.question.name}"
 
 
 @dataclass

--- a/app/common/expressions/forms.py
+++ b/app/common/expressions/forms.py
@@ -331,7 +331,6 @@ class CustomValidationExpressionForm(ExceptionRenderingFormMixin, FlaskForm):
     )
     custom_message = StringField(
         "Error message",
-        description="For example, “Total spend cannot be more than capital spend plus revenue spend”",
         widget=GovTextArea(),
         validators=[DataRequired()],
     )

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/macros/render_calculated_form_fields.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/macros/render_calculated_form_fields.html
@@ -40,19 +40,9 @@
   }}
 {% endmacro %}
 
-{% macro render_calculated_validation_custom_expression_field(form) %}
+{% macro render_calculated_validation_custom_expression_field(form, customExpressionHint) %}
   {% set addDataToExpressionButton %}
     {{ form.add_context(params={"html": "Reference data <span class='govuk-visually-hidden'>for calculation</span>", "classes": "govuk-button--secondary app-context-aware--button", "value": "custom_expression"}) }}
-  {% endset %}
-  {% set customExpressionHint %}
-    <p class="govuk-body">Use number question references, calculation symbols and numbers to describe what the answer needs to be. Start with referencing this question.</p>
-
-    <p class="govuk-body govuk-!-margin-bottom-0">For example, if this question asks for the total spend and the answer should equal previous answers for capital spend plus revenue spend, the calculation would be:</p>
-
-    <div class="govuk-inset-text govuk-!-margin-top-0">
-      <span class="app-context-aware-editor--valid-reference">((total spend))</span> == <span class="app-context-aware-editor--valid-reference">((capital spend))</span> +
-      <span class="app-context-aware-editor--valid-reference">((revenue spend))</span>
-    </div>
   {% endset %}
 
   <div data-module="context-aware-editor" data-toolbar-enabled="false" data-i18n="{}" data-wrapper-classes="govuk-input--width-40">
@@ -80,7 +70,7 @@
   }}
 {% endmacro %}
 
-{% macro render_calculated_validation_custom_message_field(form) %}
+{% macro render_calculated_validation_custom_message_field(form,customMessageHint) %}
   {% set addDataToMessageButton %}
     {{ form.add_context(params={"html": "Reference data <span class='govuk-visually-hidden'>for error message</span>", "classes": "govuk-button--secondary app-context-aware--button", "value": "custom_message"}) }}
   {% endset %}
@@ -88,6 +78,7 @@
     <div class="govuk-!-display-none" data-context nonce="{{ csp_nonce() }}">{{ g.context_keys_and_labels | tojson }}</div>
     {{
       form.custom_message(params={
+      "hint":{"html": customMessageHint},
       "label": {"classes": "govuk-!-font-weight-bold"},
         "attributes": {"data-module": "textarea-no-newlines", "data-context-aware-editor-target": ""},
         "formGroup": {

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/macros/render_calculated_form_fields.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/macros/render_calculated_form_fields.html
@@ -1,13 +1,15 @@
 {% from "deliver_grant_funding/macros/calculation_symbols.html" import calculation_symbols %}
 {% from "govuk_frontend_jinja/components/details/macro.html" import govukDetails %}
 
-{% macro render_calculated_condition_custom_expression_field(form) %}
+{% macro render_calculated_condition_custom_expression_field(form, is_group) %}
   {% set addDataToExpressionButton %}
     {{ form.add_context(params={"html": "Reference data <span class='govuk-visually-hidden'>for calculation</span>", "classes": "govuk-button--secondary app-context-aware--button", "value": "custom_expression"}) }}
   {% endset %}
   {% set customExpressionHint %}
-    <p class="govuk-body">Use number question references, calculation symbols and numbers to describe when to show this question to the user.</p>
-    <p class="govuk-body govuk-!-margin-bottom-0">For example, if you need to show the question when the capital spend value plus the revenue spend value is more than the funding value, the calculation would be:</p>
+    <p class="govuk-body">Use number question references, calculation symbols and numbers to describe when to show this {{ "group" if is_group else "question" }} to the user.</p>
+    <p class="govuk-body govuk-!-margin-bottom-0">
+      For example, if you need to show the {{ "group" if is_group else "question" }} when the capital spend value plus the revenue spend value is more than the funding value, the calculation would be:
+    </p>
 
     <div class="govuk-inset-text govuk-!-margin-top-0">
       <span class="app-context-aware-editor--valid-reference">((capital spend))</span> + <span class="app-context-aware-editor--valid-reference">((revenue spend))</span> >

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/add_question_condition_select_calculation.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/add_question_condition_select_calculation.html
@@ -18,11 +18,14 @@
 
         {{
           govukSummaryList({
-          "rows": [{
-            "key": { "text": "This question" if not component.is_group else "This group" },
-            "value": { "text": interpolate(component.text) },
-          }, ],
-          "classes": "govuk-summary-list--no-border"})
+          "rows": [
+            {"key": {"text": "Section"}, "value": {"text": component.form.title} },
+            {
+              "key": { "text": "This question" if not component.is_group else "This group" },
+              "value": { "text": interpolate(component.text) },
+            },
+          ],
+          "classes": "app-!-border-top-line"})
         }}
       {% endset %}
 

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/calculated_condition.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/calculated_condition.html
@@ -48,11 +48,14 @@
 
       {{
         govukSummaryList({
-        "rows": [{
-          "key": { "text": "This question" if not component.is_group else "This group" },
-          "value": { "text": interpolate(component.text) },
-        }, ],
-          "classes": "govuk-summary-list--no-border"})
+        "rows": [
+            {"key": {"text": "Section"}, "value": {"text": component.form.title} },
+            {
+              "key": { "text": "This question" if not component.is_group else "This group" },
+              "value": { "text": interpolate(component.text) },
+            },
+        ],
+        "classes": "app-!-border-top-line"})
       }}
       <form method="post" novalidate>
         {{ form.csrf_token }}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/calculated_condition.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/calculated_condition.html
@@ -61,10 +61,11 @@
         {{ form.csrf_token }}
         {{
           form.expression_name(params={
-          "hint":{"text":'A brief description of what the calculated answer must be to meet the condition. For example, the question is shown when “Capital and revenue spend are more than the funding amount”.'},
+          "hint":{"text":'A brief description of what the calculated answer must be to meet the condition. For example, the '
+          + ('question' if not component.is_group else 'group') + ' is shown when “Capital and revenue spend are more than the funding amount”.'},
           "label": {"classes": "govuk-!-font-weight-bold"},})
         }}
-        {{ render_calculated_condition_custom_expression_field(form) }}
+        {{ render_calculated_condition_custom_expression_field(form, component.is_group) }}
         {{ form.submit(params={"text": submit_label, "classes": "govuk-!-margin-top-6"}) }}
       </form>
     </div>

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/calculated_validation.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/calculated_validation.html
@@ -49,11 +49,13 @@
       {{
         govukSummaryList({
           "rows": [
+            {"key": {"text": "Section"}, "value": {"text": question.form.title} },
             {"key": {"text": "This question"}, "value": {"text": interpolate(question.text, with_interpolation_highlighting=True)} },
           ],
-          "classes": "govuk-summary-list--no-border"
+          "classes": "app-!-border-top-line"
         })
       }}
+
       <form method="post" novalidate>
         {{ form.csrf_token }}
 

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/calculated_validation.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/calculated_validation.html
@@ -56,8 +56,23 @@
       }}
       <form method="post" novalidate>
         {{ form.csrf_token }}
-        {{ render_calculated_validation_custom_expression_field(form) }}
-        {{ render_calculated_validation_custom_message_field(form) }}
+
+
+        {% set customExpressionHint %}
+          <p class="govuk-body">Use number question references, calculation symbols and numbers to describe what the answer needs to be. Start with referencing this question.</p>
+
+          <p class="govuk-body govuk-!-margin-bottom-0">For example, if this question asks for the total spend and the answer should equal previous answers for capital spend plus revenue spend, the calculation would be:</p>
+
+          <div class="govuk-inset-text govuk-!-margin-top-0">
+            <span class="app-context-aware-editor--valid-reference">((total spend))</span> == <span class="app-context-aware-editor--valid-reference">((capital spend))</span> +
+            <span class="app-context-aware-editor--valid-reference">((revenue spend))</span>
+          </div>
+        {% endset %}
+        {% set customMessageHint %}
+          <p class="govuk-body">For example, “Total spend cannot be more than capital spend plus revenue spend”</p>
+        {% endset %}
+        {{ render_calculated_validation_custom_expression_field(form,customExpressionHint) }}
+        {{ render_calculated_validation_custom_message_field(form,customMessageHint) }}
         {{ form.submit(params={"text": submit_label, "classes": "govuk-!-margin-top-6"}) }}
       </form>
     </div>

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/manage_group_validation.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/manage_group_validation.html
@@ -54,8 +54,21 @@
       }}
       <form method="post" novalidate>
         {{ form.csrf_token }}
-        {{ render_calculated_validation_custom_expression_field(form) }}
-        {{ render_calculated_validation_custom_message_field(form) }}
+        {% set customExpressionHint %}
+          <p class="govuk-body">Use number question references, calculation symbols and numbers to describe what the answer needs to be. You must include at least one question from this group.</p>
+
+          <p class="govuk-body govuk-!-margin-bottom-0">For example, if the actual spend and forecast spend from this question group should equal the grant allocation, the calculation would be:</p>
+
+          <div class="govuk-inset-text govuk-!-margin-top-0">
+            <span class="app-context-aware-editor--valid-reference">((actual spend))</span> + <span class="app-context-aware-editor--valid-reference">((forecast spend))</span> ==
+            <span class="app-context-aware-editor--valid-reference">((grant allocation))</span>
+          </div>
+        {% endset %}
+        {% set customMessageHint %}
+          <p class="govuk-body">For example, "The actual spend plus forecast spend must be the same as the grant allocation"</p>
+        {% endset %}
+        {{ render_calculated_validation_custom_expression_field(form,customExpressionHint) }}
+        {{ render_calculated_validation_custom_message_field(form,customMessageHint) }}
         {{ form.submit(params={"text": submit_label, "classes": "govuk-!-margin-top-6"}) }}
       </form>
     </div>

--- a/tests/e2e/deliver_grant_funding/test_create_preview_collection.py
+++ b/tests/e2e/deliver_grant_funding/test_create_preview_collection.py
@@ -198,9 +198,7 @@ section_1_questions_with_groups_to_test: dict[str, TQuestionToTest] = {
                 "options": QuestionPresentationOptions(),
                 "data_options": QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
                 "answers": [
-                    QuestionResponse(
-                        "40", "Check your answer for First number amount (40)", expect_group_validation_error=True
-                    ),
+                    QuestionResponse("40", "Check First number amount (40)", expect_group_validation_error=True),
                     QuestionResponse("30"),
                 ],
             },
@@ -211,9 +209,7 @@ section_1_questions_with_groups_to_test: dict[str, TQuestionToTest] = {
                 "options": QuestionPresentationOptions(),
                 "data_options": QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
                 "answers": [
-                    QuestionResponse(
-                        "56", "Check your answer for Second number amount (56)", expect_group_validation_error=True
-                    ),
+                    QuestionResponse("56", "Check Second number amount (56)", expect_group_validation_error=True),
                     QuestionResponse("30"),
                 ],
             },
@@ -224,9 +220,7 @@ section_1_questions_with_groups_to_test: dict[str, TQuestionToTest] = {
                 "options": QuestionPresentationOptions(),
                 "data_options": QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
                 "answers": [
-                    QuestionResponse(
-                        "45", "Check your answer for Third number amount (45)", expect_group_validation_error=True
-                    ),
+                    QuestionResponse("45", "Check Third number amount (45)", expect_group_validation_error=True),
                     QuestionResponse("30"),
                 ],
             },


### PR DESCRIPTION
## 🎫 Ticket
[FSPT-1269 ](https://mhclgdigital.atlassian.net/browse/FSPT-1269) Final content review for calculations

## 📝 Description
This PR introduces some small content tweaks to align the system with design artefacts:
- Making all the calculations pages display the current section and question/group name at the top of the page, using the govukSummaryList component with dividing lines.
- Updating the error message shown for each question in a validated group to remove 'your answer for', so it now reads "Check Q1 spend (£4)" rather than "Check your answer for Q1 spend (£4)"
- Separating out the content for the calculation hint between conditions and validations as the wording needs to be different

## 📸 Show the thing (screenshots, gifs)
| Description | Before | After |
|--------|--------|--------|
| Adding section name for context | <img width="671" height="372" alt="Screenshot 2026-04-27 at 12 23 19" src="https://github.com/user-attachments/assets/44fa2473-3e62-45f5-8497-ff0772129dd0" /> | <img width="732" height="490" alt="Screenshot 2026-04-27 at 12 08 21" src="https://github.com/user-attachments/assets/721d1e96-420e-401d-ac58-df2781bd83ec" /> |
| Question/group wording on condition page | <img width="689" height="583" alt="Screenshot 2026-04-27 at 12 22 58" src="https://github.com/user-attachments/assets/63d599c2-28e4-4248-b6dc-8fa909cb5fc8" /> | <img width="739" height="639" alt="Screenshot 2026-04-27 at 12 16 50" src="https://github.com/user-attachments/assets/1e6d457c-17c1-4701-9df8-326dcc1fcdae" /> | 
| Group validation error message | <img width="728" height="694" alt="Screenshot 2026-04-27 at 12 22 35" src="https://github.com/user-attachments/assets/27db7269-9897-4660-ae05-15f9ed9bef44" /> |<img width="718" height="695" alt="Screenshot 2026-04-27 at 12 18 21" src="https://github.com/user-attachments/assets/afa29836-54e6-485d-8bd7-d8ef6aa57eb2" /> |
| Group validation text | <img width="727" height="451" alt="Screenshot 2026-04-27 at 12 22 02" src="https://github.com/user-attachments/assets/c8009cb1-a31e-444f-bb1f-9c52e1ca0dfa" /> | <img width="739" height="451" alt="Screenshot 2026-04-27 at 12 20 47" src="https://github.com/user-attachments/assets/a052d2cd-1c47-4cc5-be6d-ff2169344201" /> |

