### PR TITLE
Export grant config via email

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -133,7 +133,6 @@ class _SharedConfig(_BaseConfig):
     AWS_S3_BUCKET_NAME: str
     SUBMISSION_FILES_PREFIX: str = "uploaded-submission-files"
     REFERENCE_FILES_PREFIX: str = "data-set-uploads"
-    GRANT_EXPORT_FILES_PREFIX: str = "grant-exports"
 
     # Basic auth
     BASIC_AUTH_ENABLED: bool = False
@@ -275,6 +274,7 @@ class _SharedConfig(_BaseConfig):
     GOVUK_NOTIFY_ACCESS_SUBMISSION_CERTIFICATION_SUBMISSION_CONFIRMATION_TEMPLATE_ID: str = (
         "a8ffd584-0899-40df-ba56-cba95b2db0de"
     )
+    GOVUK_NOTIFY_GRANT_EXPORT_TEMPLATE_ID: str = "580db095-420e-4690-a640-c0ebd9748a0b"
 
     ASSETS_VITE_BASE_URL: str = "http://localhost:5173"
     ASSETS_VITE_LIVE_ENABLED: bool = False

--- a/app/developers/commands.py
+++ b/app/developers/commands.py
@@ -64,7 +64,8 @@ from app.common.expressions import ExpressionContext
 from app.common.helpers.collections import SubmissionHelper
 from app.common.utils import slugify
 from app.developers import developers_blueprint
-from app.extensions import db, s3_service
+from app.extensions import db, notification_service, s3_service
+from app.services.notify import NotificationError
 
 export_path = Path.cwd() / "app" / "developers" / "data" / "grants.json"
 
@@ -175,15 +176,15 @@ def _import_organisations_and_handle_org_ids(export_data: ExportData) -> ExportD
 
 @developers_blueprint.cli.command("export-grants", help="Export configured grants to consistently seed environments")
 @click.argument("grant_ids", nargs=-1, type=click.UUID)
-@click.option("--output", type=click.Choice(["file", "stdout", "s3"]), default="file")
-@click.option("--s3-key", help="S3 object key to upload to. Required when --output=s3.")
+@click.option("--output", type=click.Choice(["file", "stdout", "email"]), default="file")
+@click.option("--email", "email_address", help="Email address to send the export to. Required when --output=email.")
 @click.option(
     "--exclude-users/--no-exclude-users",
     default=None,
     help="Replace all user associations when exporting with a single placeholder user. Forced on for production.",
 )
 def export_grants(  # noqa: C901
-    grant_ids: list[uuid.UUID], output: str, s3_key: str | None, exclude_users: bool | None
+    grant_ids: list[uuid.UUID], output: str, email_address: str | None, exclude_users: bool | None
 ) -> None:
     from faker import Faker
 
