### PR TITLE
Fspt 1344 data source factories

### DIFF
--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -4460,21 +4460,9 @@ class TestValidateAndSyncExpressionReferences:
         grant = factories.grant.create()
         collection = factories.collection.create(grant=grant)
         data_source = factories.data_source.create(
-            name="Budget data",
             grant=grant,
             collection=collection,
             type=DataSourceType.GRANT_RECIPIENT,
-            items=None,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_threshold": DataSourceSchemaColumn(
-                        data_type=QuestionDataType.NUMBER,
-                        presentation_options=QuestionPresentationOptions(prefix="£"),
-                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                        original_column_name="Threshold",
-                    ),
-                }
-            ),
         )
         form = factories.form.create(collection=collection)
         question = factories.question.create(form=form, data_type=QuestionDataType.NUMBER)
@@ -4483,7 +4471,7 @@ class TestValidateAndSyncExpressionReferences:
             GreaterThan(
                 subject_reference=ExpressionReference.from_question(question),
                 minimum_value=None,
-                minimum_expression=ExpressionReference.from_data_source_column(data_source, "c_threshold"),
+                minimum_expression=ExpressionReference.from_data_source_column(data_source, "c_allocation"),
             ),
             ExpressionType.VALIDATION,
             user,
@@ -4501,18 +4489,16 @@ class TestValidateAndSyncExpressionReferences:
         assert ref.expression == expression
         assert ref.depends_on_component is None
         assert ref.depends_on_data_source == data_source
-        assert ref.depends_on_column_name == "c_threshold"
+        assert ref.depends_on_column_name == "c_allocation"
 
     def test_creates_column_references_for_both_between_bounds(self, db_session, factories):
         user = factories.user.create()
         grant = factories.grant.create()
         collection = factories.collection.create(grant=grant)
         data_source = factories.data_source.create(
-            name="Budget data",
             grant=grant,
             collection=collection,
             type=DataSourceType.GRANT_RECIPIENT,
-            items=None,
             schema=DataSourceSchema.model_validate(
                 {
                     "c_min": DataSourceSchemaColumn(
@@ -4560,27 +4546,9 @@ class TestValidateAndSyncExpressionReferences:
         grant = factories.grant.create()
         collection = factories.collection.create(grant=grant)
         data_source = factories.data_source.create(
-            name="Budget data",
             grant=grant,
             collection=collection,
             type=DataSourceType.GRANT_RECIPIENT,
-            items=None,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_min": DataSourceSchemaColumn(
-                        data_type=QuestionDataType.NUMBER,
-                        presentation_options=QuestionPresentationOptions(prefix="£"),
-                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                        original_column_name="Min",
-                    ),
-                    "c_max": DataSourceSchemaColumn(
-                        data_type=QuestionDataType.NUMBER,
-                        presentation_options=QuestionPresentationOptions(prefix="£"),
-                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                        original_column_name="Max",
-                    ),
-                }
-            ),
         )
         form = factories.form.create(collection=collection)
         min_question = factories.question.create(form=form, data_type=QuestionDataType.NUMBER)
@@ -4592,7 +4560,7 @@ class TestValidateAndSyncExpressionReferences:
                 minimum_value=None,
                 minimum_expression=ExpressionReference.from_question(min_question),
                 maximum_value=None,
-                maximum_expression=ExpressionReference.from_data_source_column(data_source, "c_max"),
+                maximum_expression=ExpressionReference.from_data_source_column(data_source, "c_allocation"),
             ),
             ExpressionType.VALIDATION,
             user,
@@ -4607,28 +4575,16 @@ class TestValidateAndSyncExpressionReferences:
         component_refs = [ref for ref in expression.component_references if ref.depends_on_component_id]
         column_refs = [ref for ref in expression.component_references if ref.depends_on_data_source_id]
         assert {ref.depends_on_component for ref in component_refs} == {min_question}
-        assert {ref.depends_on_column_name for ref in column_refs} == {"c_max"}
+        assert {ref.depends_on_column_name for ref in column_refs} == {"c_allocation"}
 
     def test_rejects_column_reference_to_missing_column(self, db_session, factories):
         user = factories.user.create()
         grant = factories.grant.create()
         collection = factories.collection.create(grant=grant)
         data_source = factories.data_source.create(
-            name="Budget data",
             grant=grant,
             collection=collection,
             type=DataSourceType.GRANT_RECIPIENT,
-            items=None,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_threshold": DataSourceSchemaColumn(
-                        data_type=QuestionDataType.NUMBER,
-                        presentation_options=QuestionPresentationOptions(prefix="£"),
-                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                        original_column_name="Threshold",
-                    ),
-                }
-            ),
         )
         form = factories.form.create(collection=collection)
         question = factories.question.create(form=form, data_type=QuestionDataType.NUMBER)
@@ -4908,21 +4864,9 @@ class TestValidateAndSyncComponentReferences:
         grant = factories.grant.create()
         collection = factories.collection.create(grant=grant)
         data_source = factories.data_source.create(
-            name="Budget data",
             grant=grant,
             collection=collection,
             type=DataSourceType.GRANT_RECIPIENT,
-            items=None,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_allocation": DataSourceSchemaColumn(
-                        data_type=QuestionDataType.NUMBER,
-                        presentation_options=QuestionPresentationOptions(prefix="£"),
-                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                        original_column_name="Allocation",
-                    )
-                }
-            ),
         )
         form = factories.form.create(collection=collection)
         question = factories.question.create(form=form)
