### PR TITLE
FIX bug where changing the conditions operator with a calculated condition failed

### DIFF
--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/change_conditions_operator.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/change_conditions_operator.html
@@ -29,18 +29,27 @@
       <h2 class="govuk-heading-m">Conditions</h2>
       {% set rows = [] %}
       {% for condition in component.conditions %}
-        {% set managed = condition.managed %}
-        {% set depends_on = managed.referenced_question %}
+        {% if condition.is_managed %}
+          {% set managed = condition.managed %}
+          {% set depends_on = managed.referenced_question %}
 
 
-        {% set key_html %}
-          <span>{{ interpolate(depends_on.text, with_interpolation_highlighting=True) }}</span>
-        {% endset %}
+          {% set key_html %}
+            <span>{{ interpolate(depends_on.text, with_interpolation_highlighting=True) }}</span>
+          {% endset %}
 
 
-        {% set value_html %}
-          <span>{{ interpolate(condition.managed.message, with_interpolation_highlighting=True) }}</span>
-        {% endset %}
+          {% set value_html %}
+            <span>{{ interpolate(condition.managed.message, with_interpolation_highlighting=True) }}</span>
+          {% endset %}
+        {% else %}
+          {% set key_html %}
+            Calculated condition
+          {% endset %}
+          {% set value_html %}
+            <span>Show {{ "group" if component.is_group else "question" }} when {{ condition.evaluatable_expression.description }}</span>
+          {% endset %}
+        {% endif %}
         {% do rows.append({ "key": { "html": key_html }, "value": { "html": value_html } }) %}
       {% endfor %}
 


### PR DESCRIPTION
## 📝 Description
When multiple conditions exist for a single question or group, form designers have the option to choose if they must ALL match, or if ANY of them could match.

Clicking 'Change' for this operator was resulting in an error as the page to change between ANY and OR wasn't updated to work for non-managed expressions.

This PR updates that page to cope with both types of expression in the same way as the main list of conditions on the group/question page.

## 📸 Show the thing (screenshots, gifs)
When these conditions exist:
<img width="725" height="467" alt="Screenshot 2026-04-28 at 10 06 33" src="https://github.com/user-attachments/assets/2bf03595-f555-4032-9303-74b9a9052572" />
This page was failing to load but now works:
<img width="717" height="639" alt="Screenshot 2026-04-28 at 10 04 03" src="https://github.com/user-attachments/assets/8853cac2-7e8d-4467-bc74-2ee9062eed6d" />

## 🧪 Testing
- I've checked the page loads with different combinations of managed/unmanaged conditions, and checked the operator actually works when selected
