### PR TITLE
Fspt 1298 reopen frontend

### DIFF
--- a/app/common/auth/authorisation_helper.py
+++ b/app/common/auth/authorisation_helper.py
@@ -4,14 +4,14 @@ from uuid import UUID
 from flask import request
 from flask_login import AnonymousUserMixin
 
-from app.common.data.interfaces.collections import get_collection
+from app.common.data.interfaces.collections import get_collection, get_submission
 from app.common.data.interfaces.grant_recipients import get_grant_recipient
 from app.common.data.interfaces.grants import get_grant
 from app.common.data.models_user import User
 from app.common.data.types import OrganisationModeEnum, RoleEnum
 
 if TYPE_CHECKING:
-    from app.common.data.models import Organisation
+    from app.common.data.models import Organisation, Submission
 
 
 class AuthorisationHelper:
@@ -189,6 +189,26 @@ class AuthorisationHelper:
             return False
 
         return False
+
+    @staticmethod
+    def can_reopen_submission(user: User, submission: "Submission | UUID") -> bool:
+        # Platform admin should be able to reopen submissions
+        # The grant team should be able to reopen submissions. Their roles would be:
+        # - grant member
+        # Form designers should not be able to reopen submissions. Their roles would be:
+        # - deliver org admin / member
+        if isinstance(submission, UUID):
+            submission = get_submission(submission)
+
+        if AuthorisationHelper.is_platform_admin(user):
+            return True
+
+        has_deliver_grant_role = AuthorisationHelper.has_deliver_grant_role(
+            submission.collection.grant.id, RoleEnum.MEMBER, user
+        )
+        is_deliver_org_member = AuthorisationHelper.is_deliver_org_member(user)
+
+        return has_deliver_grant_role and not is_deliver_org_member
 
     @staticmethod
     def has_access_org_access(user: User | AnonymousUserMixin, organisation_id: UUID) -> bool:

--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -1177,15 +1177,8 @@ class SubmissionHelper:
         )
 
     def reopen_submission(self, user: User, reopened_reason: str) -> None:
-        is_platform_admin = AuthorisationHelper.is_platform_admin(user)
-        has_deliver_grant_role = AuthorisationHelper.has_deliver_grant_role(self.grant.id, RoleEnum.MEMBER, user)
-        is_deliver_org_member = AuthorisationHelper.is_deliver_org_member(user)
-        # Platform admin should be able to reopen submissions
-        # The grant team should be able to reopen submissions. Their roles would be:
-        # - grant member
-        # Form designers should not be able to reopen submissions. Their roles would be:
-        # - deliver org admin / member
-        if not (is_platform_admin or (has_deliver_grant_role and not is_deliver_org_member)):
+
+        if not AuthorisationHelper.can_reopen_submission(user, self.submission):
             raise SubmissionAuthorisationError(
                 f"User does not have permission to reopen the submission id={self.id}",
                 user,

--- a/app/deliver_grant_funding/forms.py
+++ b/app/deliver_grant_funding/forms.py
@@ -1307,8 +1307,8 @@ class ReopenSubmissionForm(FlaskForm):
     reopened_reason = TextAreaField(
         "Why are you reopening this submission?",
         validators=[
-            DataRequired(),
-            WordRange(max_words=REASON_MAX_WORDS, field_display_name="description"),
+            DataRequired("Enter the reason for reopening this submission"),
+            WordRange(max_words=REASON_MAX_WORDS, field_display_name="reason for reopening the submission"),
         ],
         widget=GovCharacterCount(),
     )

--- a/app/deliver_grant_funding/forms.py
+++ b/app/deliver_grant_funding/forms.py
@@ -1300,3 +1300,16 @@ class SelectConditionCalculationForm(FlaskForm):
         validators=[DataRequired("Please select an option")],
     )
     submit = SubmitField("Continue", widget=GovSubmitInput())
+
+
+class ReopenSubmissionForm(FlaskForm):
+    REASON_MAX_WORDS = 200
+    reopened_reason = TextAreaField(
+        "Why are you reopening this submission?",
+        validators=[
+            DataRequired(),
+            WordRange(max_words=REASON_MAX_WORDS, field_display_name="description"),
+        ],
+        widget=GovCharacterCount(),
+    )
+    submit = SubmitField("Reopen submission", widget=GovSubmitInput())

--- a/app/deliver_grant_funding/routes/reports.py
+++ b/app/deliver_grant_funding/routes/reports.py
@@ -3246,7 +3246,10 @@ def view_submission(grant_id: UUID, submission_id: UUID) -> ResponseReturnValue:
 @has_deliver_grant_role(RoleEnum.MEMBER)
 @auto_commit_after_request
 def reopen_submission(grant_id: UUID, submission_id: UUID) -> ResponseReturnValue:
+
     submission_helper = SubmissionHelper.load(submission_id)
+    if not AuthorisationHelper.can_reopen_submission(get_current_user(), submission_helper.submission):
+        abort(403)
     form = ReopenSubmissionForm()
     if form.validate_on_submit():
         submission_helper.reopen_submission(user=get_current_user(), reopened_reason=form.reopened_reason.data)  # ty:ignore[invalid-argument-type]