@@ -4945,11 +4889,9 @@ class TestValidateAndSyncComponentReferences:
         grant = factories.grant.create()
         collection = factories.collection.create(grant=grant)
         data_source = factories.data_source.create(
-            name="Budget data",
             grant=grant,
             collection=collection,
             type=DataSourceType.GRANT_RECIPIENT,
-            items=None,
             schema=DataSourceSchema.model_validate(
                 {
                     "c_allocation": DataSourceSchemaColumn(
@@ -4994,21 +4936,9 @@ class TestValidateAndSyncComponentReferences:
         grant = factories.grant.create()
         collection = factories.collection.create(grant=grant)
         data_source = factories.data_source.create(
-            name="Budget data",
             grant=grant,
             collection=collection,
             type=DataSourceType.GRANT_RECIPIENT,
-            items=None,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_allocation": DataSourceSchemaColumn(
-                        data_type=QuestionDataType.NUMBER,
-                        presentation_options=QuestionPresentationOptions(prefix="£"),
-                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                        original_column_name="Allocation",
-                    ),
-                }
-            ),
         )
         form = factories.form.create(collection=collection)
         question = factories.question.create(form=form)

--- a/tests/integration/common/data/interfaces/test_data_sets.py
+++ b/tests/integration/common/data/interfaces/test_data_sets.py
@@ -18,13 +18,9 @@ from app.common.data.interfaces.data_sets import (
 from app.common.data.models import ComponentReference, DataSource, DataSourceItem, DataSourceOrganisationItem
 from app.common.data.types import (
     DataSourceFileMetadata,
-    DataSourceSchema,
-    DataSourceSchemaColumn,
     DataSourceType,
     NumberTypeEnum,
-    QuestionDataOptions,
     QuestionDataType,
-    QuestionPresentationOptions,
 )
 from app.common.expressions import ExpressionContext
 from app.constants import DATA_SET_EXTERNAL_ID_COLUMN_HEADER, DATA_SET_GRANT_RECIPIENT_COLUMN_HEADER
@@ -577,17 +573,6 @@ class TestDeleteDataSource:
             grant=grant,
             collection=collection,
             type=DataSourceType.GRANT_RECIPIENT,
-            items=None,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_allocation": DataSourceSchemaColumn(
-                        data_type=QuestionDataType.NUMBER,
-                        presentation_options=QuestionPresentationOptions(prefix="£"),
-                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                        original_column_name="Allocation",
-                    )
-                }
-            ),
         )
         form = factories.form.create(collection=collection)
         question = factories.question.create(
@@ -613,21 +598,9 @@ class TestDeleteDataSource:
         grant = factories.grant.create()
         collection = factories.collection.create(grant=grant)
         data_source = factories.data_source.create(
-            name="Budget data",
             grant=grant,
             collection=collection,
             type=DataSourceType.GRANT_RECIPIENT,
-            items=None,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_allocation": DataSourceSchemaColumn(
-                        data_type=QuestionDataType.NUMBER,
-                        presentation_options=QuestionPresentationOptions(prefix="£"),
-                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                        original_column_name="Allocation",
-                    )
-                }
-            ),
         )
         form = factories.form.create(collection=collection)
         question = factories.question.create(

--- a/tests/integration/common/data/test_models.py
+++ b/tests/integration/common/data/test_models.py
@@ -750,7 +750,7 @@ class TestComponentReferenceModel:
         grant = factories.grant.create()
         collection = factories.collection.create(grant=grant)
         data_source = factories.data_source.create(
-            name="Budget data", grant=grant, collection=collection, type=DataSourceType.GRANT_RECIPIENT, items=None
+            name="Budget data", grant=grant, collection=collection, type=DataSourceType.GRANT_RECIPIENT
         )
         question = factories.question.create(form__collection=collection)
 
@@ -780,7 +780,10 @@ class TestComponentReferenceModel:
         grant = factories.grant.create()
         collection = factories.collection.create(grant=grant)
         data_source = factories.data_source.create(
-            name="Budget data", grant=grant, collection=collection, type=DataSourceType.GRANT_RECIPIENT, items=None
+            name="Budget data",
+            grant=grant,
+            collection=collection,
+            type=DataSourceType.GRANT_RECIPIENT,
         )
         q1 = factories.question.create(form__collection=collection)
         q2 = factories.question.create(form=q1.form)
@@ -800,7 +803,10 @@ class TestComponentReferenceModel:
         grant = factories.grant.create()
         collection = factories.collection.create(grant=grant)
         data_source = factories.data_source.create(
-            name="Budget data", grant=grant, collection=collection, type=DataSourceType.GRANT_RECIPIENT, items=None
+            name="Budget data",
+            grant=grant,
+            collection=collection,
+            type=DataSourceType.GRANT_RECIPIENT,
         )
         question = factories.question.create(form__collection=collection)
 
@@ -819,7 +825,10 @@ class TestComponentReferenceModel:
         grant = factories.grant.create()
         collection = factories.collection.create(grant=grant)
         data_source = factories.data_source.create(
-            name="Budget data", grant=grant, collection=collection, type=DataSourceType.GRANT_RECIPIENT, items=None
+            name="Budget data",
+            grant=grant,
+            collection=collection,
+            type=DataSourceType.GRANT_RECIPIENT,
         )
         question = factories.question.create(form__collection=collection)
         db_session.add(
@@ -844,7 +853,10 @@ class TestDataSourceModel:
         report = factories.collection.create(grant=grant)
         org1, org2, org3, org4 = factories.organisation.create_batch(4)
         data_source = factories.data_source.create(
-            name="Test data set", grant=grant, collection=report, type=DataSourceType.GRANT_RECIPIENT, items=None
+            name="Test data set",
+            grant=grant,
+            collection=report,
+            type=DataSourceType.GRANT_RECIPIENT,
         )
         org1_item = factories.data_source_organisation_item.create(
             data_source=data_source, external_id=org1.external_id

--- a/tests/integration/common/expressions/test_forms.py
+++ b/tests/integration/common/expressions/test_forms.py
@@ -6,15 +6,12 @@ from werkzeug.datastructures import MultiDict
 from app.common.data.interfaces.collections import DependencyOrderException, IncompatibleDataTypeInCalculationException
 from app.common.data.interfaces.exceptions import InvalidReferenceInExpression
 from app.common.data.types import (
-    DataSourceSchema,
-    DataSourceSchemaColumn,
     DataSourceType,
     ExpressionType,
     ManagedExpressionsEnum,
     NumberTypeEnum,
     QuestionDataOptions,
     QuestionDataType,
-    QuestionPresentationOptions,
 )
 from app.common.expressions import (
     DisallowedExpression,
@@ -660,16 +657,6 @@ class TestValidateCustomSyntax:
             grant=db_form.collection.grant,
             collection=db_form.collection,
             type=DataSourceType.GRANT_RECIPIENT,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_capital_allocation": DataSourceSchemaColumn(
-                        data_type=QuestionDataType.NUMBER,
-                        presentation_options=QuestionPresentationOptions(),
-                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                        original_column_name="Capital Allocation",
-                    )
-                }
-            ),
         )
 
         evaluation_context = ExpressionContext(submission_data={q1.safe_qid: 11, q2.safe_qid: 22, q3.safe_qid: 33})