@@ -194,12 +195,8 @@ def export_grants(  # noqa: C901
     else:
         exclude_users = bool(exclude_users)
 
-    if output == "s3":
-        if not s3_key:
-            raise click.ClickException("--s3-key is required when --output=s3")
-        required_prefix = current_app.config["GRANT_EXPORT_FILES_PREFIX"].rstrip("/") + "/"
-        if not s3_key.startswith(required_prefix):
-            raise click.ClickException(f"--s3-key must start with {required_prefix!r}")
+    if output == "email" and not email_address:
+        raise click.ClickException("--email is required when --output=email")
 
     if len(grant_ids) == 0:
         if not export_path.exists():
@@ -329,16 +326,18 @@ def export_grants(  # noqa: C901
             click.echo("\n\n\n")
             click.echo(f"Written {len(grants)} grants to stdout")
 
-        case "s3":
-            assert s3_key is not None
-            buf = FileStorage(
-                stream=BytesIO(export_json.encode("utf-8")),
-                filename=s3_key,
-                content_type="application/json",
-            )
-            s3_service.upload_file(buf, key=s3_key)
-            bucket = current_app.config["AWS_S3_BUCKET_NAME"]
-            click.echo(f"Written {len(grants)} grants to s3://{bucket}/{s3_key}")
+        case "email":
+            assert email_address is not None
+            try:
+                notification_service.send_grant_export(
+                    email_address,
+                    export_json=export_json,
+                    filename="grants.json",
+                )
+            except (ValueError, NotificationError) as e:
+                raise click.ClickException(f"Failed to send grant export: {e}") from e
+
+            click.echo(f"Emailed {len(grants)} grants to {email_address}")
 
 
 @developers_blueprint.cli.command("seed-grants", help="Load exported grants into the database")

--- a/app/services/notify.py
+++ b/app/services/notify.py
@@ -1,11 +1,12 @@
 import dataclasses
 import datetime
 import uuid
+from io import BytesIO
 from typing import TYPE_CHECKING, Any
 from zoneinfo import ZoneInfo
 
 from flask import Flask, current_app, url_for
-from notifications_python_client import NotificationsAPIClient
+from notifications_python_client import NotificationsAPIClient, prepare_upload
 from notifications_python_client.errors import APIError, TokenError
 
 from app.common.data.types import GrantRecipientModeEnum
@@ -364,4 +365,26 @@ class NotificationService:
             email_address,
             current_app.config["GOVUK_NOTIFY_ACCESS_SUBMISSION_CERTIFICATION_SUBMISSION_CONFIRMATION_TEMPLATE_ID"],
             personalisation=personalisation,
+        )
+
+    def send_grant_export(
+        self,
+        email_address: str,
+        *,
+        export_json: str,
+        filename: str,
+    ) -> Notification:
+        if not email_address.endswith(current_app.config["INTERNAL_DOMAINS"]):
+            raise ValueError("Cannot send grant export to external email address")
+
+        return self._send_email(
+            email_address,
+            current_app.config["GOVUK_NOTIFY_GRANT_EXPORT_TEMPLATE_ID"],
+            personalisation={
+                "link_to_file": prepare_upload(
+                    BytesIO(export_json.encode("utf-8")),
+                    filename=filename,
+                    confirm_email_before_download=True,
+                ),
+            },
         )

--- a/tests/integration/developers/test_commands.py
+++ b/tests/integration/developers/test_commands.py
@@ -3,6 +3,7 @@ import json
 
 import click
 import pytest
+from click import ClickException
 from sqlalchemy import select
 
 from app.common.collections.types import SingleChoiceFromListAnswer, TextSingleLineAnswer
@@ -422,7 +423,7 @@ class TestExportGrants:
         question = factories.question.create(data_type=QuestionDataType.TEXT_SINGLE_LINE)
         grant = question.form.collection.grant
 
-        _export_grants(grant_ids=[grant.id], output="stdout", s3_key=None, exclude_users=True)
+        _export_grants(grant_ids=[grant.id], output="stdout", email_address=None, exclude_users=True)
 
         payload = _extract_stdout_json(capsys.readouterr().out)
 
@@ -445,7 +446,7 @@ class TestExportGrants:
         grant = question.form.collection.grant
         monkeypatch.setitem(app.config, "IS_PRODUCTION", True)
 
-        _export_grants(grant_ids=[grant.id], output="stdout", s3_key=None, exclude_users=False)
+        _export_grants(grant_ids=[grant.id], output="stdout", email_address=None, exclude_users=False)
 
         captured = capsys.readouterr().out
         assert "--no-exclude-users is ignored in production" in captured
@@ -454,39 +455,41 @@ class TestExportGrants:
         assert [u["id"] for u in payload["users"]] == ["00000000-0000-0000-0000-000000000001"]
         assert payload["grants"][0]["collections"][0]["created_by_id"] == "00000000-0000-0000-0000-000000000001"
 
-    def test_s3_output_uploads_export(self, db_session, factories, mock_s3_service_calls):
+    def test_email_output_sends_export(self, db_session, factories, mock_notification_service_calls, capsys):
         question = factories.question.create(data_type=QuestionDataType.TEXT_SINGLE_LINE)
         grant = question.form.collection.grant
 
         _export_grants(
             grant_ids=[grant.id],
-            output="s3",
-            s3_key="grant-exports/test-export.json",
+            output="email",
+            email_address="dev@test.communities.gov.uk",
             exclude_users=True,
         )
 
-        assert len(mock_s3_service_calls.upload_file_calls) == 1
-        call = mock_s3_service_calls.upload_file_calls[0]
-        uploaded_file = call.args[0]
-        assert call.kwargs["key"] == "grant-exports/test-export.json"
-        uploaded_file.stream.seek(0)
-        payload = json.loads(uploaded_file.stream.read().decode("utf-8"))
-        assert [u["id"] for u in payload["users"]] == ["00000000-0000-0000-0000-000000000001"]
-        assert payload["grants"][0]["grant"]["id"] == str(grant.id)
+        assert len(mock_notification_service_calls) == 1
+        call = mock_notification_service_calls[0]
+        assert call.args[0] == "dev@test.communities.gov.uk"
+        assert call.kwargs["personalisation"]["link_to_file"]["filename"] == "grants.json"
+        assert "Emailed 1 grants to dev@test.communities.gov.uk" in capsys.readouterr().out
 
-    def test_s3_output_requires_key(self, db_session, factories):
+    def test_cannot_export_to_external_email(self, factories):
         question = factories.question.create(data_type=QuestionDataType.TEXT_SINGLE_LINE)
         grant = question.form.collection.grant
 
-        with pytest.raises(click.ClickException, match="--s3-key is required"):
-            _export_grants(grant_ids=[grant.id], output="s3", s3_key=None, exclude_users=True)
+        with pytest.raises(ClickException, match="Cannot send grant export to external email address"):
+            _export_grants(
+                grant_ids=[grant.id],
+                output="email",
+                email_address="dev@gmail.com",
+                exclude_users=True,
+            )
 
-    def test_s3_output_rejects_key_outside_prefix(self, db_session, factories):
+    def test_email_output_requires_email(self, db_session, factories):
         question = factories.question.create(data_type=QuestionDataType.TEXT_SINGLE_LINE)
         grant = question.form.collection.grant
 
-        with pytest.raises(click.ClickException, match="must start with 'grant-exports/'"):
-            _export_grants(grant_ids=[grant.id], output="s3", s3_key="exports/test.json", exclude_users=True)
+        with pytest.raises(click.ClickException, match="--email is required"):
+            _export_grants(grant_ids=[grant.id], output="email", email_address=None, exclude_users=True)
 
 
 class TestSeedGrants:

--- a/tests/unit/services/test_notify.py
+++ b/tests/unit/services/test_notify.py
@@ -1,13 +1,14 @@
 import datetime
 import uuid
 
+import pytest
 import responses
 from responses import matchers
 
-from app import notification_service
 from app.common.data.types import GrantRecipientModeEnum, SubmissionEventType
 from app.common.helpers.collections import SubmissionHelper
 from app.common.helpers.submission_events import SubmissionEventHelper
+from app.extensions import notification_service
 from app.services.notify import Notification
 
 
@@ -496,3 +497,43 @@ class TestNotificationService:
         )
         assert resp == Notification(id=uuid.UUID("00000000-0000-0000-0000-000000000000"))
         assert request_matcher.call_count == 1
