### PR TITLE
FSPT-1352 Add application collection type

### DIFF
--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-060_notify_cleanup_audit_event
+061_pre_award_collections

--- a/app/common/data/migrations/versions/061_pre_award_collections.py
+++ b/app/common/data/migrations/versions/061_pre_award_collections.py
@@ -1,4 +1,4 @@
-"""empty message
+"""Add initial pre-award collection type
 
 Revision ID: 061_pre_award_collections
 Revises: 060_notify_cleanup_audit_event
@@ -35,6 +35,9 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    with op.batch_alter_table("collection", schema=None) as batch_op:
+        batch_op.drop_constraint("ck_monitoring_certification_not_null")
+
     op.sync_enum_values(  # ty: ignore[unresolved-attribute]
         enum_schema="public",
         enum_name="collection_type",
@@ -42,3 +45,9 @@ def downgrade() -> None:
         affected_columns=[TableReference(table_schema="public", table_name="collection", column_name="type")],
         enum_values_to_rename=[],
     )
+
+    with op.batch_alter_table("collection", schema=None) as batch_op:
+        batch_op.create_check_constraint(
+            op.f("ck_monitoring_certification_not_null"),
+            "requires_certification IS NOT NULL OR type != 'MONITORING_REPORT'",
+        )

--- a/app/common/data/migrations/versions/061_pre_award_collections.py
+++ b/app/common/data/migrations/versions/061_pre_award_collections.py
@@ -1,0 +1,44 @@
+"""empty message
+
+Revision ID: 061_pre_award_collections
+Revises: 060_notify_cleanup_audit_event
+Create Date: 2026-05-14 10:22:50.502015
+
+"""
+
+from alembic import op
+from alembic_postgresql_enum import TableReference
+
+revision = "061_pre_award_collections"
+down_revision = "060_notify_cleanup_audit_event"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("collection", schema=None) as batch_op:
+        batch_op.drop_constraint("ck_monitoring_certification_not_null")
+
+    op.sync_enum_values(  # ty: ignore[unresolved-attribute]
+        enum_schema="public",
+        enum_name="collection_type",
+        new_values=["MONITORING_REPORT", "APPLICATION"],
+        affected_columns=[TableReference(table_schema="public", table_name="collection", column_name="type")],
+        enum_values_to_rename=[],
+    )
+
+    with op.batch_alter_table("collection", schema=None) as batch_op:
+        batch_op.create_check_constraint(
+            op.f("ck_monitoring_certification_not_null"),
+            "requires_certification IS NOT NULL OR type != 'MONITORING_REPORT'",
+        )
+
+
+def downgrade() -> None:
+    op.sync_enum_values(  # ty: ignore[unresolved-attribute]
+        enum_schema="public",
+        enum_name="collection_type",
+        new_values=["MONITORING_REPORT"],
+        affected_columns=[TableReference(table_schema="public", table_name="collection", column_name="type")],
+        enum_values_to_rename=[],
+    )

--- a/app/common/data/types.py
+++ b/app/common/data/types.py
@@ -138,6 +138,7 @@ class SubmissionEventType(enum.StrEnum):
 
 class CollectionType(enum.StrEnum):
     MONITORING_REPORT = "monitoring report"
+    APPLICATION = "application"
 
 
 class ReportAdminEmailTypeEnum(enum.StrEnum):

--- a/app/common/data/utils.py
+++ b/app/common/data/utils.py
@@ -24,6 +24,8 @@ def generate_submission_reference(collection: Collection, avoid_references: Sequ
         match collection.type:
             case CollectionType.MONITORING_REPORT:
                 fmt = "{grant_code}-R{submission_code}"
+            case CollectionType.APPLICATION:
+                fmt = "{grant_code}-A{submission_code}"
 
             case _:
                 raise RuntimeError(f"Cannot generate reference for unknown submission type {collection.type}")

--- a/tests/unit/common/data/test_utils.py
+++ b/tests/unit/common/data/test_utils.py
@@ -1,5 +1,6 @@
 import pytest
 
+from app.common.data.types import CollectionType
 from app.common.data.utils import generate_submission_reference
 
 
@@ -7,9 +8,11 @@ class TestGenerateSubmissionReference:
     def test_generate_code(self, factories, mocker):
         mocker.patch("random.choices", return_value=["1", "2", "3", "4", "5", "6"])
 
-        collection = factories.collection.build(grant__code="TEST")
+        report = factories.collection.build(grant__code="TEST", type=CollectionType.MONITORING_REPORT)
+        application = factories.collection.build(grant__code="TEST", type=CollectionType.APPLICATION)
 
-        assert generate_submission_reference(collection) == "TEST-R123456"
+        assert generate_submission_reference(report) == "TEST-R123456"
+        assert generate_submission_reference(application) == "TEST-A123456"
 
     def test_avoid_reference(self, factories, mocker):
         mocker.patch(
@@ -20,14 +23,14 @@ class TestGenerateSubmissionReference:
             ],
         )
 
-        collection = factories.collection.build(grant__code="TEST")
+        collection = factories.collection.build(grant__code="TEST", type=CollectionType.MONITORING_REPORT)
 
         assert generate_submission_reference(collection, avoid_references=["TEST-R123456"]) == "TEST-R123457"
 
     def test_max_100_attempts(self, factories, mocker):
         mocker.patch("random.choices", return_value=["1", "2", "3", "4", "5", "6"])
 
-        collection = factories.collection.build(grant__code="TEST")
+        collection = factories.collection.build(grant__code="TEST", type=CollectionType.MONITORING_REPORT)
 
         with pytest.raises(RuntimeError, match="Could not generate a unique submission reference"):
             generate_submission_reference(collection, avoid_references=["TEST-R123456"])


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-1369

## 📝 Description
Add the pre-award colleciton type "APPLICATION". For now we'll use this collection type for all pre-award forms (competed application, uncompeted acceptance or validation forms, expression of interests) but in the future we might split these out to allow form designers to be specific - we would likely model that in the data when the individual joureys need to differ based on the type (emails, content on pages).

The existing form builder and form runner pages should work with any given collection type, pre-award and monitoring forms will be able to be listed and displayed separately in Deliver and Access based on their type.

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions
