### PR TITLE
Read a secret HTTP header to force tracing on

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,5 +1,6 @@
 import copy
 import os
+import secrets
 import urllib.parse
 from enum import Enum
 from typing import Any, Self
@@ -129,6 +130,10 @@ class _SharedConfig(_BaseConfig):
     PROXY_FIX_HOST: int = 1  # We inject X-Forwarded-For using Cloudfront custom headings
     SERVER_NAME: str
     SEND_FILE_MAX_AGE_DEFAULT: int = 31536000
+
+    # This default is randomly generated each app startup, so effectively unusable. It is overridden by an environment
+    # variable from parameter store in deployed envs.
+    FORCE_TRACE_TOKEN: str = secrets.token_urlsafe(16)
 
     AWS_S3_BUCKET_NAME: str
     SUBMISSION_FILES_PREFIX: str = "uploaded-submission-files"

--- a/app/sentry.py
+++ b/app/sentry.py
@@ -1,6 +1,8 @@
 import os
+import secrets
 
 import sentry_sdk
+from flask import current_app
 from sentry_sdk.integrations.logging import LoggingIntegration, ignore_logger
 from sentry_sdk.types import Event, Hint
 
@@ -16,6 +18,11 @@ def traces_sampler(sampling_context: Hint) -> float:
     if wsgi_environ and wsgi_environ.get("PATH_INFO") == "/healthcheck":
         return 0
 
+    force_trace_token = current_app.config["FORCE_TRACE_TOKEN"]
+    header_token = wsgi_environ.get("HTTP_X_FORCE_TRACE") if wsgi_environ else None
+    if force_trace_token and header_token and secrets.compare_digest(force_trace_token, header_token):
+        return 1.0
+
     return float(os.getenv("SENTRY_TRACES_SAMPLE_RATE", "0.02"))
 
 
@@ -23,6 +30,11 @@ def profiles_sampler(sampling_context: Hint) -> float:
     wsgi_environ = sampling_context.get("wsgi_environ")
     if wsgi_environ and wsgi_environ.get("PATH_INFO") == "/healthcheck":
         return 0
+
+    force_trace_token = current_app.config["FORCE_TRACE_TOKEN"]
+    header_token = wsgi_environ.get("HTTP_X_FORCE_TRACE") if wsgi_environ else None
+    if force_trace_token and header_token and secrets.compare_digest(force_trace_token, header_token):
+        return 1.0
 
     return float(os.getenv("SENTRY_PROFILES_SAMPLE_RATE", "0.02"))
 

--- a/tests/unit/test_sentry.py
+++ b/tests/unit/test_sentry.py
@@ -1,0 +1,59 @@
+from app.sentry import profiles_sampler, traces_sampler
+
+
+class TestSentry:
+    class TestTracesSampler:
+        def test_healthcheck_is_never_sampled(self, app):
+            assert traces_sampler({"wsgi_environ": {"PATH_INFO": "/healthcheck"}}) == 0
+
+        def test_default_sample_rate_when_no_environ(self, app):
+            assert traces_sampler({}) == 0.02
+
+        def test_default_sample_rate_when_trace_header_absent(self, app, monkeypatch):
+            monkeypatch.setitem(app.config, "FORCE_TRACE_TOKEN", "secret")
+
+            assert traces_sampler({"wsgi_environ": {"PATH_INFO": "/anything"}}) == 0.02
+
+        def test_default_sample_rate_when_trace_header_wrong(self, app, monkeypatch):
+            monkeypatch.setitem(app.config, "FORCE_TRACE_TOKEN", "secret")
+
+            assert traces_sampler({"wsgi_environ": {"PATH_INFO": "/anything", "HTTP_X_FORCE_TRACE": "wrong"}}) == 0.02
+
+        def test_force_sampled_when_trace_component_visibility_header_set(self, app, monkeypatch):
+            monkeypatch.setitem(app.config, "FORCE_TRACE_TOKEN", "secret")
+
+            assert traces_sampler({"wsgi_environ": {"PATH_INFO": "/anything", "HTTP_X_FORCE_TRACE": "secret"}}) == 1.0
+
+        def test_healthcheck_takes_precedence_over_trace_header(self, app, monkeypatch):
+            monkeypatch.setitem(app.config, "FORCE_TRACE_TOKEN", "secret")
+
+            assert traces_sampler({"wsgi_environ": {"PATH_INFO": "/healthcheck", "HTTP_X_FORCE_TRACE": "secret"}}) == 0
+
+    class TestProfilesSampler:
+        def test_healthcheck_is_never_sampled(self, app):
+            assert profiles_sampler({"wsgi_environ": {"PATH_INFO": "/healthcheck"}}) == 0
+
+        def test_default_sample_rate_when_no_environ(self, app):
+            assert profiles_sampler({}) == 0.02
+
+        def test_default_sample_rate_when_trace_header_absent(self, app, monkeypatch):
+            monkeypatch.setitem(app.config, "FORCE_TRACE_TOKEN", "secret")
+
+            assert profiles_sampler({"wsgi_environ": {"PATH_INFO": "/anything"}}) == 0.02
+
+        def test_default_sample_rate_when_trace_header_wrong(self, app, monkeypatch):
+            monkeypatch.setitem(app.config, "FORCE_TRACE_TOKEN", "secret")
+
+            assert profiles_sampler({"wsgi_environ": {"PATH_INFO": "/anything", "HTTP_X_FORCE_TRACE": "wrong"}}) == 0.02
+
+        def test_force_sampled_when_trace_component_visibility_header_set(self, app, monkeypatch):
+            monkeypatch.setitem(app.config, "FORCE_TRACE_TOKEN", "secret")
+
+            assert profiles_sampler({"wsgi_environ": {"PATH_INFO": "/anything", "HTTP_X_FORCE_TRACE": "secret"}}) == 1.0
+
+        def test_healthcheck_takes_precedence_over_trace_header(self, app, monkeypatch):
+            monkeypatch.setitem(app.config, "FORCE_TRACE_TOKEN", "secret")
+
+            assert (
+                profiles_sampler({"wsgi_environ": {"PATH_INFO": "/healthcheck", "HTTP_X_FORCE_TRACE": "secret"}}) == 0
+            )


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
This will allow us (developers) to easily trace specific requests to aid with debugging.

To merge after: https://github.com/communitiesuk/funding-service-terraform/pull/102

## 🧪 Testing
- Set the environment variable FORCE_TRACE_TOKEN to some value in your local env
- Restart docker compose
- Enable sentry locally with the DSN
- Send an HTTP request with the HTTP-X-FORCE-TRACE header set to the token value
- See that all requests to the app are traced/profile logged in sentry
- Send an HTTP request without the header set
- See that (98% of the time) nothing is sent to Sentry.

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [ ] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [ ] End-to-end tests have been updated (if applicable)
- [ ] Edge cases and error conditions are tested