### PR TITLE
Add platform admin page for editing question names

### DIFF
--- a/app/deliver_grant_funding/admin/__init__.py
+++ b/app/deliver_grant_funding/admin/__init__.py
@@ -8,6 +8,7 @@ from app.deliver_grant_funding.admin.entities import (
     PlatformAdminGrantView,
     PlatformAdminInvitationView,
     PlatformAdminOrganisationView,
+    PlatformAdminQuestionView,
     PlatformAdminSubmissionEventView,
     PlatformAdminSubmissionView,
     PlatformAdminUserRoleView,
@@ -64,5 +65,6 @@ def register_admin_views(flask_admin: Admin, db_: SQLAlchemy) -> None:
     flask_admin.add_view(PlatformAdminGrantView(ProxySession(db_)))  # type: ignore[arg-type]
     flask_admin.add_view(PlatformAdminGrantRecipientView(ProxySession(db_)))  # type: ignore[arg-type]
     flask_admin.add_view(PlatformAdminCollectionView(ProxySession(db_)))  # type: ignore[arg-type]
+    flask_admin.add_view(PlatformAdminQuestionView(ProxySession(db_)))  # type: ignore[arg-type]
     flask_admin.add_view(PlatformAdminInvitationView(ProxySession(db_)))  # type: ignore[arg-type]
     flask_admin.add_view(PlatformAdminAuditEventView(ProxySession(db_)))  # type: ignore[arg-type]

--- a/app/deliver_grant_funding/admin/entities.py
+++ b/app/deliver_grant_funding/admin/entities.py
@@ -24,7 +24,15 @@ from app.common.audit import (
 )
 from app.common.data.base import BaseModel
 from app.common.data.interfaces.user import get_current_user
-from app.common.data.models import Collection, Grant, GrantRecipient, Organisation, Submission, SubmissionEvent
+from app.common.data.models import (
+    Collection,
+    Grant,
+    GrantRecipient,
+    Organisation,
+    Question,
+    Submission,
+    SubmissionEvent,
+)
 from app.common.data.models_audit import AuditEvent
 from app.common.data.models_user import Invitation, User, UserRole
 from app.common.data.types import RoleEnum, SubmissionEventType
@@ -622,6 +630,41 @@ class PlatformAdminSubmissionView(FlaskAdminPlatformAdminGrantLifecycleManagerAc
                 kwargs["helper"] = SubmissionHelper(cast("Submission", model))
 
         return super().render(template, **kwargs)
+
+
+class PlatformAdminQuestionView(FlaskAdminPlatformAdminAccessibleMixin, PlatformAdminModelView):
+    _model = Question
+
+    can_edit = True
+    can_create = False
+    can_delete = False
+
+    edit_template = "deliver_grant_funding/admin/edit-question.html"
+
+    column_list = [
+        "name",
+        "text",
+        "data_type",
+        "form.collection.grant.name",
+        "form.collection.name",
+        "form.title",
+    ]
+    column_labels = {
+        "data_type": "Type",
+        "form.title": "Section",
+        "form.collection.name": "Collection",
+        "form.collection.grant.name": "Grant",
+    }
+    column_filters = [
+        "form.collection.grant.name",
+        "form.collection.name",
+        "form.title",
+        "name",
+        "data_type",
+    ]
+    column_searchable_list = ["name", "text"]
+    form_columns = ["name"]
+    column_default_sort = "name"
 
 
 class PlatformAdminSubmissionEventView(FlaskAdminPlatformAdminAccessibleMixin, PlatformAdminModelView):

--- a/app/deliver_grant_funding/admin/forms.py
+++ b/app/deliver_grant_funding/admin/forms.py
@@ -6,7 +6,13 @@ from typing import TYPE_CHECKING, Any
 import email_validator
 from flask import current_app, flash
 from flask_wtf import FlaskForm
-from govuk_frontend_wtf.wtforms_widgets import GovCheckboxInput, GovDateInput, GovSubmitInput, GovTextArea, GovTextInput
+from govuk_frontend_wtf.wtforms_widgets import (
+    GovCheckboxInput,
+    GovDateInput,
+    GovSubmitInput,
+    GovTextArea,
+    GovTextInput,
+)
 from markupsafe import Markup, escape
 from wtforms import DateField, SubmitField
 from wtforms.fields.choices import SelectField, SelectMultipleField
@@ -14,7 +20,10 @@ from wtforms.fields.simple import BooleanField, EmailField, StringField, TextAre
 from wtforms.validators import DataRequired, Email, Optional
 from xgovuk_flask_admin import GovSelectWithSearch
 
-from app.common.data.types import OrganisationData, OrganisationType
+from app.common.data.types import (
+    OrganisationData,
+    OrganisationType,
+)
 
 if TYPE_CHECKING:
     from app.common.data.models import Collection, Grant, GrantRecipient, Organisation

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/admin/edit-question.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/admin/edit-question.html
@@ -1,0 +1,32 @@
+{% extends 'admin/model/edit.html' %}
+
+{% block edit_form %}
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Grant</dt>
+      <dd class="govuk-summary-list__value">{{ model.form.collection.grant.name }}</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Collection</dt>
+      <dd class="govuk-summary-list__value">{{ model.form.collection.name }}</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Section</dt>
+      <dd class="govuk-summary-list__value">{{ model.form.title }}</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Type</dt>
+      <dd class="govuk-summary-list__value">{{ model.data_type.value }}</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Text</dt>
+      <dd class="govuk-summary-list__value">{{ model.text }}</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Hint</dt>
+      <dd class="govuk-summary-list__value">{{ model.hint or "" }}</dd>
+    </div>
+  </dl>
+
+  {{ super() }}
+{% endblock %}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 
 import pytest
 from _pytest.fixtures import FixtureRequest
-from flask import Flask, Response, abort, template_rendered
+from flask import Flask, Request, Response, abort, template_rendered
 from flask.sessions import SessionMixin
 from flask.typing import ResponseReturnValue
 from flask_login import login_user
@@ -144,6 +144,11 @@ def app(setup_db_container: PostgresContainer) -> Generator[Flask, None, None]:
 def _validate_form_argument_to_render_template(response: TestResponse, templates_rendered: TTemplatesRendered) -> None:
     if response.headers["content-type"].startswith("text/html"):
         for _endpoint, render_template in templates_rendered.items():
+            # Don't check templates rendered by/for Flask-Admin - we don't control the `form` arg passed there.
+            request = cast(Request, render_template.context.get("request"))
+            if request and request.path.startswith("/deliver/admin"):
+                continue
+
             if "form" in render_template.context and render_template.context["form"]:
                 assert isinstance(render_template.context["form"], FlaskForm), (
                     "The `form` argument passed to `render_template` is expected to be a FlaskForm instance. "

--- a/tests/integration/deliver_grant_funding/admin/test_views.py
+++ b/tests/integration/deliver_grant_funding/admin/test_views.py
@@ -10,7 +10,9 @@ from app.common.collections.types import TextSingleLineAnswer
 from app.common.data.interfaces.organisations import get_organisation_count, get_organisations
 from app.common.data.interfaces.user import get_user, get_user_by_email
 from app.common.data.models import Organisation
+from app.common.data.models_audit import AuditEvent
 from app.common.data.types import (
+    AuditEventType,
     CollectionStatusEnum,
     GrantRecipientModeEnum,
     GrantStatusEnum,
@@ -5088,3 +5090,161 @@ class TestPlatformAdminSubmissionEventView:
         page = response.data.decode()
         assert submitted_event.submission.reference in page
         assert completed_event.submission.reference not in page
+
+
+class TestPlatformAdminQuestionView:
+    @pytest.mark.parametrize(
+        "client_fixture, expected_code",
+        [
+            ("authenticated_platform_admin_client", 200),
+            ("authenticated_platform_grant_lifecycle_manager_client", 403),
+            ("authenticated_platform_data_analyst_client", 403),
+            ("authenticated_platform_member_client", 403),
+            ("authenticated_grant_admin_client", 403),
+            ("authenticated_grant_member_client", 403),
+            ("authenticated_no_role_client", 403),
+            ("anonymous_client", 302),
+        ],
+    )
+    def test_question_list_permissions(self, client_fixture, expected_code, request):
+        client = request.getfixturevalue(client_fixture)
+        response = client.get("/deliver/admin/question/")
+        assert response.status_code == expected_code
+
+    def test_list_shows_question_and_chain(self, authenticated_platform_admin_client, factories, db_session):
+        grant = factories.grant.create(name="Stargazer Grant")
+        collection = factories.collection.create(grant=grant, name="Quarterly Report")
+        form = factories.form.create(collection=collection, title="Project details")
+        question = factories.question.create(form=form, name="project_name", text="Project name?")
+
+        response = authenticated_platform_admin_client.get("/deliver/admin/question/")
+        assert response.status_code == 200
+        page = response.data.decode()
+        assert question.name in page
+        assert "Project name?" in page
+        assert "Project details" in page
+        assert "Quarterly Report" in page
+        assert "Stargazer Grant" in page
+
+    def test_list_excludes_groups(self, authenticated_platform_admin_client, factories, db_session):
+        question = factories.question.create(name="visible_question")
+        group = factories.group.create(name="hidden_group", form=question.form)
+
+        response = authenticated_platform_admin_client.get("/deliver/admin/question/")
+        assert response.status_code == 200
+        page = response.data.decode()
+        assert question.name in page
+        assert group.name not in page
+
+    def test_filter_by_grant_name(self, authenticated_platform_admin_client, factories, db_session):
+        wanted_grant = factories.grant.create(name="Wanted Grant")
+        unwanted_grant = factories.grant.create(name="Unwanted Grant")
+        wanted_collection = factories.collection.create(grant=wanted_grant)
+        unwanted_collection = factories.collection.create(grant=unwanted_grant)
+        wanted_question = factories.question.create(form__collection=wanted_collection, name="wanted_question")
+        unwanted_question = factories.question.create(form__collection=unwanted_collection, name="unwanted_question")
+
+        response = authenticated_platform_admin_client.get("/deliver/admin/question/?flt2_2=Wanted+Grant")
+        assert response.status_code == 200
+        page = response.data.decode()
+        assert wanted_question.name in page
+        assert unwanted_question.name not in page
+
+    def test_create_is_disabled(self, authenticated_platform_admin_client):
+        response = authenticated_platform_admin_client.get("/deliver/admin/question/new/", follow_redirects=False)
+        assert response.status_code == 302
+
+    def test_delete_is_disabled(self, authenticated_platform_admin_client, factories, db_session):
+        question = factories.question.create()
+        response = authenticated_platform_admin_client.post(
+            "/deliver/admin/question/delete/",
+            data={"id": str(question.id)},
+            follow_redirects=False,
+        )
+        assert response.status_code == 302
+
+    def test_edit_form_renders_question_details_and_name_input(
+        self, authenticated_platform_admin_client, factories, db_session
+    ):
+        question = factories.question.create(
+            data_type=QuestionDataType.TEXT_SINGLE_LINE,
+            text="Original text",
+            hint="Original hint",
+            name="original_name",
+        )
+
+        response = authenticated_platform_admin_client.get(f"/deliver/admin/question/edit/?id={question.id}")
+        assert response.status_code == 200
+        soup = BeautifulSoup(response.data, "html.parser")
+
+        assert soup.find("input", attrs={"name": "text"}) is None
+        assert soup.find("input", attrs={"name": "hint"}) is None
+        assert soup.find("input", attrs={"name": "data_type"}) is None
+
+        summary = soup.find("dl", class_="govuk-summary-list")
+        assert summary is not None
+        details_text = summary.get_text()
+        assert QuestionDataType.TEXT_SINGLE_LINE.value in details_text
+        assert "Original text" in details_text
+        assert "Original hint" in details_text
+
+        name_field = soup.find("input", attrs={"name": "name"})
+        assert name_field is not None and name_field.get("value") == "original_name"
+        assert not name_field.has_attr("readonly")
+
+    def test_edit_updates_name(self, authenticated_platform_admin_client, factories, db_session):
+        question = factories.question.create(
+            data_type=QuestionDataType.TEXT_SINGLE_LINE,
+            text="Untouched text",
+            hint="Untouched hint",
+            name="old_name",
+        )
+        original_slug = question.slug
+        initial_audit_count = db_session.query(AuditEvent).count()
+
+        response = authenticated_platform_admin_client.post(
+            f"/deliver/admin/question/edit/?id={question.id}",
+            data={"name": "new_name"},
+            follow_redirects=False,
+        )
+        assert response.status_code == 302
+
+        db_session.expire(question)
+        assert question.name == "new_name"
+        assert question.text == "Untouched text"
+        assert question.hint == "Untouched hint"
+        assert question.slug == original_slug
+
+        assert db_session.query(AuditEvent).count() == initial_audit_count + 1
+        audit_event = db_session.query(AuditEvent).order_by(AuditEvent.created_at_utc.desc()).first()
+        assert audit_event.event_type == AuditEventType.PLATFORM_ADMIN_DB_EVENT
+        assert audit_event.data["model_class"] == "Question"
+        assert audit_event.data["action"] == "update"
+        assert audit_event.data["model_id"] == str(question.id)
+        assert audit_event.data["changes"]["name"]["old"] == "old_name"
+        assert audit_event.data["changes"]["name"]["new"] == "new_name"
+        assert audit_event.user_id == authenticated_platform_admin_client.user.id
+
+    def test_edit_ignores_posted_text_and_hint(self, authenticated_platform_admin_client, factories, db_session):
+        question = factories.question.create(
+            data_type=QuestionDataType.TEXT_SINGLE_LINE,
+            text="Untouched text",
+            hint="Untouched hint",
+            name="original_name",
+        )
+
+        response = authenticated_platform_admin_client.post(
+            f"/deliver/admin/question/edit/?id={question.id}",
+            data={
+                "text": "Bypass attempt",
+                "hint": "Also a bypass",
+                "name": "renamed",
+            },
+            follow_redirects=False,
+        )
+        assert response.status_code == 302
+
+        db_session.expire(question)
+        assert question.text == "Untouched text"
+        assert question.hint == "Untouched hint"
+        assert question.name == "renamed"

--- a/tests/unit/test_all_routes_access.py
+++ b/tests/unit/test_all_routes_access.py
@@ -321,6 +321,15 @@ routes_with_access_controlled_by_flask_admin = [
     "submissionevent.edit_view",
     "submissionevent.export",
     "submissionevent.index_view",
+    "question.action_view",
+    "question.ajax_lookup",
+    "question.ajax_update",
+    "question.create_view",
+    "question.delete_view",
+    "question.details_view",
+    "question.edit_view",
+    "question.export",
+    "question.index_view",
 ]
 
 


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
We have a case where the question names that were set up for a report are not quite in line with the question text.

The report is currently live and so edits by form designers are blocked.

This small opening in editing live questions through a developer interface will allow us to safely realign the question names while keeping an audit trail of the change having been made by an administrator.

## 📸 Show the thing (screenshots, gifs)
<img width="1336" height="1451" alt="image" src="https://github.com/user-attachments/assets/56b28b88-f1e6-4c38-8bd4-84fd394e9278" />

<img width="1293" height="1082" alt="image" src="https://github.com/user-attachments/assets/2727ec18-cb8f-4015-9408-bc605224c6d5" />


## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [ ] End-to-end tests have been updated (if applicable)
- [ ] Edge cases and error conditions are tested