### PR TITLE
FSPT-1335: Add MoJ scrollable pane to 'view data set'

### DIFF
--- a/app/assets/main.scss
+++ b/app/assets/main.scss
@@ -18,8 +18,9 @@ $new-organisation-colours: true;
     $govuk-brand-colour: $brand-colour
 );
 
-@use "../../node_modules/accessible-autocomplete"; // TODO: replace with select-with-search
+@use "moj/objects/scrollable-pane";
 
+@use "../../node_modules/accessible-autocomplete"; // TODO: replace with select-with-search
 @use "components/accessible-autocomplete-overrides";
 @use "components/context-aware-editor";
 @use "components/destructive-link";

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/data_sets/view_data_set.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/data_sets/view_data_set.html
@@ -121,7 +121,7 @@
           %}
           {% do rows.append([key_cell, val_cell]) %}
         {% endfor %}
-        {{ govukTable({"head": head, "rows": rows}) }}
+        <div class="moj-scrollable-pane" role="region" aria-label="{{ data_source.name }}" tabindex="0">{{ govukTable({"head": head, "rows": rows}) }}</div>
       {% elif data_source.type == enum.data_source_type_enum.GRANT_RECIPIENT %}
         {%
           set head = [
@@ -155,7 +155,8 @@
           {% endfor %}
           {% do rows.append(row) %}
         {% endfor %}
-        {{ govukTable({"head": head, "rows": rows}) }}
+
+        <div class="moj-scrollable-pane" role="region" aria-label="{{ data_source.name }}" tabindex="0">{{ govukTable({"head": head, "rows": rows}) }}</div>
       {% elif data_source.type == enum.data_source_type_enum.PROJECT_LEVEL %}
         {%
           set head = [
@@ -188,7 +189,7 @@
             {% do rows.append(row) %}
           {% endfor %}
         {% endfor %}
-        {{ govukTable({"head": head, "rows": rows}) }}
+        <div class="moj-scrollable-pane" role="region" aria-label="{{ data_source.name }}" tabindex="0">{{ govukTable({"head": head, "rows": rows}) }}</div>
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-1335

## 📝 Description
Brings in the MoJ scrollable pane and adds it to the 'view data set' page to prevent very squashed or overrunning tables for data sets with many columns. We add this to each of the table set ups on the view data set page (ie. for STATIC and PROJECT_LEVEL data sets too), even though these other ones will likely be removed as we scope the upload flow down to just GRANT_RECIPIENT level.

At a certain screen resolution (1020px) the `white-space: nowrap;` gets added in - perhaps this is a value we want to override?

## 📸 Show the thing (screenshots, gifs)

### Before
<img width="1232" height="902" alt="image" src="https://github.com/user-attachments/assets/c31a0431-bd05-4dab-8ffb-f89aab4b3683" />


### After
<img width="934" height="924" alt="2026-05-13 17 01 52" src="https://github.com/user-attachments/assets/448b6e34-88e3-4186-9320-a1bb71a4c513" />


## 🧪 Testing
Upload a data set with a lorra columns (or a lorra long content in some of the columns) and witness the glory.

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [X] PR title and description provide sufficient context for reviewers
- [X] Commits are logical, self-contained, and have clear descriptions

### Testing
- [X] I have tested this change and it meets the acceptance criteria for the ticket
- ~[ ] I need the reviewer(s) to pull and run this change locally~
- [ ] New (non-developer) functionality has appropriate unit and integration tests
- ~[ ] End-to-end tests have been updated (if applicable)~
- ~[ ] Edge cases and error conditions are tested~
