### PR TITLE
FSPT-1298 - Reopen info in admin views

### DIFF
--- a/app/deliver_grant_funding/admin/entities.py
+++ b/app/deliver_grant_funding/admin/entities.py
@@ -638,3 +638,6 @@ class PlatformAdminSubmissionEventView(FlaskAdminPlatformAdminAccessibleMixin, P
         "submission.mode": "Submission mode",
         "created_by.email": "Created by",
     }
+    column_formatters_detail = {
+        "data": _format_json_data,
+    }

--- a/app/deliver_grant_funding/admin/entities.py
+++ b/app/deliver_grant_funding/admin/entities.py
@@ -533,7 +533,15 @@ class PlatformAdminAuditEventView(FlaskAdminPlatformAdminAccessibleMixin, Platfo
         return query, count_query, joins, count_joins
 
 
-MoJTimelineEvent = namedtuple("MoJTimelineEvent", ["title", "byline", "datetime", "description"])
+MoJTimelineEvent = namedtuple(
+    "MoJTimelineEvent",
+    [
+        "title",
+        "byline",
+        "datetime",
+        "description",
+    ],
+)
 
 
 def _build_submission_timeline_items(submission: Submission) -> list[MoJTimelineEvent]:
@@ -553,13 +561,15 @@ def _build_submission_timeline_items(submission: Submission) -> list[MoJTimeline
             title += f": {form_titles.get(event.related_entity_id, '(form no longer exists)')}"
         elif event.event_type == SubmissionEventType.SUBMISSION_DECLINED_BY_CERTIFIER:
             description = event.data.get("declined_reason") or ""
-
+        elif event.event_type == SubmissionEventType.SUBMISSION_REOPENED:
+            for line in cast(str, event.data.get("reopened_reason", "")).split("\n"):
+                description += f"<p>{markupsafe.escape(line)}</p>"
         items.append(
             MoJTimelineEvent(
                 title=title,
                 byline=actor.name or actor.email,
                 datetime=event.created_at_utc,
-                description=description,
+                description=markupsafe.Markup(description),
             )
         )
 


### PR DESCRIPTION
Couple of small tweaks to the admin views following the reopen submissions work:

## Adding the reopened reason to the submission timeline
<img width="609" height="519" alt="Screenshot 2026-05-06 at 14 57 46" src="https://github.com/user-attachments/assets/aa4ef132-01a2-4c01-8edd-766d0f9dfbc4" />

## Formatting the event data as JSON for Submission Events
<img width="1274" height="557" alt="Screenshot 2026-05-06 at 14 58 34" src="https://github.com/user-attachments/assets/a639eaef-b747-4ed7-bb32-7cf0679ec19a" />
