### PR TITLE
Display UTC timestamps in Europe/London time

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -49,6 +49,7 @@ from app.common.filters import (
     format_datetime_range,
     format_datetime_short,
     format_thousands,
+    iso_utc,
     to_ordinal,
 )
 from app.common.helpers.collections import SubmissionAuthorisationError
@@ -299,6 +300,7 @@ def create_app() -> Flask:  # noqa: C901
             format_datetime_range=format_datetime_range,
             format_datetime_short=format_datetime_short,
             format_thousands=format_thousands,
+            iso_utc=iso_utc,
             timedelta=datetime.timedelta,
             to_ordinal=to_ordinal,
             get_google_tag_manager_id=get_google_tag_manager_id,

--- a/app/common/filters.py
+++ b/app/common/filters.py
@@ -1,35 +1,47 @@
 import decimal
-from datetime import date, datetime
+from datetime import UTC, date, datetime
 from typing import cast
+from zoneinfo import ZoneInfo
 
 from num2words import num2words
 
+DEFAULT_DISPLAY_TZ = ZoneInfo("Europe/London")
 
-def format_date(value: date | datetime) -> str:
+
+def _coerce_tz[T: date | datetime](value: T, tz: ZoneInfo | None) -> T:
+    if tz is None or not isinstance(value, datetime):
+        return value
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+
+    return cast(T, value.astimezone(tz))
+
+
+def format_date(value: date | datetime, tz: ZoneInfo | None = DEFAULT_DISPLAY_TZ) -> str:
     """Format a date or datetime as follows:
 
     > Friday 16 May 2025
     """
-    return value.strftime("%A %-d %B %-Y")
+    return _coerce_tz(value, tz).strftime("%A %-d %B %-Y")
 
 
-def format_date_short(value: date | datetime) -> str:
+def format_date_short(value: date | datetime, tz: ZoneInfo | None = DEFAULT_DISPLAY_TZ) -> str:
     """Format a date or datetime as follows:
 
     > 16 May 2025
     """
-    return value.strftime("%-d %B %-Y")
+    return _coerce_tz(value, tz).strftime("%-d %B %-Y")
 
 
-def format_date_approximate(value: date | datetime) -> str:
+def format_date_approximate(value: date | datetime, tz: ZoneInfo | None = DEFAULT_DISPLAY_TZ) -> str:
     """Format a date or datetime as follows:
 
     > May 2025
     """
-    return value.strftime("%B %-Y")
+    return _coerce_tz(value, tz).strftime("%B %-Y")
 
 
-def format_datetime(value: datetime) -> str:
+def format_datetime(value: datetime, tz: ZoneInfo | None = DEFAULT_DISPLAY_TZ) -> str:
     """Format a datetime as follows:
 
     > 10:37am on Friday 16 May 2025
@@ -38,6 +50,7 @@ def format_datetime(value: datetime) -> str:
 
     > 10am on Friday 16 May 2025
     """
+    value = _coerce_tz(value, tz)
     fmt = "%-I:%M%p on %A %-d %B %-Y"
 
     if value.minute == 0:
@@ -49,7 +62,7 @@ def format_datetime(value: datetime) -> str:
     return formatted_datetime
 
 
-def format_datetime_short(value: datetime) -> str:
+def format_datetime_short(value: datetime, tz: ZoneInfo | None = DEFAULT_DISPLAY_TZ) -> str:
     """Format a datetime as follows:
 
     > 22 Feb 2026 at 3:41pm
@@ -58,6 +71,7 @@ def format_datetime_short(value: datetime) -> str:
 
     > 22 Feb 2026 at 3pm
     """
+    value = _coerce_tz(value, tz)
     fmt = "%-d %b %-Y at %-I:%M%p"
 
     if value.minute == 0:
@@ -69,25 +83,25 @@ def format_datetime_short(value: datetime) -> str:
     return formatted_datetime
 
 