@@ -678,7 +665,7 @@ class TestValidateCustomSyntax:
         _validate_custom_syntax(
             q3,
             ExpressionContext.build_expression_context(db_form.collection, "interpolation"),
-            f"(({q3.safe_qid})) < (({data_source.safe_did}.c_capital_allocation))",
+            f"(({q3.safe_qid})) < (({data_source.safe_did}.c_allocation))",
             ExpressionType.VALIDATION,
             "custom_expression",
             validate_with_evaluation=True,

--- a/tests/integration/common/expressions/test_init.py
+++ b/tests/integration/common/expressions/test_init.py
@@ -12,7 +12,6 @@ from app.common.data.types import (
     DataSourceSchemaColumn,
     DataSourceType,
     ExpressionType,
-    NumberTypeEnum,
     QuestionDataOptions,
     QuestionDataType,
     QuestionPresentationOptions,
@@ -252,23 +251,13 @@ class TestExpressionContext:
                 grant=grant,
                 collection=collection,
                 type=DataSourceType.GRANT_RECIPIENT,
-                schema=DataSourceSchema.model_validate(
-                    {
-                        "capital_allocation": DataSourceSchemaColumn(
-                            data_type=QuestionDataType.NUMBER,
-                            presentation_options=QuestionPresentationOptions(),
-                            data_options=QuestionDataOptions(),
-                            original_column_name="Capital Allocation",
-                        )
-                    }
-                ),
             )
 
             helper = SubmissionHelper.load(submission.id, grant_recipient_id=grant_recipient.id)
             context = ExpressionContext._build_data_source_context(mode="evaluation", submission_helper=helper)
 
             assert data_source.safe_did in context
-            assert context[data_source.safe_did]["capital_allocation"] is None
+            assert context[data_source.safe_did]["c_allocation"] is None
 
         def test_org_item_none_interpolation_exposes_placeholder_labels(self, factories):
             grant = factories.grant.create()
@@ -281,26 +270,13 @@ class TestExpressionContext:
                 grant=grant,
                 collection=collection,
                 type=DataSourceType.GRANT_RECIPIENT,
-                schema=DataSourceSchema.model_validate(
-                    {
-                        "capital_allocation": DataSourceSchemaColumn(
-                            data_type=QuestionDataType.NUMBER,
-                            presentation_options=QuestionPresentationOptions(),
-                            data_options=QuestionDataOptions(),
-                            original_column_name="Capital Allocation",
-                        )
-                    }
-                ),
             )
 
             helper = SubmissionHelper.load(submission.id, grant_recipient_id=grant_recipient.id)
             context = ExpressionContext._build_data_source_context(mode="interpolation", submission_helper=helper)
 
             assert data_source.safe_did in context
-            assert (
-                context[data_source.safe_did]["capital_allocation"]
-                == "((Capital Allocation from Allocations data set))"
-            )
+            assert context[data_source.safe_did]["c_allocation"] == "((Allocation from Allocations data set))"
 
         def test_non_dict_typed_data_is_skipped(self, factories, mocker):
             grant = factories.grant.create()
@@ -312,21 +288,11 @@ class TestExpressionContext:
                 grant=grant,
                 collection=collection,
                 type=DataSourceType.GRANT_RECIPIENT,
-                schema=DataSourceSchema.model_validate(
-                    {
-                        "c_capital_allocation": DataSourceSchemaColumn(
-                            data_type=QuestionDataType.NUMBER,
-                            presentation_options=QuestionPresentationOptions(),
-                            data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                            original_column_name="Capital Allocation",
-                        )
-                    }
-                ),
             )
             org_item = factories.data_source_organisation_item.create(
                 data_source=data_source,
                 external_id=organisation.external_id,
-                _data={"c_capital_allocation": 1000},
+                _data={"c_allocation": 1000},
             )
 
             mocker.patch.object(type(org_item), "data", new_callable=PropertyMock, return_value=[{"col": "val"}])
@@ -345,28 +311,18 @@ class TestExpressionContext:
                 grant=grant,
                 collection=collection,
                 type=DataSourceType.GRANT_RECIPIENT,
-                schema=DataSourceSchema.model_validate(
-                    {
-                        "c_capital_allocation": DataSourceSchemaColumn(
-                            data_type=QuestionDataType.NUMBER,
-                            presentation_options=QuestionPresentationOptions(),
-                            data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                            original_column_name="Capital Allocation",
-                        )
-                    }
-                ),
             )
             factories.data_source_organisation_item.create(
                 data_source=data_source,
                 external_id=organisation.external_id,
-                _data={"c_capital_allocation": 1000},
+                _data={"c_allocation": 1000},
             )
 
             helper = SubmissionHelper.load(submission.id, grant_recipient_id=grant_recipient.id)
             context = ExpressionContext._build_data_source_context(mode="evaluation", submission_helper=helper)
 
             assert data_source.safe_did in context
-            assert context[data_source.safe_did]["c_capital_allocation"] == 1000
+            assert context[data_source.safe_did]["c_allocation"] == 1000
 
         def test_data_source_organisation_item_filtering(self, factories):
             grant = factories.grant.create()
@@ -384,35 +340,25 @@ class TestExpressionContext:
                 grant=grant,
                 collection=collection,
                 type=DataSourceType.GRANT_RECIPIENT,
