### PR TITLE
FSPT-1298 Reopen submission statuses and permissions

### DIFF
--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -1199,6 +1199,21 @@ class SubmissionHelper:
         if not self.is_submitted:
             raise ValueError(f"Could not reopen submission id={self.id} because it is not submitted.")
 
+        interfaces.collections.add_submission_event(
+            self.submission,
+            event_type=SubmissionEventType.SUBMISSION_REOPENED,
+            user=user,
+            reopened_reason=reopened_reason,
+            submission_data=self.submission.data_manager.data,
+        )
+        for form in self.collection.forms:
+            interfaces.collections.add_submission_event(
+                self.submission,
+                event_type=SubmissionEventType.FORM_RUNNER_FORM_RESET_TO_IN_PROGRESS,
+                user=user,
+                related_entity_id=form.id,
+            )
+
     def toggle_form_completed(self, form: Form, user: User, is_complete: bool) -> None:
         form_complete = self.get_status_for_form(form) == TasklistSectionStatusEnum.COMPLETED
         if is_complete == form_complete:

--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -439,6 +439,18 @@ class SubmissionHelper:
         return max(filter(None, [self.events.latest_event_utc, self.submission.updated_at_utc]))
 
     @property
+    def reopened_at_utc(self) -> datetime | None:
+        return self.events.submission_state.reopened_at_utc
+
+    @property
+    def reopened_reason(self) -> str | None:
+        return self.events.submission_state.reopened_reason
+
+    @property
+    def reopened_by(self) -> User | None:
+        return self.events.submission_state.reopened_by
+
+    @property
     def id(self) -> UUID:
         return self.submission.id
 
@@ -1163,6 +1175,29 @@ class SubmissionHelper:
         interfaces.collections.add_submission_event(
             self.submission, event_type=SubmissionEventType.SUBMISSION_APPROVED_BY_CERTIFIER, user=user
         )
+
+    def reopen_submission(self, user: User, reopened_reason: str) -> None:
+        is_platform_admin = AuthorisationHelper.is_platform_admin(user)
+        has_deliver_grant_role = AuthorisationHelper.has_deliver_grant_role(self.grant.id, RoleEnum.MEMBER, user)
+        is_deliver_org_member = AuthorisationHelper.is_deliver_org_member(user)
+        # Platform admin should be able to reopen submissions
+        # The grant team should be able to reopen submissions. Their roles would be:
+        # - grant member
+        # Form designers should not be able to reopen submissions. Their roles would be:
+        # - deliver org admin / member
+        if not (is_platform_admin or (has_deliver_grant_role and not is_deliver_org_member)):
+            raise SubmissionAuthorisationError(
+                f"User does not have permission to reopen the submission id={self.id}",
+                user,
+                self.id,
+                RoleEnum.MEMBER,
+            )
+
+        if not self.collection.is_open:
+            raise ValueError(f"Could not reopen submission id={self.id} because the report is not open.")
+
+        if not self.is_submitted:
+            raise ValueError(f"Could not reopen submission id={self.id} because it is not submitted.")
 
     def toggle_form_completed(self, form: Form, user: User, is_complete: bool) -> None:
         form_complete = self.get_status_for_form(form) == TasklistSectionStatusEnum.COMPLETED

--- a/tests/integration/common/helpers/test_collections.py
+++ b/tests/integration/common/helpers/test_collections.py
@@ -1698,6 +1698,81 @@ class TestSubmissionHelper:
 
             assert len(mock_notification_service_calls) == 0
 
