### PR TITLE
FSPT-1350: Adding cancel link during upload dataset journey

### DIFF
--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/data_sets/data_set_missing_data.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/data_sets/data_set_missing_data.html
@@ -77,6 +77,7 @@
         <div class="govuk-button-group">
           {{ form.csrf_token }}
           {{ form.submit(params={"text": "Continue and upload data set" }) }}
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.list_report_data_sets', grant_id=grant.id, report_id=report.id) }}">Cancel</a>
         </div>
       </form>
     </div>

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/data_sets/map_columns.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/data_sets/map_columns.html
@@ -55,7 +55,10 @@
           })
         }}
 
-        {{ form.submit }}
+        <div class="govuk-button-group">
+          {{ form.submit }}
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.list_report_data_sets', grant_id=grant.id, report_id=report.id) }}">Cancel</a>
+        </div>
       </form>
     </div>
   </div>

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/data_sets/map_number_columns.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/data_sets/map_number_columns.html
@@ -59,7 +59,10 @@
           })
         }}
 
-        {{ form.submit }}
+        <div class="govuk-button-group">
+          {{ form.submit }}
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.list_report_data_sets', grant_id=grant.id, report_id=report.id) }}">Cancel</a>
+        </div>
       </form>
     </div>
   </div>

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/data_sets/upload_dataset.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/data_sets/upload_dataset.html
@@ -51,7 +51,10 @@
           })
         }}
         {{ form.file(params={"javascript": true}) }}
-        {{ form.submit(params={"text": "Continue and map columns" }) }}
+        <div class="govuk-button-group">
+          {{ form.submit(params={"text": "Continue and map columns" }) }}
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.list_report_data_sets', grant_id=grant.id, report_id=report.id) }}">Cancel</a>
+        </div>
       </form>
     </div>
   </div>


### PR DESCRIPTION
## 🎫 Ticket
[FSPT-1350](https://mhclgdigital.atlassian.net/browse/FSPT-1350): Cancel button

## 📝 Description
Adds a Cancel link to each page of the upload dataset journey. This takes the user back to the list of existing datasets.

## 📸 Show the thing (screenshots, gifs)
| Page | Screenshot |
|--------|--------|
| Upload new dataset | <img width="796" height="804" alt="Screenshot 2026-05-13 at 17 11 25" src="https://github.com/user-attachments/assets/bcaa8fee-e30f-4788-978d-47e390bd121e" /> |
| Map columns | <img width="844" height="563" alt="Screenshot 2026-05-13 at 17 10 08" src="https://github.com/user-attachments/assets/263840e9-baae-4821-a0cf-4a25d8ba4565" /> |
| Row contains missing data | <img width="992" height="390" alt="Screenshot 2026-05-13 at 17 09 18" src="https://github.com/user-attachments/assets/c6a9ef49-58c6-499c-b8f4-70b367a77282" /> |
| Number formatting options | <img width="843" height="509" alt="Screenshot 2026-05-13 at 17 10 30" src="https://github.com/user-attachments/assets/ba225880-6804-47d6-ae0d-4e81074f906f" /> | 



[FSPT-1350]: https://mhclgdigital.atlassian.net/browse/FSPT-1350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