-                schema=DataSourceSchema.model_validate(
-                    {
-                        "c_capital_allocation": DataSourceSchemaColumn(
-                            data_type=QuestionDataType.NUMBER,
-                            presentation_options=QuestionPresentationOptions(prefix="£"),
-                            data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                            original_column_name="Capital Allocation",
-                        )
-                    }
-                ),
             )
             factories.data_source_organisation_item.create(
                 data_source=data_source,
                 external_id=organisation.external_id,
-                _data={"c_capital_allocation": 1000},
+                _data={"c_allocation": 1000},
             )
             factories.data_source_organisation_item.create(
                 data_source=data_source,
                 external_id=organisation_2.external_id,
-                _data={"c_capital_allocation": 9999},
+                _data={"c_allocation": 9999},
             )
 
             helper = SubmissionHelper.load(submission.id, grant_recipient_id=grant_recipient.id)
             context = ExpressionContext._build_data_source_context(mode="interpolation", submission_helper=helper)
-            assert context[data_source.safe_did]["c_capital_allocation"] == "£1,000"
+            assert context[data_source.safe_did]["c_allocation"] == "£1,000"
 
             helper = SubmissionHelper.load(submission_2.id, grant_recipient_id=grant_recipient_2.id)
             context = ExpressionContext._build_data_source_context(mode="interpolation", submission_helper=helper)
-            assert context[data_source.safe_did]["c_capital_allocation"] == "£9,999"
+            assert context[data_source.safe_did]["c_allocation"] == "£9,999"
 
         def test_real_org_item_interpolation_returns_formatted_string(self, factories):
             grant = factories.grant.create()
@@ -424,28 +370,18 @@ class TestExpressionContext:
                 grant=grant,
                 collection=collection,
                 type=DataSourceType.GRANT_RECIPIENT,
-                schema=DataSourceSchema.model_validate(
-                    {
-                        "c_capital_allocation": DataSourceSchemaColumn(
-                            data_type=QuestionDataType.NUMBER,
-                            presentation_options=QuestionPresentationOptions(prefix="£"),
-                            data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                            original_column_name="Capital Allocation",
-                        )
-                    }
-                ),
             )
             factories.data_source_organisation_item.create(
                 data_source=data_source,
                 external_id=organisation.external_id,
-                _data={"c_capital_allocation": 1000},
+                _data={"c_allocation": 1000},
             )
 
             helper = SubmissionHelper.load(submission.id, grant_recipient_id=grant_recipient.id)
             context = ExpressionContext._build_data_source_context(mode="interpolation", submission_helper=helper)
 
             assert data_source.safe_did in context
-            assert context[data_source.safe_did]["c_capital_allocation"] == "£1,000"
+            assert context[data_source.safe_did]["c_allocation"] == "£1,000"
 
         def test_none_column_value_in_org_item_not_in_context(self, factories):
             # This is explicitly testing _build_data_source_context where _data with None values do not get added to
@@ -460,27 +396,17 @@ class TestExpressionContext:
                 grant=grant,
                 collection=collection,
                 type=DataSourceType.GRANT_RECIPIENT,
-                schema=DataSourceSchema.model_validate(
-                    {
-                        "c_capital_allocation": DataSourceSchemaColumn(
-                            data_type=QuestionDataType.NUMBER,
-                            presentation_options=QuestionPresentationOptions(),
-                            data_options=QuestionDataOptions(),
-                            original_column_name="Capital Allocation",
-                        )
-                    }
-                ),
             )
             factories.data_source_organisation_item.create(
                 data_source=data_source,
                 external_id=organisation.external_id,
-                _data={"c_capital_allocation": None},
+                _data={"c_allocation": None},
             )
 
             helper = SubmissionHelper.load(submission.id, grant_recipient_id=grant_recipient.id)
             context = ExpressionContext._build_data_source_context(mode="evaluation", submission_helper=helper)
 
-            assert "c_capital_allocation" not in context[data_source.safe_did]
+            assert "c_allocation" not in context[data_source.safe_did]
 
         def test_multiple_data_sources_all_included(self, factories):
             grant = factories.grant.create()
@@ -494,16 +420,6 @@ class TestExpressionContext:
                 grant=grant,
                 collection=collection,
                 type=DataSourceType.GRANT_RECIPIENT,
-                schema=DataSourceSchema.model_validate(
-                    {
-                        "capital_allocation": DataSourceSchemaColumn(
-                            data_type=QuestionDataType.NUMBER,
-                            presentation_options=QuestionPresentationOptions(),
-                            data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                            original_column_name="Capital Allocation",
-                        )
-                    }
-                ),
             )
             ds2 = factories.data_source.create(
                 name="Test data set 2",
@@ -961,28 +877,18 @@ class TestDataSourceInterpolation:
             grant=grant,
             collection=collection,
             type=DataSourceType.GRANT_RECIPIENT,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_capital_allocation": DataSourceSchemaColumn(
-                        data_type=QuestionDataType.NUMBER,
-                        presentation_options=QuestionPresentationOptions(prefix="£"),
-                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                        original_column_name="Capital Allocation",
-                    )
-                }
-            ),
         )
         factories.data_source_organisation_item.create(
             data_source=data_source,
             external_id=organisation.external_id,
-            _data={"c_capital_allocation": 1000},
+            _data={"c_allocation": 1000},
         )
 
         helper = SubmissionHelper.load(submission.id, grant_recipient_id=grant_recipient.id)
         ds_context = ExpressionContext._build_data_source_context(mode="interpolation", submission_helper=helper)
         context = ExpressionContext(data_source_context=ds_context)
 
-        result = interpolate(f"(({data_source.safe_did}.c_capital_allocation))", context)
+        result = interpolate(f"(({data_source.safe_did}.c_allocation))", context)
         assert result == "£1,000"
 
     def test_data_source_reference_with_no_org_item_renders_placeholder(self, factories):
@@ -992,28 +898,17 @@ class TestDataSourceInterpolation:
         grant_recipient = factories.grant_recipient.create(grant=grant, organisation=organisation)
         submission = factories.submission.create(collection=collection, grant_recipient=grant_recipient)
         data_source = factories.data_source.create(
-            name="Allocations",
             grant=grant,
             collection=collection,
             type=DataSourceType.GRANT_RECIPIENT,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "capital_allocation": DataSourceSchemaColumn(
-                        data_type=QuestionDataType.NUMBER,
-                        presentation_options=QuestionPresentationOptions(prefix="£"),
-                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                        original_column_name="Capital Allocation",
-                    )
-                }
-            ),
         )
 
         helper = SubmissionHelper.load(submission.id, grant_recipient_id=grant_recipient.id)
         ds_context = ExpressionContext._build_data_source_context(mode="interpolation", submission_helper=helper)
         context = ExpressionContext(data_source_context=ds_context)
 