-def format_date_range(start: date, end: date) -> str:
+def format_date_range(start: date, end: date, tz: ZoneInfo | None = DEFAULT_DISPLAY_TZ) -> str:
     """Format a pair of dates as follows:
 
     > Wednesday 1 January 2025 to Saturday 1 February 2025
     """
-    from_, to = format_date(start), format_date(end)
+    from_, to = format_date(start, tz=tz), format_date(end, tz=tz)
     return f"{from_} to {to}"
 
 
-def format_date_range_short(start: date, end: date) -> str:
+def format_date_range_short(start: date, end: date, tz: ZoneInfo | None = DEFAULT_DISPLAY_TZ) -> str:
     """Format a pair of dates as follows:
 
     > 1 January 2025 to 1 February 2025
     """
-    from_, to = format_date_short(start), format_date_short(end)
+    from_, to = format_date_short(start, tz=tz), format_date_short(end, tz=tz)
     return f"{from_} to {to}"
 
 
-def format_datetime_range(start: datetime, end: datetime) -> str:
+def format_datetime_range(start: datetime, end: datetime, tz: ZoneInfo | None = DEFAULT_DISPLAY_TZ) -> str:
     """Format a pair of dates as follows:
 
     > 9:15am on Wednesday 1 January 2025 to 5:45pm on Saturday 1 February 2025
@@ -96,8 +110,18 @@ def format_datetime_range(start: datetime, end: datetime) -> str:
 
     > 9am on Wednesday 1 January 2025 to 5pm on Saturday 1 February 2025
     """
-    from_, to = format_datetime(start), format_datetime(end)
+    from_, to = format_datetime(start, tz=tz), format_datetime(end, tz=tz)
     return f"{from_} to {to}"
+
+
+def iso_utc(value: datetime) -> str:
+    """Render a datetime as an ISO 8601 string with an explicit UTC offset.
+
+    Naive datetimes are assumed to be UTC.
+    """
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    return value.astimezone(UTC).isoformat()
 
 
 def to_ordinal(number: int) -> str:

--- a/app/deliver_grant_funding/admin/entities.py
+++ b/app/deliver_grant_funding/admin/entities.py
@@ -505,11 +505,11 @@ class PlatformAdminAuditEventView(FlaskAdminPlatformAdminAccessibleMixin, Platfo
     ]
     column_searchable_list = ["user.email", "event_type"]
     column_labels = {
-        "created_at_utc": "Timestamp",
+        "created_at_utc": "Created at UTC",
         "user.email": "User",
         "model_class": "Model class",
         "action": "Action",
-        "updated_at_utc": "Updated at",
+        "updated_at_utc": "Updated at UTC",
         "event_type": "Event type",
     }
 
