### PR TITLE
Loosen uv requirements for heroku buildpack

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dev = [
 ]
 
 [tool.uv]
-required-version = ">=0.11.14"
+required-version = ">=0.11.11"
 add-bounds = "exact"
 
 [tool.ty.terminal]


### PR DESCRIPTION
Heroku's buildpack uses 0.11.11 so we can't hard require 0.11.14 yet.

I only bumped it to 0.11.14 to help developers locally realise they'd need to upgrade.