-        result = interpolate(f"(({data_source.safe_did}.capital_allocation))", context)
-        assert result == "((Capital Allocation from Allocations data set))"
+        result = interpolate(f"(({data_source.safe_did}.c_allocation))", context)
+        assert result == "((Allocation from Grant allocation data set))"
 
     def test_unknown_data_source_reference_renders_raw(self):
         context = ExpressionContext(data_source_context={})
@@ -1033,21 +928,11 @@ class TestDataSourceEvaluation:
             grant=grant,
             collection=collection,
             type=DataSourceType.GRANT_RECIPIENT,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_capital_allocation": DataSourceSchemaColumn(
-                        data_type=QuestionDataType.NUMBER,
-                        presentation_options=QuestionPresentationOptions(prefix="£"),
-                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                        original_column_name="Capital Allocation",
-                    )
-                }
-            ),
         )
         factories.data_source_organisation_item.create(
             data_source=data_source,
             external_id=organisation.external_id,
-            _data={"c_capital_allocation": 1000},
+            _data={"c_allocation": 1000},
         )
 
         helper = SubmissionHelper.load(submission.id, grant_recipient_id=grant_recipient.id)
@@ -1055,7 +940,7 @@ class TestDataSourceEvaluation:
         context = ExpressionContext(data_source_context=ds_context)
 
         expr = Expression(
-            statement=f"{data_source.safe_did}.c_capital_allocation > 500",
+            statement=f"{data_source.safe_did}.c_allocation > 500",
             type_=ExpressionType.CONDITION,
         )
         assert evaluate(expr, context) is True

--- a/tests/integration/common/expressions/test_managed.py
+++ b/tests/integration/common/expressions/test_managed.py
@@ -5,15 +5,12 @@ import pytest
 from app.common.data.interfaces.collections import get_question_by_id
 from app.common.data.models import Expression
 from app.common.data.types import (
-    DataSourceSchema,
-    DataSourceSchemaColumn,
     DataSourceType,
     ExpressionType,
     ManagedExpressionsEnum,
     NumberTypeEnum,
     QuestionDataOptions,
     QuestionDataType,
-    QuestionPresentationOptions,
 )
 from app.common.expressions import ExpressionContext, evaluate
 from app.common.expressions.custom import CustomExpression
@@ -424,18 +421,10 @@ class TestAnyOfExpression:
 
     def test_needs_a_question_subject_reference(self, factories):
         collection = factories.collection.create()
-        allocation_column = DataSourceSchemaColumn(
-            data_type=QuestionDataType.NUMBER,
-            presentation_options=QuestionPresentationOptions(prefix="£"),
-            data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-            original_column_name="Allocation",
-        )
         data_source = factories.data_source.create(
             grant=collection.grant,
             collection=collection,
             type=DataSourceType.GRANT_RECIPIENT,
-            items=None,
-            schema=DataSourceSchema.model_validate({"c_allocation": allocation_column}),
         )
         data_source_ref = ExpressionReference.from_data_source_column(data_source, "c_allocation")
         items: list[TRadioItem] = [{"key": "red", "label": "Red"}]
@@ -503,18 +492,10 @@ class TestSpecificallyExpression:
 
     def test_needs_a_question_subject_reference(self, factories):
         collection = factories.collection.create()
-        allocation_column = DataSourceSchemaColumn(
-            data_type=QuestionDataType.NUMBER,
-            presentation_options=QuestionPresentationOptions(prefix="£"),
-            data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-            original_column_name="Allocation",
-        )
         data_source = factories.data_source.create(
             grant=collection.grant,
             collection=collection,
             type=DataSourceType.GRANT_RECIPIENT,
-            items=None,
-            schema=DataSourceSchema.model_validate({"c_allocation": allocation_column}),
         )
         data_source_ref = ExpressionReference.from_data_source_column(data_source, "c_allocation")
         item: TRadioItem = {"key": "red", "label": "Red"}

--- a/tests/integration/common/expressions/test_references.py
+++ b/tests/integration/common/expressions/test_references.py
@@ -3,13 +3,8 @@ from uuid import uuid4
 import pytest
 
 from app.common.data.types import (
-    DataSourceSchema,
-    DataSourceSchemaColumn,
     DataSourceType,
-    NumberTypeEnum,
-    QuestionDataOptions,
     QuestionDataType,
-    QuestionPresentationOptions,
 )
 from app.common.expressions.references import ExpressionReference
 
@@ -46,22 +41,12 @@ class TestExpressionReference:
     class TestDataSourceColumn:
         def test_data_source_exists(self, factories):
             collection = factories.collection.create()
-            allocation_column = DataSourceSchemaColumn(
-                data_type=QuestionDataType.NUMBER,
-                presentation_options=QuestionPresentationOptions(prefix="£"),
-                data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                original_column_name="Allocation",
-            )
             data_source = factories.data_source.create(
-                grant=collection.grant,
-                collection=collection,
-                type=DataSourceType.GRANT_RECIPIENT,
-                items=None,
-                schema=DataSourceSchema.model_validate({"c_allocation": allocation_column}),
+                grant=collection.grant, collection=collection, type=DataSourceType.GRANT_RECIPIENT
             )
 
             reference = ExpressionReference(f"{data_source.safe_did}.c_allocation")
-            assert reference.data_source_column == allocation_column
+            assert reference.data_source_column == data_source.schema.root["c_allocation"]
 
         def test_data_source_does_not_exist(self):
             reference = ExpressionReference(f"d_{uuid4().hex}.c_col")
