### PR TITLE
FSPT-1298 Improve error handling for reopening submissions

### DIFF
--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -323,6 +323,10 @@ class Collection(BaseModel):
         return self.status == CollectionStatusEnum.OPEN
 
     @property
+    def is_closed(self) -> bool:
+        return self.status == CollectionStatusEnum.CLOSED
+
+    @property
     def is_overdue(self) -> bool:
         if not self.submission_period_end_date:
             return False

--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -114,6 +114,14 @@ class SubmissionAuthorisationError(Exception):
         )
 
 
+class CollectionIsNotOpenError(Exception):
+    pass
+
+
+class SubmissionIsNotSubmittedError(Exception):
+    pass
+
+
 class SubmissionHelper:
     """
     This offensively-named class is a helper for the `app.common.data.models.Submission` and associated sub-models.
@@ -1187,10 +1195,12 @@ class SubmissionHelper:
             )
 
         if not self.collection.is_open:
-            raise ValueError(f"Could not reopen submission id={self.id} because the report is not open.")
+            raise CollectionIsNotOpenError(f"Could not reopen submission id={self.id} because the report is not open.")
 
         if not self.is_submitted:
-            raise ValueError(f"Could not reopen submission id={self.id} because it is not submitted.")
+            raise SubmissionIsNotSubmittedError(
+                f"Could not reopen submission id={self.id} because it is not submitted."
+            )
 
         interfaces.collections.add_submission_event(
             self.submission,

--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -47,6 +47,7 @@ from app.common.data.types import (
     ConditionsOperator,
     ExpressionType,
     GrantRecipientModeEnum,
+    GrantStatusEnum,
     NumberTypeEnum,
     QuestionDataType,
     RoleEnum,
@@ -1183,6 +1184,22 @@ class SubmissionHelper:
         interfaces.collections.add_submission_event(
             self.submission, event_type=SubmissionEventType.SUBMISSION_APPROVED_BY_CERTIFIER, user=user
         )
+
+    def can_be_reopened_by_user(self, user: User) -> bool:
+        if not self.is_submitted:
+            return False
+        if self.is_test:
+            if self.collection.is_closed:
+                return False
+            return True
+
+        if (
+            self.collection.is_open
+            and self.collection.grant.status == GrantStatusEnum.LIVE
+            and AuthorisationHelper.can_reopen_submission(user, self.submission)
+        ):
+            return True
+        return False
 
     def reopen_submission(self, user: User, reopened_reason: str) -> None:
 

--- a/app/deliver_grant_funding/routes/reports.py
+++ b/app/deliver_grant_funding/routes/reports.py
@@ -100,7 +100,13 @@ from app.common.expressions.forms import (
 from app.common.expressions.references import ExpressionReference
 from app.common.expressions.registry import get_managed_validators_by_data_type, lookup_managed_expression
 from app.common.forms import GenericConfirmDeletionForm, GenericSubmitForm
-from app.common.helpers.collections import AllSubmissionsHelper, SubmissionHelper
+from app.common.helpers.collections import (
+    AllSubmissionsHelper,
+    CollectionIsNotOpenError,
+    SubmissionAuthorisationError,
+    SubmissionHelper,
+    SubmissionIsNotSubmittedError,
+)
 from app.constants import (
     DATA_SET_EXTERNAL_ID_COLUMN_HEADER,
     DATA_SET_GRANT_RECIPIENT_COLUMN_HEADER,
@@ -3252,11 +3258,18 @@ def reopen_submission(grant_id: UUID, submission_id: UUID) -> ResponseReturnValu
         abort(403)
     form = ReopenSubmissionForm()
     if form.validate_on_submit():
-        submission_helper.reopen_submission(user=get_current_user(), reopened_reason=form.reopened_reason.data)  # ty:ignore[invalid-argument-type]
-        flash("Submission reopened", FlashMessageType.SUBMISSION_REOPENED)
-        return redirect(
-            url_for("deliver_grant_funding.view_submission", grant_id=grant_id, submission_id=submission_id)
-        )
+        try:
+            submission_helper.reopen_submission(user=get_current_user(), reopened_reason=form.reopened_reason.data)  # ty:ignore[invalid-argument-type]
+            flash("Submission reopened", FlashMessageType.SUBMISSION_REOPENED)
+            return redirect(
+                url_for("deliver_grant_funding.view_submission", grant_id=grant_id, submission_id=submission_id)
+            )
+        except SubmissionAuthorisationError:
+            form.form_errors.append("You do not have permission to reopen this submission")
+        except CollectionIsNotOpenError:
+            form.form_errors.append("You cannot reopen this submission because the report is not open")
+        except SubmissionIsNotSubmittedError:
+            form.form_errors.append("You cannot reopen this submission because it has not been submitted")
     return render_template(
         "deliver_grant_funding/reports/reopen_submission.html",
         form=form,

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/view_submission.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/view_submission.html
@@ -56,7 +56,7 @@
     <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Submission</h1>
     {{ submissionStatusTag(helper.status, helper.is_overdue) }}
   </div>
-  {% if helper.status == enum.submission_status.SUBMITTED and  authorisation_helper.can_reopen_submission(current_user, helper.submission) %}
+  {% if helper.can_be_reopened_by_user(current_user) %}
     <div class="govuk-body">
       {{
         govukButton(

--- a/tests/integration/common/helpers/test_collections.py
+++ b/tests/integration/common/helpers/test_collections.py
@@ -42,8 +42,10 @@ from app.common.expressions.managed import GreaterThan, IsYes
 from app.common.expressions.references import ExpressionReference
 from app.common.helpers.collections import (
     AllSubmissionsHelper,
+    CollectionIsNotOpenError,
     SubmissionAuthorisationError,
     SubmissionHelper,
+    SubmissionIsNotSubmittedError,
 )
 from tests.models import FactoryAnswer
 from tests.utils import AnyStringMatching
@@ -1735,7 +1737,7 @@ class TestSubmissionHelper:
             collection = submission_submitted.collection
             collection.status = CollectionStatusEnum.CLOSED
 
-            with pytest.raises(ValueError, match="report is not open"):
+            with pytest.raises(CollectionIsNotOpenError, match="report is not open"):
                 helper.reopen_submission(user=grant_team_user, reopened_reason="Test reason")
 
             assert helper.status == SubmissionStatusEnum.SUBMITTED
@@ -1746,7 +1748,7 @@ class TestSubmissionHelper:
             helper = SubmissionHelper(submission_awaiting_sign_off)
             assert helper.status == SubmissionStatusEnum.AWAITING_SIGN_OFF
 
-            with pytest.raises(ValueError, match="it is not submitted"):
+            with pytest.raises(SubmissionIsNotSubmittedError, match="it is not submitted"):
                 helper.reopen_submission(user=grant_team_user, reopened_reason="Test reason")
 
             assert helper.status == SubmissionStatusEnum.AWAITING_SIGN_OFF

--- a/tests/unit/common/helpers/test_collections.py
+++ b/tests/unit/common/helpers/test_collections.py
@@ -16,9 +16,11 @@ from app.common.collections.types import (
 from app.common.data.models import ComponentReference
 from app.common.data.submission_data_manager import _deserialise_question_type
 from app.common.data.types import (
+    CollectionStatusEnum,
     ComponentVisibilityState,
     ConditionsOperator,
     ExpressionType,
+    GrantStatusEnum,
     NumberTypeEnum,
     QuestionDataOptions,
     QuestionDataType,
@@ -1801,6 +1803,69 @@ class TestSubmissionHelper:
                 helper.get_component_visibility_state(group, helper.cached_evaluation_context)
                 == ComponentVisibilityState.VISIBLE
             )
+
+    class TestCanBeReopenedByUser:
+        @pytest.mark.parametrize(
+            "collection_status,grant_status,is_submitted,expected_result",
+            [
+                (CollectionStatusEnum.OPEN, GrantStatusEnum.LIVE, True, True),
+                (CollectionStatusEnum.OPEN, GrantStatusEnum.DRAFT, True, True),
+                (CollectionStatusEnum.OPEN, GrantStatusEnum.LIVE, False, False),
+                (CollectionStatusEnum.CLOSED, GrantStatusEnum.LIVE, False, False),
+                (CollectionStatusEnum.CLOSED, GrantStatusEnum.LIVE, True, False),
+            ],
+        )
+        def test_when_in_test_mode(
+            self, factories, collection_status, grant_status, is_submitted, expected_result, mocker
+        ):
+            submission = factories.submission.build(
+                mode=SubmissionModeEnum.TEST,
+                collection__status=collection_status,
+                collection__grant__status=grant_status,
+            )
+            user = factories.user.build()
+            mocker.patch(
+                "app.common.helpers.collections.SubmissionHelper.is_submitted",
+                new_callable=mocker.PropertyMock,
+                return_value=is_submitted,
+            )
+            helper = SubmissionHelper(submission)
+            assert helper.can_be_reopened_by_user(user) == expected_result
+
+        @pytest.mark.parametrize(
+            "collection_status,grant_status,is_submitted, user_can_reopen,expected_result",
+            [
+                (CollectionStatusEnum.OPEN, GrantStatusEnum.LIVE, True, True, True),
+                (CollectionStatusEnum.OPEN, GrantStatusEnum.DRAFT, True, True, False),
+                (CollectionStatusEnum.OPEN, GrantStatusEnum.ONBOARDING, True, True, False),
+                (CollectionStatusEnum.DRAFT, GrantStatusEnum.LIVE, True, True, False),
+                (CollectionStatusEnum.SCHEDULED, GrantStatusEnum.LIVE, True, True, False),
+                (CollectionStatusEnum.CLOSED, GrantStatusEnum.LIVE, True, True, False),
+                (CollectionStatusEnum.OPEN, GrantStatusEnum.LIVE, False, True, False),
+                (CollectionStatusEnum.OPEN, GrantStatusEnum.LIVE, True, False, False),
+            ],
+        )
+        def test_when_in_live_mode(
+            self, factories, collection_status, grant_status, is_submitted, user_can_reopen, expected_result, mocker
+        ):
+
+            submission = factories.submission.build(
+                mode=SubmissionModeEnum.LIVE,
+                collection__status=collection_status,
+                collection__grant__status=grant_status,
+            )
+            user = factories.user.build()
+            mocker.patch(
+                "app.common.helpers.collections.SubmissionHelper.is_submitted",
+                new_callable=mocker.PropertyMock,
+                return_value=is_submitted,
+            )
+            mocker.patch(
+                "app.common.helpers.collections.AuthorisationHelper.can_reopen_submission",
+                return_value=user_can_reopen,
+            )
+            helper = SubmissionHelper(submission)
+            assert helper.can_be_reopened_by_user(user) == expected_result
 
 
 class TestDeserialiseQuestionType:


### PR DESCRIPTION
## 🎫 Ticket
[FSPT-1298](https://mhclgdigital.atlassian.net/browse/FSPT-1298)

## 📝 Description
Makes some small improvements to the handling of errors (invalid permissions and statuses) for reopening submissions, flagged during product sign off:
- Allows any user who can view a submission to reopen it if it is a `TEST` mode submission
- Hides the Reopen submission button on the view submissions page if that user cannot reopen that submission right now (either due to insufficient permissions, or an incorrect status on the submission, collection or grant)
- If the user bypasses these checks (eg. by editing the URL, or if the status changes in the background whilst a user is on the reopen submission page) we now display an informative error message when they click Reopen, rather than a 500 error.

## 📸 Show the thing (screenshots, gifs)
<img width="343" height="308" alt="Screenshot 2026-05-06 at 12 59 49" src="https://github.com/user-attachments/assets/16f9b0c6-e6bf-4ffc-bbc2-43f9987d2dbc" />

<img width="356" height="305" alt="Screenshot 2026-05-06 at 13 00 32" src="https://github.com/user-attachments/assets/9b9531d8-0b7b-4541-9a7a-649d949c8863" />

<img width="367" height="250" alt="Screenshot 2026-05-06 at 13 01 04" src="https://github.com/user-attachments/assets/031d6816-42f3-447e-a11a-fc8f06f8e967" />




[FSPT-1298]: https://mhclgdigital.atlassian.net/browse/FSPT-1298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