### PR TITLE
Lock report PDF generation

### DIFF
--- a/app/access_grant_funding/routes/reports.py
+++ b/app/access_grant_funding/routes/reports.py
@@ -1,5 +1,6 @@
 import io
 import os
+import threading
 from uuid import UUID
 
 from flask import abort, current_app, flash, redirect, render_template, send_file, url_for
@@ -20,6 +21,13 @@ from app.common.helpers.collections import CollectionHelper, SubmissionHelper
 from app.extensions import auto_commit_after_request
 from app.metrics import MetricEventName, emit_metric_count
 from app.types import FlashMessageType
+
+# Playwright's sync API runs an asyncio loop while it talks to chromium. Under gunicorn+gevent,
+# multiple greenlets share an OS thread and asyncio's running-loop is thread-local, so concurrent
+# PDF exports on one worker would observe each other's loop and Playwright would raise. Serialise
+# PDF generation per worker. threading.Lock is monkey-patched by gevent into a greenlet-aware lock,
+# so blocked greenlets cooperatively yield rather than block the OS thread.
+_pdf_export_lock = threading.Lock()
 
 
 @access_grant_funding_blueprint.route(
@@ -149,36 +157,37 @@ def export_report_pdf(organisation_id: UUID, grant_id: UUID, submission_id: UUID
         interpolate=SubmissionHelper.get_interpolator(collection=submission.collection, submission_helper=submission),
     )
 
-    # as we're calling to an external binary this makes sure we're set up if the flask app
-    # has defined its own path, this could also be set in the container terraform
-    if current_app.config["PLAYWRIGHT_BROWSERS_PATH"] is not None:
-        os.environ["PLAYWRIGHT_BROWSERS_PATH"] = current_app.config["PLAYWRIGHT_BROWSERS_PATH"]
+    with _pdf_export_lock:
+        # as we're calling to an external binary this makes sure we're set up if the flask app
+        # has defined its own path, this could also be set in the container terraform
+        if current_app.config["PLAYWRIGHT_BROWSERS_PATH"] is not None:
+            os.environ["PLAYWRIGHT_BROWSERS_PATH"] = current_app.config["PLAYWRIGHT_BROWSERS_PATH"]
 
-    # note that we're opening a new browser per request
-    # with a single request at a time this responds in ~200ms but if we ever anticipate higher
-    # simultaneous usage we'd probably want a singleton module to manage the browser connection
-    # and close and open pages as needed, this would allow a lot more simultaneous requests to be
-    # processed performantly
-    with sync_playwright() as playwright:
-        browser = playwright.chromium.launch()
+        # note that we're opening a new browser per request
+        # with a single request at a time this responds in ~200ms but if we ever anticipate higher
+        # simultaneous usage we'd probably want a singleton module to manage the browser connection
+        # and close and open pages as needed, this would allow a lot more simultaneous requests to be
+        # processed performantly
+        with sync_playwright() as playwright:
+            browser = playwright.chromium.launch()
 
-        page = browser.new_page(
-            java_script_enabled=False,
-            http_credentials={
-                "username": current_app.config["BASIC_AUTH_USERNAME"],
-                "password": current_app.config["BASIC_AUTH_PASSWORD"],
-            }
-            if current_app.config["BASIC_AUTH_ENABLED"]
-            else None,
-        )
-        page.set_content(html_content, wait_until="load")
+            page = browser.new_page(
+                java_script_enabled=False,
+                http_credentials={
+                    "username": current_app.config["BASIC_AUTH_USERNAME"],
+                    "password": current_app.config["BASIC_AUTH_PASSWORD"],
+                }
+                if current_app.config["BASIC_AUTH_ENABLED"]
+                else None,
+            )
+            page.set_content(html_content, wait_until="load")
 
-        pdf_bytes = page.pdf(
-            format="A4",
-            print_background=True,
-            scale=0.9,
-            margin={"top": "5mm", "bottom": "5mm", "left": "5mm", "right": "5mm"},
-        )
+            pdf_bytes = page.pdf(
+                format="A4",
+                print_background=True,
+                scale=0.9,
+                margin={"top": "5mm", "bottom": "5mm", "left": "5mm", "right": "5mm"},
+            )
 
     emit_metric_count(MetricEventName.SUBMISSION_PDF_DOWNLOADED, submission=submission.submission)
 

--- a/tests/integration/access_grant_funding/routes/test_reports.py
+++ b/tests/integration/access_grant_funding/routes/test_reports.py
@@ -349,6 +349,62 @@ class TextExportReportPDF:
             assert response.headers["Content-Type"] == "application/pdf"
 
 
+class TestExportReportPDFLock:
+    def test_lock_is_held_around_sync_playwright(
+        self,
+        authenticated_grant_recipient_member_client,
+        submission_awaiting_sign_off,
+        monkeypatch,
+    ):
+        from app.access_grant_funding.routes import reports as reports_module
+
+        observed_lock_states: list[bool] = []
+
+        class _FakePage:
+            def set_content(self, html_content, wait_until):
+                pass
+
+            def pdf(self, **kwargs):
+                return b"%PDF-fake-content"
+
+        class _FakeBrowser:
+            def new_page(self, **kwargs):
+                return _FakePage()
+
+        class _FakeChromium:
+            def launch(self):
+                return _FakeBrowser()
+
+        class _FakePlaywright:
+            chromium = _FakeChromium()
+
+        class _FakeSyncPlaywrightCM:
+            def __enter__(self_inner):
+                observed_lock_states.append(reports_module._pdf_export_lock.locked())
+                return _FakePlaywright()
+
+            def __exit__(self_inner, *args):
+                pass
+
+        monkeypatch.setattr(reports_module, "sync_playwright", lambda: _FakeSyncPlaywrightCM())
+
+        client = authenticated_grant_recipient_member_client
+        grant_recipient = client.grant_recipient
+
+        response = client.get(
+            url_for(
+                "access_grant_funding.export_report_pdf",
+                organisation_id=grant_recipient.organisation.id,
+                grant_id=grant_recipient.grant.id,
+                submission_id=submission_awaiting_sign_off.id,
+            )
+        )
+
+        assert response.status_code == 200
+        assert observed_lock_states == [True]
+        assert not reports_module._pdf_export_lock.locked()
+
+
 class TestListReports:
     def test_get_list_reports(self, authenticated_grant_recipient_member_client, factories):
         organisation = authenticated_grant_recipient_member_client.organisation or factories.organisation.create(


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
We've seen intermittent errors on the export_report_pdf endpoint where Playwright errors because it's "already in" an async event loop.

This is happening when multiple requests are fired to the server at once to export a report, eg double clicking the "Export PDF" link. If these two requests reach the backend at the same time, gevent can spin up two workers for the requests in the same thread. These two requests can then both try to go into Playwright's sync API, which under the hood just wraps an async loop temporarily.

When the first request launches the browser to build the PDF it starts an async loop; when the second request arrives it tries to enter the sync loop and spawn another async loop under the hood, which then throws the error.

This patch adds a lock around PDF generation so that only one worker in a thread can be handling playwright at a time. The second worker will block until the first is complete.

We've only seen this in deployed environments because of the difference in how we run the apps (locally we use flask's debugging server which is single thread/single worker).

Fixes: https://communitiesuk.sentry.io/issues/116414809

## 🧪 Testing
Deployed to dev and confirmed fix by spamming 'Download PDF' - no longer erroring and all PDFs download correctly, albeit some delayed due to the locking.

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [ ] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [ ] End-to-end tests have been updated (if applicable)
- [ ] Edge cases and error conditions are tested