### PR TITLE
Bugfix/catch empty data set csv

### DIFF
--- a/app/common/data/interfaces/data_sets.py
+++ b/app/common/data/interfaces/data_sets.py
@@ -45,6 +45,9 @@ def get_data_source(
 
 
 def _build_schema_from_column_mappings(column_mappings: list[DataSetColumnMapping]) -> DataSourceSchema:
+    if not column_mappings:
+        raise ValueError("Cannot build a schema from an empty list of column mappings")
+
     schema_dict = {}
     for mapping in column_mappings:
         if mapping.data_type == QuestionDataType.NUMBER:

--- a/app/deliver_grant_funding/forms.py
+++ b/app/deliver_grant_funding/forms.py
@@ -49,7 +49,7 @@ from app.common.forms.fields import MHCLGAccessibleAutocomplete
 from app.common.forms.helpers import get_referenceable_questions
 from app.common.forms.validators import CommunitiesEmail, WordRange
 from app.common.helpers.feature_flags import FeatureFlags
-from app.constants import DATA_SET_EXTERNAL_ID_COLUMN_HEADER, DATA_SET_GRANT_RECIPIENT_COLUMN_HEADER
+from app.constants import DATA_SET_IDENTIFIER_COLUMN_HEADERS
 from app.deliver_grant_funding.data_sets import CellError, DataTypeError, DecimalError, PrefixError, SuffixError
 from app.deliver_grant_funding.session_models import DataSetColumnMapping
 
@@ -958,19 +958,24 @@ class UploadDataSetForm(FlaskForm):
             if not fieldnames or not any(fieldname.strip() for fieldname in fieldnames):
                 raise ValidationError("The CSV file must have at least one column")
 
+            if any(not fieldname.strip() for fieldname in fieldnames):
+                raise ValidationError("The CSV file must have a name for each column")
+
             if any(None in row or None in row.values() for row in rows):
                 raise ValidationError(
                     "The CSV file contains rows which are longer or shorter than the number of columns"
                 )
 
             if self.data_source_type.data in [DataSourceType.GRANT_RECIPIENT, DataSourceType.PROJECT_LEVEL]:
-                missing = []
-                if DATA_SET_EXTERNAL_ID_COLUMN_HEADER not in fieldnames:
-                    missing.append(DATA_SET_EXTERNAL_ID_COLUMN_HEADER)
-                if DATA_SET_GRANT_RECIPIENT_COLUMN_HEADER not in fieldnames:
-                    missing.append(DATA_SET_GRANT_RECIPIENT_COLUMN_HEADER)
+                missing = [col for col in DATA_SET_IDENTIFIER_COLUMN_HEADERS if col not in fieldnames]
                 if missing:
                     raise ValidationError(f"The CSV file must contain the columns: {', '.join(missing)}")
+
+                data_columns = [
+                    col for col in fieldnames if col.strip() and col not in DATA_SET_IDENTIFIER_COLUMN_HEADERS
+                ]
+                if not data_columns:
+                    raise ValidationError("The CSV file must contain at least one column of data")
 
             if self.data_source_type.data == DataSourceType.STATIC:
                 rows_with_missing = [

--- a/tests/integration/common/data/interfaces/test_data_sets.py
+++ b/tests/integration/common/data/interfaces/test_data_sets.py
@@ -590,16 +590,40 @@ class TestCreateUploadedDataSourceStatic:
             )
 
 
-class TestCreateUploadedDataSourceUnsupportedType:
+class TestCreateUploadedDataSourceErrors:
     def test_raises_error_for_unsupported_type(self, db_session, factories):
         grant = factories.grant.create()
         report = factories.collection.create(grant=grant)
         user = factories.user.create()
 
+        column_mappings = [
+            DataSetColumnMapping(column_name="Code", data_type=QuestionDataType.TEXT_SINGLE_LINE),
+            DataSetColumnMapping(column_name="Label", data_type=QuestionDataType.TEXT_SINGLE_LINE),
+        ]
+
         with pytest.raises(ValueError, match="Unsupported data source type"):
             create_uploaded_data_source(
                 name="Test Unsupported",
                 data_source_type=DataSourceType.CUSTOM,
+                grant_id=grant.id,
+                collection_id=report.id,
+                column_mappings=column_mappings,
+                all_rows=[],
+                user=user,
+                data_source_id=uuid.uuid4(),
+                original_filename="test.csv",
+                s3_key="data-set-uploads/test.csv",
+            )
+
+    def test_raises_error_for_empty_schema(self, db_session, factories):
+        grant = factories.grant.create()
+        report = factories.collection.create(grant=grant)
+        user = factories.user.create()
+
+        with pytest.raises(ValueError, match="Cannot build a schema from an empty list of column mappings"):
+            create_uploaded_data_source(
+                name="Test Unsupported",
+                data_source_type=DataSourceType.GRANT_RECIPIENT,
                 grant_id=grant.id,
                 collection_id=report.id,
                 column_mappings=[],

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -8077,6 +8077,56 @@ class TestUploadDataSet:
         assert response.status_code == 200
         assert page_has_error(soup, "The CSV file must have at least one column")
 
+    def test_post_raises_error_for_empty_grant_recipient_csv(
+        self, authenticated_grant_admin_client, factories, mock_s3_service_calls
+    ):
+        grant = authenticated_grant_admin_client.grant
+        report = factories.collection.create(grant=grant)
+        factories.grant_recipient.create(grant=grant, organisation__external_id="E123", organisation__name="Lothlorien")
+        factories.grant_recipient.create(grant=grant, organisation__external_id="E456", organisation__name="Numenor")
+
+        csv_content = "Organisation ID,Grant recipient\nE123,Lothlorien\nE456,Numenor"
+        data = {
+            "name": "Test Data Set",
+            "data_source_type": DataSourceType.GRANT_RECIPIENT,
+            "file": (io.BytesIO(csv_content.encode("utf-8")), "test.csv"),
+        }
+
+        response = authenticated_grant_admin_client.post(
+            url_for("deliver_grant_funding.upload_data_set", grant_id=grant.id, report_id=report.id),
+            data=data,
+            content_type="multipart/form-data",
+        )
+
+        assert response.status_code == 200
+        soup = BeautifulSoup(response.data, "html.parser")
+        assert page_has_error(soup, "The CSV file must contain at least one column of data")
+
+    def test_post_raises_error_for_empty_csv_headers(
+        self, authenticated_grant_admin_client, factories, mock_s3_service_calls
+    ):
+        grant = authenticated_grant_admin_client.grant
+        report = factories.collection.create(grant=grant)
+        factories.grant_recipient.create(grant=grant, organisation__external_id="E123", organisation__name="Lothlorien")
+        factories.grant_recipient.create(grant=grant, organisation__external_id="E456", organisation__name="Numenor")
+
+        csv_content = "Organisation ID,Grant recipient,,Identifier\nE123,Lothlorien,Elves,Trees\nE456,Numenor,Men,Boats"
+        data = {
+            "name": "Test Data Set",
+            "data_source_type": DataSourceType.GRANT_RECIPIENT,
+            "file": (io.BytesIO(csv_content.encode("utf-8")), "test.csv"),
+        }
+
+        response = authenticated_grant_admin_client.post(
+            url_for("deliver_grant_funding.upload_data_set", grant_id=grant.id, report_id=report.id),
+            data=data,
+            content_type="multipart/form-data",
+        )
+
+        assert response.status_code == 200
+        soup = BeautifulSoup(response.data, "html.parser")
+        assert page_has_error(soup, "The CSV file must have a name for each column")
+
     def test_post_too_many_rows(self, authenticated_grant_admin_client, factories):
         grant = authenticated_grant_admin_client.grant
         report = factories.collection.create(grant=grant)


### PR DESCRIPTION
## 🎫 Ticket
Bugfix

## 📝 Description
We recently saw a sentry error where an empty Grant Recipient data set had been successfully uploaded with no data columns and therefore no schema, which led to an unhandled 500 when a data set reference/expression context tried to load. 

We should never allow uploaded data sets to exist without a schema, and this was a bug in the initial upload flow work which allowed users to upload a data set with the right grant recipients but no data columns and proceed through the flow. This should be caught and flagged as an error on the file field instead, and we should also ensure that the interfaces don't allow a data set to be created with an empty schema (shouldn't happen with the guard on the file upload but just for extra safety).

## 📸 Show the thing (screenshots, gifs)
<img width="680" height="840" alt="image" src="https://github.com/user-attachments/assets/7832e203-f237-4133-b820-37cccfbd8d89" />

## 🧪 Testing
Download the grant recipient CSV and try to upload it again directly when it has no columns of data except the Organisation ID and Grant recipient name columns. It should now error.

## 📋 Developer Checklist

### Review Readiness
- [X] PR title and description provide sufficient context for reviewers
- [X] Commits are logical, self-contained, and have clear descriptions

### Testing
- [X] I have tested this change and it meets the acceptance criteria for the ticket
- ~[ ] I need the reviewer(s) to pull and run this change locally~
- [X] New (non-developer) functionality has appropriate unit and integration tests
- ~[ ] End-to-end tests have been updated (if applicable)~
- [X] Edge cases and error conditions are tested