### PR TITLE
FSPT-1290 - Prevent create submission race condition

### DIFF
--- a/app/access_grant_funding/routes/runner.py
+++ b/app/access_grant_funding/routes/runner.py
@@ -13,7 +13,7 @@ from app.common.collections.runner import AGFFormRunner
 from app.common.collections.types import FileUploadAnswer
 from app.common.data import interfaces
 from app.common.data.interfaces import rollback
-from app.common.data.interfaces.collections import get_collection, get_submissions_by_grant_recipient_collection
+from app.common.data.interfaces.collections import get_collection
 from app.common.data.types import FormRunnerState, RoleEnum, SubmissionModeEnum
 from app.common.exceptions import SubmissionAnswerConflict
 from app.common.expressions import ExpressionContext, interpolate
@@ -41,21 +41,12 @@ def route_to_submission(organisation_id: UUID, grant_id: UUID, collection_id: UU
             )
         )
 
-    submissions = get_submissions_by_grant_recipient_collection(grant_recipient, collection_id)
-    if len(submissions) > 1:
-        raise RuntimeError(
-            f"Multiple submissions found for collection {collection_id} and grant recipient {grant_recipient.id}"
-        )
-
-    submission = submissions[0] if submissions else None
-    if not submission:
-        # ensure the collection is part of this grant
-        collection = get_collection(collection_id, grant_id=grant_id)
-        # Use the grant recipient's mode to determine the submission mode
-        submission_mode = SubmissionModeEnum(grant_recipient.mode.value)
-        submission = interfaces.collections.create_submission(
-            collection=collection, grant_recipient=grant_recipient, created_by=user, mode=submission_mode
-        )
+    submission = interfaces.collections.get_or_create_submission(
+        collection=collection,
+        grant_recipient=grant_recipient,
+        created_by=user,
+        mode=SubmissionModeEnum(grant_recipient.mode.value),
+    )
 
     submission_helper = SubmissionHelper(submission)
     if submission_helper.in_answers_locked_state:

--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -386,6 +386,30 @@ def get_submissions_by_grant_recipient_collection(
     ).all()
 
 
+def get_or_create_submission(
+    *, collection: Collection, grant_recipient: GrantRecipient, created_by: User, mode: SubmissionModeEnum
+) -> Submission:
+    # Acquire a transaction-scoped advisory lock keyed on (grant_recipient, collection) BEFORE
+    # reading submissions. This prevents the double-click race condition: without the lock, two
+    # concurrent requests can both read an empty list and each proceed to create a submission
+    # before either commits. The lock serialises them so the second request re-reads after the
+    # first commits and finds the existing submission instead. pg_advisory_xact_lock releases
+    # automatically when the transaction ends, with no manual cleanup required.
+    db.session.execute(
+        text("SELECT pg_advisory_xact_lock(hashtext(:key))"),
+        {"key": f"{grant_recipient.id}:{collection.id}"},
+    )
+
+    submissions = get_submissions_by_grant_recipient_collection(grant_recipient, collection.id)
+    if len(submissions) > 1:
+        raise RuntimeError(
+            f"Multiple submissions found for collection {collection.id} and grant recipient {grant_recipient.id}"
+        )
+    if submissions:
+        return submissions[0]
+    return create_submission(collection=collection, grant_recipient=grant_recipient, created_by=created_by, mode=mode)
+
+
 def get_submissions_by_user(
     user: User, collection_id: UUID, submission_mode: SubmissionModeEnum
 ) -> Sequence[Submission]:

--- a/tests/integration/access_grant_funding/routes/test_runner.py
+++ b/tests/integration/access_grant_funding/routes/test_runner.py
@@ -1,6 +1,5 @@
 from datetime import date, datetime
 from io import BytesIO
-from unittest.mock import patch
 
 import pytest
 from _pytest.fixtures import FixtureRequest
@@ -151,14 +150,13 @@ class TestRouteToSubmission:
             collection_id=collection.id,
         )
 
-        # Simulate a double-click race condition: both requests read an empty submissions list before
-        # either has committed, so both proceed to create a submission.
-        with patch(
-            "app.access_grant_funding.routes.runner.get_submissions_by_grant_recipient_collection",
-            return_value=[],
-        ):
-            authenticated_grant_recipient_member_client.get(url, follow_redirects=False)
-            authenticated_grant_recipient_member_client.get(url, follow_redirects=False)
+        # Simulate a double-click by making two requests in rapid succession. In production the
+        # requests would be concurrent, but the test client is single-threaded so they run
+        # sequentially — this means the test cannot directly exercise the advisory lock blocking
+        # behaviour. What it does verify is that the route handles repeated calls correctly and
+        # produces a single submission.
+        response1 = authenticated_grant_recipient_member_client.get(url, follow_redirects=False)
+        response2 = authenticated_grant_recipient_member_client.get(url, follow_redirects=False)
 
         submissions = (
             db_session.query(Submission)
@@ -170,9 +168,16 @@ class TestRouteToSubmission:
         )
         assert len(submissions) == 1
 
