### PR TITLE
FSPT-1298 - Reopening submission event

### DIFF
--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -1522,6 +1522,14 @@ def add_submission_event(
         case SubmissionEventType.SUBMISSION_DECLINED_BY_CERTIFIER:
             emit_metric_count(MetricEventName.SUBMISSION_CERTIFICATION_DECLINED, submission=submission)
 
+        case SubmissionEventType.SUBMISSION_REOPENED:
+            emit_metric_count(MetricEventName.SUBMISSION_REOPENED, submission=submission)
+        case _:
+            current_app.logger.error(
+                "No metric configured for submission event %(event_type)s for submission %(submission_id)s",
+                {"event_type": event_type, "submission_id": submission.id},
+            )
+
     return submission
 
 

--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -65,7 +65,11 @@ from app.common.expressions.references import DataSourceReference, ExpressionRef
 from app.common.forms.helpers import (
     components_in_valid_add_another_combination,
 )
-from app.common.helpers.submission_events import DeclinedByCertifierKwargs, SubmissionEventHelper
+from app.common.helpers.submission_events import (
+    DeclinedByCertifierKwargs,
+    ReopenedKwargs,
+    SubmissionEventHelper,
+)
 from app.common.utils import slugify
 from app.extensions import db
 from app.metrics import MetricAttributeName, MetricEventName, emit_metric_count
@@ -1454,6 +1458,17 @@ def add_submission_event(
     user: User,
     related_entity_id: UUID | None = None,
     **kwargs: Unpack[DeclinedByCertifierKwargs],
+) -> Submission: ...
+
+
+@overload
+def add_submission_event(
+    submission: Submission,
+    *,
+    event_type: Literal[SubmissionEventType.SUBMISSION_REOPENED],
+    user: User,
+    related_entity_id: UUID | None = None,
+    **kwargs: Unpack[ReopenedKwargs],
 ) -> Submission: ...
 
 

--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-058_drop_legacy_question_id
+059_reopen_submission

--- a/app/common/data/migrations/versions/059_reopen_submission.py
+++ b/app/common/data/migrations/versions/059_reopen_submission.py
@@ -1,0 +1,56 @@
+"""Reopen submission event
+
+Revision ID: 059_reopen_submission
+Revises: 058_drop_legacy_question_id
+Create Date: 2025-11-26 02:01:20.319522
+
+"""
+
+from alembic import op
+from alembic_postgresql_enum import TableReference
+
+revision = "059_reopen_submission"
+down_revision = "058_drop_legacy_question_id"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.sync_enum_values(  # ty: ignore[unresolved-attribute]
+        enum_schema="public",
+        enum_name="submission_event_type_enum",
+        new_values=[
+            "FORM_RUNNER_FORM_COMPLETED",
+            "FORM_RUNNER_FORM_RESET_TO_IN_PROGRESS",
+            "FORM_RUNNER_FORM_RESET_BY_CERTIFIER",
+            "SUBMISSION_SENT_FOR_CERTIFICATION",
+            "SUBMISSION_DECLINED_BY_CERTIFIER",
+            "SUBMISSION_APPROVED_BY_CERTIFIER",
+            "SUBMISSION_SUBMITTED",
+            "SUBMISSION_REOPENED",
+        ],
+        affected_columns=[
+            TableReference(table_schema="public", table_name="submission_event", column_name="event_type")
+        ],
+        enum_values_to_rename=[],
+    )
+
+
+def downgrade() -> None:
+    op.sync_enum_values(  # ty: ignore[unresolved-attribute]
+        enum_schema="public",
+        enum_name="submission_event_type_enum",
+        new_values=[
+            "FORM_RUNNER_FORM_COMPLETED",
+            "FORM_RUNNER_FORM_RESET_TO_IN_PROGRESS",
+            "FORM_RUNNER_FORM_RESET_BY_CERTIFIER",
+            "SUBMISSION_SENT_FOR_CERTIFICATION",
+            "SUBMISSION_DECLINED_BY_CERTIFIER",
+            "SUBMISSION_APPROVED_BY_CERTIFIER",
+            "SUBMISSION_SUBMITTED",
+        ],
+        affected_columns=[
+            TableReference(table_schema="public", table_name="submission_event", column_name="event_type")
+        ],
+        enum_values_to_rename=[],
+    )

--- a/app/common/data/types.py
+++ b/app/common/data/types.py
@@ -129,6 +129,7 @@ class SubmissionEventType(enum.StrEnum):
     SUBMISSION_DECLINED_BY_CERTIFIER = "Submission declined by certifier"
     SUBMISSION_APPROVED_BY_CERTIFIER = "Submission approved by certifier"
     SUBMISSION_SUBMITTED = "Submission submitted"
+    SUBMISSION_REOPENED = "Submission reopened"
 
 
 class CollectionType(enum.StrEnum):

--- a/app/common/helpers/submission_events.py
+++ b/app/common/helpers/submission_events.py
@@ -80,11 +80,11 @@ class SubmissionDeclinedByCertifierEvent(SubmissionEventBase, SignOffMixin, Decl
 
 @dataclass
 class SubmissionReopenedEvent(SubmissionEventBase, SignOffMixin, ReopenedMixin, SubmittedMixin):
+    reopened_reason: str = field(metadata={"stored": True})
     event_type: ClassVar[SubmissionEventType] = SubmissionEventType.SUBMISSION_REOPENED
     is_awaiting_sign_off: bool = False
     is_approved: bool = False
     is_submitted: bool = False
-    reopened_reason: str | None = field(default=None, metadata={"stored": True})
     submission_data: dict[str, Any] = field(default_factory=dict, metadata={"stored": True})
 
 

--- a/app/common/helpers/submission_events.py
+++ b/app/common/helpers/submission_events.py
@@ -34,6 +34,10 @@ class DeclinedMixin(Protocol):
     declined_reason: str | None
 
 
+class ReopenedMixin(Protocol):
+    reopened_reason: str | None
+
+
 @dataclass
 class SubmissionEventBase:
     """Base class for all submission event dataclasses."""
@@ -74,6 +78,15 @@ class SubmissionDeclinedByCertifierEvent(SubmissionEventBase, SignOffMixin, Decl
     declined_reason: str | None = field(default=None, metadata={"stored": True})
 
 
+@dataclass
+class SubmissionReopenedEvent(SubmissionEventBase, SignOffMixin, ReopenedMixin, SubmittedMixin):
+    event_type: ClassVar[SubmissionEventType] = SubmissionEventType.SUBMISSION_REOPENED
+    is_awaiting_sign_off: bool = False
+    is_approved: bool = False
+    is_submitted: bool = False
+    reopened_reason: str | None = field(default=None, metadata={"stored": True})
+
+
 class DeclinedByCertifierKwargs(TypedDict, total=False):
     """
     TypedDict to help ty correctly enforce kwargs that should be passed when creating Events that have
@@ -81,6 +94,10 @@ class DeclinedByCertifierKwargs(TypedDict, total=False):
     """
 
     declined_reason: str | None
+
+
+class ReopenedKwargs(TypedDict, total=False):
+    reopened_reason: str | None
 
 
 @dataclass
@@ -123,19 +140,29 @@ class SubmittedMetadata:
 
 
 @dataclass
+class ReopenedMetadata:
+    reopened_by: User | None = None
+    reopened_at_utc: datetime | None = None
+
+
+@dataclass
 class SubmissionState(
     SentForCertificationMetadata,
     SubmittedMetadata,
     CertifiedMetadata,
     CertificationDeclinedMetadata,
+    ReopenedMetadata,
     SignOffMixin,
     SubmittedMixin,
     DeclinedMixin,
+    ReopenedMixin,
 ):
     is_awaiting_sign_off: bool | None = None
     is_submitted: bool = False
     is_approved: bool | None = None
     declined_reason: str | None = None
+    reopened_reason: str | None = None
+    submission_data: dict[str, Any] | None = None
 
 
 @dataclass
@@ -249,14 +276,23 @@ class SubmissionEventHelper:
                         declined_at_utc=event.created_at_utc,
                     )
                 )
+            case SubmissionEventType.SUBMISSION_REOPENED:
+                return shallow_asdict(
+                    ReopenedMetadata(
+                        reopened_by=event.created_by,
+                        reopened_at_utc=event.created_at_utc,
+                    )
+                )
             case _:
                 return {}
 
     @overload
     @staticmethod
     def event_from(
-        event_type: Literal[SubmissionEventType.SUBMISSION_DECLINED_BY_CERTIFIER],
-        **kwargs: Unpack[DeclinedByCertifierKwargs],
+        event_type: Literal[
+            SubmissionEventType.SUBMISSION_DECLINED_BY_CERTIFIER, SubmissionEventType.SUBMISSION_REOPENED
+        ],
+        **kwargs: Unpack[DeclinedByCertifierKwargs, ReopenedKwargs],
     ) -> dict[str, Any]: ...
 
     @overload

--- a/app/common/helpers/submission_events.py
+++ b/app/common/helpers/submission_events.py
@@ -85,6 +85,7 @@ class SubmissionReopenedEvent(SubmissionEventBase, SignOffMixin, ReopenedMixin, 
     is_approved: bool = False
     is_submitted: bool = False
     reopened_reason: str | None = field(default=None, metadata={"stored": True})
+    submission_data: dict[str, Any] = field(default_factory=dict, metadata={"stored": True})
 
 
 class DeclinedByCertifierKwargs(TypedDict, total=False):
@@ -98,6 +99,7 @@ class DeclinedByCertifierKwargs(TypedDict, total=False):
 
 class ReopenedKwargs(TypedDict, total=False):
     reopened_reason: str | None
+    submission_data: dict[str, Any] | None
 
 
 @dataclass

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -50,6 +50,7 @@ class MetricEventName(StrEnum):
     SUBMISSION_CERTIFICATION_DECLINED = "submission-certification-declined"
     SUBMISSION_SUBMITTED = "submission-submitted"
     SUBMISSION_BLOCKED_BY_INVALID_ANSWERS = "submission-blocked-by-invalid-answers"
+    SUBMISSION_REOPENED = "submission-reopened"
 
     SUBMISSION_MANAGED_VALIDATION_ERROR = "submission-managed-validation-error"
     SUBMISSION_CUSTOM_VALIDATION_ERROR = "submission-custom-validation-error"

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -2898,151 +2898,180 @@ class TestUpdateSubmissionData:
         )
 
 
-def test_add_submission_event(db_session, factories):
-    user = factories.user.create()
-    form = factories.form.create()
-    submission = factories.submission.create(collection=form.collection)
-    db_session.add(submission)
+class TestAddSubmissionEvent:
+    def test_add_submission_event(self, db_session, factories):
+        user = factories.user.create()
+        form = factories.form.create()
+        submission = factories.submission.create(collection=form.collection)
+        db_session.add(submission)
 
-    add_submission_event(
-        submission=submission,
-        user=user,
-        event_type=SubmissionEventType.FORM_RUNNER_FORM_COMPLETED,
-        related_entity_id=form.id,
+        add_submission_event(
+            submission=submission,
+            user=user,
+            event_type=SubmissionEventType.FORM_RUNNER_FORM_COMPLETED,
+            related_entity_id=form.id,
+        )
+        add_submission_event(submission=submission, user=user, event_type=SubmissionEventType.SUBMISSION_SUBMITTED)
+
+        # pull it back out of the database to also check all of the serialisation/ enums are mapped appropriately
+        from_db = get_submission(submission.id, with_full_schema=True)
+
+        assert len(from_db.events) == 2
+        assert from_db.events[0].event_type == SubmissionEventType.FORM_RUNNER_FORM_COMPLETED
+        assert from_db.events[0].related_entity_id == form.id
+        assert from_db.events[0].data == {}
+
+        assert from_db.events[1].event_type == SubmissionEventType.SUBMISSION_SUBMITTED
+        assert from_db.events[1].related_entity_id is submission.id
+        assert from_db.events[1].data == {}
+
+    def test_add_certification_and_submission_event(self, db_session, factories):
+        user = factories.user.create()
+        form = factories.form.create()
+        submission = factories.submission.create(collection=form.collection)
+        db_session.add(submission)
+
+        add_submission_event(
+            submission=submission,
+            user=user,
+            event_type=SubmissionEventType.FORM_RUNNER_FORM_COMPLETED,
+            related_entity_id=form.id,
+        )
+        add_submission_event(
+            submission=submission, user=user, event_type=SubmissionEventType.SUBMISSION_SENT_FOR_CERTIFICATION
+        )
+        add_submission_event(
+            submission=submission, user=user, event_type=SubmissionEventType.SUBMISSION_APPROVED_BY_CERTIFIER
+        )
+        add_submission_event(submission=submission, user=user, event_type=SubmissionEventType.SUBMISSION_SUBMITTED)
+        add_submission_event(
+            submission=submission,
+            user=user,
+            event_type=SubmissionEventType.SUBMISSION_DECLINED_BY_CERTIFIER,
+            declined_reason="inaccurate data",
+        )
+
+        # pull it back out of the database to also check all of the serialisation/ enums are mapped appropriately
+        from_db = get_submission(submission.id, with_full_schema=True)
+
+        assert len(from_db.events) == 5
+        assert from_db.events[0].event_type == SubmissionEventType.FORM_RUNNER_FORM_COMPLETED
+        assert from_db.events[0].related_entity_id == form.id
+        assert from_db.events[0].data == {}
+
+        assert from_db.events[1].event_type == SubmissionEventType.SUBMISSION_SENT_FOR_CERTIFICATION
+        assert from_db.events[1].related_entity_id == submission.id
+        assert from_db.events[1].data == {}
+
+        assert from_db.events[2].event_type == SubmissionEventType.SUBMISSION_APPROVED_BY_CERTIFIER
+        assert from_db.events[2].related_entity_id == submission.id
+        assert from_db.events[2].data == {}
+
+        assert from_db.events[3].event_type == SubmissionEventType.SUBMISSION_SUBMITTED
+        assert from_db.events[3].related_entity_id == submission.id
+        assert from_db.events[3].data == {}
+
+        assert from_db.events[4].event_type == SubmissionEventType.SUBMISSION_DECLINED_BY_CERTIFIER
+        assert from_db.events[4].related_entity_id == submission.id
+        assert from_db.events[4].data == {"declined_reason": "inaccurate data"}
+
+    def test_reopen_submission_event(self, db_session, factories):
+        user = factories.user.create()
+        form = factories.form.create()
+        submission = factories.submission.create(collection=form.collection)
+        test_data = {
+            "q_123": "First answer",
+            "q_234": "Second answer",
+        }
+        submission._data = test_data
+        db_session.add(submission)
+
+        add_submission_event(
+            submission=submission,
+            user=user,
+            event_type=SubmissionEventType.SUBMISSION_REOPENED,
+            reopened_reason="Test reason",
+            submission_data=submission._data,
+        )
+        from_db = get_submission(submission.id, with_full_schema=True)
+
+        assert len(from_db.events) == 1
+        assert from_db.events[0].event_type == SubmissionEventType.SUBMISSION_REOPENED
+        assert from_db.events[0].related_entity_id == submission.id
+        assert from_db.events[0].data == {"reopened_reason": "Test reason", "submission_data": test_data}
+
+    def test_reopen_submission_event_with_helpers(self, db_session, factories):
+
+        from app.common.collections.forms import build_question_form
+        from app.common.helpers.collections import SubmissionHelper
+
+        user = factories.user.create()
+        form = factories.form.create()
+        q1 = factories.question.create(id=uuid.UUID("d696aebc-49d2-4170-a92f-b6ef42994294"), form=form)
+        submission = factories.submission.create(collection=form.collection)
+
+        helper = SubmissionHelper(submission)
+        q_form = build_question_form(
+            [q1], evaluation_context=ExpressionContext(), interpolation_context=ExpressionContext()
+        )(q_d696aebc49d24170a92fb6ef42994294="q1 answer")
+        helper.submit_answer_for_question(q1.id, q_form, submission.created_by)
+
+        db_session.add(submission)
+
+        add_submission_event(
+            submission=submission,
+            user=user,
+            event_type=SubmissionEventType.SUBMISSION_REOPENED,
+            reopened_reason="Test reason",
+            submission_data=submission._data,
+        )
+        from_db = get_submission(submission.id, with_full_schema=True)
+
+        assert len(from_db.events) == 1
+        assert from_db.events[0].event_type == SubmissionEventType.SUBMISSION_REOPENED
+        assert from_db.events[0].related_entity_id == submission.id
+        assert from_db.events[0].data == {
+            "reopened_reason": "Test reason",
+            "submission_data": {"d696aebc-49d2-4170-a92f-b6ef42994294": "q1 answer"},
+        }
+
+        from app.common.helpers.submission_events import SubmissionEventHelper
+
+        event_helper = SubmissionEventHelper(submission)
+        state = event_helper.submission_state
+        assert state.reopened_reason == "Test reason"
+        assert state.reopened_by == user
+
+    @pytest.mark.parametrize(
+        "event_type,exp_metric",
+        [
+            (SubmissionEventType.SUBMISSION_SENT_FOR_CERTIFICATION, MetricEventName.SUBMISSION_SENT_FOR_CERTIFICATION),
+            (SubmissionEventType.SUBMISSION_SUBMITTED, MetricEventName.SUBMISSION_SUBMITTED),
+            (SubmissionEventType.FORM_RUNNER_FORM_RESET_TO_IN_PROGRESS, MetricEventName.SECTION_RESET_TO_IN_PROGRESS),
+            (SubmissionEventType.FORM_RUNNER_FORM_COMPLETED, MetricEventName.SECTION_MARKED_COMPLETE),
+            (
+                SubmissionEventType.FORM_RUNNER_FORM_RESET_BY_CERTIFIER,
+                MetricEventName.SECTION_RESET_TO_IN_PROGRESS_BY_CERTIFIER,
+            ),
+            (SubmissionEventType.SUBMISSION_APPROVED_BY_CERTIFIER, MetricEventName.SUBMISSION_CERTIFIED),
+            (SubmissionEventType.SUBMISSION_DECLINED_BY_CERTIFIER, MetricEventName.SUBMISSION_CERTIFICATION_DECLINED),
+            (SubmissionEventType.SUBMISSION_REOPENED, MetricEventName.SUBMISSION_REOPENED),
+        ],
     )
-    add_submission_event(submission=submission, user=user, event_type=SubmissionEventType.SUBMISSION_SUBMITTED)
+    def test_add_submission_event_metrics(self, db_session, factories, mock_sentry_metrics, event_type, exp_metric):
 
-    # pull it back out of the database to also check all of the serialisation/ enums are mapped appropriately
-    from_db = get_submission(submission.id, with_full_schema=True)
+        user = factories.user.create()
+        form = factories.form.create()
+        submission = factories.submission.create(collection=form.collection)
 
-    assert len(from_db.events) == 2
-    assert from_db.events[0].event_type == SubmissionEventType.FORM_RUNNER_FORM_COMPLETED
-    assert from_db.events[0].related_entity_id == form.id
-    assert from_db.events[0].data == {}
+        add_submission_event(
+            submission=submission,
+            user=user,
+            event_type=event_type,
+        )
 
-    assert from_db.events[1].event_type == SubmissionEventType.SUBMISSION_SUBMITTED
-    assert from_db.events[1].related_entity_id is submission.id
-    assert from_db.events[1].data == {}
-
-
-def test_add_certification_and_submission_event(db_session, factories):
-    user = factories.user.create()
-    form = factories.form.create()
-    submission = factories.submission.create(collection=form.collection)
-    db_session.add(submission)
-
-    add_submission_event(
-        submission=submission,
-        user=user,
-        event_type=SubmissionEventType.FORM_RUNNER_FORM_COMPLETED,
-        related_entity_id=form.id,
-    )
-    add_submission_event(
-        submission=submission, user=user, event_type=SubmissionEventType.SUBMISSION_SENT_FOR_CERTIFICATION
-    )
-    add_submission_event(
-        submission=submission, user=user, event_type=SubmissionEventType.SUBMISSION_APPROVED_BY_CERTIFIER
-    )
-    add_submission_event(submission=submission, user=user, event_type=SubmissionEventType.SUBMISSION_SUBMITTED)
-    add_submission_event(
-        submission=submission,
-        user=user,
-        event_type=SubmissionEventType.SUBMISSION_DECLINED_BY_CERTIFIER,
-        declined_reason="inaccurate data",
-    )
-
-    # pull it back out of the database to also check all of the serialisation/ enums are mapped appropriately
-    from_db = get_submission(submission.id, with_full_schema=True)
-
-    assert len(from_db.events) == 5
-    assert from_db.events[0].event_type == SubmissionEventType.FORM_RUNNER_FORM_COMPLETED
-    assert from_db.events[0].related_entity_id == form.id
-    assert from_db.events[0].data == {}
-
-    assert from_db.events[1].event_type == SubmissionEventType.SUBMISSION_SENT_FOR_CERTIFICATION
-    assert from_db.events[1].related_entity_id == submission.id
-    assert from_db.events[1].data == {}
-
-    assert from_db.events[2].event_type == SubmissionEventType.SUBMISSION_APPROVED_BY_CERTIFIER
-    assert from_db.events[2].related_entity_id == submission.id
-    assert from_db.events[2].data == {}
-
-    assert from_db.events[3].event_type == SubmissionEventType.SUBMISSION_SUBMITTED
-    assert from_db.events[3].related_entity_id == submission.id
-    assert from_db.events[3].data == {}
-
-    assert from_db.events[4].event_type == SubmissionEventType.SUBMISSION_DECLINED_BY_CERTIFIER
-    assert from_db.events[4].related_entity_id == submission.id
-    assert from_db.events[4].data == {"declined_reason": "inaccurate data"}
-
-
-def test_reopen_submission_event(db_session, factories):
-    user = factories.user.create()
-    form = factories.form.create()
-    submission = factories.submission.create(collection=form.collection)
-    test_data = {
-        "q_123": "First answer",
-        "q_234": "Second answer",
-    }
-    submission._data = test_data
-    db_session.add(submission)
-
-    add_submission_event(
-        submission=submission,
-        user=user,
-        event_type=SubmissionEventType.SUBMISSION_REOPENED,
-        reopened_reason="Test reason",
-        submission_data=submission._data,
-    )
-    from_db = get_submission(submission.id, with_full_schema=True)
-
-    assert len(from_db.events) == 1
-    assert from_db.events[0].event_type == SubmissionEventType.SUBMISSION_REOPENED
-    assert from_db.events[0].related_entity_id == submission.id
-    assert from_db.events[0].data == {"reopened_reason": "Test reason", "submission_data": test_data}
-
-
-def test_reopen_submission_event_with_helpers(db_session, factories):
-
-    from app.common.collections.forms import build_question_form
-    from app.common.helpers.collections import SubmissionHelper
-
-    user = factories.user.create()
-    form = factories.form.create()
-    q1 = factories.question.create(id=uuid.UUID("d696aebc-49d2-4170-a92f-b6ef42994294"), form=form)
-    submission = factories.submission.create(collection=form.collection)
-
-    helper = SubmissionHelper(submission)
-    q_form = build_question_form(
-        [q1], evaluation_context=ExpressionContext(), interpolation_context=ExpressionContext()
-    )(q_d696aebc49d24170a92fb6ef42994294="q1 answer")
-    helper.submit_answer_for_question(q1.id, q_form, submission.created_by)
-
-    db_session.add(submission)
-
-    add_submission_event(
-        submission=submission,
-        user=user,
-        event_type=SubmissionEventType.SUBMISSION_REOPENED,
-        reopened_reason="Test reason",
-        submission_data=submission._data,
-    )
-    from_db = get_submission(submission.id, with_full_schema=True)
-
-    assert len(from_db.events) == 1
-    assert from_db.events[0].event_type == SubmissionEventType.SUBMISSION_REOPENED
-    assert from_db.events[0].related_entity_id == submission.id
-    assert from_db.events[0].data == {
-        "reopened_reason": "Test reason",
-        "submission_data": {"d696aebc-49d2-4170-a92f-b6ef42994294": "q1 answer"},
-    }
-
-    from app.common.helpers.submission_events import SubmissionEventHelper
-
-    event_helper = SubmissionEventHelper(submission)
-    state = event_helper.submission_state
-    assert state.reopened_reason == "Test reason"
-    assert state.reopened_by == user
+        assert mock_sentry_metrics.call_count == 1
+        assert mock_sentry_metrics.call_args[0] == (exp_metric, 1)
 
 
 def test_get_collection_with_full_schema(db_session, factories, track_sql_queries):

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -2980,6 +2980,11 @@ def test_reopen_submission_event(db_session, factories):
     user = factories.user.create()
     form = factories.form.create()
     submission = factories.submission.create(collection=form.collection)
+    test_data = {
+        "q_123": "First answer",
+        "q_234": "Second answer",
+    }
+    submission._data = test_data
     db_session.add(submission)
 
     add_submission_event(
@@ -2987,13 +2992,57 @@ def test_reopen_submission_event(db_session, factories):
         user=user,
         event_type=SubmissionEventType.SUBMISSION_REOPENED,
         reopened_reason="Test reason",
+        submission_data=submission._data,
     )
     from_db = get_submission(submission.id, with_full_schema=True)
 
     assert len(from_db.events) == 1
     assert from_db.events[0].event_type == SubmissionEventType.SUBMISSION_REOPENED
     assert from_db.events[0].related_entity_id == submission.id
-    assert from_db.events[0].data == {"reopened_reason": "Test reason"}
+    assert from_db.events[0].data == {"reopened_reason": "Test reason", "submission_data": test_data}
+
+
+def test_reopen_submission_event_with_helpers(db_session, factories):
+
+    from app.common.collections.forms import build_question_form
+    from app.common.helpers.collections import SubmissionHelper
+
+    user = factories.user.create()
+    form = factories.form.create()
+    q1 = factories.question.create(id=uuid.UUID("d696aebc-49d2-4170-a92f-b6ef42994294"), form=form)
+    submission = factories.submission.create(collection=form.collection)
+
+    helper = SubmissionHelper(submission)
+    q_form = build_question_form(
+        [q1], evaluation_context=ExpressionContext(), interpolation_context=ExpressionContext()
+    )(q_d696aebc49d24170a92fb6ef42994294="q1 answer")
+    helper.submit_answer_for_question(q1.id, q_form, submission.created_by)
+
+    db_session.add(submission)
+
+    add_submission_event(
+        submission=submission,
+        user=user,
+        event_type=SubmissionEventType.SUBMISSION_REOPENED,
+        reopened_reason="Test reason",
+        submission_data=submission._data,
+    )
+    from_db = get_submission(submission.id, with_full_schema=True)
+
+    assert len(from_db.events) == 1
+    assert from_db.events[0].event_type == SubmissionEventType.SUBMISSION_REOPENED
+    assert from_db.events[0].related_entity_id == submission.id
+    assert from_db.events[0].data == {
+        "reopened_reason": "Test reason",
+        "submission_data": {"d696aebc-49d2-4170-a92f-b6ef42994294": "q1 answer"},
+    }
+
+    from app.common.helpers.submission_events import SubmissionEventHelper
+
+    event_helper = SubmissionEventHelper(submission)
+    state = event_helper.submission_state
+    assert state.reopened_reason == "Test reason"
+    assert state.reopened_by == user
 
 
 def test_get_collection_with_full_schema(db_session, factories, track_sql_queries):

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -2976,6 +2976,26 @@ def test_add_certification_and_submission_event(db_session, factories):
     assert from_db.events[4].data == {"declined_reason": "inaccurate data"}
 
 
+def test_reopen_submission_event(db_session, factories):
+    user = factories.user.create()
+    form = factories.form.create()
+    submission = factories.submission.create(collection=form.collection)
+    db_session.add(submission)
+
+    add_submission_event(
+        submission=submission,
+        user=user,
+        event_type=SubmissionEventType.SUBMISSION_REOPENED,
+        reopened_reason="Test reason",
+    )
+    from_db = get_submission(submission.id, with_full_schema=True)
+
+    assert len(from_db.events) == 1
+    assert from_db.events[0].event_type == SubmissionEventType.SUBMISSION_REOPENED
+    assert from_db.events[0].related_entity_id == submission.id
+    assert from_db.events[0].data == {"reopened_reason": "Test reason"}
+
+
 def test_get_collection_with_full_schema(db_session, factories, track_sql_queries):
     collection = factories.collection.create()
     forms = factories.form.create_batch(3, collection=collection)


### PR DESCRIPTION
## 🎫 Ticket
[FSPT-1298](https://mhclgdigital.atlassian.net/browse/FSPT-1298) - Reopening submissions

## 📝 Description
First part of being able to reopen a submission. This PR creates a new submission event, `SUBMISSION_REOPENED_BY_GRANT_TEAM`, with an accompanying metric. It adds the value to the enum in the DB and some basic tests to make sure it functions as expected

## 📸 Show the thing (screenshots, gifs)
Nothing to see yet

## 🧪 Testing
Tests added, new code not used anywhere yet except in tests



[FSPT-1298]: https://mhclgdigital.atlassian.net/browse/FSPT-1298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