### PR TITLE
Bugfix: 'View data set' missing Grant Recipient tag

### DIFF
--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/data_sets/view_data_set.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/data_sets/view_data_set.html
@@ -130,13 +130,15 @@
 
         {% set rows = [] %}
         {% for item in data_source.organisation_items %}
-          {% set gr_name = grant_recipient_name_by_external_id.get(item.external_id, item.external_id) %}
-          {%
-            set row = [
-              {"text": item.external_id},
-              {"text": gr_name}
-            ]
-          %}
+          {% set gr_name = grant_recipient_name_by_external_id.get(item.external_id) %}
+          {% set row = [{"text": item.external_id}] %}
+
+          {% if gr_name is none %}
+            {% do row.append({"html":govukTag({"text": "Grant recipient not set up", "classes": "govuk-tag--orange"})}) %}
+          {% else %}
+            {% do row.append({"text": gr_name}) %}
+          {% endif %}
+
           {% set typed_row = item.data %}
           {% for slug, col_schema in data_source.schema.root.items() %}
             {% set answer = typed_row[slug] %}

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -10865,6 +10865,50 @@ class TestViewDataSource:
         assert "France" in soup.text
 
     def test_get_shows_missing_data_tag_for_empty_values(self, authenticated_grant_member_client, factories):
+        org = factories.organisation.create(can_manage_grants=False, external_id="E123")
+        factories.grant_recipient.create(
+            organisation=org, grant=authenticated_grant_member_client.grant, mode=GrantRecipientModeEnum.LIVE
+        )
+        report = factories.collection.create(grant=authenticated_grant_member_client.grant)
+        data_source = factories.data_source.create(
+            collection=report,
+            grant=authenticated_grant_member_client.grant,
+            name="Test data set",
+            type=DataSourceType.GRANT_RECIPIENT,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_notes": {
+                        "data_type": QuestionDataType.TEXT_SINGLE_LINE,
+                        "original_column_name": "Notes",
+                        "presentation_options": {},
+                        "data_options": {},
+                    }
+                }
+            ),
+            items=None,
+        )
+        factories.data_source_organisation_item.create(
+            data_source=data_source,
+            external_id=org.external_id,
+            _data={"c_notes": None},
+        )
+
+        response = authenticated_grant_member_client.get(
+            url_for(
+                "deliver_grant_funding.view_data_source",
+                grant_id=authenticated_grant_member_client.grant.id,
+                report_id=report.id,
+                data_source_id=data_source.id,
+            )
+        )
+
+        assert response.status_code == 200
+        soup = BeautifulSoup(response.data, "html.parser")
+        assert "Data missing" in soup.text
+
+    def test_get_shows_missing_grant_recipient_tag_for_not_set_up_grant_recipient(
+        self, authenticated_grant_member_client, factories
+    ):
         report = factories.collection.create(grant=authenticated_grant_member_client.grant)
         data_source = factories.data_source.create(
             collection=report,
@@ -10900,7 +10944,7 @@ class TestViewDataSource:
 
         assert response.status_code == 200
         soup = BeautifulSoup(response.data, "html.parser")
-        assert "Data missing" in soup.text
+        assert "Grant recipient not set up" in soup.text
 
     def test_get_excludes_test_grant_recipients_from_name_lookup(self, authenticated_grant_member_client, factories):
         report = factories.collection.create(grant=authenticated_grant_member_client.grant)


### PR DESCRIPTION
## 🎫 Ticket
Bugfix

## 📝 Description
The 'view data set' page was using a fallback of a DataSourceOrganisationItem external_id where the Grant Recipient organisation name was missing. However we realised this makes it hard to spot if a grant recipient name was missing which suggests that the link to a real Grant Recipient org is broken.

We currently block data set uploads from including grant recipients that haven't already been set up for that grant, so this would only occur in the instance that a grant recipient was set up at the time of the data set upload and then later removed.

This makes these rows more visible and, with the reupload flow, mean they can be remedied.

_NOTE: Leaving as a draft PR for now until the view/content can be checked with design colleagues_

## 📸 Show the thing (screenshots, gifs)

### Before
<img width="1004" height="683" alt="image" src="https://github.com/user-attachments/assets/0a68cfff-db17-41bf-a331-0aa1d8a68ae9" />

### After
<img width="1021" height="726" alt="image" src="https://github.com/user-attachments/assets/c221d6ee-12bf-4a32-88b1-839663cc85d7" />

## 🧪 Testing
- Upload a data set to a report, then remove one of the grant recipients for that grant and view the data set.

## 📋 Developer Checklist

### Review Readiness
- [X] PR title and description provide sufficient context for reviewers
- [X] Commits are logical, self-contained, and have clear descriptions

### Testing
- [X] I have tested this change and it meets the acceptance criteria for the ticket
- ~[ ] I need the reviewer(s) to pull and run this change locally~
- [X] New (non-developer) functionality has appropriate unit and integration tests
- ~[ ] End-to-end tests have been updated (if applicable)~
- ~[ ] Edge cases and error conditions are tested~