-        response = authenticated_grant_recipient_member_client.get(url, follow_redirects=False)
-        assert response.status_code == 302
-        assert str(submissions[0].id) in response.location
+        expected_location = url_for(
+            "access_grant_funding.tasklist",
+            organisation_id=grant_recipient.organisation.id,
+            grant_id=grant_recipient.grant.id,
+            submission_id=submissions[0].id,
+        )
+        assert response1.status_code == 302
+        assert response1.location == expected_location
+        assert response2.status_code == 302
+        assert response2.location == expected_location
 
     def test_route_to_submission_redirects_to_locked_page_if_locked(
         self, factories, authenticated_grant_recipient_member_client, submission_awaiting_sign_off

--- a/tests/integration/access_grant_funding/routes/test_runner.py
+++ b/tests/integration/access_grant_funding/routes/test_runner.py
@@ -1,5 +1,6 @@
 from datetime import date, datetime
 from io import BytesIO
+from unittest.mock import patch
 
 import pytest
 from _pytest.fixtures import FixtureRequest
@@ -137,6 +138,41 @@ class TestRouteToSubmission:
                 ),
                 follow_redirects=False,
             )
+
+    def test_double_click_start_report_does_not_create_duplicate_submissions(
+        self, factories, authenticated_grant_recipient_member_client, db_session
+    ):
+        grant_recipient = authenticated_grant_recipient_member_client.grant_recipient
+        collection = factories.collection.create(grant=grant_recipient.grant)
+        url = url_for(
+            "access_grant_funding.route_to_submission",
+            organisation_id=grant_recipient.organisation.id,
+            grant_id=grant_recipient.grant.id,
+            collection_id=collection.id,
+        )
+
+        # Simulate a double-click race condition: both requests read an empty submissions list before
+        # either has committed, so both proceed to create a submission.
+        with patch(
+            "app.access_grant_funding.routes.runner.get_submissions_by_grant_recipient_collection",
+            return_value=[],
+        ):
+            authenticated_grant_recipient_member_client.get(url, follow_redirects=False)
+            authenticated_grant_recipient_member_client.get(url, follow_redirects=False)
+
+        submissions = (
+            db_session.query(Submission)
+            .where(
+                Submission.grant_recipient_id == grant_recipient.id,
+                Submission.collection_id == collection.id,
+            )
+            .all()
+        )
+        assert len(submissions) == 1
+
+        response = authenticated_grant_recipient_member_client.get(url, follow_redirects=False)
+        assert response.status_code == 302
+        assert str(submissions[0].id) in response.location
 
     def test_route_to_submission_redirects_to_locked_page_if_locked(
         self, factories, authenticated_grant_recipient_member_client, submission_awaiting_sign_off


### PR DESCRIPTION
## 🎫 Ticket
[FSPT-1290](https://mhclgdigital.atlassian.net/browse/FSPT-1290) - Prevent duplicate submissions

## 📝 Description
The above ticket was raised after we had a P4 incident where a user was able to create duplicate submission records for a report that does not support multiple submissions. Our theory is that they double clicked the 'start report' link, creating 2 concurrent requests to start the same report.

This PR creates a new function `get_or_create_submission` for use on the 'Start Report' link. It uses an advisory lock, keyed on the grant recipient and collection ids, to check if a submission already exists and then create one if it doesn't. If one already exists, it returns the existing submission.

This lock is released automatically when the transaction completes. 

The flow is now:                                                               
                                                                                                                                                                                
  Request A: BEGIN TRANSACTION                                                                                                                                                  
  Request B: BEGIN TRANSACTION                                                                                                                                                  
                                                                                                                                                                                
  Request A: pg_advisory_xact_lock('grant_recipient_id:collection_id') → acquired                                                                                               
  Request B: pg_advisory_xact_lock('grant_recipient_id:collection_id') → blocks, waiting...                                                                                     
                                                                                                                                                                                
  Request A: get_submissions_by_grant_recipient_collection → []                                                                                                                 
  Request A: create_submission → INSERT submission                                                                                                                              
  Request A: COMMIT, lock released                                                                                                                                              
                                                                                                                                                                                
  Request B: lock acquired (unblocks)                                                                                                                                           
  Request B: get_submissions_by_grant_recipient_collection → [A's submission]                                                                                                   
  Request B: submission found, returns it without creating                                                                                                                      
  Request B: COMMIT                                                                                                                                                             
                                                                                                                                                                                
  Both requests redirect to the same submission. One INSERT, no duplicates.  

## 📸 Show the thing (screenshots, gifs)
No visible changes to the users

## 🧪 Testing
- Integration test added to make two sequential calls to start report. This doesn't test the race condition, but does confirm that two requests will only result in one submission.
- Haven't been able to recreate the exact conditions that led to the error.

## 📋 Developer Checklist

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- [x] No N+1 query problems introduced
- [x] Any new DB queries include appropriate where clauses based on the user's permissions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [ ] New (non-developer) functionality has appropriate unit and integration tests
- [ ] End-to-end tests have been updated (if applicable)
- [ ] Edge cases and error conditions are tested



[FSPT-1290]: https://mhclgdigital.atlassian.net/browse/FSPT-1290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