### PR TITLE
Allow seeding grants from any file path

### DIFF
--- a/app/developers/commands.py
+++ b/app/developers/commands.py
@@ -341,11 +341,19 @@ def export_grants(  # noqa: C901
 
 
 @developers_blueprint.cli.command("seed-grants", help="Load exported grants into the database")
-def seed_grants() -> None:  # noqa: C901
+@click.option(
+    "--file",
+    "file",
+    type=click.Path(exists=True, dir_okay=False, readable=True, path_type=Path),
+    default=export_path,
+    show_default=True,
+    help="Path to the exported grants JSON file to load.",
+)
+def seed_grants(file: Path) -> None:  # noqa: C901
     if current_app.config["IS_PRODUCTION"]:
         raise click.ClickException("seed-grants must not be run in production; it deletes and recreates grants.")
 
-    with open(export_path) as infile:
+    with open(file) as infile:
         raw_export_json = infile.read()
         export_data: ExportData = json.loads(raw_export_json)
 

--- a/tests/integration/developers/test_commands.py
+++ b/tests/integration/developers/test_commands.py
@@ -493,7 +493,9 @@ class TestExportGrants:
 
 
 class TestSeedGrants:
-    def test_refuses_to_run_in_production(self, app, monkeypatch):
+    def test_refuses_to_run_in_production(self, app, monkeypatch, tmp_path):
         monkeypatch.setitem(app.config, "IS_PRODUCTION", True)
+        export_file = tmp_path / "grants.json"
+        export_file.write_text("{}")
         with pytest.raises(click.ClickException, match="must not be run in production"):
-            _seed_grants()
+            _seed_grants(file=export_file)


### PR DESCRIPTION
Previously this was hardcoded to read from `app/developers/data/grants.json` - now you can point it at anything on your file system. Makes it easier to read eg a downloaded grant config in your downloads folder.