@@ -74,20 +59,7 @@ class TestExpressionReference:
         def test_data_source_column_only_queries_db_on_first_access(self, factories, track_sql_queries):
             collection = factories.collection.create()
             data_source = factories.data_source.create(
-                grant=collection.grant,
-                collection=collection,
-                type=DataSourceType.GRANT_RECIPIENT,
-                items=None,
-                schema=DataSourceSchema.model_validate(
-                    {
-                        "c_allocation": DataSourceSchemaColumn(
-                            data_type=QuestionDataType.NUMBER,
-                            presentation_options=QuestionPresentationOptions(prefix="£"),
-                            data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                            original_column_name="Allocation",
-                        ),
-                    }
-                ),
+                grant=collection.grant, collection=collection, type=DataSourceType.GRANT_RECIPIENT
             )
             reference = ExpressionReference(f"{data_source.safe_did}.c_allocation")
 
@@ -119,22 +91,9 @@ class TestExpressionReference:
             grant = factories.grant.create()
             collection = factories.collection.create(grant=grant)
             data_source = factories.data_source.create(
-                grant=grant,
-                collection=collection,
-                type=DataSourceType.GRANT_RECIPIENT,
-                items=None,
-                schema=DataSourceSchema.model_validate(
-                    {
-                        "c_threshold": DataSourceSchemaColumn(
-                            data_type=QuestionDataType.NUMBER,
-                            presentation_options=QuestionPresentationOptions(prefix="£"),
-                            data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                            original_column_name="Threshold",
-                        ),
-                    }
-                ),
+                grant=collection.grant, collection=collection, type=DataSourceType.GRANT_RECIPIENT
             )
-            reference = ExpressionReference.from_data_source_column(data_source, "c_threshold")
+            reference = ExpressionReference.from_data_source_column(data_source, "c_allocation")
 
             assert reference.data_type == QuestionDataType.NUMBER
 
@@ -142,20 +101,7 @@ class TestExpressionReference:
             grant = factories.grant.create()
             collection = factories.collection.create(grant=grant)
             data_source = factories.data_source.create(
-                grant=grant,
-                collection=collection,
-                type=DataSourceType.GRANT_RECIPIENT,
-                items=None,
-                schema=DataSourceSchema.model_validate(
-                    {
-                        "c_threshold": DataSourceSchemaColumn(
-                            data_type=QuestionDataType.NUMBER,
-                            presentation_options=QuestionPresentationOptions(),
-                            data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                            original_column_name="Threshold",
-                        ),
-                    }
-                ),
+                grant=collection.grant, collection=collection, type=DataSourceType.GRANT_RECIPIENT
             )
             reference = ExpressionReference.from_data_source_column(data_source, "c_missing")
 
@@ -177,20 +123,9 @@ class TestExpressionReference:
     class TestGetDataSource:
         def test_data_source_exists(self, factories):
             collection = factories.collection.create()
-            allocation_column = DataSourceSchemaColumn(
-                data_type=QuestionDataType.NUMBER,
-                presentation_options=QuestionPresentationOptions(prefix="£"),
-                data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                original_column_name="Allocation",
-            )
             data_source = factories.data_source.create(
-                grant=collection.grant,
-                collection=collection,
-                type=DataSourceType.GRANT_RECIPIENT,
-                items=None,
-                schema=DataSourceSchema.model_validate({"c_allocation": allocation_column}),
+                grant=collection.grant, collection=collection, type=DataSourceType.GRANT_RECIPIENT
             )
-
             reference = ExpressionReference(f"{data_source.safe_did}.c_allocation")
             assert reference.data_source == data_source
 
@@ -205,20 +140,7 @@ class TestExpressionReference:
         def test_data_source_only_queries_db_on_first_access(self, factories, track_sql_queries):
             collection = factories.collection.create()
             data_source = factories.data_source.create(
-                grant=collection.grant,
-                collection=collection,
-                type=DataSourceType.GRANT_RECIPIENT,
-                items=None,
-                schema=DataSourceSchema.model_validate(
-                    {
-                        "c_allocation": DataSourceSchemaColumn(
-                            data_type=QuestionDataType.NUMBER,
-                            presentation_options=QuestionPresentationOptions(prefix="£"),
-                            data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                            original_column_name="Allocation",
-                        ),
-                    }
-                ),
+                grant=collection.grant, collection=collection, type=DataSourceType.GRANT_RECIPIENT
             )
             reference = ExpressionReference(f"{data_source.safe_did}.c_allocation")
 
@@ -240,22 +162,11 @@ class TestExpressionReference:
 
         def test_data_source_label(self, factories):
             collection = factories.collection.create()
-            allocation_column = DataSourceSchemaColumn(
-                data_type=QuestionDataType.NUMBER,
-                presentation_options=QuestionPresentationOptions(prefix="£"),
-                data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                original_column_name="Allocation",
-            )
             data_source = factories.data_source.create(
-                grant=collection.grant,
-                collection=collection,
-                type=DataSourceType.GRANT_RECIPIENT,
-                items=None,
-                schema=DataSourceSchema.model_validate({"c_allocation": allocation_column}),
+                grant=collection.grant, collection=collection, type=DataSourceType.GRANT_RECIPIENT
             )
-
             reference = ExpressionReference(f"{data_source.safe_did}.c_allocation")
-            assert reference.label == f"{allocation_column.original_column_name} from {data_source.name} data set"
+            assert reference.label == f"Allocation from {data_source.name} data set"
 
         def test_invalid_reference_error(self):
             reference = ExpressionReference("something_else")

--- a/tests/integration/deliver_grant_funding/routes/test_collections.py
+++ b/tests/integration/deliver_grant_funding/routes/test_collections.py
@@ -595,16 +595,6 @@ class TestListCollectionSections:
             grant=grant,
             collection=collection,
             type=DataSourceType.GRANT_RECIPIENT,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_capital_allocation": DataSourceSchemaColumn(