--- a/app/deliver_grant_funding/routes/reports.py
+++ b/app/deliver_grant_funding/routes/reports.py
@@ -3254,7 +3254,12 @@ def reopen_submission(grant_id: UUID, submission_id: UUID) -> ResponseReturnValu
         return redirect(
             url_for("deliver_grant_funding.view_submission", grant_id=grant_id, submission_id=submission_id)
         )
-    return ""
+    return render_template(
+        "deliver_grant_funding/reports/reopen_submission.html",
+        form=form,
+        helper=submission_helper,
+        grant=submission_helper.grant,
+    )
 
 
 @deliver_grant_funding_blueprint.route(

--- a/app/deliver_grant_funding/routes/reports.py
+++ b/app/deliver_grant_funding/routes/reports.py
@@ -126,6 +126,7 @@ from app.deliver_grant_funding.forms import (
     PublicSignUpSettingsForm,
     QuestionForm,
     QuestionTypeForm,
+    ReopenSubmissionForm,
     SelectConditionCalculationForm,
     SelectDataSourceDataSetColumnForm,
     SelectDataSourceDataSetForm,
@@ -3237,6 +3238,23 @@ def view_submission(grant_id: UUID, submission_id: UUID) -> ResponseReturnValue:
         interpolate=SubmissionHelper.get_interpolator(collection=helper.collection, submission_helper=helper),
         delete_form=delete_wtform,
     )
+
+
+@deliver_grant_funding_blueprint.route(
+    "/grant/<uuid:grant_id>/submission/<uuid:submission_id>/reopen", methods=["GET", "POST"]
+)
+@has_deliver_grant_role(RoleEnum.MEMBER)
+@auto_commit_after_request
+def reopen_submission(grant_id: UUID, submission_id: UUID) -> ResponseReturnValue:
+    submission_helper = SubmissionHelper.load(submission_id)
+    form = ReopenSubmissionForm()
+    if form.validate_on_submit():
+        submission_helper.reopen_submission(user=get_current_user(), reopened_reason=form.reopened_reason.data)  # ty:ignore[invalid-argument-type]
+        flash("Submission reopened", FlashMessageType.SUBMISSION_REOPENED)
+        return redirect(
+            url_for("deliver_grant_funding.view_submission", grant_id=grant_id, submission_id=submission_id)
+        )
+    return ""
 
 
 @deliver_grant_funding_blueprint.route(

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/reopen_submission.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/reopen_submission.html
@@ -1,0 +1,61 @@
+{% from "common/partials/mhclg-test-banner.html" import mhclgInlinePageTestDataBanner %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% extends "deliver_grant_funding/grant_base.html" %}
+
+{% set page_title = "Submission - " ~ helper.long_collection_name %}
+{% set active_item_identifier = "reports" %}
+
+{% block beforeContent %}
+  {% if helper.is_test %}
+    {{ mhclgInlinePageTestDataBanner("Test submission") }}
+  {% endif %}
+  {{
+    govukBackLink({
+      "text": "Back",
+      "href": url_for("deliver_grant_funding.view_submission", grant_id=grant.id, submission_id=helper.submission.id)
+    })
+  }}
+{% endblock beforeContent %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% set label_html %}
+        <span class="govuk-caption-l">{{ helper.submission.grant_recipient.organisation.name if helper.submission.grant_recipient else helper.submission.created_by.email }}</span>
+        Why are you reopening this {{ helper.long_collection_name }} submission?
+      {% endset %}
+      {% set hint_html %}
+        <p class="govuk-body govuk-hint">We will send an email with your reason for reopening to:</p>
+        <ul class="govuk-list govuk-list--bullet govuk-hint">
+          {% if helper.collection.requires_certification %}
+            {% for user in helper.submission.grant_recipient.unique_data_providers_and_certifiers | sort(attribute="name") %}
+              <li>{{ user.name }} ({{ user.email }})</li>
+            {% endfor %}
+          {% else %}
+            {% for user in helper.submission.grant_recipient.data_providers | sort(attribute="name") %}
+              <li>{{ user.name }} ({{ user.email }})</li>
+            {% endfor %}
+          {% endif %}
+        </ul>
+      {% endset %}
+      <form method="post" novalidate>
+        {{ form.csrf_token }}
+        {{
+          form.reopened_reason(
+                    params={
+                      "label":{
+                        "isPageHeading":true,
+                        "html": label_html
+                      },
+                      "hint":{
+                        "html":hint_html
+                      },
+                      "maxwords": form.REASON_MAX_WORDS
+                    }
+          )
+        }}
+        {{ form.submit }}
+      </form>
+    </div>
+  </div>
+{% endblock content %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/reopen_submission.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/reopen_submission.html
@@ -20,35 +20,32 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      {% set label_html %}
+      <h1 class="govuk-heading-l">
         <span class="govuk-caption-l">{{ helper.submission.grant_recipient.organisation.name if helper.submission.grant_recipient else helper.submission.created_by.email }}</span>
         Why are you reopening this {{ helper.long_collection_name }} submission?
-      {% endset %}
-      {% set hint_html %}
-        <p class="govuk-body govuk-hint">We will send an email with your reason for reopening to:</p>
-        <ul class="govuk-list govuk-list--bullet govuk-hint">
-          {% if helper.collection.requires_certification %}
-            {% for user in helper.submission.grant_recipient.unique_data_providers_and_certifiers | sort(attribute="name") %}
-              <li>{{ user.name }} ({{ user.email }})</li>
-            {% endfor %}
-          {% else %}
-            {% for user in helper.submission.grant_recipient.data_providers | sort(attribute="name") %}
-              <li>{{ user.name }} ({{ user.email }})</li>
-            {% endfor %}
-          {% endif %}
-        </ul>
-      {% endset %}
+      </h1>
+      <p class="govuk-body">We will send an email with your reason for reopening to:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        {% if helper.collection.requires_certification %}
+          {% for user in helper.submission.grant_recipient.unique_data_providers_and_certifiers | sort(attribute="name") %}
+            <li>{{ user.name }} ({{ user.email }})</li>
+          {% endfor %}
+        {% else %}
+          {% for user in helper.submission.grant_recipient.data_providers | sort(attribute="name") %}
+            <li>{{ user.name }} ({{ user.email }})</li>
+          {% endfor %}
+        {% endif %}
+      </ul>
       <form method="post" novalidate>
+        {% set label_html %}
+          <p class="govuk-visually-hidden">Why are you reopening the submission?</p>
+        {% endset %}
         {{ form.csrf_token }}
         {{
           form.reopened_reason(
                     params={
                       "label":{
-                        "isPageHeading":true,
                         "html": label_html
-                      },
-                      "hint":{
-                        "html":hint_html
                       },
                       "maxwords": form.REASON_MAX_WORDS
                     }

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/view_submission.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/view_submission.html
@@ -3,6 +3,7 @@
 {% from "common/macros/status.html" import submissionStatusTag with context %}
 {% from "common/macros/submissions.html" import answers_summary_list with context %}
 {% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
+{% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% extends "deliver_grant_funding/grant_base.html" %}
 
 {% set page_title = "Submission - " ~ helper.long_collection_name %}
@@ -17,6 +18,25 @@
 {% endblock beforeContent %}
 
 {% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% with flashes = get_flashed_messages(category_filter=[enum.flash_message_type.SUBMISSION_REOPENED]) %}
+        {% if flashes %}
+          {% set submission_reopened_html %}
+            <h3 class="govuk-notification-banner__heading">Submission reopened and email sent to {{ helper.submission.grant_recipient.organisation.name if helper.submission.grant_recipient else helper.submission.created_by.email }}</h3>
+            <p class="govuk-body">Email sent to {{ helper.submission.grant_recipient.organisation.name ~ " users" if helper.submission.grant_recipient else helper.submission.created_by.email }} with your reason for reopening.</p>
+          {% endset %}
+          {{
+            govukNotificationBanner({
+              "html": submission_reopened_html,
+              "type":"success",
+              "titleText": "Success"
+            })
+          }}
+        {% endif %}
+      {% endwith %}
+    </div>
+  </div>
   {% if delete_form %}
     {% set banner_html %}
       <p class="govuk-body govuk-!-font-weight-bold">Are you sure you want to reset this test submission?</p>
@@ -36,7 +56,19 @@
     <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Submission</h1>
     {{ submissionStatusTag(helper.status, helper.is_overdue) }}
   </div>
-
+  {% if helper.status == enum.submission_status.SUBMITTED and  authorisation_helper.can_reopen_submission(current_user, helper.submission) %}
+    <div class="govuk-body">
+      {{
+        govukButton(
+        params={
+          "text": "Reopen submission",
+          "href": url_for('deliver_grant_funding.reopen_submission', grant_id=grant.id, submission_id=helper.submission.id),
+          "classes": "govuk-button--secondary"
+        }
+        )
+      }}
+    </div>
+  {% endif %}
   {% for form in helper.get_ordered_visible_forms() %}
     <h2 class="govuk-heading-m govuk-!-margin-top-4">{{ form.title }}</h2>
     {{ answers_summary_list(helper, form) }}

--- a/app/services/notify.py
+++ b/app/services/notify.py
@@ -374,13 +374,26 @@ class NotificationService:
     ) -> Notification:
         submission_state = submission_helper.events.submission_state
 
+        if not submission_state.reopened_reason:
+            raise ValueError(
+                f"Could not send submission reopened email for submission id={submission_helper.id} because there is "
+                "no reopened reason"
+            )
+
+        # The reopened reason shows as indented text in the email, but we need to account for this here as notify
+        # doesn't take into account multiple lines within the inset text.
+        # For notify emails, inset text needs tos tart the line with a ^
+        lines_for_email = ""
+        for line in submission_state.reopened_reason.splitlines():
+            lines_for_email += f"^ {line}\n"
+
         personalisation = {
             "is_test_data": "yes"
             if submission_helper.submission.grant_recipient.mode == GrantRecipientModeEnum.TEST
             else "no",
             "report_name": submission_helper.long_collection_name,
             "grant_name": submission_helper.collection.grant.name,
-            "reopening_reason": submission_state.reopened_reason,
+            "reopening_reason": lines_for_email,
             "requires_certification": "yes" if submission_helper.collection.requires_certification else "no",
             "grant_report_url": url_for(
                 "access_grant_funding.route_to_submission",

--- a/app/types.py
+++ b/app/types.py
@@ -27,6 +27,7 @@ class FlashMessageType(StrEnum):
     TEST_SUBMISSION_RESET = "test_submission_reset"
     TEST_SUBMISSIONS_RESET = "test_submissions_reset"
     SUBMISSION_VALIDATION_ERROR = "submission_validation_error"
+    SUBMISSION_REOPENED = "submission_reopened"
 
 
 class TRadioItem(TypedDict):

--- a/tests/integration/common/helpers/test_collections.py
+++ b/tests/integration/common/helpers/test_collections.py
@@ -1818,6 +1818,20 @@ class TestSubmissionHelper:
             assert data_provider_user.email in recipients
             assert certifier_user.email not in recipients
 
+        def test_reopen_submission_multi_submissions(
+            self, grant_team_user, submission_submitted_multiple_submissions, factories
+        ):
+            submission_1 = submission_submitted_multiple_submissions[0]
+            submission_2 = submission_submitted_multiple_submissions[1]
+            helper_1 = SubmissionHelper(submission_1)
+            helper_2 = SubmissionHelper(submission_2)
+            assert helper_1.status == SubmissionStatusEnum.SUBMITTED
+            assert helper_2.status == SubmissionStatusEnum.SUBMITTED
+
+            helper_2.reopen_submission(grant_team_user, reopened_reason="Test reason")
+            assert helper_1.status == SubmissionStatusEnum.SUBMITTED
+            assert helper_2.status == SubmissionStatusEnum.IN_PROGRESS
+
     class TestLastUpdatedAt:
         @pytest.mark.freeze_time("2026-03-09 12:00:00")
         def test_last_updated_at_utc_returns_last_submission_event_utc(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -35,6 +35,7 @@ from app.common.data.types import (
     AuthMethodEnum,
     CollectionStatusEnum,
     GrantStatusEnum,
+    QuestionDataType,
     RoleEnum,
     SubmissionEventType,
     SubmissionModeEnum,
@@ -745,6 +746,60 @@ def submission_submitted(factories: _Factories, grant_recipient: GrantRecipient,
         created_by=user,
     )
     return cast(Submission, submission)
+
+
+@pytest.fixture(scope="function")
+def submission_submitted_multiple_submissions(factories: _Factories, grant_recipient, db_session) -> list[Submission]:
+    question = factories.question.create(
+        id=uuid.UUID("d696aebc-49d2-4170-a92f-b6ef42994294"),
+        data_type=QuestionDataType.TEXT_SINGLE_LINE,
+        form__collection__allow_multiple_submissions=True,
+        form__collection__requires_certification=False,
+        form__collection__grant=grant_recipient.grant,
+        form__collection__status=CollectionStatusEnum.OPEN,
+    )
+    collection = question.form.collection
+    collection.submission_name_question_id = question.id
+    db_session.flush()
+    user = factories.user.create()
+
+    grant_recipient = factories.grant_recipient.create(grant=collection.grant)
+    submission_1 = factories.submission.create(
+        collection=collection,
+        grant_recipient=grant_recipient,
+        mode=SubmissionModeEnum.LIVE,
+        answers=[FactoryAnswer(question, TextSingleLineAnswer("Alpha"))],
+    )
+    factories.submission_event.create(
+        submission=submission_1,
+        related_entity_id=question.form.id,
+        event_type=SubmissionEventType.FORM_RUNNER_FORM_COMPLETED,
+        created_by=user,
+    )
+    factories.submission_event.create(
+        submission=submission_1,
+        event_type=SubmissionEventType.SUBMISSION_SUBMITTED,
+        created_by=user,
+    )
+    submission_2 = factories.submission.create(
+        collection=collection,
+        grant_recipient=grant_recipient,
+        mode=SubmissionModeEnum.LIVE,
+        answers=[FactoryAnswer(question, TextSingleLineAnswer("Beta"))],
+    )
+    factories.submission_event.create(
+        submission=submission_2,
+        related_entity_id=question.form.id,
+        event_type=SubmissionEventType.FORM_RUNNER_FORM_COMPLETED,
+        created_by=user,
+    )
+    factories.submission_event.create(
+        submission=submission_2,
+        event_type=SubmissionEventType.SUBMISSION_SUBMITTED,
+        created_by=user,
+    )
+
+    return [submission_1, submission_2]
 
 
 @pytest.fixture(scope="function")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -302,14 +302,48 @@ def authenticated_no_role_client(
 
 
 @pytest.fixture()
-def authenticated_grant_member_client(
-    anonymous_client: FundingServiceTestClient, factories: _Factories, db_session: Session, request: FixtureRequest
+def authenticated_grant_member_client_no_grant_recipients(
+    anonymous_client: FundingServiceTestClient,
+    factories: _Factories,
+    db_session: Session,
+    request: FixtureRequest,
 ) -> Generator[FundingServiceTestClient, None, None]:
     email_mark = request.node.get_closest_marker("authenticate_as")
     email = email_mark.args[0] if email_mark else "test2@communities.gov.uk"
 
     user = factories.user.create(email=email)
     grant = factories.grant.create()
+    factories.user_role.create(
+        user=user,
+        permissions=[RoleEnum.MEMBER],
+        organisation=grant.organisation,
+        grant=grant,
+    )
+
+    login_user(user)
+    with anonymous_client.session_transaction() as session:
+        session["auth"] = AuthMethodEnum.SSO
+    anonymous_client.user = user
+    anonymous_client.grant = grant
+    anonymous_client.organisation = grant.organisation
+    db_session.commit()
+
+    yield anonymous_client
+
+
+@pytest.fixture()
+def authenticated_grant_member_client(
+    anonymous_client: FundingServiceTestClient,
+    grant_recipient,
+    factories: _Factories,
+    db_session: Session,
+    request: FixtureRequest,
+) -> Generator[FundingServiceTestClient, None, None]:
+    email_mark = request.node.get_closest_marker("authenticate_as")
+    email = email_mark.args[0] if email_mark else "test2@communities.gov.uk"
+
+    user = factories.user.create(email=email)
+    grant = grant_recipient.grant
     factories.user_role.create(
         user=user,
         permissions=[RoleEnum.MEMBER],

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -44,6 +44,7 @@ from app.common.data.types import (
     QuestionPresentationOptions,
     SubmissionEventType,
     SubmissionModeEnum,
+    SubmissionStatusEnum,
 )
 from app.common.expressions import (
     ExpressionContext,
@@ -58,6 +59,7 @@ from app.common.expressions.managed import AnyOf, GreaterThan, IsAfter, IsNo, Is
 from app.common.expressions.references import ExpressionReference
 from app.common.filters import format_datetime_short
 from app.common.forms import GenericConfirmDeletionForm, GenericSubmitForm
+from app.common.helpers.collections import SubmissionHelper
 from app.constants import DATA_SET_EXTERNAL_ID_COLUMN_HEADER, DATA_SET_GRANT_RECIPIENT_COLUMN_HEADER
 from app.deliver_grant_funding.data_sets import build_data_set_upload_s3_key
 from app.deliver_grant_funding.forms import (
@@ -70,6 +72,7 @@ from app.deliver_grant_funding.forms import (
     GroupForm,
     QuestionForm,
     QuestionTypeForm,
+    ReopenSubmissionForm,
     SetUpReportForm,
 )
 from app.deliver_grant_funding.routes.reports import (
@@ -9032,6 +9035,79 @@ class TestViewSubmission:
                 f"Reset this submission link should NOT be present for {submission_mode.value} mode"
             )
 
+    @pytest.mark.parametrize(
+        "client_fixture, submission_fixture, can_see_reopen_button",
+        [
+            ("authenticated_org_member_client", "submission_submitted", False),
+            ("authenticated_grant_member_client", "submission_in_progress", False),
+            ("authenticated_grant_member_client", "submission_submitted", True),
+        ],
+    )
+    def test_can_see_reopen_submission_button(
+        self, request, client_fixture, grant_recipient, submission_fixture, can_see_reopen_button, factories
+    ):
+
+        client = request.getfixturevalue(client_fixture)
+        submission = request.getfixturevalue(submission_fixture)
+        response = client.get(
+            url_for(
+                "deliver_grant_funding.view_submission",
+                grant_id=grant_recipient.grant.id,
+                submission_id=submission.id,
+            )
+        )
+
+        assert response.status_code == 200
+        soup = BeautifulSoup(response.data, "html.parser")
+        reopen_button = page_has_link(soup, "Reopen submission")
+        if can_see_reopen_button:
+            assert reopen_button is not None
+        else:
+            assert reopen_button is None
+
+
+class TestReopenSubmission:
+    def test_404(self, authenticated_platform_member_client):
+        response = authenticated_platform_member_client.get(
+            url_for("deliver_grant_funding.reopen_submission", grant_id=uuid.uuid4(), submission_id=uuid.uuid4())
+        )
+        assert response.status_code == 404
+
+    def test_get(self, authenticated_grant_member_client, submission_submitted):
+        response = authenticated_grant_member_client.get(
+            url_for(
+                "deliver_grant_funding.reopen_submission",
+                grant_id=submission_submitted.collection.grant.id,
+                submission_id=submission_submitted.id,
+            )
+        )
+        assert response.status_code == 200
+        soup = BeautifulSoup(response.data, "html.parser")
+        assert f"Why are you reopening this {submission_submitted.collection.name} submission?" in get_h1_text(soup)
+        assert submission_submitted.grant_recipient.organisation.name in get_h1_text(soup)
+        assert page_has_button(soup, "Reopen submission")
+
+    def test_post(self, authenticated_grant_member_client, submission_submitted):
+        helper = SubmissionHelper(submission_submitted)
+        assert helper.status == SubmissionStatusEnum.SUBMITTED
+        form = ReopenSubmissionForm(data={"reopened_reason": "as discussed"})
+        response = authenticated_grant_member_client.post(
+            url_for(
+                "deliver_grant_funding.reopen_submission",
+                grant_id=submission_submitted.collection.grant.id,
+                submission_id=submission_submitted.id,
+            ),
+            data=get_form_data(form),
+            follow_redirects=False,
+        )
+        assert response.status_code == 302
+        assert response.location == url_for(
+            "deliver_grant_funding.view_submission",
+            grant_id=submission_submitted.collection.grant.id,
+            submission_id=submission_submitted.id,
+        )
+        assert helper.status == SubmissionStatusEnum.IN_PROGRESS
+
 
 class TestListReportDataSets:
     def test_404(self, authenticated_grant_member_client):
@@ -9154,35 +9230,36 @@ class TestDownloadGrantRecipientDataSetTemplate:
         )
         assert response.status_code == 404
 
-    def test_csv_download(self, authenticated_grant_member_client, factories):
-        report = factories.collection.create(grant=authenticated_grant_member_client.grant)
+    def test_csv_download(self, authenticated_grant_member_client_no_grant_recipients, factories):
+        grant = authenticated_grant_member_client_no_grant_recipients.grant
+        report = factories.collection.create(grant=grant)
 
         grant_recipient_1 = factories.grant_recipient.create(
-            grant=authenticated_grant_member_client.grant,
+            grant=grant,
             organisation__external_id="E12345",
             organisation__name="Rivendell",
         )
         grant_recipient_2 = factories.grant_recipient.create(
-            grant=authenticated_grant_member_client.grant,
+            grant=grant,
             organisation__external_id="E67890",
             organisation__name="Lothlorien",
         )
         grant_recipient_3 = factories.grant_recipient.create(
-            grant=authenticated_grant_member_client.grant,
+            grant=grant,
             organisation__name="Isengard",
             organisation__external_id="E00000",
             organisation__mode=OrganisationModeEnum.TEST,
         )
         grant_recipient_4 = factories.grant_recipient.create(
-            grant=authenticated_grant_member_client.grant,
+            grant=grant,
             organisation__name="Shire",
             organisation__external_id="E99999",
         )
 
-        response = authenticated_grant_member_client.get(
+        response = authenticated_grant_member_client_no_grant_recipients.get(
             url_for(
                 "deliver_grant_funding.download_grant_recipient_data_set_template",
-                grant_id=authenticated_grant_member_client.grant.id,
+                grant_id=grant.id,
                 report_id=report.id,
             )
         )
@@ -9207,13 +9284,18 @@ class TestDownloadGrantRecipientDataSetTemplate:
         # Test grant recipient organisations excluded
         assert grant_recipient_3.organisation.name not in response.text
 
-    def test_csv_download_empty_grant_recipients(self, authenticated_grant_member_client, factories):
-        report = factories.collection.create(grant=authenticated_grant_member_client.grant, name="Test Report")
+    def test_csv_download_empty_grant_recipients(
+        self, factories, authenticated_grant_member_client_no_grant_recipients
+    ):
 
-        response = authenticated_grant_member_client.get(
+        report = factories.collection.create(
+            grant=authenticated_grant_member_client_no_grant_recipients.grant, name="Test Report"
+        )
+
+        response = authenticated_grant_member_client_no_grant_recipients.get(
             url_for(
                 "deliver_grant_funding.download_grant_recipient_data_set_template",
-                grant_id=authenticated_grant_member_client.grant.id,
+                grant_id=authenticated_grant_member_client_no_grant_recipients.grant.id,
                 report_id=report.id,
             )
         )

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -9073,19 +9073,31 @@ class TestReopenSubmission:
         )
         assert response.status_code == 404
 
-    def test_get(self, authenticated_grant_member_client, submission_submitted):
-        response = authenticated_grant_member_client.get(
+    @pytest.mark.parametrize(
+        "client_fixture, can_access",
+        (
+            ("authenticated_no_role_client", False),
+            ("authenticated_org_member_client", False),
+            ("authenticated_grant_member_client", True),
+        ),
+    )
+    def test_get(self, request, client_fixture, can_access, submission_submitted):
+        client = request.getfixturevalue(client_fixture)
+        response = client.get(
             url_for(
                 "deliver_grant_funding.reopen_submission",
                 grant_id=submission_submitted.collection.grant.id,
                 submission_id=submission_submitted.id,
             )
         )
-        assert response.status_code == 200
-        soup = BeautifulSoup(response.data, "html.parser")
-        assert f"Why are you reopening this {submission_submitted.collection.name} submission?" in get_h1_text(soup)
-        assert submission_submitted.grant_recipient.organisation.name in get_h1_text(soup)
-        assert page_has_button(soup, "Reopen submission")
+        if not can_access:
+            assert response.status_code == 403
+        else:
+            assert response.status_code == 200
+            soup = BeautifulSoup(response.data, "html.parser")
+            assert f"Why are you reopening this {submission_submitted.collection.name} submission?" in get_h1_text(soup)
+            assert submission_submitted.grant_recipient.organisation.name in get_h1_text(soup)
+            assert page_has_button(soup, "Reopen submission")
 
     def test_post(self, authenticated_grant_member_client, submission_submitted):
         helper = SubmissionHelper(submission_submitted)

--- a/tests/unit/common/auth/test_authorisation_helper.py
+++ b/tests/unit/common/auth/test_authorisation_helper.py
@@ -449,3 +449,21 @@ class TestAuthorisationHelper:
         factories.user_role.build(user=user, permissions=[RoleEnum.MEMBER], organisation=organisation, grant=None)
 
         assert AuthorisationHelper.has_access_grant_recipient_role(user=user) is False
+
+    @pytest.mark.parametrize("user_fixture", ["platform_member_user", "deliver_org_admin_user"])
+    def test_can_user_reopen_submission_is_false(self, factories, request, user_fixture, submission_submitted, mocker):
+        user = request.getfixturevalue(user_fixture)
+        mocker.patch(
+            "app.common.auth.authorisation_helper.get_grant", return_value=submission_submitted.collection.grant
+        )
+
+        assert AuthorisationHelper.can_reopen_submission(user, submission_submitted) is False
+
+    @pytest.mark.parametrize("user_fixture", ["platform_admin_user", "grant_team_member_user"])
+    def test_can_user_reopen_submission_is_true(self, factories, request, user_fixture, submission_submitted, mocker):
+        user = request.getfixturevalue(user_fixture)
+        mocker.patch(
+            "app.common.auth.authorisation_helper.get_grant", return_value=submission_submitted.collection.grant
+        )
+
+        assert AuthorisationHelper.can_reopen_submission(user, submission_submitted) is True

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -11,7 +11,8 @@ from flask_sqlalchemy_lite import SQLAlchemy
 from app import create_app
 from app.common.collections.types import TextSingleLineAnswer
 from app.common.data.models import Submission
-from app.common.data.types import SubmissionEventType, SubmissionModeEnum
+from app.common.data.models_user import User
+from app.common.data.types import RoleEnum, SubmissionEventType, SubmissionModeEnum
 from tests.conftest import _Factories, _precompile_templates
 from tests.models import FactoryAnswer
 from tests.utils import build_db_config
@@ -123,3 +124,67 @@ def submission_submitted(factories: _Factories, submission_awaiting_sign_off) ->
         created_at_utc=datetime(2025, 11, 25, 10, 37, 0),
     )
     yield submission_awaiting_sign_off
+
+
+@pytest.fixture(scope="function")
+def platform_member_user(
+    factories: _Factories,
+) -> Generator[User, None, None]:
+    user = factories.user.build()
+    factories.user_role.build(
+        user=user,
+        permissions=[
+            RoleEnum.MEMBER,
+        ],
+        organisation=None,
+        grant=None,
+    )
+    yield user
+
+
+@pytest.fixture(scope="function")
+def platform_admin_user(
+    factories: _Factories,
+) -> Generator[User, None, None]:
+    user = factories.user.build()
+    factories.user_role.build(
+        user=user,
+        permissions=[
+            RoleEnum.MEMBER,
+            RoleEnum.ADMIN,
+        ],
+        organisation=None,
+        grant=None,
+    )
+    yield user
+
+
+@pytest.fixture(scope="function")
+def deliver_org_admin_user(factories: _Factories, submission_awaiting_sign_off) -> Generator[User, None, None]:
+    user = factories.user.build()
+    grant = submission_awaiting_sign_off.collection.grant
+    factories.user_role.build(
+        user=user,
+        permissions=[
+            RoleEnum.MEMBER,
+            RoleEnum.ADMIN,
+        ],
+        organisation=grant.organisation,
+        grant=None,
+    )
+    yield user
+
+
+@pytest.fixture(scope="function")
+def grant_team_member_user(factories: _Factories, submission_awaiting_sign_off) -> Generator[User, None, None]:
+    user = factories.user.build()
+    grant = submission_awaiting_sign_off.collection.grant
+    factories.user_role.build(
+        user=user,
+        permissions=[
+            RoleEnum.MEMBER,
+        ],
+        organisation=grant.organisation,
+        grant=grant,
+    )
+    yield user

--- a/tests/unit/services/test_notify.py
+++ b/tests/unit/services/test_notify.py
@@ -390,7 +390,7 @@ class TestNotificationService:
             "is_test_data": "no",
             "report_name": "Test collection",
             "grant_name": "Test grant",
-            "reopening_reason": "Reopen reason",
+            "reopening_reason": "^ Reopen reason\n",
             "requires_certification": "yes",
             "grant_report_url": f"http://funding.communities.gov.localhost:8080/access/organisation/{submission_submitted.grant_recipient.organisation.id}/grants/{submission_submitted.grant_recipient.grant.id}/collection/{submission_submitted.collection.id}",
         }
@@ -403,6 +403,66 @@ class TestNotificationService:
         assert mock_notification_service_calls[0].kwargs["personalisation"] == expected_personalisation
         assert mock_notification_service_calls[0].kwargs["template_id"] == "ad07a53a-d930-4cb3-ad57-595a1c104e61"
         assert mock_notification_service_calls[0].kwargs["email_address"] == "certifier@communities.gov.uk"
+
+    @responses.activate
+    def test_send_access_submission_reopened_reason_on_multiple_lines(
+        self,
+        app,
+        factories,
+        submission_submitted,
+        mock_notification_service_calls,
+    ):
+        grant_team_user = factories.user.build(name="Grant Team User")
+        factories.submission_event.build(
+            submission=submission_submitted,
+            event_type=SubmissionEventType.SUBMISSION_REOPENED,
+            created_by=grant_team_user,
+            created_at_utc=datetime.datetime(2025, 12, 1, 9, 30, 0),
+            data={"reopened_reason": "Reopen reason\nOn\n\nMultiple lines"},
+        )
+        helper = SubmissionHelper(submission_submitted)
+
+        expected_personalisation = {
+            "is_test_data": "no",
+            "report_name": "Test collection",
+            "grant_name": "Test grant",
+            "reopening_reason": "^ Reopen reason\n^ On\n^ \n^ Multiple lines\n",
+            "requires_certification": "yes",
+            "grant_report_url": f"http://funding.communities.gov.localhost:8080/access/organisation/{submission_submitted.grant_recipient.organisation.id}/grants/{submission_submitted.grant_recipient.grant.id}/collection/{submission_submitted.collection.id}",
+        }
+
+        notification_service.send_access_submission_reopened(
+            submission_helper=helper,
+            user=helper.submitted_by,
+        )
+        assert len(mock_notification_service_calls) == 1
+        assert mock_notification_service_calls[0].kwargs["personalisation"] == expected_personalisation
+        assert mock_notification_service_calls[0].kwargs["template_id"] == "ad07a53a-d930-4cb3-ad57-595a1c104e61"
+        assert mock_notification_service_calls[0].kwargs["email_address"] == "certifier@communities.gov.uk"
+
+    @responses.activate
+    def test_send_access_submission_reopened_fails_when_no_reason_provided(
+        self,
+        app,
+        factories,
+        submission_submitted,
+        mock_notification_service_calls,
+    ):
+        grant_team_user = factories.user.build(name="Grant Team User")
+        factories.submission_event.build(
+            submission=submission_submitted,
+            event_type=SubmissionEventType.SUBMISSION_REOPENED,
+            created_by=grant_team_user,
+            created_at_utc=datetime.datetime(2025, 12, 1, 9, 30, 0),
+            data={"reopened_reason": None},
+        )
+        helper = SubmissionHelper(submission_submitted)
+
+        with pytest.raises(ValueError, match="because there is no reopened reason"):
+            notification_service.send_access_submission_reopened(
+                submission_helper=helper,
+                user=helper.submitted_by,
+            )
 
     @responses.activate
     def test_send_access_submission_submitted_requires_certification(self, app, factories):

--- a/tests/unit/test_all_routes_access.py
+++ b/tests/unit/test_all_routes_access.py
@@ -140,6 +140,7 @@ routes_with_expected_member_only_access = [
     "deliver_grant_funding.download_grant_recipient_data_set_template",
     "deliver_grant_funding.view_data_source",
     "deliver_grant_funding.download_data_source_csv",
+    "deliver_grant_funding.reopen_submission",
 ]
 
 routes_with_expected_access_grant_funding_logged_in_access = [


### PR DESCRIPTION
## 🎫 Ticket
FSPT-1298

## 📝 Description
This PR adds the frontend routes and template to be able to reopen a submission:
- New form
- New template
- New route
- Uses the backend logic introduced in the previous PRs, but moves the permissions checks into `AuthorisationHelper` so they can be reused in the template.
- Fixes the notify email body so that the reopened reason correctly indents the text (doing it in the template didn't work if the reason spanned multiple lines)

## 📸 Show the thing (screenshots, gifs)

https://github.com/user-attachments/assets/424c9c6f-b8fe-42d0-be28-4cc4e534fd43


## 🧪 Testing
- Tested locally with test and live submissions

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [ ] PR title and description provide sufficient context for reviewers
- [ ] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- [ ] No N+1 query problems introduced
- [ ] Any new DB queries include appropriate where clauses based on the user's permissions

### Testing
- [ ] I have tested this change and it meets the acceptance criteria for the ticket
- [ ] I need the reviewer(s) to pull and run this change locally
- [ ] New (non-developer) functionality has appropriate unit and integration tests
- [ ] End-to-end tests have been updated (if applicable)
- [ ] Edge cases and error conditions are tested


