### PR TITLE
Fix/calculated condition incompatible data types

### DIFF
--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -1556,6 +1556,7 @@ def _validate_reference(  # noqa:C901
 ) -> ExpressionReference:
     wrapped_reference = reference.wrapped
     unwrapped_reference = reference.unwrapped
+    is_calculation: bool = field_name_for_error_message == "custom_expression"
 
     if not unwrapped_reference:
         raise InvalidReferenceInExpression(
@@ -1585,6 +1586,16 @@ def _validate_reference(  # noqa:C901
         )
 
     if referenced_question := reference.question:
+        # For calculations, the reference must of type number
+        if is_calculation and referenced_question.data_type != QuestionDataType.NUMBER:
+            raise IncompatibleDataTypeException(
+                f"Incompatible data type: {referenced_question.id} ({referenced_question.data_type}). "
+                "Only numbers can be referenced in custom_expression",
+                component=attached_to_component,
+                depends_on_component=referenced_question,
+                field_name=field_name_for_error_message,
+                form_error_message=f"Reference is not valid due to incompatible data types: {wrapped_reference}",
+            )
         # for validation, the question being validated (ie attached to) needs to have the same data type as the question
         # being referenced. Groups have no data_type so this check is skipped for group-level validations.
         if (
@@ -1603,19 +1614,17 @@ def _validate_reference(  # noqa:C901
 
         # for conditions, the question being tested (could be any prior question) needs to have the same data type as
         # the question being referenced.
-        if (
-            expression_type == ExpressionType.CONDITION
-            and question_to_test
-            and not question_to_test.data_type == referenced_question.data_type
-        ):
-            raise IncompatibleDataTypeException(
-                f"Incompatible data types: {attached_to_component.id} ({attached_to_component.data_type}) and "
-                f"{referenced_question.id} ({referenced_question.data_type})",
-                component=attached_to_component,
-                depends_on_component=referenced_question,
-                field_name=field_name_for_error_message,
-                form_error_message=f"Reference is not valid due to incompatible data types: {wrapped_reference}",
-            )
+        if expression_type == ExpressionType.CONDITION:
+            if question_to_test and not question_to_test.data_type == referenced_question.data_type:
+                raise IncompatibleDataTypeException(
+                    f"Incompatible data types: {attached_to_component.id} ({attached_to_component.data_type}) and "
+                    f"{referenced_question.id} ({referenced_question.data_type})",
+                    component=attached_to_component,
+                    depends_on_component=referenced_question,
+                    field_name=field_name_for_error_message,
+                    form_error_message=f"Reference is not valid due to incompatible data types: {wrapped_reference}",
+                )
+
         if not is_component_dependency_order_valid(attached_to_component, referenced_question):
             # Can't think of a better way right now for a custom validation expression to reference itself
             # TODO: ideally this would check a pre-configured ExpressionContext that uses an
@@ -1623,7 +1632,7 @@ def _validate_reference(  # noqa:C901
             #       don't need to have this logic in multiple places.
             references_self_in_custom_validation = (
                 expression_type == ExpressionType.VALIDATION
-                and field_name_for_error_message == "custom_expression"
+                and is_calculation
                 and referenced_question == attached_to_component
             )
             # A validation attached to a group is allowed to reference any question nested within that group:

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -5236,7 +5236,7 @@ class TestValidateReference:
         assert e.value.field_name == "custom_expression"
         assert e.value.bad_reference == "((q_bad_ref))"
 
-    def test_custom_expression_wrong_data_type(self, factories):
+    def test_custom_expression_wrong_data_type_validation(self, factories):
         form = factories.form.create()
         q1 = factories.question.create(form=form)
         q2 = factories.question.create(form=form, data_type=QuestionDataType.NUMBER)
@@ -5253,6 +5253,42 @@ class TestValidateReference:
         assert "Reference is not valid due to incompatible data types" in e.value.form_error_message
         assert e.value.field_name == "custom_expression"
         assert e.value.depends_on_question == q1
+
+    def test_validate_reference_wrong_data_type_condition_referenced_question(self, factories):
+        form = factories.form.create()
+        q1 = factories.question.create(form=form, data_type=QuestionDataType.TEXT_SINGLE_LINE)
+        q2, q3 = factories.question.create_batch(2, form=form, data_type=QuestionDataType.NUMBER)
+        context = ExpressionContext.build_expression_context(form.collection, mode="interpolation")
+        with pytest.raises(IncompatibleDataTypeException) as e:
+            _validate_reference(
+                reference=ExpressionReference(q2.safe_qid),
+                attached_to_component=q3,
+                expression_context=context,
+                expression_type=ExpressionType.CONDITION,
+                field_name_for_error_message="test",
+                question_to_test=q1,
+            )
+        assert "Reference is not valid due to incompatible data types" in e.value.form_error_message
+        assert e.value.field_name == "test"
+        assert e.value.depends_on_question == q2
+
+    def test_validate_reference_non_number_in_calculated_condition(self, factories):
+        form = factories.form.create()
+        q1 = factories.question.create(form=form, data_type=QuestionDataType.TEXT_SINGLE_LINE)
+        q2 = factories.question.create(form=form, data_type=QuestionDataType.NUMBER)
+        context = ExpressionContext.build_expression_context(form.collection, mode="interpolation")
+        with pytest.raises(IncompatibleDataTypeException) as e:
+            _validate_reference(
+                reference=ExpressionReference(q1.safe_qid),
+                attached_to_component=q2,
+                expression_context=context,
+                expression_type=ExpressionType.CONDITION,
+                field_name_for_error_message="custom_expression",
+                question_to_test=None,
+            )
+        assert "Reference is not valid due to incompatible data types" in e.value.form_error_message
+        assert e.value.field_name == "custom_expression"
+        assert e.value.depends_on_question == q2
 
     def test_invalid_add_another_reference(self, factories):
         form = factories.form.create()

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -3063,7 +3063,7 @@ class TestExpressions:
 
     def test_add_question_condition_custom(self, db_session, factories):
         form = factories.form.create()
-        q1, q2, q3 = factories.question.create_batch(3, form=form)
+        q1, q2, q3 = factories.question.create_batch(3, form=form, data_type=QuestionDataType.NUMBER)
         user = factories.user.create()
 
         # configured by the user interface
@@ -3083,6 +3083,31 @@ class TestExpressions:
         # check the serialised context lines up with the values in the managed expression
         assert from_db.expressions[0].managed_name is None
         assert from_db.expressions[0].is_custom
+
+    def test_add_question_condition_custom_raises_incompatible_data_type(self, db_session, factories):
+        form = factories.form.create()
+        q1, q2, q3 = factories.question.create_batch(3, form=form)
+        user = factories.user.create()
+
+        # configured by the user interface
+        custom_expr = CustomExpression(
+            custom_expression=f"(({q1.safe_qid})) > (({q2.safe_qid}))", custom_message="Failed condition"
+        )
+        with pytest.raises(IncompatibleDataTypeException):
+            add_component_condition(q3, user, custom_expr)
+
+    def test_add_group_condition_custom_raises_incompatible_data_type(self, db_session, factories):
+        form = factories.form.create()
+        q1, q2, q3 = factories.question.create_batch(3, form=form)
+        group = factories.group.create(form=form)
+        user = factories.user.create()
+
+        # configured by the user interface
+        custom_expr = CustomExpression(
+            custom_expression=f"(({q1.safe_qid})) > (({q2.safe_qid}))", custom_message="Failed condition"
+        )
+        with pytest.raises(IncompatibleDataTypeException):
+            add_component_condition(group, user, custom_expr)
 
     def test_add_condition_raises_if_same_page(self, db_session, factories):
         group = factories.group.create(
@@ -3248,7 +3273,7 @@ class TestExpressions:
 
     def test_add_component_validation_custom(self, db_session, factories, mock_sentry_metrics):
         form = factories.form.create()
-        q1, q2 = factories.question.create_batch(2, form=form)
+        q1, q2 = factories.question.create_batch(2, form=form, data_type=QuestionDataType.NUMBER)
         user = factories.user.create()
 
         # configured by the user interface
@@ -3362,6 +3387,50 @@ class TestExpressions:
         from_db = get_group_by_id(group.id)
         assert from_db.validations == []
 
+    def test_add_component_validation_on_group_rejects_wrong_data_type(self, db_session, factories):
+        from app.common.data.types import QuestionPresentationOptions
+
+        db_form = factories.form.create()
+        text_question = factories.question.create(
+            form=db_form,
+            name="text question",
+        )
+        group = factories.group.create(
+            form=db_form,
+            name="Spend totals",
+            presentation_options=QuestionPresentationOptions(show_questions_on_the_same_page=True),
+        )
+        factories.question.create(
+            form=db_form,
+            parent=group,
+            data_type=QuestionDataType.NUMBER,
+        )
+        user = factories.user.create()
+
+        custom_expression = CustomExpression(
+            custom_expression=f"(({text_question.safe_qid})) > 0",
+            custom_message="Must be positive",
+        )
+
+        with pytest.raises(IncompatibleDataTypeException):
+            add_component_validation(group, user, custom_expression)
+
+    def test_add_component_validation_custom_raises_incompatible_data_type(
+        self, db_session, factories, mock_sentry_metrics
+    ):
+        form = factories.form.create()
+        q1, q2 = factories.question.create_batch(2, form=form)
+        user = factories.user.create()
+
+        # configured by the user interface
+        custom_expression = CustomExpression(
+            custom_expression=f"(({q2.safe_qid})) >= (({q1.safe_qid}))",
+            custom_message=f"The answer must be greater than or equal to (({q1.safe_qid}))",
+        )
+
+        with pytest.raises(IncompatibleDataTypeException):
+            add_component_validation(q2, user, custom_expression)
+
     def test_update_expression(self, db_session, factories):
         q0 = factories.question.create()
         question = factories.question.create(form=q0.form)
@@ -3378,7 +3447,7 @@ class TestExpressions:
 
     def test_update_expression_custom(self, db_session, factories):
         form = factories.form.create()
-        q1, q2 = factories.question.create_batch(2, form=form)
+        q1, q2 = factories.question.create_batch(2, form=form, data_type=QuestionDataType.NUMBER)
         user = factories.user.create()
 
         # configured by the user interface
@@ -5288,7 +5357,7 @@ class TestValidateReference:
             )
         assert "Reference is not valid due to incompatible data types" in e.value.form_error_message
         assert e.value.field_name == "custom_expression"
-        assert e.value.depends_on_question == q2
+        assert e.value.depends_on_question == q1
 
     def test_invalid_add_another_reference(self, factories):
         form = factories.form.create()
@@ -5396,6 +5465,23 @@ class TestValidateReference:
                     question_to_test=None,
                 )
                 == q1.safe_qid
+            )
+
+    def test_invalid_data_type_group_validation(self, factories):
+        form = factories.form.create()
+        q1 = factories.question.create(form=form, data_type=QuestionDataType.TEXT_SINGLE_LINE)
+        group = factories.group.create(form=form)
+
+        expression_context = ExpressionContext.build_expression_context(form.collection, "interpolation", None, None)
+
+        with pytest.raises(IncompatibleDataTypeException):
+            _validate_reference(
+                reference=ExpressionReference(q1.safe_qid),
+                attached_to_component=group,
+                expression_context=expression_context,
+                expression_type=ExpressionType.VALIDATION,
+                field_name_for_error_message="custom_expression",
+                question_to_test=None,
             )
 
 

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -6009,7 +6009,7 @@ class TestEditCalculatedCondition:
         form = factories.form.create(collection=report, title="Organisation information")
 
         target_question = factories.question.create(form=form)
-        later_question = factories.question.create(form=form)
+        later_question = factories.question.create(form=form, data_type=QuestionDataType.NUMBER)
         question_condition = Expression.from_evaluatable_expression(
             evaluatable_expression=CustomExpression(custom_expression="4>5", expression_name="test name"),
             expression_type=ExpressionType.CONDITION,


### PR DESCRIPTION
## 🎫 Ticket
Bug found during PO sign off of calculations work ([FSPT-1105](https://mhclgdigital.atlassian.net/browse/FSPT-1105))

## 📝 Description
If a form designer were to copy and paste a reference to a non-number question into the calculation field of a custom condition, or of a group validation expression, this should fail validation. However we discovered this was passing validation.

This change adds a check to `validate_reference` to make this correctly fail validation.

## 📸 Show the thing (screenshots, gifs)

### Before
The condition would save with a reference to a previous text question (called name)
<img width="705" height="498" alt="Screenshot 2026-04-29 at 13 52 10" src="https://github.com/user-attachments/assets/f858f9e7-336f-4023-acf3-69622b62dfeb" />


### After
Validation failure message when trying to use a text question reference (called name)
<img width="708" height="571" alt="Screenshot 2026-04-29 at 13 51 33" src="https://github.com/user-attachments/assets/02a311b0-2b52-4b03-bd97-54612e2cfca4" />


[FSPT-1105]: https://mhclgdigital.atlassian.net/browse/FSPT-1105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