### PR TITLE
Fix n+1 on `list_reports` page

### DIFF
--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -359,6 +359,10 @@ def get_all_submissions_with_mode_for_collection(
             .joinedload(Collection.forms)
             .selectinload(Form.components)
             .joinedload(Component.expressions),
+            joinedload(Submission.collection)
+            .joinedload(Collection.forms)
+            .selectinload(Form._all_components)
+            .selectinload(Component.owned_component_references),
             selectinload(Submission.events),
             joinedload(Submission.created_by),
         )

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -4914,6 +4914,57 @@ class TestGetSubmissions:
                 with_users=True,
             )
 
+    def test_get_all_submissions_with_mode_for_collection_with_full_schema_no_n_plus_one(
+        self, db_session, factories, track_sql_queries
+    ):
+        collection = factories.collection.create(create_submissions__live=2)
+        form = factories.form.create(collection=collection)
+        anchor = factories.question.create(form=form)
+        for i in range(2):
+            factories.question.create(
+                form=form, text=f"Top-level ref {i} (({ExpressionReference.from_question(anchor)}))"
+            )
+        group = factories.group.create(form=form)
+        for i in range(2):
+            factories.question.create(
+                form=form, parent=group, text=f"Nested ref {i} (({ExpressionReference.from_question(anchor)}))"
+            )
+
+        with track_sql_queries() as iterate_queries:
+            submissions = get_all_submissions_with_mode_for_collection(
+                collection_id=collection.id,
+                submission_mode=SubmissionModeEnum.LIVE,
+                with_full_schema=True,
+            )
+            for submission in submissions:
+                for f in submission.collection.forms:
+                    for component in f._all_components:
+                        for _ref in component.owned_component_references:
+                            pass
+
+        baseline_queries = len(iterate_queries)
+
+        factories.submission.create(collection=collection, mode=SubmissionModeEnum.LIVE)
+        anchor2 = factories.question.create(form=form)
+        for i in range(2):
+            factories.question.create(form=form, text=f"Extra ref {i} (({ExpressionReference.from_question(anchor2)}))")
+
+        db_session.expire_all()
+
+        with track_sql_queries() as iterate_queries:
+            submissions = get_all_submissions_with_mode_for_collection(
+                collection_id=collection.id,
+                submission_mode=SubmissionModeEnum.LIVE,
+                with_full_schema=True,
+            )
+            for submission in submissions:
+                for f in submission.collection.forms:
+                    for component in f._all_components:
+                        for _ref in component.owned_component_references:
+                            pass
+
+        assert len(iterate_queries) == baseline_queries
+
 
 class TestResetTestSubmission:
     def test_reset_test_submission_only_deletes_specified_submission(self, db_session, factories):


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
The `list_reports` page iterates over all components of a report and its forms in order to calculate the status of the report. This means computing visibility for all components and checking references using `component.owned_component_references`. As we weren't preloading this, it was sending an extra SQL query for each component iterated. This will be tens/hundreds of components in all of our real reports.

Let's nix this by preloading all component references.

## 📸 Show the thing (screenshots, gifs)
<!-- Include screenshots for UI changes, new features, or visual modifications -->
<!-- Use "Before" and "After" sections if showing changes to existing functionality -->

### Before
<img width="242" height="96" alt="image" src="https://github.com/user-attachments/assets/3b48ed2e-3173-4163-9332-1550558bde8c" />


### After
<img width="241" height="111" alt="image" src="https://github.com/user-attachments/assets/7e927724-395a-49e2-8bc0-12ea71eb245d" />


## 🧪 Testing
<!-- Describe how you've tested this change, and how a reviewer can test it -->

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- [x] No N+1 query problems introduced
- [x] Any new DB queries include appropriate where clauses based on the user's permissions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [ ] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [ ] End-to-end tests have been updated (if applicable)
- [ ] Edge cases and error conditions are tested