+    class TestSubmissionReopened:
+        def test_submission_reopened_grant_team(
+            self, grant_team_user, submission_submitted, mock_notification_service_calls
+        ) -> None:
+            helper = SubmissionHelper(submission_submitted)
+            assert helper.status == SubmissionStatusEnum.SUBMITTED
+            for form in helper.get_ordered_visible_forms():
+                assert helper.get_status_for_form(form) == TasklistSectionStatusEnum.COMPLETED
+
+            helper.reopen_submission(user=grant_team_user, reopened_reason="Test reason")
+
+            assert helper.status == SubmissionStatusEnum.IN_PROGRESS
+            assert helper.reopened_reason == "Test reason"
+            assert helper.reopened_by == grant_team_user
+            for form in helper.get_ordered_visible_forms():
+                assert helper.get_status_for_form(form) == TasklistSectionStatusEnum.IN_PROGRESS
+
+        def test_submission_reopened_platform_admin(
+            self, platform_admin_user, submission_submitted, mock_notification_service_calls
+        ) -> None:
+            helper = SubmissionHelper(submission_submitted)
+            assert helper.status == SubmissionStatusEnum.SUBMITTED
+
+            helper.reopen_submission(user=platform_admin_user, reopened_reason="Test reason")
+
+            assert helper.status == SubmissionStatusEnum.IN_PROGRESS
+            assert helper.reopened_reason == "Test reason"
+            assert helper.reopened_by == platform_admin_user
+
+        def test_submission_reopened_fails_when_report_closed(
+            self, grant_team_user, submission_submitted, mock_notification_service_calls
+        ) -> None:
+            helper = SubmissionHelper(submission_submitted)
+            assert helper.status == SubmissionStatusEnum.SUBMITTED
+            collection = submission_submitted.collection
+            collection.status = CollectionStatusEnum.CLOSED
+
+            with pytest.raises(ValueError, match="report is not open"):
+                helper.reopen_submission(user=grant_team_user, reopened_reason="Test reason")
+
+            assert helper.status == SubmissionStatusEnum.SUBMITTED
+
+        def test_submission_reopened_fails_when_submission_not_submitted(
+            self, grant_team_user, submission_awaiting_sign_off, mock_notification_service_calls
+        ) -> None:
+            helper = SubmissionHelper(submission_awaiting_sign_off)
+            assert helper.status == SubmissionStatusEnum.AWAITING_SIGN_OFF
+
+            with pytest.raises(ValueError, match="it is not submitted"):
+                helper.reopen_submission(user=grant_team_user, reopened_reason="Test reason")
+
+            assert helper.status == SubmissionStatusEnum.AWAITING_SIGN_OFF
+
+        @pytest.mark.parametrize(
+            "user_fixture",
+            [
+                "data_provider_user",
+                "form_designer_user",
+                "platform_member_user",
+                "certifier_user",
+                "org_admin_user",
+            ],
+        )
+        def test_submission_reopened_fails_when_not_grant_team_or_platform_admin_user(
+            self,
+            request,
+            user_fixture,
+            submission_submitted,
+        ):
+            helper = SubmissionHelper(submission_submitted)
+            user = request.getfixturevalue(user_fixture)
+
+            with pytest.raises(SubmissionAuthorisationError, match="does not have permission to reopen the submission"):
+                helper.reopen_submission(user=user, reopened_reason="Test reason")
+
     class TestLastUpdatedAt:
         @pytest.mark.freeze_time("2026-03-09 12:00:00")
         def test_last_updated_at_utc_returns_last_submission_event_utc(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -454,25 +454,15 @@ def authenticated_platform_member_client(
 
 @pytest.fixture()
 def authenticated_org_admin_client(
-    anonymous_client: FundingServiceTestClient, factories: _Factories, db_session: Session
+    anonymous_client: FundingServiceTestClient, org_admin_user, factories: _Factories, db_session: Session
 ) -> Generator[FundingServiceTestClient, None, None]:
     """Create a client authenticated as an org admin for an org with can_manage_grants=True"""
-    from tests.models import _get_grant_managing_organisation
 
-    user = factories.user.create(email="orgadmin@communities.gov.uk")
-    organisation = _get_grant_managing_organisation()
-    factories.user_role.create(
-        user=user,
-        permissions=[RoleEnum.ADMIN],
-        organisation=organisation,
-        grant=None,
-    )
-
-    login_user(user)
+    login_user(org_admin_user)
     with anonymous_client.session_transaction() as session:
         session["auth"] = AuthMethodEnum.SSO
-    anonymous_client.user = user
-    anonymous_client.organisation = organisation
+    anonymous_client.user = org_admin_user
+    anonymous_client.organisation = org_admin_user.roles[0].organisation
     db_session.commit()
 
     yield anonymous_client
@@ -507,6 +497,70 @@ def authenticated_org_member_client(
 @pytest.fixture(scope="function")
 def user(factories: _Factories) -> User:
     return cast(User, factories.user.create(email="accessgrantfundinguser@communities.gov.uk"))
+
+
+@pytest.fixture(scope="function")
+def grant_team_user(factories: _Factories, grant_recipient: GrantRecipient) -> User:
+    user = cast(User, factories.user.create(email="grant_team_member@communities.gov.uk"))
+    from tests.models import _get_grant_managing_organisation
+
+    factories.user_role.create(
+        user=user,
+        permissions=[
+            RoleEnum.MEMBER,
+        ],
+        organisation=_get_grant_managing_organisation(),
+        grant=grant_recipient.grant,
+    )
+    return user
+
+
+@pytest.fixture()
+def platform_member_user(factories) -> User:
+
+    user = factories.user.create(email="platform_member@communities.gov.uk")
+    factories.user_role.create(user_id=user.id, user=user, permissions=[RoleEnum.MEMBER], organisation=None, grant=None)
+    return user
+
+
+@pytest.fixture()
+def form_designer_user(factories, grant_recipient) -> User:
+    from tests.models import _get_grant_managing_organisation
+
+    user = factories.user.create(email="form_designer@communities.gov.uk")
+
+    factories.user_role.create(
+        user=user,
+        permissions=[
+            RoleEnum.MEMBER,
+        ],
+        organisation=_get_grant_managing_organisation(),
+        grant=None,
+    )
+    return user
+
+
+@pytest.fixture()
+def org_admin_user(factories: _Factories) -> User:
+    from tests.models import _get_grant_managing_organisation
+
+    user = factories.user.create(email="orgadmin@communities.gov.uk")
+    organisation = _get_grant_managing_organisation()
+    factories.user_role.create(
+        user=user,
+        permissions=[RoleEnum.ADMIN],
+        organisation=organisation,
+        grant=None,
+    )
+    return user
+
+
+@pytest.fixture()
+def platform_admin_user(factories) -> User:
+
+    user = factories.user.create(email="platform_admin@communities.gov.uk")
+    factories.user_role.create(user_id=user.id, user=user, permissions=[RoleEnum.ADMIN], organisation=None, grant=None)
+    return user
 
 
 @pytest.fixture(scope="function")
@@ -594,6 +648,7 @@ def submission_awaiting_sign_off(factories: _Factories, grant_recipient: GrantRe
         form__collection__submission_period_end_date=date.today() + timedelta(days=30),
         form__collection__reporting_period_start_date=date.today() - timedelta(days=60),
         form__collection__reporting_period_end_date=date.today() - timedelta(days=30),
+        form__collection__status=CollectionStatusEnum.OPEN,
     )
     submission = factories.submission.create(
         grant_recipient=grant_recipient,
@@ -626,6 +681,7 @@ def submission_submitted(factories: _Factories, grant_recipient: GrantRecipient,
         form__collection__submission_period_end_date=date.today() + timedelta(days=30),
         form__collection__reporting_period_start_date=date.today(),
         form__collection__reporting_period_end_date=date.today() + timedelta(days=30),
+        form__collection__status=CollectionStatusEnum.OPEN,
     )
     submission = factories.submission.create(
         grant_recipient=grant_recipient,


### PR DESCRIPTION
## 🎫 Ticket
[FSPT-1298](https://mhclgdigital.atlassian.net/browse/FSPT-1298)

## 📝 Description
Next step in reopening submissions:
- Adds a method to submission helper to reopen a submission
- Checks permissions of the user requesting the reopneing
- Checks status of the report and the collection
- Raises exceptions if status or permission is not right
- If all those pass, creates submission events:
  - `SUBMISSION_REOPENED` for the submission
  - `FORM_RUNNER_FORM_RESET_TO_IN_PROGRESS` for each form

Can be reviewed commit by commit, but tests will fail on the first commit - deliberately added these first to help shape the scope.

## 📸 Show the thing (screenshots, gifs)
Nothing to see here 👁️ 

## 📚 Additional Notes
- Appreciate thoughts on the permissions checking. It felt complicated to reason through what the right roles were here, be good to have reviewers think this through and confirm please :)


[FSPT-1298]: https://mhclgdigital.atlassian.net/browse/FSPT-1298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