@@ -688,7 +688,8 @@ class PlatformAdminSubmissionEventView(FlaskAdminPlatformAdminAccessibleMixin, P
     ]
     column_searchable_list = ["id", "submission.reference"]
     column_labels = {
-        "created_at_utc": "Timestamp",
+        "created_at_utc": "Created at UTC",
+        "updated_at_utc": "Updated at UTC",
         "event_type": "Event type",
         "submission.reference": "Submission reference",
         "submission.mode": "Submission mode",

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/admin/submission-details.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/admin/submission-details.html
@@ -58,7 +58,7 @@
           <p class="moj-timeline__byline">by {{ item.byline }}</p>
         </div>
         <p class="moj-timeline__date">
-          <time datetime="{{ item.datetime.isoformat() }}">{{ format_datetime_short(item.datetime) }}</time>
+          <time datetime="{{ iso_utc(item.datetime) }}">{{ format_datetime_short(item.datetime) }}</time>
         </p>
         {% if item.description %}
           <div class="moj-timeline__description">{{ item.description }}</div>

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/data_sets/view_data_set.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/data_sets/view_data_set.html
@@ -63,6 +63,11 @@
         <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.download_data_source_csv', grant_id=grant.id, report_id=report.id, data_source_id=data_source.id) }}"> Download data set (CSV) </a>
       {% endset %}
 
+
+      {% set uploaded_time %}
+        <time datetime="{{ iso_utc(data_source.created_at_utc) }}">{{ format_datetime_short(data_source.created_at_utc) }}</time>
+      {% endset %}
+
       {%
         set summary_rows = [
           {
@@ -75,7 +80,7 @@
           },
           {
             "key": {"text": "Date and time uploaded"},
-            "value": {"text": format_datetime_short(data_source.created_at_utc) if data_source.created_at_utc else "Unknown"}
+            "value": {"html": uploaded_time},
           },
           {
             "key": {"text": "Uploaded data set"},

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_data_sets.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_data_sets.html
@@ -47,7 +47,10 @@
           {% set data_set_name_html %}
             <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.view_data_source', grant_id=grant.id, report_id=report.id, data_source_id=data_set.id) }}">{{ data_set.name }}</a>
           {% endset %}
-          {% do rows.append([{"html": data_set_name_html}, {"text": format_datetime_short(data_set.updated_at_utc if data_set.updated_at_utc else data_set.created_at_utc)}, {"text": data_set.updated_by.name if data_set.updated_by else data_set.created_by.name}]) %}
+          {% set data_set_timestamp %}
+            <time datetime="{{ iso_utc(data_set.updated_at_utc) }}">{{ format_datetime_short(data_set.updated_at_utc) }}</time>
+          {% endset %}
+          {% do rows.append([{"html": data_set_name_html}, {"html": data_set_timestamp}, {"text": data_set.updated_by.name if data_set.updated_by else data_set.created_by.name}]) %}
         {% endfor %}
       {% else %}
         {% set no_data_sets_text %}

--- a/tests/integration/deliver_grant_funding/admin/test_views.py
+++ b/tests/integration/deliver_grant_funding/admin/test_views.py
@@ -5003,7 +5003,7 @@ class TestPlatformAdminSubmissionsView:
         page_text = soup.get_text()
         assert "Missing evidence" in page_text
         assert f"Reference: {submission.reference}" in page_text
-        assert "3 Jun 2025 at 2pm" in page_text
+        assert "3 Jun 2025 at 3pm" in page_text
 
 
 class TestPlatformAdminSubmissionEventView:

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -1,4 +1,5 @@
 import csv
+import datetime
 import io
 import logging
 import uuid
@@ -57,7 +58,6 @@ from app.common.expressions.forms import (
 )
 from app.common.expressions.managed import AnyOf, GreaterThan, IsAfter, IsNo, IsYes, LessThan
 from app.common.expressions.references import ExpressionReference
-from app.common.filters import format_datetime_short
 from app.common.forms import GenericConfirmDeletionForm, GenericSubmitForm
 from app.common.helpers.collections import SubmissionHelper
 from app.constants import DATA_SET_EXTERNAL_ID_COLUMN_HEADER, DATA_SET_GRANT_RECIPIENT_COLUMN_HEADER
@@ -9145,6 +9145,7 @@ class TestListReportDataSets:
             collection=report,
             created_by=uploader,
             updated_by=None,
+            created_at_utc=datetime.datetime(2025, 7, 1, 13, 30, 0),
             items=None,
         )
         data_source_2 = factories.data_source.create(
@@ -9154,6 +9155,8 @@ class TestListReportDataSets:
             collection=report,
             created_by=uploader,
             updated_by=uploader_2,
+            created_at_utc=datetime.datetime(2025, 7, 1, 13, 30, 0),
+            updated_at_utc=datetime.datetime(2025, 7, 1, 14, 30, 0),
         )
 
         other_report = factories.collection.create(name="Other Report")
@@ -9176,8 +9179,9 @@ class TestListReportDataSets:
         assert uploader.name in soup.text
         assert uploader_2.name in soup.text
         assert data_source_3.name not in soup.text
-        assert format_datetime_short(data_source_1.created_at_utc) in soup.text
-        assert format_datetime_short(data_source_1.updated_at_utc) in soup.text
+        data_source_timestamps = soup.find_all("time")
+        assert data_source_timestamps[0].text == "1 Jul 2025 at 2:30pm"
+        assert data_source_timestamps[1].text == "1 Jul 2025 at 3:30pm"
 
         if not can_upload:
             assert page_has_button(soup, button_text="Upload new data set") is None
@@ -10387,6 +10391,7 @@ class TestViewDataSource:
             collection=report,
             grant=grant,
             name="Test data set",
+            created_at_utc=datetime.datetime(2026, 7, 1, 12, 0, 0),
             type=DataSourceType.STATIC,
         )
 
@@ -10405,6 +10410,9 @@ class TestViewDataSource:
             assert response.status_code == 200
             soup = BeautifulSoup(response.data, "html.parser")
             assert "Test data set" in get_h1_text(soup)
+            uploaded_at = soup.find("time")
+            assert uploaded_at.text == "1 Jul 2026 at 1pm", "Uploaded at UTC should be converted to local London"
+
             if can_delete:
                 assert page_has_link(soup, "Delete data set")
             else:

--- a/tests/models.py
+++ b/tests/models.py
@@ -883,9 +883,13 @@ class _DataSourceFactory(SQLAlchemyModelFactory):
     collection = None
     collection_id = factory.LazyAttribute(lambda o: o.collection.id if o.collection else None)
 
+    created_at_utc = factory.LazyFunction(lambda: datetime.datetime.now())
     created_by = None
     created_by_id = factory.LazyAttribute(lambda o: o.created_by.id if o.created_by else None)
 
+    updated_at_utc = factory.LazyAttribute(
+        lambda o: datetime.datetime.now() if o.updated_by is not None else o.created_at_utc
+    )
     updated_by = None
     updated_by_id = factory.LazyAttribute(lambda o: o.updated_by.id if o.updated_by else None)
 

--- a/tests/unit/common/test_filters.py
+++ b/tests/unit/common/test_filters.py
@@ -1,7 +1,8 @@
 import datetime
+from zoneinfo import ZoneInfo
 
 from app import format_date, format_date_range, format_datetime, format_datetime_range
-from app.common.filters import format_date_range_short, format_datetime_short
+from app.common.filters import format_date_range_short, format_datetime_short, iso_utc
 
 
 class TestFormatDate:
@@ -10,6 +11,15 @@ class TestFormatDate:
 
     def test_datetime(self):
         assert format_date(datetime.datetime(2025, 1, 1, 12, 0, 0)) == "Wednesday 1 January 2025"
+
+    def test_datetime_crosses_midnight_in_bst(self):
+        assert format_date(datetime.datetime(2025, 6, 1, 23, 30, 0)) == "Monday 2 June 2025"
+
+    def test_datetime_tz_none_keeps_utc(self):
+        assert format_date(datetime.datetime(2025, 6, 1, 23, 30, 0), tz=None) == "Sunday 1 June 2025"
+
+    def test_date_ignores_tz(self):
+        assert format_date(datetime.date(2025, 6, 1), tz=None) == "Sunday 1 June 2025"
 
 
 class TestFormatDatetime:
@@ -27,6 +37,19 @@ class TestFormatDatetime:
 
     def test_datetime_midnight(self):
         assert format_datetime(datetime.datetime(2025, 1, 1, 0, 0, 0)) == "12am on Wednesday 1 January 2025"
+
+    def test_naive_utc_in_bst_shifts_one_hour(self):
+        assert format_datetime(datetime.datetime(2025, 6, 1, 23, 30, 0)) == "12:30am on Monday 2 June 2025"
+
+    def test_naive_utc_in_gmt_unchanged(self):
+        assert format_datetime(datetime.datetime(2025, 1, 1, 9, 0, 0)) == "9am on Wednesday 1 January 2025"
+
+    def test_tz_none_keeps_raw_utc(self):
+        assert format_datetime(datetime.datetime(2025, 6, 1, 23, 30, 0), tz=None) == "11:30pm on Sunday 1 June 2025"
+
+    def test_aware_non_utc_input_converted(self):
+        eastern = datetime.datetime(2025, 6, 1, 19, 30, 0, tzinfo=ZoneInfo("America/New_York"))
+        assert format_datetime(eastern) == "12:30am on Monday 2 June 2025"
 
 
 class TestFormatDateRange:
@@ -74,3 +97,19 @@ class TestFormatDatetimeShort:
 
     def test_datetime_midnight(self):
         assert format_datetime_short(datetime.datetime(2025, 1, 1, 0, 0, 0)) == "1 Jan 2025 at 12am"
+
+    def test_naive_utc_in_bst_shifts_one_hour(self):
+        assert format_datetime_short(datetime.datetime(2025, 6, 1, 23, 30, 0)) == "2 Jun 2025 at 12:30am"
+
+
+class TestIsoUtc:
+    def test_naive_input_treated_as_utc(self):
+        assert iso_utc(datetime.datetime(2025, 6, 1, 23, 30, 0)) == "2025-06-01T23:30:00+00:00"
+
+    def test_aware_non_utc_input_converted(self):
+        eastern = datetime.datetime(2025, 6, 1, 18, 30, 0, tzinfo=ZoneInfo("America/New_York"))
+        assert iso_utc(eastern) == "2025-06-01T22:30:00+00:00"
+
+    def test_aware_utc_input_unchanged(self):
+        utc = datetime.datetime(2025, 1, 1, 9, 0, 0, tzinfo=datetime.UTC)
+        assert iso_utc(utc) == "2025-01-01T09:00:00+00:00"


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-1365

## 📝 Description
We store all of our DB timestamps in UTC; but we should display these in local time on the frontend as that is what our users expect (it's confusing to upload a dataset at 1:30pm in summer but then see the service say it was uploaded at 12:30pm)

This patch changes all of our datetime formatters to cast naive datetimes to Europe/London.

CSV exports/etc will stay as UTC for now - changing either the timestamp or the column headers could break downstream consumers, so need to take some input on this. JSON exports as UTC but does include `utc` in the data keys.

## 📸 Show the thing (screenshots, gifs)
<!-- Include screenshots for UI changes, new features, or visual modifications -->
<!-- Use "Before" and "After" sections if showing changes to existing functionality -->

### Before
<img width="670" height="367" alt="image" src="https://github.com/user-attachments/assets/ed2faa09-3e21-4940-ae6a-5c0e832fdccc" />

<img width="884" height="597" alt="image" src="https://github.com/user-attachments/assets/760b50cc-12a4-4628-bf73-b7e0d93deba2" />


### After
<img width="667" height="433" alt="image" src="https://github.com/user-attachments/assets/fee1a767-9877-4d25-9dc6-09b58941a1c4" />

<img width="451" height="601" alt="image" src="https://github.com/user-attachments/assets/5369f411-66d4-41c5-8bf0-08b19cc4c9c8" />

## 🧪 Testing
- Checkout the main branch
- Upload a dataset and complete a submission
- Check the 'view dataset' page and the platform admin 'view submission' page to see its timeline.
- Confirm that the datetimes shown are UTC (an hour behind current wall-clock time)
- Switch to this branch and confirm the datetimes are now showing the local/summer wallclock time.

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [-] I need the reviewer(s) to pull and run this change locally
- [-] New (non-developer) functionality has appropriate unit and integration tests
- [ ] End-to-end tests have been updated (if applicable)
- [ ] Edge cases and error conditions are tested