### PR TITLE
Revoke Access grant funding permissions on permanent delivery failures

### DIFF
--- a/app/common/audit.py
+++ b/app/common/audit.py
@@ -28,6 +28,11 @@ class DatabaseModelChange(AuditEvent):
     changes: dict[str, Any]
 
 
+class SystemEvent(DatabaseModelChange):
+    event_type: AuditEventType = AuditEventType.SYSTEM
+    context: dict[str, Any]
+
+
 def _serialize_value(value: Any) -> Any:
     if isinstance(value, UUID):
         return str(value)
@@ -125,6 +130,23 @@ def create_database_model_change_for_delete(
         model_id=model.id,
         action="delete",
         changes=snapshot,
+    )
+
+
+def create_system_event_for_delete(
+    model: SQLAlchemyBaseModel,
+    user: User,
+    context: dict[str, Any],
+) -> SystemEvent:
+    snapshot = _get_model_snapshot(model)
+
+    return SystemEvent(
+        user_id=user.id,
+        model_class=model.__class__.__name__,
+        model_id=model.id,
+        action="delete",
+        changes=snapshot,
+        context=context,
     )
 
 

--- a/app/common/data/interfaces/user.py
+++ b/app/common/data/interfaces/user.py
@@ -4,8 +4,9 @@ from collections.abc import Sequence
 from itertools import groupby
 from typing import cast
 
+from flask import current_app
 from flask_login import current_user
-from sqlalchemy import and_, func, update
+from sqlalchemy import and_, func, or_, update
 from sqlalchemy.dialects.postgresql import insert as postgresql_upsert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.sql.expression import delete, select
