### PR TITLE
Address n+1 queries on data sources on list_submissions

### DIFF
--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -364,6 +364,7 @@ def get_all_submissions_with_mode_for_collection(
             .selectinload(Form._all_components)
             .selectinload(Component.owned_component_references),
             selectinload(Submission.events),
+            selectinload(Submission.data_sources),
             joinedload(Submission.created_by),
         )
     elif with_users:
@@ -454,6 +455,7 @@ def get_submission(
                     ),
                 ),
                 selectinload(Submission.events),
+                selectinload(Submission.data_sources),
             ]
         )
 

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -837,10 +837,11 @@ class TestGetSubmission:
         # Expected queries:
         # * Load the submission with collection and forms(sections)
         # * Load the submission events
+        # * Load the submission data_sources
         # * For all forms, load the top-level components and their expressions
         # * For all forms, load every component, their expressions, their nested components+expressions
         # * For all forms, load every component's set of component references
-        assert len(queries) == 5
+        assert len(queries) == 6
 
         # Iterate over all the related models; check that no further SQL queries are emitted. The count is just a noop.
         count = 0


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
This view needs to evaluate the status of all submissions, which is currently done by walking every form and component for every submission. Walking the components for a submission needs to pull the data sources to evaluate certain conditions.

Because we don't eagerly load data sources for each submission, we end up emitting an extra query for each submission as we load the page. 

By eagerly loading the data source we can make sure it's available to SQLAlchemy when iterating submissions, avoiding the n+1 query loop.

This will be required for performance until we start caching each submission's status and can avoid calculating it dynamically on demand each time.


## 📸 Show the thing (screenshots, gifs)
<!-- Include screenshots for UI changes, new features, or visual modifications -->
<!-- Use "Before" and "After" sections if showing changes to existing functionality -->

### Before
<img width="234" height="98" alt="image" src="https://github.com/user-attachments/assets/7a4f43f8-ab75-44c3-9f1f-3f929cb1ac4c" />

### After
<img width="259" height="101" alt="image" src="https://github.com/user-attachments/assets/f34ae1d9-a244-4bce-9719-7337e3f7e854" />


## 🧪 Testing
<!-- Describe how you've tested this change, and how a reviewer can test it -->

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- [x] No N+1 query problems introduced
- [x] Any new DB queries include appropriate where clauses based on the user's permissions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [ ] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [ ] End-to-end tests have been updated (if applicable)
- [ ] Edge cases and error conditions are tested