### PR TITLE
Make app deploys match terraform values for CPU and memory

### DIFF
--- a/.github/workflows/ad_hoc_dev_deploy.yml
+++ b/.github/workflows/ad_hoc_dev_deploy.yml
@@ -8,13 +8,13 @@ permissions:
 on:
   workflow_dispatch:
     inputs:
-        run_e2e_tests:
-            required: false
-            default: true
-            type: boolean
-            description: Run e2e tests
+      run_e2e_tests:
+        required: false
+        default: true
+        type: boolean
+        description: Run e2e tests
   schedule:
-  - cron:  '0 2 * * 1'
+    - cron: '0 2 * * 1'
 jobs:
   cnb_build:
     name: Build
@@ -44,7 +44,9 @@ jobs:
       cancel-in-progress: false
     with:
       environment: dev
-      run_e2e_tests:  ${{ inputs.run_e2e_tests }}
+      run_e2e_tests: ${{ inputs.run_e2e_tests }}
+      image_cpu: 1
+      image_memory: 2
     secrets:
       AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
       CI_AWS_ACCOUNT: ${{ secrets.CI_AWS_ACCOUNT }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,10 +14,22 @@ on:
         required: true
         default: dev
       run_e2e_tests:
-          description: "Run end-to-end tests?"
-          type: boolean
-          default: true
-          required: true
+        description: "Run end-to-end tests?"
+        type: boolean
+        default: true
+        required: true
+      image_cpu:
+        # Keep in sync with terraform otherwise this value will be reverted on the next terraform apply
+        description: "CPU units for the App Runner service"
+        type: number
+        default: 2
+        required: false
+      image_memory:
+        # Keep in sync with terraform otherwise this value will be reverted on the next terraform apply
+        description: "Memory (in GB) for the App Runner service"
+        type: number
+        default: 4
+        required: false
     secrets:
       AWS_ACCOUNT:
         required: true
@@ -76,31 +88,31 @@ jobs:
         env:
           ENVIRONMENT: ${{ inputs.environment }}
         run: |
-            # Get the current deployed DB version
-            if [ "$ENVIRONMENT" != "prod" ]; then
-              DEPLOYED_VERSION=$(curl -s -f -u "${{ secrets.FS_BASIC_AUTH_USERNAME }}:${{ secrets.FS_BASIC_AUTH_PASSWORD }}" "${{ vars.BASE_URL }}/healthcheck/db") || exit 1
-            else
-              DEPLOYED_VERSION=$(curl -s -f "${{ vars.BASE_URL }}/healthcheck/db") || exit 1
-            fi
+          # Get the current deployed DB version
+          if [ "$ENVIRONMENT" != "prod" ]; then
+            DEPLOYED_VERSION=$(curl -s -f -u "${{ secrets.FS_BASIC_AUTH_USERNAME }}:${{ secrets.FS_BASIC_AUTH_PASSWORD }}" "${{ vars.BASE_URL }}/healthcheck/db") || exit 1
+          else
+            DEPLOYED_VERSION=$(curl -s -f "${{ vars.BASE_URL }}/healthcheck/db") || exit 1
+          fi
 
-            # Get the local repository version
-            LOCAL_VERSION=$(cat app/common/data/migrations/.current-alembic-head)
+          # Get the local repository version
+          LOCAL_VERSION=$(cat app/common/data/migrations/.current-alembic-head)
 
-            if [ -z "$LOCAL_VERSION" ]; then
-              echo "::error::Local DB version could not be read or is empty. Please check app/common/data/migrations/.current-alembic-head."
-              exit 1
-            fi
-            echo "::notice::Deployed DB version: $DEPLOYED_VERSION"
-            echo "::notice::Local DB version: $LOCAL_VERSION"
+          if [ -z "$LOCAL_VERSION" ]; then
+            echo "::error::Local DB version could not be read or is empty. Please check app/common/data/migrations/.current-alembic-head."
+            exit 1
+          fi
+          echo "::notice::Deployed DB version: $DEPLOYED_VERSION"
+          echo "::notice::Local DB version: $LOCAL_VERSION"
 
-            # Compare versions and set output
-            if [ "$DEPLOYED_VERSION" != "$LOCAL_VERSION" ]; then
-              echo "::notice::Versions differ - migrations needed"
-              echo "RUN_MIGRATIONS=true" >> $GITHUB_OUTPUT
-            else
-              echo "::notice::Versions match - no migrations needed"
-              echo "RUN_MIGRATIONS=false" >> $GITHUB_OUTPUT
-            fi
+          # Compare versions and set output
+          if [ "$DEPLOYED_VERSION" != "$LOCAL_VERSION" ]; then
+            echo "::notice::Versions differ - migrations needed"
+            echo "RUN_MIGRATIONS=true" >> $GITHUB_OUTPUT
+          else
+            echo "::notice::Versions match - no migrations needed"
+            echo "RUN_MIGRATIONS=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Run Database Migrations
         if: steps.changes.outputs.RUN_MIGRATIONS == 'true'
@@ -116,14 +128,14 @@ jobs:
           access-role-arn: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/${{ inputs.environment }}-funding-service-app-runner-build-role
           region: eu-west-2
           port: 8080
-          cpu: 2
-          memory: 4
+          cpu: ${{inputs.image_cpu}}
+          memory: ${{inputs.image_memory}}
           wait-for-service-stability-seconds: 600
 
   e2e_tests:
     name: Python E2E tests
     if: ${{ inputs.run_e2e_tests == true }}
-    needs: [deploy]
+    needs: [ deploy ]
     uses: ./.github/workflows/run_e2e_tests.yml
     with:
       environment: ${{ inputs.environment }}
@@ -133,7 +145,7 @@ jobs:
       SERVICE_ACCOUNT_PASSWORD: ${{ secrets.SERVICE_ACCOUNT_PASSWORD }}
 
   notify_slack:
-    needs: [deploy, e2e_tests]
+    needs: [ deploy, e2e_tests ]
     if: ${{ always() && (needs.deploy.result == 'failure' || needs.e2e_tests.result == 'failure') && github.ref_name == 'main' }}
     uses: communitiesuk/funding-service-design-workflows/.github/workflows/notify-slack-deployment-failed.yml@d4a4c7d63b1d5c82a8c1fe57edea8ef529a60d04  # PR #313
     with:


### PR DESCRIPTION
Fixing a small issue whereby our terraform code sets different values for CPU and memory depending on the target environment (dev vs test/prod) but our app deploy always uses the prod values.

--- 

Parameterising the values for cpu and memory on the deployed app runner image. 

This means that when we deploy to dev we match our terraform settings of having different values for dev and test/prod. Without this, every time we run terraform in dev it is generating changes to the cpu and memory values which is unnecessary noise for other deployments