-                        data_type=QuestionDataType.NUMBER,
-                        presentation_options=QuestionPresentationOptions(prefix="£"),
-                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                        original_column_name="Capital Allocation",
-                    )
-                }
-            ),
         )
 
         response = authenticated_grant_member_client.get(
@@ -2614,16 +2604,6 @@ class TestListSectionQuestions:
             grant=grant,
             collection=collection,
             type=DataSourceType.GRANT_RECIPIENT,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_capital_allocation": DataSourceSchemaColumn(
-                        data_type=QuestionDataType.NUMBER,
-                        presentation_options=QuestionPresentationOptions(prefix="£"),
-                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                        original_column_name="Capital Allocation",
-                    )
-                }
-            ),
         )
 
         response = authenticated_grant_admin_client.get(
@@ -3739,18 +3719,8 @@ class TestSelectContextSourceQuestion:
             collection=collection,
             name="Test data set",
             type=DataSourceType.GRANT_RECIPIENT,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_capital_allocation": DataSourceSchemaColumn(
-                        data_type=QuestionDataType.NUMBER,
-                        presentation_options=QuestionPresentationOptions(),
-                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                        original_column_name="Capital Allocation",
-                    )
-                }
-            ),
         )
-        data_set_reference = ExpressionReference.from_data_source_column(data_set, "c_capital_allocation")
+        data_set_reference = ExpressionReference.from_data_source_column(data_set, "c_allocation")
 
         with authenticated_grant_admin_client.session_transaction() as sess:
             sess["question"] = AddContextToExpressionsModel(
@@ -4120,16 +4090,6 @@ class TestSelectContextSourceDataSet:
             collection=collection,
             name="Test data set",
             type=DataSourceType.GRANT_RECIPIENT,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_capital_allocation": DataSourceSchemaColumn(
-                        data_type=QuestionDataType.NUMBER,
-                        presentation_options=QuestionPresentationOptions(),
-                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                        original_column_name="Capital Allocation",
-                    )
-                }
-            ),
         )
 
         data_source_2 = factories.data_source.create(
@@ -4137,16 +4097,6 @@ class TestSelectContextSourceDataSet:
             collection=collection,
             name="Second data set",
             type=DataSourceType.GRANT_RECIPIENT,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_capital_allocation": DataSourceSchemaColumn(
-                        data_type=QuestionDataType.NUMBER,
-                        presentation_options=QuestionPresentationOptions(),
-                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                        original_column_name="Capital Allocation",
-                    )
-                }
-            ),
         )
 
         data_source_3 = factories.data_source.create(
@@ -4171,16 +4121,6 @@ class TestSelectContextSourceDataSet:
             collection=report_2,
             name="Data set that shouldn't be shown",
             type=DataSourceType.GRANT_RECIPIENT,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_capital_allocation": DataSourceSchemaColumn(
-                        data_type=QuestionDataType.NUMBER,
-                        presentation_options=QuestionPresentationOptions(),
-                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                        original_column_name="Capital Allocation",
-                    )
-                }
-            ),
         )
 
         with authenticated_grant_admin_client.session_transaction() as sess:

--- a/tests/integration/deliver_grant_funding/routes/test_runner.py
+++ b/tests/integration/deliver_grant_funding/routes/test_runner.py
@@ -8,13 +8,9 @@ from flask import url_for
 from app.common.collections.types import FileUploadAnswer, IntegerAnswer, TextSingleLineAnswer, YesNoAnswer
 from app.common.data.interfaces.collections import add_component_validation
 from app.common.data.types import (
-    DataSourceSchema,
-    DataSourceSchemaColumn,
     DataSourceType,
     ExpressionType,
     ManagedExpressionsEnum,
-    NumberTypeEnum,
-    QuestionDataOptions,
     QuestionDataType,
     QuestionPresentationOptions,
     SubmissionModeEnum,
@@ -921,20 +917,9 @@ class TestGroupValidation:
         grant_recipient = factories.grant_recipient.create(grant=client.grant, organisation=organisation)
 
         data_source = factories.data_source.create(
-            name="Allocations",
             grant=client.grant,
             collection=group.form.collection,
             type=DataSourceType.GRANT_RECIPIENT,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_allocation": DataSourceSchemaColumn(
-                        data_type=QuestionDataType.NUMBER,
-                        presentation_options=QuestionPresentationOptions(prefix="£"),
-                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                        original_column_name="Capital Allocation",
-                    )
-                }
-            ),
         )
         factories.data_source_organisation_item.create(
             data_source=data_source,
@@ -977,7 +962,7 @@ class TestGroupValidation:
         assert "On this page:" in error_summary.text
         assert "On a different page:" not in error_summary.text
         assert "Other information referenced:" in error_summary.text
-        assert "Capital Allocation" in error_summary.text
+        assert "Allocation" in error_summary.text
         assert "£1,000" in error_summary.text
 
         on_page_links = error_summary.find_all("a")

--- a/tests/models.py
+++ b/tests/models.py
@@ -13,6 +13,7 @@ from dataclasses import field
 from typing import Any, cast
 from uuid import uuid4
 
+import factory
 import factory.fuzzy
 import faker
 from factory.alchemy import SQLAlchemyModelFactory
@@ -57,6 +58,7 @@ from app.common.data.types import (
     ConditionsOperator,
     DataSourceFileMetadata,
     DataSourceSchema,
+    DataSourceSchemaColumn,
     DataSourceType,
     ExpressionType,
     GrantRecipientModeEnum,
@@ -865,6 +867,18 @@ class _DataSourceItemFactory(SQLAlchemyModelFactory):
     data_source = None
 
 
+_GRANT_RECIPIENT_DEFAULT_SCHEMA = DataSourceSchema.model_validate(
+    {
+        "c_allocation": DataSourceSchemaColumn(
+            data_type=QuestionDataType.NUMBER,
+            presentation_options=QuestionPresentationOptions(prefix="£"),
+            data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+            original_column_name="Allocation",
+        )
+    }
+)
+
+
 class _DataSourceFactory(SQLAlchemyModelFactory):
     class Meta:
         model = DataSource
@@ -873,16 +887,7 @@ class _DataSourceFactory(SQLAlchemyModelFactory):
 
     id = factory.LazyFunction(uuid4)
     type = DataSourceType.CUSTOM
-    name = factory.LazyAttribute(lambda o: None if o.type == DataSourceType.CUSTOM else "Test data set")
-    schema = factory.LazyAttribute(lambda o: None if o.type == DataSourceType.CUSTOM else DataSourceSchema({}))
-    file_metadata = factory.LazyAttribute(
-        lambda o: (
-            None
-            if o.type == DataSourceType.CUSTOM
-            else DataSourceFileMetadata.model_validate({"s3_key": "file/key", "original_filename": "test-file.csv"})
-        )
-    )
-    items = factory.RelatedFactoryList(_DataSourceItemFactory, size=3, factory_related_name="data_source")
+
     # No organisation items are created by default - tests which need them should create them explicitly and set the
     # items size to 0
     organisation_items = factory.RelatedFactoryList(
@@ -890,6 +895,33 @@ class _DataSourceFactory(SQLAlchemyModelFactory):
         size=0,
         factory_related_name="data_source",
     )
+    items = factory.Maybe(
+        factory.LazyAttribute(lambda o: o.type == DataSourceType.CUSTOM),
+        yes_declaration=factory.RelatedFactoryList(
+            _DataSourceItemFactory,
+            factory_related_name="data_source",  # Triggers parent relation mapping
+            size=3,
+        ),
+        no_declaration=[],
+    )
+
+    @classmethod
+    def _adjust_kwargs(cls, **kwargs) -> dict[str, Any]:
+        ds_type = kwargs.get("type", DataSourceType.CUSTOM)
+
+        match ds_type:
+            case DataSourceType.GRANT_RECIPIENT:
+                kwargs.setdefault("name", "Grant allocation")
+                kwargs.setdefault("schema", _GRANT_RECIPIENT_DEFAULT_SCHEMA)
+
+                kwargs.setdefault(
+                    "file_metadata",
+                    DataSourceFileMetadata.model_validate({"s3_key": "file/key", "original_filename": "test-file.csv"}),
+                )
+            case DataSourceType.CUSTOM:
+                pass
+
+        return kwargs
 
     grant = None
     grant_id = factory.LazyAttribute(lambda o: o.grant.id if o.grant else None)

--- a/tests/unit/common/expressions/test_references.py
+++ b/tests/unit/common/expressions/test_references.py
@@ -1,15 +1,7 @@
 import pytest
 from pydantic import BaseModel
 
-from app.common.data.types import (
-    DataSourceSchema,
-    DataSourceSchemaColumn,
-    DataSourceType,
-    NumberTypeEnum,
-    QuestionDataOptions,
-    QuestionDataType,
-    QuestionPresentationOptions,
-)
+from app.common.data.types import DataSourceType
 from app.common.expressions.references import (
     DataSourceReference,
     ExpressionReference,
@@ -55,18 +47,8 @@ class TestExpressionReference:
 
         def test_data_source_reference_decomposes_to_ds_ref(self, factories):
             collection = factories.collection.build()
-            allocation_column = DataSourceSchemaColumn(
-                data_type=QuestionDataType.NUMBER,
-                presentation_options=QuestionPresentationOptions(prefix="£"),
-                data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                original_column_name="Allocation",
-            )
             data_source = factories.data_source.build(
-                grant=collection.grant,
-                collection=collection,
-                type=DataSourceType.GRANT_RECIPIENT,
-                items=None,
-                schema=DataSourceSchema.model_validate({"c_allocation": allocation_column}),
+                grant=collection.grant, collection=collection, type=DataSourceType.GRANT_RECIPIENT
             )
 
             reference = ExpressionReference.from_data_source_column(data_source, "c_allocation")

--- a/tests/unit/deliver_grant_funding/test_forms.py
+++ b/tests/unit/deliver_grant_funding/test_forms.py
@@ -9,14 +9,11 @@ from werkzeug.datastructures import FileStorage, MultiDict
 from wtforms import ValidationError
 
 from app.common.data.types import (
-    DataSourceSchema,
-    DataSourceSchemaColumn,
     DataSourceType,
     ExpressionType,
     ManagedExpressionsEnum,
     MaximumFileSize,
     NumberTypeEnum,
-    QuestionDataOptions,
     QuestionDataType,
     QuestionPresentationOptions,
     RoleEnum,
@@ -577,19 +574,10 @@ class TestSelectDataSourceQuestionForm:
             form=integer_q1.form, parent=group, data_type=QuestionDataType.TEXT_SINGLE_LINE
         )
 
-        data_set_column = DataSourceSchemaColumn(
-            data_type=QuestionDataType.NUMBER,
-            presentation_options=QuestionPresentationOptions(),
-            data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-            original_column_name="Capital Allocation",
-        )
-
         data_set = factories.data_source.build(
             grant=integer_q1.form.collection.grant,
             collection=integer_q1.form.collection,
-            name="Test data set",
             type=DataSourceType.GRANT_RECIPIENT,
-            schema=DataSourceSchema.model_validate({"c_capital_allocation": data_set_column}),
         )
 
         all_questions = [integer_q1, multi_line_q, integer_q2, text_question, integer_q3, text_q4]
@@ -601,7 +589,10 @@ class TestSelectDataSourceQuestionForm:
         mocker.patch.object(group.form, "cached_all_components", [group] + all_questions)
         mocker.patch.object(ExpressionReference, "question", new_callable=mock.PropertyMock, return_value=None)
         mocker.patch.object(
-            ExpressionReference, "data_source_column", new_callable=mock.PropertyMock, return_value=data_set_column
+            ExpressionReference,
+            "data_source_column",
+            new_callable=mock.PropertyMock,
+            return_value=data_set.schema.root["c_allocation"],
         )
 
         form = SelectDataSourceQuestionForm(


### PR DESCRIPTION
## 🎫 Ticket
[FSPT-1344](https://mhclgdigital.atlassian.net/browse/FSPT-1344): Add default columns for grant recipient data sources in factories

## 📝 Description
    Updating the DataSourceFactory to create a grant recipient data source if `type==DataSourceType.GRANT_RECIPIENT`.
    - uses _adjust_kwargs to set defaults for certain attributes if type is grant_recipient
    - changes items to use a `factory.Maybe` to determine whether to create related DataSourceItems. This isn't in adjust_kwargs as that doesn't work nicely with things that need the id of the object created (`data_source_item` `needs data_source_id`)

- Also updates any existing tests that were creating a simple grant recipient data source with a single column to just use the new defaults


[FSPT-1344]: https://mhclgdigital.atlassian.net/browse/FSPT-1344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