### PR TITLE
Fix admin filter styling

### DIFF
--- a/app/assets/_importants.scss
+++ b/app/assets/_importants.scss
@@ -1,4 +1,4 @@
-@use "govuk";
+@use "govuk/base" as govuk;
 
 .app-\!-no-wrap {
     white-space: nowrap !important;

--- a/app/assets/_overrides.scss
+++ b/app/assets/_overrides.scss
@@ -1,4 +1,4 @@
-@use "govuk";
+@use "govuk/base" as govuk;
 
 // Temporary: return notification banners to their correct colours. We have set `govuk-brand-colour`, and currently
 // the notification banner uses that as its border colour. This has been confirmed as unintended by the GDS Design System

--- a/app/assets/_tweaks.scss
+++ b/app/assets/_tweaks.scss
@@ -1,4 +1,4 @@
-@use "govuk";
+@use "govuk/base" as govuk;
 
 // this class will only be applied if GOV.UK Frontend Jinja has set the `.js-enabled` class meaning
 // it could execute JavaScript

--- a/app/assets/admin.scss
+++ b/app/assets/admin.scss
@@ -2,7 +2,7 @@
 // of Access grant funding or Deliver grant funding.
 
 @use "sass:color";
-@use "govuk" as govuk with (
+@use "govuk/base" as govuk with (
     $govuk-brand-colour: #912b88
 );
 

--- a/app/assets/components/context-aware-editor/_index.scss
+++ b/app/assets/components/context-aware-editor/_index.scss
@@ -1,4 +1,4 @@
-@use "govuk";
+@use "govuk/base" as govuk;
 
 // Context Aware Editor Styles
 // Integrates styles for toolbar and reference highlighting

--- a/app/assets/components/destructive-link/_index.scss
+++ b/app/assets/components/destructive-link/_index.scss
@@ -1,4 +1,4 @@
-@use "govuk";
+@use "govuk/base" as govuk;
 
 // Custom colours for our destructive link
 // Based on the error colour in:

--- a/app/assets/components/link-button/_index.scss
+++ b/app/assets/components/link-button/_index.scss
@@ -1,4 +1,4 @@
-@use "govuk";
+@use "govuk/base" as govuk;
 
 .app-link-button {
     @include govuk.govuk-font(19);

--- a/app/assets/components/metadata/_index.scss
+++ b/app/assets/components/metadata/_index.scss
@@ -1,4 +1,4 @@
-@use "govuk";
+@use "govuk/base" as govuk;
 
 .app-metadata {
     @include govuk.govuk-font(19);

--- a/app/assets/components/move-up-down-table/_index.scss
+++ b/app/assets/components/move-up-down-table/_index.scss
@@ -1,4 +1,4 @@
-@use "govuk";
+@use "govuk/base" as govuk;
 
 .app-move-up-down-table__actions {
     width: 50%;

--- a/app/assets/components/print-header/_index.scss
+++ b/app/assets/components/print-header/_index.scss
@@ -1,4 +1,4 @@
-@use "govuk";
+@use "govuk/base" as govuk;
 
 .app-print-header {
     margin-left: govuk.govuk-spacing(6);

--- a/app/assets/components/section/_index.scss
+++ b/app/assets/components/section/_index.scss
@@ -1,4 +1,4 @@
-@use "govuk";
+@use "govuk/base" as govuk;
 
 .app-section-nav-container {
     @include govuk.govuk-media-query($from: desktop) {

--- a/app/assets/components/service-navigation/_index.scss
+++ b/app/assets/components/service-navigation/_index.scss
@@ -1,4 +1,4 @@
-@use "govuk";
+@use "govuk/base" as govuk;
 
 .app-service-navigation__wrapper--sectional {
     flex: 1;

--- a/app/assets/components/summary-list/_index.scss
+++ b/app/assets/components/summary-list/_index.scss
@@ -1,4 +1,4 @@
-@use "govuk";
+@use "govuk/base" as govuk;
 
 $inset-nested-rows: 30px;
 

--- a/app/assets/components/test-data-banner/_index.scss
+++ b/app/assets/components/test-data-banner/_index.scss
@@ -1,4 +1,4 @@
-@use "govuk";
+@use "govuk/base" as govuk;
 
 .app-test-data-banner {
     background-color: govuk.govuk-colour("orange");

--- a/app/assets/main.scss
+++ b/app/assets/main.scss
@@ -1,8 +1,14 @@
-@use "govuk" with (
+@use "govuk" as govuk with (
     $govuk-new-organisation-colours: true,
     $govuk-assets-path: "/static/assets/",
     $govuk-brand-colour: #00625e
 );
+@use "govuk/base" with (
+    $govuk-new-organisation-colours: true,
+    $govuk-assets-path: "/static/assets/",
+    $govuk-brand-colour: #00625e
+); // share config with partials
+
 @use "../../node_modules/accessible-autocomplete"; // TODO: replace with select-with-search
 // TODO: import moj frontend to start using things from there, eg number components and sortable tables
 


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
Since PR #1575, the admin layout that uses a filter button group has been misaligned. This was caused using `import "govuk"` in the admin.scss; for these pages we rely on the GOV.UK Frontend and MoJ Frontend assets bundled in xgovuk-flask-admin. By pulling in GOV.UK Frontend a second time, we created conflicting CSS rules that then applied govuk-button's styling in preference over moj-button-menu__toggle-button. It also shrunk the page width down from our desired wider state.

We switch here to just pulling in settings/helpers from GOV.UK Frontend for the admin CSS, and switch all of our partials to also only pull those in. Our main.scss continues to pull all of the actual GOV.UK Frontend by using `use "govuk"` directly.

## 📸 Show the thing (screenshots, gifs)

| Scenario | Before | After |
|---|---|---|
| Platform admin filters | <img width="1052" height="614" alt="image" src="https://github.com/user-attachments/assets/a947493f-ef96-45e1-b9e6-427115eed8df" /> | <img width="1322" height="549" alt="image" src="https://github.com/user-attachments/assets/dc20a7e9-b269-4ffd-b105-cff6924c8d7e" /> |

## 🧪 Testing
<!-- Describe how you've tested this change, and how a reviewer can test it -->

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [ ] I need the reviewer(s) to pull and run this change locally
- [ ] New (non-developer) functionality has appropriate unit and integration tests
- [ ] End-to-end tests have been updated (if applicable)
- [ ] Edge cases and error conditions are tested