@@ -66,6 +67,32 @@ def get_users_with_permission(
 
     stmt = stmt.where(*filters)
 
+    return db.session.scalars(stmt).unique().all()
+
+
+def get_users_covering_grant_role(
+    role: RoleEnum,
+    grant: Grant,
+    organisation: Organisation,
+    *,
+    exclude_user_id: uuid.UUID | None = None,
+) -> Sequence[User]:
+    """Users with `role` on `grant` via the access-grant-funding `organisation`.
+
+    `organisation` must be a non-grant-managing recipient on `grant`. Matches either an exact
+    (organisation, grant) UserRole or an org-level UserRole (grant_id IS NULL) on the same organisation.
+    """
+    stmt = (
+        select(User)
+        .join(UserRole)
+        .where(
+            UserRole.organisation_id == organisation.id,
+            UserRole.permissions.contains([role]),
+            or_(UserRole.grant_id == grant.id, UserRole.grant_id.is_(None)),
+        )
+    )
+    if exclude_user_id is not None:
+        stmt = stmt.where(User.id != exclude_user_id)
     return db.session.scalars(stmt).unique().all()
 
 
@@ -135,6 +162,17 @@ def upsert_user_by_azure_ad_subject_id(
     ).one()
 
     return user
+
+
+def get_or_create_system_user() -> User:
+    """Return the funding-service system user, creating it on first use.
+
+    Used as the acting user on audit events emitted by automated processes (e.g. permission removal
+    triggered by a GOV.UK Notify permanent-failure callback)."""
+    return upsert_user_by_email(
+        email_address=current_app.config["SYSTEM_USER_EMAIL"],
+        name=current_app.config["SYSTEM_USER_NAME"],
+    )
 
 
 def get_user_role(user: User, organisation_id: uuid.UUID | None, grant_id: uuid.UUID | None) -> UserRole | None:

--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-059_reopen_submission
+060_notify_cleanup_audit_event

--- a/app/common/data/migrations/versions/060_notify_cleanup_audit_event.py
+++ b/app/common/data/migrations/versions/060_notify_cleanup_audit_event.py
@@ -1,0 +1,35 @@
+"""Add system-notification-failure-cleanup audit event type.
+
+Revision ID: 060_notify_cleanup_audit_event
+Revises: 059_reopen_submission
+Create Date: 2026-05-12 11:08:45.815081
+
+"""
+
+from alembic import op
+from alembic_postgresql_enum import TableReference
+
+revision = "060_notify_cleanup_audit_event"
+down_revision = "059_reopen_submission"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.sync_enum_values(  # ty: ignore[unresolved-attribute]
+        enum_schema="public",
+        enum_name="auditeventtype",
+        new_values=["PLATFORM_ADMIN_DB_EVENT", "SYSTEM"],
+        affected_columns=[TableReference(table_schema="public", table_name="audit_event", column_name="event_type")],
+        enum_values_to_rename=[],
+    )
+
+
+def downgrade() -> None:
+    op.sync_enum_values(  # ty: ignore[unresolved-attribute]
+        enum_schema="public",
+        enum_name="auditeventtype",
+        new_values=["PLATFORM_ADMIN_DB_EVENT"],
+        affected_columns=[TableReference(table_schema="public", table_name="audit_event", column_name="event_type")],
+        enum_values_to_rename=[],
+    )

--- a/app/common/data/types.py
+++ b/app/common/data/types.py
@@ -58,6 +58,10 @@ class RoleEnum(enum.StrEnum):
     GRANT_LIFECYCLE_MANAGER = "grant-lifecycle-manager"
     DATA_ANALYST = "data-analyst"
 
+    @staticmethod
+    def get_access_grant_funding_roles() -> tuple[RoleEnum, ...]:
+        return RoleEnum.DATA_PROVIDER, RoleEnum.CERTIFIER
+
 
 class AuthMethodEnum(str, enum.Enum):
     SSO = "sso"
@@ -438,6 +442,7 @@ class OrganisationData(BaseModel):
 
 class AuditEventType(enum.Enum):
     PLATFORM_ADMIN_DB_EVENT = "platform-admin-db-event"
+    SYSTEM = "system"
 
 
 class DataSourceType(enum.StrEnum):

--- a/app/config.py
+++ b/app/config.py
@@ -284,6 +284,11 @@ class _SharedConfig(_BaseConfig):
     GOVUK_NOTIFY_ACCESS_SUBMISSION_REOPENED_TEMPLATE_ID: str = "ad07a53a-d930-4cb3-ad57-595a1c104e61"
     GOVUK_NOTIFY_GRANT_EXPORT_TEMPLATE_ID: str = "580db095-420e-4690-a640-c0ebd9748a0b"
 
+    # System user used as the acting user for automated audit events (e.g. permission removal
+    # triggered by a GOV.UK Notify permanent-failure callback).
+    SYSTEM_USER_EMAIL: str = "funding-service-notify@communities.gov.uk"
+    SYSTEM_USER_NAME: str = "Funding Service System"
+
     ASSETS_VITE_BASE_URL: str = "http://localhost:5173"
     ASSETS_VITE_LIVE_ENABLED: bool = False
 

--- a/app/deliver_grant_funding/routes/api/callbacks.py
+++ b/app/deliver_grant_funding/routes/api/callbacks.py
@@ -2,14 +2,29 @@ import datetime
 import enum
 import secrets
 import uuid
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import sentry_sdk
 from flask import current_app, jsonify, request
 from flask.typing import ResponseReturnValue
 from pydantic import BaseModel, ValidationError
+from sqlalchemy import select
 
+from app.common.audit import create_system_event_for_delete, track_audit_event
+from app.common.auth.authorisation_helper import AuthorisationHelper
+from app.common.data.interfaces.user import (
+    get_or_create_system_user,
+    get_user_by_email,
+    get_users_covering_grant_role,
+    remove_all_roles_from_user,
+)
+from app.common.data.types import GrantRecipientModeEnum, OrganisationModeEnum, RoleEnum
 from app.deliver_grant_funding.routes.api import deliver_grant_funding_api_blueprint
+from app.extensions import auto_commit_after_request, db
+
+if TYPE_CHECKING:
+    from app.common.data.models import Grant, GrantRecipient, Organisation
+    from app.common.data.models_user import User
 
 
 class GovukNotifyStatus(enum.StrEnum):
@@ -36,7 +51,136 @@ class GovukNotifyCallbackModel(BaseModel):
     completed_at: datetime.datetime | None
 
 
+def handle_permanent_email_failure(notification_id: uuid.UUID, recipient_email: str) -> None:
+    user = get_user_by_email(recipient_email)
+    if user is None:
+        current_app.logger.error(
+            "GOV.UK Notify permanent failure for unknown user: %(recipient_email)s",
+            dict(recipient_email=recipient_email),
+        )
+        return
+
+    if AuthorisationHelper.is_deliver_grant_funding_user(user):
+        # Specifically ignore Deliver grant funding users for now - TBD what we should do in the future.
+        current_app.logger.info(
+            "GOV.UK Notify permanent failure for Deliver grant funding user: %(user_id)s. No action taken.",
+            dict(user_id=user.id),
+        )
+        return
+
+    access_grant_funding_roles = _get_access_grant_funding_roles_for_user(user)
+
+    system_user = get_or_create_system_user()
+    audit_events = [
+        create_system_event_for_delete(
+            ur,
+            system_user,
+            context=dict(
+                notification_id=notification_id, reason="GOV.UK Notify callback indicated permanent delivery failure"
+            ),
+        )
+        for ur in user.roles
+    ]
+
+    remove_all_roles_from_user(user)
+
+    for event in audit_events:
+        track_audit_event(db.session, event, system_user)
+
+    _log_error_for_access_grant_funding_roles_with_no_alternate_users(
+        access_grant_funding_roles, exclude_user_id=None, reason="permanent failure"
+    )
+
+
+def handle_temporary_email_failure(recipient_email: str) -> None:
+    user = get_user_by_email(recipient_email)
+    if user is None:
+        current_app.logger.error(
+            "GOV.UK Notify temporary failure for unknown user: %(recipient_email)s",
+            dict(recipient_email=recipient_email),
+        )
+        return
+
+    if AuthorisationHelper.is_deliver_grant_funding_user(user):
+        # Specifically ignore Deliver grant funding users for now - TBD what we should do in the future.
+        current_app.logger.info(
+            "GOV.UK Notify temporary failure for Deliver grant funding user: %(user_id)s. No action taken.",
+            dict(user_id=user.id),
+        )
+        return
+
+    access_grant_funding_roles = _get_access_grant_funding_roles_for_user(user)
+    _log_error_for_access_grant_funding_roles_with_no_alternate_users(
+        access_grant_funding_roles, exclude_user_id=user.id, reason="temporary failure"
+    )
+
+
+def _get_access_grant_funding_roles_for_user(
+    user: "User",
+) -> list[tuple["Organisation", "Grant", RoleEnum]]:
+    triples: list[tuple[Organisation, Grant, RoleEnum]] = []
+    for ur in user.roles:
+        if (
+            ur.organisation is None
+            or ur.organisation.can_manage_grants
+            or ur.organisation.mode != OrganisationModeEnum.LIVE
+        ):
+            continue
+
+        roles_present = [r for r in RoleEnum.get_access_grant_funding_roles() if r in ur.permissions]
+        if not roles_present:
+            continue
+
+        if ur.grant_id is not None:
+            grants: list[Grant] = [ur.grant]
+        else:
+            grants = [
+                gr.grant
+                for gr in db.session.scalars(
+                    select(GrantRecipient).where(
+                        GrantRecipient.organisation_id == ur.organisation_id,
+                        GrantRecipient.mode == GrantRecipientModeEnum.LIVE,
+                    )
+                ).all()
+            ]
+
+        for grant in grants:
+            for role in roles_present:
+                triples.append((ur.organisation, grant, role))
+    return triples
+
+
+def _log_error_for_access_grant_funding_roles_with_no_alternate_users(
+    access_grant_funding_roles: list[tuple["Organisation", "Grant", RoleEnum]],
+    *,
+    exclude_user_id: uuid.UUID | None,
+    reason: str,
+) -> None:
+    seen: set[tuple[uuid.UUID, uuid.UUID, RoleEnum]] = set()
+    for organisation, grant, role in access_grant_funding_roles:
+        key = (organisation.id, grant.id, role)
+        if key in seen:
+            continue
+        seen.add(key)
+        remaining = get_users_covering_grant_role(role, grant, organisation, exclude_user_id=exclude_user_id)
+        if not remaining:
+            current_app.logger.error(
+                "Grant '%(grant_name)s' (%(grant_id)s) at organisation '%(organisation_name)s' "
+                "(%(organisation_id)s) has no other users with %(role_name)s after %(reason)s; "
+                "manual intervention required.",
+                dict(
+                    grant_name=grant.name,
+                    grant_id=grant.id,
+                    organisation_name=organisation.name,
+                    organisation_id=organisation.id,
+                    role_name=role.name,
+                    reason=reason,
+                ),
+            )
+
+
 @deliver_grant_funding_api_blueprint.post("/govuk-notify-callback")
+@auto_commit_after_request
 def govuk_notify_callback() -> ResponseReturnValue:
     if not current_app.config["GOVUK_NOTIFY_CALLBACK_TOKEN"]:
         return jsonify(), 500
@@ -51,8 +195,8 @@ def govuk_notify_callback() -> ResponseReturnValue:
         return jsonify(), 403
 
     if request.mimetype != "application/json":
-        sentry_sdk.capture_message(
-            f"GOV.UK Notify callback received with invalid content type: {request.mimetype}", level="error"
+        current_app.logger.error(
+            "GOV.UK Notify callback received with invalid content type: %(mimetype)s", dict(mimetype=request.mimetype)
         )
         return jsonify(), 400
 
@@ -66,19 +210,27 @@ def govuk_notify_callback() -> ResponseReturnValue:
         scope.set_context("notify_callback", callback_data.model_dump(mode="json"))
 
         if callback_data.notification_type != "email":
-            sentry_sdk.capture_message(
-                f"GOV.UK Notify callback received for unhandled notification type: {callback_data.notification_type}",
-                level="warning",
+            current_app.logger.warning(
+                "GOV.UK Notify callback received for unhandled notification type: %(notification_type)s",
+                dict(notification_type=callback_data.notification_type),
             )
             return jsonify(), 202
 
         if callback_data.to.endswith(current_app.config["GOVUK_NOTIFY_IGNORE_CALLBACK_DOMAINS"]):
             return jsonify(), 202
 
+        if callback_data.status == GovukNotifyStatus.PERMANENT_FAILURE:
+            handle_permanent_email_failure(callback_data.id, callback_data.to)
+            return jsonify(), 202
+
+        if callback_data.status == GovukNotifyStatus.TEMPORARY_FAILURE:
+            handle_temporary_email_failure(callback_data.to)
+            return jsonify(), 202
+
         if callback_data.status != GovukNotifyStatus.DELIVERED:
-            sentry_sdk.capture_message(
-                f"GOV.UK Notify callback indicates {callback_data.status} for email notification",
-                level="error",
+            current_app.logger.error(
+                "GOV.UK Notify callback indicates %(status)s for email notification",
+                dict(status=callback_data.status),
             )
             return jsonify(), 202
 

--- a/tests/integration/deliver_grant_funding/routes/api/test_callbacks.py
+++ b/tests/integration/deliver_grant_funding/routes/api/test_callbacks.py
@@ -1,8 +1,28 @@
+import logging
 import uuid
 
-import pytest
 from flask import url_for
 from pytest_mock import MockerFixture
+from sqlalchemy import select
+
+from app.common.data.models_audit import AuditEvent
+from app.common.data.models_user import UserRole
+from app.common.data.types import (
+    AuditEventType,
+    GrantRecipientModeEnum,
+    GrantStatusEnum,
+    OrganisationModeEnum,
+    RoleEnum,
+)
+from app.extensions import db
+
+
+def _manual_intervention_logs(caplog) -> list[str]:
+    return [
+        r.getMessage()
+        for r in caplog.records
+        if r.levelno == logging.ERROR and "manual intervention required" in r.getMessage()
+    ]
 
 
 class TestGovukNotifyCallback:
@@ -35,14 +55,12 @@ class TestGovukNotifyCallback:
         assert response.status_code == 204
         capture_message.assert_not_called()
 
-    @pytest.mark.parametrize("status", ["temporary-failure", "permanent-failure", "technical-failure"])
-    def test_failed_email_captures_error_with_full_context(
-        self, anonymous_client, mocker: MockerFixture, status
+    def test_technical_failure_captures_error_with_full_context(
+        self, anonymous_client, mocker: MockerFixture, caplog
     ) -> None:
-        capture_message = mocker.patch("app.deliver_grant_funding.routes.api.callbacks.sentry_sdk.capture_message")
         new_scope = mocker.patch("app.deliver_grant_funding.routes.api.callbacks.sentry_sdk.new_scope")
         scope = new_scope.return_value.__enter__.return_value
-        payload = self._payload(status=status, to="failed@example.com")
+        payload = self._payload(status="technical-failure", to="failed@example.com")
 
         response = anonymous_client.post(
             url_for("deliver_grant_funding.api.govuk_notify_callback"),
@@ -51,20 +69,18 @@ class TestGovukNotifyCallback:
         )
 
         assert response.status_code == 202
-        capture_message.assert_called_once()
-        _, kwargs = capture_message.call_args
-        assert kwargs["level"] == "error"
-        assert status in capture_message.call_args.args[0]
+
+        assert any("technical-failure" in r.getMessage() for r in caplog.records if r.levelno == logging.ERROR)
+
         scope.set_context.assert_called_once()
         context_name, context = scope.set_context.call_args.args
         assert context_name == "notify_callback"
         assert context["to"] == "failed@example.com"
-        assert context["status"] == status
+        assert context["status"] == "technical-failure"
         assert context["id"] == payload["id"]
         assert context["template_id"] == payload["template_id"]
 
-    def test_non_email_notification_captures_warning(self, anonymous_client, mocker: MockerFixture) -> None:
-        capture_message = mocker.patch("app.deliver_grant_funding.routes.api.callbacks.sentry_sdk.capture_message")
+    def test_non_email_notification_captures_warning(self, anonymous_client, mocker: MockerFixture, caplog) -> None:
         new_scope = mocker.patch("app.deliver_grant_funding.routes.api.callbacks.sentry_sdk.new_scope")
         scope = new_scope.return_value.__enter__.return_value
         payload = self._payload(notification_type="sms", to="+447700900000")
@@ -74,11 +90,11 @@ class TestGovukNotifyCallback:
             json=payload,
             headers={"Authorization": "Bearer local-use-secret"},
         )
-
         assert response.status_code == 202
-        capture_message.assert_called_once()
-        _, kwargs = capture_message.call_args
-        assert kwargs["level"] == "warning"
+
+        assert any(
+            "unhandled notification type" in r.getMessage() for r in caplog.records if r.levelno == logging.WARNING
+        )
         scope.set_context.assert_called_once()
         context_name, context = scope.set_context.call_args.args
         assert context_name == "notify_callback"
@@ -133,3 +149,253 @@ class TestGovukNotifyCallback:
             headers={"Authorization": "Bearer local-use-secret", "Content-Type": "text/plain"},
         )
         assert response.status_code == 400
+
+    class TestPermanentFailureCallback:
+        @staticmethod
+        def _post(anonymous_client, *, status: str, to: str, notification_id: uuid.UUID | None = None) -> tuple:
+            payload = {
+                "id": str(notification_id or uuid.uuid4()),
+                "reference": None,
+                "notification_type": "email",
+                "template_id": str(uuid.uuid4()),
+                "template_version": 1,
+                "to": to,
+                "status": status,
+                "created_at": "2026-04-30T12:00:00Z",
+                "sent_at": "2026-04-30T12:00:01Z",
+                "completed_at": "2026-04-30T12:00:02Z",
+            }
+            response = anonymous_client.post(
+                url_for("deliver_grant_funding.api.govuk_notify_callback"),
+                json=payload,
+                headers={"Authorization": "Bearer local-use-secret"},
+            )
+            return response, payload
+
+        def test_permanent_failure_removes_all_roles_and_writes_audit_events(
+            self, anonymous_client, factories, caplog
+        ) -> None:
+            grant = factories.grant.create(status=GrantStatusEnum.LIVE)
+            recipient_org = factories.organisation.create(can_manage_grants=False)
+            factories.grant_recipient.create(grant=grant, organisation=recipient_org)
+
+            affected_user = factories.user.create(email="bouncer@example.com")
+            other_user = factories.user.create(email="backup@example.com")
+            factories.user_role.create(
+                user=affected_user,
+                organisation=recipient_org,
+                grant=grant,
+                permissions=[RoleEnum.DATA_PROVIDER, RoleEnum.CERTIFIER],
+            )
+            factories.user_role.create(
+                user=other_user,
+                organisation=recipient_org,
+                grant=grant,
+                permissions=[RoleEnum.DATA_PROVIDER, RoleEnum.CERTIFIER],
+            )
+
+            with caplog.at_level(logging.ERROR, logger="app"):
+                response, payload = self._post(anonymous_client, status="permanent-failure", to="bouncer@example.com")
+
+            assert response.status_code == 202
+
+            remaining = db.session.scalars(select(UserRole).where(UserRole.user_id == affected_user.id)).all()
+            assert remaining == []
+            other_user_role = db.session.scalars(select(UserRole).where(UserRole.user_id == other_user.id)).one()
+            assert other_user_role.organisation == recipient_org
+            assert set(other_user_role.permissions) == {RoleEnum.MEMBER, RoleEnum.DATA_PROVIDER, RoleEnum.CERTIFIER}
+
+            audit_events = db.session.scalars(
+                select(AuditEvent).where(AuditEvent.event_type == AuditEventType.SYSTEM)
+            ).all()
+            assert len(audit_events) == 1
+            event = audit_events[0]
+            assert event.data["model_class"] == "UserRole"
+            assert event.data["action"] == "delete"
+            assert event.data["context"]["notification_id"] == payload["id"]
+            assert event.data["changes"]["user_id"] == str(affected_user.id)
+            assert event.data["changes"]["grant_id"] == str(grant.id)
+            assert event.data["changes"]["organisation_id"] == str(recipient_org.id)
+
+            assert _manual_intervention_logs(caplog) == []
+
+        def test_permanent_failure_flags_uncovered_grant(self, anonymous_client, factories, caplog) -> None:
+            grant = factories.grant.create(status=GrantStatusEnum.LIVE)
+            recipient_org = factories.organisation.create(can_manage_grants=False)
+            factories.grant_recipient.create(grant=grant, organisation=recipient_org)
+
+            affected_user = factories.user.create(email="bouncer@example.com")
+            factories.user_role.create(
+                user=affected_user, organisation=recipient_org, grant=grant, permissions=[RoleEnum.DATA_PROVIDER]
+            )
+
+            with caplog.at_level(logging.ERROR, logger="app"):
+                response, _ = self._post(anonymous_client, status="permanent-failure", to="bouncer@example.com")
+
+            assert response.status_code == 202
+
+            remaining = db.session.scalars(select(UserRole).where(UserRole.user_id == affected_user.id)).all()
+            assert remaining == []
+
+            logs = _manual_intervention_logs(caplog)
+            assert any("DATA_PROVIDER" in msg and str(grant.id) in msg and str(recipient_org.id) in msg for msg in logs)
+
+        def test_permanent_failure_with_org_level_backup_does_not_flag(
+            self, anonymous_client, factories, caplog
+        ) -> None:
+            grant = factories.grant.create(status=GrantStatusEnum.LIVE)
+            recipient_org = factories.organisation.create(can_manage_grants=False)
+            factories.grant_recipient.create(grant=grant, organisation=recipient_org)
+
+            affected_user = factories.user.create(email="bouncer@example.com")
+            backup_user = factories.user.create(email="org-backup@example.com")
+            factories.user_role.create(
+                user=affected_user, organisation=recipient_org, grant=grant, permissions=[RoleEnum.CERTIFIER]
+            )
+            factories.user_role.create(
+                user=backup_user, organisation=recipient_org, grant=None, permissions=[RoleEnum.CERTIFIER]
+            )
+
+            with caplog.at_level(logging.ERROR, logger="app"):
+                response, _ = self._post(anonymous_client, status="permanent-failure", to="bouncer@example.com")
+
+            assert response.status_code == 202
+            assert _manual_intervention_logs(caplog) == []
+            backup_user_role = db.session.scalars(select(UserRole).where(UserRole.user_id == backup_user.id)).one()
+            assert backup_user_role.organisation == recipient_org
+            assert set(backup_user_role.permissions) == {RoleEnum.MEMBER, RoleEnum.CERTIFIER}
+
+        def test_permanent_failure_cover_on_different_recipient_org_does_not_count(
+            self, anonymous_client, factories, caplog
+        ) -> None:
+            """A DATA_PROVIDER on a different recipient organisation for the same grant does NOT cover the
+            affected user's recipient organisation — this was the bug the org-aware helper fixes."""
+            grant = factories.grant.create(status=GrantStatusEnum.LIVE)
+            recipient_org_a = factories.organisation.create(can_manage_grants=False)
+            recipient_org_b = factories.organisation.create(can_manage_grants=False)
+            factories.grant_recipient.create(grant=grant, organisation=recipient_org_a)
+            factories.grant_recipient.create(grant=grant, organisation=recipient_org_b)
+
+            affected_user = factories.user.create(email="bouncer@example.com")
+            unrelated_user = factories.user.create(email="other-org@example.com")
+            factories.user_role.create(
+                user=affected_user, organisation=recipient_org_a, grant=grant, permissions=[RoleEnum.DATA_PROVIDER]
+            )
+            factories.user_role.create(
+                user=unrelated_user, organisation=recipient_org_b, grant=grant, permissions=[RoleEnum.DATA_PROVIDER]
+            )
+
+            with caplog.at_level(logging.ERROR, logger="app"):
+                response, _ = self._post(anonymous_client, status="permanent-failure", to="bouncer@example.com")
+
+            assert response.status_code == 202
+            logs = _manual_intervention_logs(caplog)
+            assert any(str(recipient_org_a.id) in msg and "DATA_PROVIDER" in msg for msg in logs)
+
+        def test_permanent_failure_unknown_email_logs_error_and_no_db_changes(self, anonymous_client, caplog) -> None:
+            response, _ = self._post(anonymous_client, status="permanent-failure", to="not-a-user@example.com")
+
+            assert response.status_code == 202
+            assert any("not-a-user@example.com" in r.getMessage() for r in caplog.records if r.levelno == logging.ERROR)
+
+            audit_events = db.session.scalars(
+                select(AuditEvent).where(AuditEvent.event_type == AuditEventType.SYSTEM)
+            ).all()
+            assert audit_events == []
+
+        def test_permanent_failure_on_test_org_removes_roles_without_flagging(
+            self, anonymous_client, factories, caplog
+        ) -> None:
+            grant = factories.grant.create()
+            recipient_org = factories.organisation.create(can_manage_grants=False, mode=OrganisationModeEnum.TEST)
+            factories.grant_recipient.create(grant=grant, organisation=recipient_org, mode=GrantRecipientModeEnum.TEST)
+
+            affected_user = factories.user.create(email="bouncer@example.com")
+            factories.user_role.create(
+                user=affected_user, organisation=recipient_org, grant=grant, permissions=[RoleEnum.DATA_PROVIDER]
+            )
+
+            with caplog.at_level(logging.ERROR, logger="app"):
+                response, _ = self._post(anonymous_client, status="permanent-failure", to="bouncer@example.com")
+
+            assert response.status_code == 202
+
+            remaining = db.session.scalars(select(UserRole).where(UserRole.user_id == affected_user.id)).all()
+            assert remaining == []
+            assert _manual_intervention_logs(caplog) == []
+
+    class TestTemporaryFailureCallback:
+        @staticmethod
+        def _post(anonymous_client, *, to: str) -> tuple:
+            payload = {
+                "id": str(uuid.uuid4()),
+                "reference": None,
+                "notification_type": "email",
+                "template_id": str(uuid.uuid4()),
+                "template_version": 1,
+                "to": to,
+                "status": "temporary-failure",
+                "created_at": "2026-04-30T12:00:00Z",
+                "sent_at": "2026-04-30T12:00:01Z",
+                "completed_at": "2026-04-30T12:00:02Z",
+            }
+            response = anonymous_client.post(
+                url_for("deliver_grant_funding.api.govuk_notify_callback"),
+                json=payload,
+                headers={"Authorization": "Bearer local-use-secret"},
+            )
+            return response, payload
+
+        def test_temporary_failure_flags_when_user_is_only_certifier(self, anonymous_client, factories, caplog) -> None:
+            grant = factories.grant.create(status=GrantStatusEnum.LIVE)
+            recipient_org = factories.organisation.create(can_manage_grants=False)
+            factories.grant_recipient.create(grant=grant, organisation=recipient_org)
+
+            affected_user = factories.user.create(email="bouncer@example.com")
+            factories.user_role.create(
+                user=affected_user, organisation=recipient_org, grant=grant, permissions=[RoleEnum.CERTIFIER]
+            )
+
+            with caplog.at_level(logging.ERROR, logger="app"):
+                response, _ = self._post(anonymous_client, to="bouncer@example.com")
+
+            assert response.status_code == 202
+
+            remaining = db.session.scalars(select(UserRole).where(UserRole.user_id == affected_user.id)).all()
+            assert len(remaining) == 1
+
+            audit_events = db.session.scalars(
+                select(AuditEvent).where(AuditEvent.event_type == AuditEventType.SYSTEM)
+            ).all()
+            assert audit_events == []
+
+            logs = _manual_intervention_logs(caplog)
+            assert any("CERTIFIER" in msg and str(grant.id) in msg and str(recipient_org.id) in msg for msg in logs)
+
+        def test_temporary_failure_with_coverage_does_not_flag(self, anonymous_client, factories, caplog) -> None:
+            grant = factories.grant.create(status=GrantStatusEnum.LIVE)
+            recipient_org = factories.organisation.create(can_manage_grants=False)
+            factories.grant_recipient.create(grant=grant, organisation=recipient_org)
+
+            affected_user = factories.user.create(email="bouncer@example.com")
+            other_user = factories.user.create(email="backup@example.com")
+            factories.user_role.create(
+                user=affected_user, organisation=recipient_org, grant=grant, permissions=[RoleEnum.CERTIFIER]
+            )
+            factories.user_role.create(
+                user=other_user, organisation=recipient_org, grant=grant, permissions=[RoleEnum.CERTIFIER]
+            )
+
+            with caplog.at_level(logging.ERROR, logger="app"):
+                response, _ = self._post(anonymous_client, to="bouncer@example.com")
+
+            assert response.status_code == 202
+            assert _manual_intervention_logs(caplog) == []
+
+        def test_unknown_email_logs_error_and_no_db_changes(self, anonymous_client, caplog) -> None:
+            with caplog.at_level(logging.ERROR, logger="app"):
+                response, _ = self._post(anonymous_client, to="not-a-user@example.com")
+
+            assert response.status_code == 202
+            assert any("not-a-user@example.com" in r.getMessage() for r in caplog.records if r.levelno == logging.ERROR)
+            assert _manual_intervention_logs(caplog) == []


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-1356

## 📝 Description
When GOV.UK Notify tells us that an email address is undeliverable, we manually revoke that user's permissions.

Now that we've integrated callbacks from Notify we can take this action automatically to reduce manual intervention/chores.

We will revoke all permissions for Access grant funding users and suppress the error, unless by revoking those permissions we leave any grant without another person who has roles covering theirs. If they were the last data provider or certifier, we will log an error to flag manual intervention required still.

## 📸 Show the thing (screenshots, gifs)
```
funding-service-1  | 2026-05-12 12:29:20,367 INFO - --- POST https://funding.communities.gov.localhost:8080/deliver/api/v1/govuk-notify-callback - from before_request() in logging.py:118
funding-service-1  | 2026-05-12 12:29:20,375 INFO - audit_event: AuditEventType.SYSTEM by funding-service-notify@communities.gov.uk - from track_audit_event() in audit.py:161
funding-service-1  | 2026-05-12 12:29:20,378 ERROR - Grant 'Cheeseboards in parks' (caf0ce3f-5175-f69c-66a9-41e2c2245845) at organisation 'Ministry of Testing' (74b2ee5d-20e6-4ab9-b5d0-150444bf9510) has no other users with CERTIFIER after permanent failure; manual intervention required. - from _log_error_for_access_grant_funding_roles_with_no_alternate_users() in callbacks.py:138
funding-service-1  | 2026-05-12 12:29:20,379 INFO - 202 POST https://funding.communities.gov.localhost:8080/deliver/api/v1/govuk-notify-callback - [real:0.01s] [process:0.01s] - from after_request() in logging.py:141
funding-service-1  | 2026-05-12 12:29:30,798 INFO - --- POST https://funding.communities.gov.localhost:8080/deliver/api/v1/govuk-notify-callback - from before_request() in logging.py:118
funding-service-1  | 2026-05-12 12:29:30,808 INFO - audit_event: AuditEventType.SYSTEM by funding-service-notify@communities.gov.uk - from track_audit_event() in audit.py:161
funding-service-1  | 2026-05-12 12:29:30,808 INFO - audit_event: AuditEventType.SYSTEM by funding-service-notify@communities.gov.uk - from track_audit_event() in audit.py:161
funding-service-1  | 2026-05-12 12:29:30,808 INFO - audit_event: AuditEventType.SYSTEM by funding-service-notify@communities.gov.uk - from track_audit_event() in audit.py:161
funding-service-1  | 2026-05-12 12:29:30,810 ERROR - Grant 'Cheeseboards in parks' (caf0ce3f-5175-f69c-66a9-41e2c2245845) at organisation 'Ministry of Testing' (74b2ee5d-20e6-4ab9-b5d0-150444bf9510) has no other users with DATA_PROVIDER after permanent failure; manual intervention required. - from _log_error_for_access_grant_funding_roles_with_no_alternate_users() in callbacks.py:138
funding-service-1  | 2026-05-12 12:29:30,815 INFO - 202 POST https://funding.communities.gov.localhost:8080/deliver/api/v1/govuk-notify-callback - [real:0.02s] [process:0.01s] - from after_request() in logging.py:141
```

<img width="1296" height="838" alt="image" src="https://github.com/user-attachments/assets/3a1b8eaa-7c2a-4fec-aee8-969ea6d84ac2" />

<img width="1311" height="1177" alt="image" src="https://github.com/user-attachments/assets/1a627abc-101c-4667-b1ef-267cc380574e" />


## 🧪 Testing
- Manually create some user roles for seeded users giving them Access grant funding permissions (eg for darin.lewis@test.communities.gov.uk with data provider/certifier for Ministry of Testing+Cheeseboards in Parks).
- Comment out this line:
    ```python
            if callback_data.to.endswith(current_app.config["GOVUK_NOTIFY_IGNORE_CALLBACK_DOMAINS"]):
                return jsonify(), 202
    ```
- POST to the /deliver/api/v1/govuk-notify-callback endpoint with `Authorisation: Bearer local-use-secret` header and payload:
    ```
    {
    "completed_at": "2026-05-12T07:46:45.250646Z",
    "created_at": "2026-05-12T07:46:44.422635Z",
    "id": "1fdbe5d2-f7e4-4a8e-af8d-592c943cfd0f",
    "notification_type": "email",
    "reference": null,
    "sent_at": "2026-05-12T07:46:44.564077Z",
    "status": "permanent-failure",
    "template_id": "e511c0d0-2ac8-4ded-80a2-13b79023c5d5",
    "template_version": 13,
    "to": "darin.lewis@test.communities.gov.uk"
    }
    ```
- Check that all user roles for that user were dropped.
- Check that error log messages were emitted if they were the last DATA_PROVIDER/CERTIFIER.
- Check that log messages are not emitted if other users have permissions covering the same org+grant+role.
- Check that users with any Deliver grant funding permissions do not have any permissions revoked.

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [ ] End-to-end tests have been updated (if applicable)
- [ ] Edge cases and error conditions are tested