### PR TITLE
Fix/calculations error messages

### DIFF
--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -1664,11 +1664,11 @@ def _validate_reference(  # noqa:C901
             attached_to_component, referenced_question
         ):
             raise InvalidReferenceInExpression(
-                f"Reference is not valid: {wrapped_reference}",
+                f"Reference is not valid: {referenced_question.name}",
                 field_name=field_name_for_error_message,
                 bad_reference=wrapped_reference,
-                form_error_message=f"You cannot use {wrapped_reference} because it is in the same group as "
-                f"{referenced_question.name}",
+                form_error_message=f"You cannot use {referenced_question.name} because it is in the same group as "
+                f"{attached_to_component.name}",
             )
 
         if not components_in_valid_add_another_combination(

--- a/app/common/expressions/__init__.py
+++ b/app/common/expressions/__init__.py
@@ -75,8 +75,10 @@ class UndefinedOperatorInExpression(
         operator: str,
     ):
         self.operator = operator
-        # TODO map these to better names as this will print the ast node name, eg. Pow() not **
-        super().__init__(message, f"You cannot use {self.operator} in calculations")
+        super().__init__(
+            message,
+            "The calculation does not make sense. Check it is a complete calculation that only uses accepted symbols",
+        )
 
 
 class DisallowedExpression(

--- a/app/deliver_grant_funding/routes/reports.py
+++ b/app/deliver_grant_funding/routes/reports.py
@@ -2194,7 +2194,7 @@ def add_calculated_condition(grant_id: UUID, component_id: UUID) -> ResponseRetu
 
     # Note: Mild shortcut; the alternative is passing this through a lot of templates/template logic
     g.context_keys_and_labels = ExpressionContext.get_context_keys_and_labels(
-        collection=component.form.collection, expression_context_end_point=component
+        collection=component.form.collection,
     )
     return render_template(
         "deliver_grant_funding/reports/calculated_condition.html",
@@ -2287,7 +2287,7 @@ def edit_calculated_condition(grant_id: UUID, expression_id: UUID) -> ResponseRe
 
     # Note: Mild shortcut; the alternative is passing this through a lot of templates/template logic
     g.context_keys_and_labels = ExpressionContext.get_context_keys_and_labels(
-        collection=component.form.collection, expression_context_end_point=component
+        collection=component.form.collection,
     )
     return render_template(
         "deliver_grant_funding/reports/calculated_condition.html",
@@ -2833,7 +2833,7 @@ def add_custom_question_validation(grant_id: UUID, question_id: UUID) -> Respons
 
     # Note: Mild shortcut; the alternative is passing this through a lot of templates/template logic
     g.context_keys_and_labels = ExpressionContext.get_context_keys_and_labels(
-        collection=question.form.collection, expression_context_end_point=question
+        collection=question.form.collection,
     )
     return render_template(
         "deliver_grant_funding/reports/calculated_validation.html",
@@ -2930,7 +2930,7 @@ def edit_custom_question_validation(grant_id: UUID, question_id: UUID, expressio
 
     # Note: Mild shortcut; the alternative is passing this through a lot of templates/template logic
     g.context_keys_and_labels = ExpressionContext.get_context_keys_and_labels(
-        collection=question.form.collection, expression_context_end_point=question
+        collection=question.form.collection,
     )
     return render_template(
         "deliver_grant_funding/reports/calculated_validation.html",
@@ -3013,7 +3013,7 @@ def add_group_validation(grant_id: UUID, group_id: UUID) -> ResponseReturnValue:
             )
 
     g.context_keys_and_labels = ExpressionContext.get_context_keys_and_labels(
-        collection=group.form.collection, expression_context_end_point=group, expression_type=ExpressionType.VALIDATION
+        collection=group.form.collection, expression_type=ExpressionType.VALIDATION
     )
     return render_template(
         "deliver_grant_funding/reports/manage_group_validation.html",
@@ -3107,7 +3107,7 @@ def edit_group_validation(grant_id: UUID, group_id: UUID, expression_id: UUID) -
             )
 
     g.context_keys_and_labels = ExpressionContext.get_context_keys_and_labels(
-        collection=group.form.collection, expression_context_end_point=group, expression_type=ExpressionType.VALIDATION
+        collection=group.form.collection, expression_type=ExpressionType.VALIDATION
     )
     return render_template(
         "deliver_grant_funding/reports/manage_group_validation.html",

--- a/tests/integration/common/expressions/test_forms.py
+++ b/tests/integration/common/expressions/test_forms.py
@@ -519,7 +519,10 @@ class TestValidateCustomSyntax:
                 evaluation_context=evaluation_context,
             )
 
-        assert e.value.form_error_message == "You cannot use Pow() in calculations"
+        assert (
+            e.value.form_error_message
+            == "The calculation does not make sense. Check it is a complete calculation that only uses accepted symbols"
+        )
 
     def test_invalid_expression_multiple_references_to_self(self, factories, mocker):
         db_form = factories.form.create()

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -5845,6 +5845,42 @@ class TestAddCalculatedCondition:
             "The calculation does not make sense",
         )
 
+    def test_post_error_wrong_order(self, authenticated_platform_admin_client, factories, db_session):
+        report = factories.collection.create(name="Test Report")
+        db_form = factories.form.create(collection=report, title="Organisation information")
+
+        q1, q2, q3 = factories.question.create_batch(3, form=db_form, data_type=QuestionDataType.NUMBER)
+
+        assert len(q1.expressions) == 0
+
+        form = CalculatedConditionForm(
+            data={
+                "custom_expression": f"(({q1.safe_qid}))<(({q2.safe_qid}))",
+                "expression_name": "new name",
+            },
+            component=q1,
+            interpolation_context=ExpressionContext(),
+            evaluation_context=ExpressionContext(),
+        )
+
+        response = authenticated_platform_admin_client.post(
+            url_for(
+                "deliver_grant_funding.add_calculated_condition",
+                grant_id=authenticated_platform_admin_client.grant.id,
+                component_id=q1.id,
+            ),
+            data=get_form_data(form),
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 200
+
+        assert len(q1.expressions) == 0
+        assert page_has_error(
+            BeautifulSoup(response.data, "html.parser"),
+            "because it comes after this question",
+        )
+
 
 class TestEditCalculatedCondition:
     @pytest.mark.parametrize(


### PR DESCRIPTION
## 📝 Description
Fixing error message bugs found during PO sign off for the calculations work (overarching parent: [FSPT-1105](https://mhclgdigital.atlassian.net/browse/FSPT-1105))

## 📸 Show the thing (screenshots, gifs)
| Notes | Before | After | Testing |
|--------|--------|--------|--------|
| Using generic error message instead of ast node name for unavailable symbols | <img width="708" height="396" alt="Screenshot 2026-04-29 at 06 39 17" src="https://github.com/user-attachments/assets/ae4b2c83-e453-4d39-b546-8eee431b2984" /> | <img width="702" height="406" alt="Screenshot 2026-04-29 at 06 40 29" src="https://github.com/user-attachments/assets/3a999276-4cd7-4e84-acf0-5cfb9fb7abcd" /> | Use an unavailable symbol, eg. `**`, in a calculation |
| Error message displaying safe_qid not question name when trying to reference a question in the same single page group | <img width="710" height="427" alt="Screenshot 2026-04-29 at 06 38 11" src="https://github.com/user-attachments/assets/de42278d-57f3-417c-b4a2-5a78ea32cdf7" /> | <img width="704" height="419" alt="Screenshot 2026-04-29 at 06 37 11" src="https://github.com/user-attachments/assets/08d77136-dd6d-450b-bc42-c4ed11efa3ff" /> | Paste in the reference to another question in the same single page group |
| If you pasted in a reference to a later question, it told you it didn't exist rather than it was in the wrong order | <img width="710" height="419" alt="Screenshot 2026-04-29 at 06 42 23" src="https://github.com/user-attachments/assets/6980cfae-ddc3-448d-b9db-3139b38c06c2" /> | <img width="701" height="387" alt="Screenshot 2026-04-29 at 07 00 05" src="https://github.com/user-attachments/assets/a9da1f0e-9db4-47b7-b42b-34dcbcfcce2a" /> | Paste in a reference to a later question |



[FSPT-1105]: https://mhclgdigital.atlassian.net/browse/FSPT-1105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