+
+    @responses.activate
+    def test_send_grant_export(self, app):
+        export_json = '{"hello": "world"}'
+        request_matcher = responses.post(
+            url="https://api.notifications.service.gov.uk/v2/notifications/email",
+            status=201,
+            match=[
+                matchers.json_params_matcher(
+                    {
+                        "email_address": "dev@communities.gov.uk",
+                        "template_id": "580db095-420e-4690-a640-c0ebd9748a0b",
+                        "personalisation": {
+                            "link_to_file": {
+                                "file": "eyJoZWxsbyI6ICJ3b3JsZCJ9",
+                                "filename": "grants.json",
+                                "confirm_email_before_download": True,
+                                "retention_period": None,
+                            },
+                        },
+                    }
+                )
+            ],
+            json={"id": "00000000-0000-0000-0000-000000000000"},
+        )
+        resp = notification_service.send_grant_export(
+            "dev@communities.gov.uk",
+            export_json=export_json,
+            filename="grants.json",
+        )
+        assert resp == Notification(id=uuid.UUID("00000000-0000-0000-0000-000000000000"))
+        assert request_matcher.call_count == 1
+
+    def test_send_grant_export_rejects_external_email(self, app):
+        with pytest.raises(ValueError, match="Cannot send grant export to external email address"):
+            notification_service.send_grant_export(
+                "external@gmail.com",
+                export_json='{"hello": "world"}',
+                filename="grants.json",
+            )


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
Having to log into s3 and find/download the file has proven annoying - let's allow it to be sent directly to a developer by email.

Used like so: `awsedev -- uv run ./scripts/run-ad-hoc-task.py --command "flask developers export-grants <uuid> --output email --email <email> --exclude-users"`