### PR TITLE
BAU: Include uploaded data sets in seed/export grants cmd

### DIFF
--- a/.wiz
+++ b/.wiz
@@ -1,0 +1,5 @@
+ignoreFindings:
+  - ruleId: "BUILTIN-125"
+    paths:
+      - "app/developers/data/grants.json"
+    comment: "pseudonymised file"

--- a/app/common/data/interfaces/temporary.py
+++ b/app/common/data/interfaces/temporary.py
@@ -11,10 +11,11 @@ The only place that should import from here is the `app.developers` package.
 
 from uuid import UUID
 
-from sqlalchemy import select, update
+from sqlalchemy import delete, select, update
 
 from app.common.data.models import (
     Collection,
+    ComponentReference,
     Grant,
     Submission,
 )
@@ -31,17 +32,30 @@ def delete_grant(grant_id: UUID) -> None:
         .values(submission_name_question_id=None)
     )
     grant = db.session.query(Grant).where(Grant.id == grant_id).one()
-    data_sources_to_delete = [
+
+    custom_data_sources_to_delete = [
         c.data_source
         for collection in grant.collections
         for form in collection.forms
         for c in form._all_components
         if hasattr(c, "data_source") and c.data_source and c.data_source.type == DataSourceType.CUSTOM
     ]
+    non_custom_data_sources_to_delete = [
+        ds for collection in grant.collections for ds in collection.data_sources if ds.type != DataSourceType.CUSTOM
+    ]
+
+    if non_custom_data_sources_to_delete:
+        non_custom_ds_ids = [ds.id for ds in non_custom_data_sources_to_delete]
+        db.session.execute(
+            delete(ComponentReference).where(ComponentReference.depends_on_data_source_id.in_(non_custom_ds_ids))
+        )
+        for ds in non_custom_data_sources_to_delete:
+            db.session.delete(ds)
+        db.session.flush()
 
     db.session.delete(grant)
 
-    for ds in data_sources_to_delete:
+    for ds in custom_data_sources_to_delete:
         db.session.delete(ds)
 
     db.session.flush()

--- a/app/developers/commands.py
+++ b/app/developers/commands.py
@@ -39,6 +39,7 @@ from app.common.data.models import (
     ComponentReference,
     DataSource,
     DataSourceItem,
+    DataSourceOrganisationItem,
     Expression,
     Form,
     Grant,
@@ -52,6 +53,9 @@ from app.common.data.models import (
 from app.common.data.models_user import User, UserRole
 from app.common.data.types import (
     ComponentType,
+    DataSourceFileMetadata,
+    DataSourceSchema,
+    DataSourceType,
     GrantRecipientModeEnum,
     OrganisationModeEnum,
     QuestionDataOptions,
@@ -97,6 +101,7 @@ class GrantExport(TypedDict):
     expressions: list[Any]
     data_sources: list[Any]
     data_source_items: list[Any]
+    data_source_organisation_items: list[Any]
     component_references: list[Any]
 
 
@@ -241,6 +246,7 @@ def export_grants(  # noqa: C901
             "expressions": [],
             "data_sources": [],
             "data_source_items": [],
+            "data_source_organisation_items": [],
             "component_references": [],
         }
 
@@ -255,6 +261,24 @@ def export_grants(  # noqa: C901
 
                 for component in form.components:
                     add_all_components_flat(component, users, grant_export)
+
+            for ds in collection.data_sources:
+                # CUSTOM data sources won't ever be tied explicitly to a collection, but if something rogue happens then
+                # this avoids duplicate data sources being exported
+                if ds.type == DataSourceType.CUSTOM:
+                    continue
+                grant_export["data_sources"].append(to_dict(ds))
+                if ds.created_by:
+                    users.add(ds.created_by)
+                if ds.updated_by:
+                    users.add(ds.updated_by)
+                for org_item in ds.organisation_items:
+                    org_item_dict = to_dict(org_item)
+                    # _data is the DB model attribute but underscored attributes are skipped by to_dict so
+                    # explicitly set it here - persisting the underscored name means no need for explicit handling
+                    # when seeding the grants
+                    org_item_dict["_data"] = org_item._data
+                    grant_export["data_source_organisation_items"].append(org_item_dict)
 
         for gr in grant.grant_recipients:
             if gr.organisation_id not in [o["id"] for o in export_data["organisations"]]:
@@ -421,6 +445,10 @@ def seed_grants(file: Path) -> None:  # noqa: C901
 
         for data_source in grant_data["data_sources"]:
             data_source["id"] = uuid.UUID(data_source["id"])
+            if data_source.get("schema") is not None:
+                data_source["schema"] = DataSourceSchema.model_validate(data_source["schema"])
+            if data_source.get("file_metadata") is not None:
+                data_source["file_metadata"] = DataSourceFileMetadata.model_validate(data_source["file_metadata"])
             data_source = DataSource(**data_source)
             db.session.add(data_source)
 
@@ -428,6 +456,12 @@ def seed_grants(file: Path) -> None:  # noqa: C901
             data_source_item["id"] = uuid.UUID(data_source_item["id"])
             data_source_item = DataSourceItem(**data_source_item)
             db.session.add(data_source_item)
+
+        for organisation_item in grant_data["data_source_organisation_items"]:
+            organisation_item["id"] = uuid.UUID(organisation_item["id"])
+            organisation_item["data_source_id"] = uuid.UUID(organisation_item["data_source_id"])
+            organisation_item = DataSourceOrganisationItem(**organisation_item)
+            db.session.add(organisation_item)
 
         db.session.flush()
 

--- a/app/developers/data/grants.json
+++ b/app/developers/data/grants.json
@@ -1054,6 +1054,7 @@
           "order": 33
         }
       ],
+      "data_source_organisation_items": [],
       "data_sources": [
         {
           "id": "078503ab-e87d-4dac-9533-1491943ab9c1",
@@ -3330,6 +3331,7 @@
           "order": 1
         }
       ],
+      "data_source_organisation_items": [],
       "data_sources": [
         {
           "id": "126d2070-99df-4c1f-ad52-40d28936c3ea",


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
Now that we are beginning to allow uploaded data sets in our grants, our export/seed grants commands need to be able to handle uploaded data sets and ensure they're exported and seeded correctly, including with the relevant DataSourceOrganisationItems.

These changes allow us to make this change but don't yet include an example of a data set and references in the grants.json because we need to think through a solution for the S3 file link in local and deployed environments.

## 🧪 Testing
* Export/reseed grants a few times, it should all work as expected
* Upload a Grant Recipient-level data set to one of the seeded grant collections, and include a reference somewhere to that data set
* Run export-grants and observe the data set and reference and org items are created
* Try reseeding
* Remove from the grants.json and reseed and see the data set and reference are removed

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [X] PR title and description provide sufficient context for reviewers
- [X] Commits are logical, self-contained, and have clear descriptions

### Testing
- [X] I have tested this change and it meets the acceptance criteria for the ticket
- [X] I need the reviewer(s) to pull and run this change locally
- ~[ ] New (non-developer) functionality has appropriate unit and integration tests~
- ~[ ] End-to-end tests have been updated (if applicable)~
- ~[ ] Edge cases and error conditions are tested~