### PR TITLE
FSPT-1352 Add Deliver pre-award tab to list application collections

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -24,6 +24,7 @@ from app.common.data import interfaces
 from app.common.data.interfaces.system import seed_system_data
 from app.common.data.types import (
     CollectionStatusEnum,
+    CollectionType,
     ComponentType,
     DataSourceType,
     ExpressionType,
@@ -333,6 +334,7 @@ def create_app() -> Flask:  # noqa: C901
                 file_upload_types_enum=FileUploadTypes,
                 maximum_file_size_enum=MaximumFileSize,
                 data_source_type_enum=DataSourceType,
+                collection_type_enum=CollectionType,
             ),
             feature_flags=FeatureFlags,
             request_tracing_state=get_tracing_state(),

--- a/app/common/auth/decorators.py
+++ b/app/common/auth/decorators.py
@@ -20,6 +20,7 @@ from app.common.data.interfaces.grant_recipients import get_grant_recipient
 from app.common.data.interfaces.grants import get_grant
 from app.common.data.interfaces.organisations import get_organisation
 from app.common.data.types import AuthMethodEnum, GrantStatusEnum, RoleEnum
+from app.common.helpers.feature_flags import FeatureFlag
 
 
 def access_grant_funding_login_required[**P](
@@ -352,3 +353,18 @@ def is_access_org_member[**P](
         return func(*args, **kwargs)
 
     return access_grant_funding_login_required(wrapper)
+
+
+def has_feature_flag_enabled(
+    flag: FeatureFlag,
+) -> Callable[[Callable[..., ResponseReturnValue]], Callable[..., ResponseReturnValue]]:
+    def decorator[**P](func: Callable[P, ResponseReturnValue]) -> Callable[P, ResponseReturnValue]:
+        @functools.wraps(func)
+        def wrapped(*args: P.args, **kwargs: P.kwargs) -> ResponseReturnValue:
+            if not flag.is_enabled:
+                return abort(404)
+            return func(*args, **kwargs)
+
+        return wrapped
+
+    return decorator

--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -18,6 +18,8 @@ from app.common.data.base import BaseModel, CIStr
 from app.common.data.models_user import Invitation, User, UserRole
 from app.common.data.submission_data_manager import SubmissionDataManager
 from app.common.data.types import (
+    MONITORING_COLLECTIONS,
+    PRE_AWARD_COLLECTIONS,
     CollectionStatusEnum,
     CollectionType,
     ComponentType,
@@ -97,7 +99,11 @@ class Grant(BaseModel):
 
     @property
     def reports(self) -> list[Collection]:
-        return [collection for collection in self.collections if collection.type == CollectionType.MONITORING_REPORT]
+        return [collection for collection in self.collections if collection.is_monitoring_collection]
+
+    @property
+    def pre_award_forms(self) -> list[Collection]:
+        return [collection for collection in self.collections if collection.is_pre_award_collection]
 
     @property
     def test_grant_recipients(self) -> list[GrantRecipient]:
@@ -331,6 +337,14 @@ class Collection(BaseModel):
         if not self.submission_period_end_date:
             return False
         return self.submission_period_end_date < datetime.date.today()
+
+    @property
+    def is_monitoring_collection(self) -> bool:
+        return self.type in MONITORING_COLLECTIONS
+
+    @property
+    def is_pre_award_collection(self) -> bool:
+        return self.type in PRE_AWARD_COLLECTIONS
 
     @property
     def public_sign_up(self) -> str:

--- a/app/common/data/types.py
+++ b/app/common/data/types.py
@@ -141,6 +141,10 @@ class CollectionType(enum.StrEnum):
     APPLICATION = "application"
 
 
+PRE_AWARD_COLLECTIONS = frozenset([CollectionType.APPLICATION])
+MONITORING_COLLECTIONS = frozenset([CollectionType.MONITORING_REPORT])
+
+
 class ReportAdminEmailTypeEnum(enum.StrEnum):
     REPORT_OPEN_NOTIFICATION = "report-open-notification"
     DEADLINE_REMINDER = "deadline-reminder"

--- a/app/common/helpers/feature_flags.py
+++ b/app/common/helpers/feature_flags.py
@@ -52,7 +52,7 @@ class FeatureFlag:
 def _check_grant_allows_pre_award() -> bool:
     grant_id = request.view_args.get("grant_id") if request.view_args else None
     if not grant_id:
-        raise ValueError("grant_id required in URL for PRE_AWARD feature flag")
+        return False
     return get_grant(grant_id).allow_pre_award
 
 

--- a/app/deliver_grant_funding/routes/__init__.py
+++ b/app/deliver_grant_funding/routes/__init__.py
@@ -8,6 +8,7 @@ from app.deliver_grant_funding.routes import (  # noqa: E402, F401
     grant_setup,
     grant_team,
     misc,
+    pre_award,
     reports,
     runner,
 )

--- a/app/deliver_grant_funding/routes/pre_award.py
+++ b/app/deliver_grant_funding/routes/pre_award.py
@@ -1,0 +1,49 @@
+import uuid
+
+from flask import abort, redirect, render_template, request, url_for
+from flask.typing import ResponseReturnValue
+
+from app.common.auth.authorisation_helper import AuthorisationHelper
+from app.common.auth.decorators import has_deliver_grant_role
+from app.common.data.interfaces.collections import delete_collection, get_collection
+from app.common.data.interfaces.grants import get_grant
+from app.common.data.interfaces.user import get_current_user
+from app.common.data.types import CollectionType, RoleEnum
+from app.common.forms import GenericConfirmDeletionForm
+from app.deliver_grant_funding.routes import deliver_grant_funding_blueprint
+from app.extensions import auto_commit_after_request
+
+
+@deliver_grant_funding_blueprint.route("/grant/<uuid:grant_id>/pre-award", methods=["GET", "POST"])
+@has_deliver_grant_role(RoleEnum.MEMBER)
+@auto_commit_after_request
+def list_pre_award_forms(grant_id: uuid.UUID) -> ResponseReturnValue:
+    grant = get_grant(grant_id, with_all_collections=True)
+
+    delete_wtform, delete_pre_award_form = None, None
+    if delete_pre_award_form_id := request.args.get("delete"):
+        if not AuthorisationHelper.can_edit_collection(
+            user=get_current_user(), collection_id=uuid.UUID(delete_pre_award_form_id)
+        ):
+            return redirect(url_for("deliver_grant_funding.list_pre_award_forms", grant_id=grant_id))
+
+        delete_pre_award_form = get_collection(
+            uuid.UUID(delete_pre_award_form_id), grant_id=grant_id, type_=CollectionType.APPLICATION
+        )
+        if delete_pre_award_form.live_submissions:
+            abort(403)
+
+        if delete_pre_award_form and not delete_pre_award_form.live_submissions:
+            delete_wtform = GenericConfirmDeletionForm()
+
+            if delete_wtform and delete_wtform.validate_on_submit():
+                delete_collection(delete_pre_award_form)
+
+                return redirect(url_for("deliver_grant_funding.list_pre_award_forms", grant_id=grant_id))
+
+    return render_template(
+        "deliver_grant_funding/pre_award/list_pre_award_forms.html",
+        grant=grant,
+        delete_form=delete_wtform,
+        delete_pre_award_form=delete_pre_award_form,
+    )

--- a/app/deliver_grant_funding/routes/pre_award.py
+++ b/app/deliver_grant_funding/routes/pre_award.py
@@ -4,18 +4,20 @@ from flask import abort, redirect, render_template, request, url_for
 from flask.typing import ResponseReturnValue
 
 from app.common.auth.authorisation_helper import AuthorisationHelper
-from app.common.auth.decorators import has_deliver_grant_role
+from app.common.auth.decorators import has_deliver_grant_role, has_feature_flag_enabled
 from app.common.data.interfaces.collections import delete_collection, get_collection
 from app.common.data.interfaces.grants import get_grant
 from app.common.data.interfaces.user import get_current_user
 from app.common.data.types import CollectionType, RoleEnum
 from app.common.forms import GenericConfirmDeletionForm
+from app.common.helpers.feature_flags import FeatureFlags
 from app.deliver_grant_funding.routes import deliver_grant_funding_blueprint
 from app.extensions import auto_commit_after_request
 
 
 @deliver_grant_funding_blueprint.route("/grant/<uuid:grant_id>/pre-award", methods=["GET", "POST"])
 @has_deliver_grant_role(RoleEnum.MEMBER)
+@has_feature_flag_enabled(FeatureFlags.PRE_AWARD)
 @auto_commit_after_request
 def list_pre_award_forms(grant_id: uuid.UUID) -> ResponseReturnValue:
     grant = get_grant(grant_id, with_all_collections=True)

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_base.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_base.html
@@ -2,8 +2,20 @@
 
 {% set cspNonce = csp_nonce() %}
 
+{% set nav_items = [] %}
+
+{% if feature_flags.PRE_AWARD.is_enabled %}
+  {%
+    do nav_items.append({
+        "text": "Pre-award",
+        "key": "pre_award",
+        "href": url_for("deliver_grant_funding.list_pre_award_forms", grant_id=grant.id),
+        "current": active_item_identifier == "pre_award"
+    })
+  %}
+{% endif %}
 {%
-  set nav_items = [
+  do nav_items.extend([
       {
           "text": "Reports",
           "key": "reports",
@@ -22,7 +34,7 @@
           "href": url_for("deliver_grant_funding.grant_details", grant_id=grant.id),
           "current": active_item_identifier == "details"
       },
-  ]
+  ])
 %}
 
 {% set right_nav_items = [] %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/macros/collection_card.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/macros/collection_card.html
@@ -1,0 +1,104 @@
+{% from "common/macros/status.html" import reportStatusTag with context %}
+{% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
+
+{% macro collection_card(collection) %}
+  {% set can_edit = authorisation_helper.can_edit_collection(current_user, collection.id) %}
+  {% set grant = collection.grant %}
+  {% set formSectionsText %}
+    {% if can_edit %}
+      {% if collection.forms | length == 0 %}
+        {# TODO: in the next commit the collection type will be included to any url for collection pages like add section, change name, etc. #}
+        {# appropriate language for each context will then be swapped out as needed #}
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.add_section', grant_id=grant.id, report_id=collection.id) }}"
+          >Add sections<span class="govuk-visually-hidden"> to {{ collection.name }}</span></a
+        >
+        to create your report
+        <br />
+        Sections are groups of questions with a common theme
+      {% else %}
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.list_report_sections', grant_id=grant.id, report_id=collection.id) }}">
+          {% trans count = collection.forms | length %}{{ count }} section{% pluralize %}{{ count }} sections{% endtrans %}
+          <span class="govuk-visually-hidden"> in form for {{ collection.name }}</span>
+        </a>
+      {% endif %}
+    {% else %}
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.list_report_sections', grant_id=grant.id, report_id=collection.id) }}">
+        {% trans count = collection.forms | length %}{{ count }} section{% pluralize %}{{ count }} sections{% endtrans %}
+        <span class="govuk-visually-hidden"> in form for {{ collection.name }}</span>
+      </a>
+    {% endif %}
+  {% endset %}
+
+
+  {% set dataSetsHtml %}
+    <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.list_report_data_sets', grant_id=grant.id, report_id=collection.id) }}">
+      {% trans count = collection.data_sources | length %}{{ count }} data set{% pluralize %}{{ count }} data sets{% endtrans %}
+      <span class="govuk-visually-hidden"> for {{ collection.name }}</span>
+    </a>
+  {% endset %}
+
+
+  {% set liveSubmissionsText %}
+    {% trans count = collection.live_submissions | length %}{{ count }} live submission{% pluralize %}{{ count }} live submissions{% endtrans %}
+    <span class="govuk-visually-hidden">for {{ collection.name }}</span>
+  {% endset %}
+  {% set testSubmissionsText %}
+    {% trans count = collection.test_submissions | length %}{{ count }} test submission{% pluralize %}{{ count }} test submissions{% endtrans %}
+    <span class="govuk-visually-hidden">for {{ collection.name }}</span>
+  {% endset %}
+
+
+  {% set submissionsHtml %}
+    <p class="govuk-body">
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.list_submissions', grant_id=grant.id, report_id=collection.id, submission_mode=enum.submission_mode.LIVE) }}"> {{ liveSubmissionsText }} </a>
+    </p>
+
+    {# TODO: hide test submissions link when the reporting round status is live #}
+    <p class="govuk-body">
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.list_submissions', grant_id=grant.id, report_id=collection.id, submission_mode=enum.submission_mode.TEST) }}"> {{ testSubmissionsText }} </a>
+    </p>
+  {% endset %}
+
+
+  {% set reportingPeriodText %}
+    {% if collection.reporting_period_start_date and collection.reporting_period_end_date %}
+      {{ format_date_range(collection.reporting_period_start_date, collection.reporting_period_end_date) }}
+    {% else %}
+      Not set
+    {% endif %}
+  {% endset %}
+
+
+  {% set submissionPeriodText %}
+    {% if collection.submission_period_start_date and collection.submission_period_end_date %}
+      {{ format_date_range(collection.submission_period_start_date, collection.submission_period_end_date) }}
+    {% else %}
+      Not set
+    {% endif %}
+  {% endset %}
+
+  {% set actions = [] %}
+  {% if can_edit %}
+    {% do actions.append({"text": "Change name", "visuallyHiddenText": collection.title, "href": url_for("deliver_grant_funding.change_report_name", grant_id=grant.id, report_id=collection.id), "classes": "govuk-link--no-visited-state" }) %}
+    {% if not collection.live_submissions %}
+      {% set delete_url = url_for("deliver_grant_funding.list_reports", grant_id=grant.id, delete=collection.id) if collection.is_monitoring_collection else url_for("deliver_grant_funding.list_pre_award_forms", grant_id=grant.id, delete=collection.id) %}
+      {% do actions.append({"text": "Delete", "visuallyHiddenText": collection.title, "href": delete_url, "classes": "govuk-link--no-visited-state" }) %}
+    {% endif %}
+  {% endif %}
+
+  {# TODO: see if this logic can be moved out to a macro that can factor in collection type if it needs to (for things like labels) #}
+  {{
+    govukSummaryList({
+        "card": {"title": {"text": collection.name}, "actions": {"items": actions} },
+        "rows": [
+            {"key": {"text": "Status"}, "value": {"html": reportStatusTag(collection.status)} },
+            {"key": {"text": "Form"}, "value": {"text": formSectionsText} },
+            {"key": {"text": "Uploaded data sets"}, "value": {"html": dataSetsHtml} } if authorisation_helper.is_platform_member(current_user) else {},
+            {"key": {"text": "Reporting period"}, "value": {"text": reportingPeriodText} } if collection.is_monitoring_collection else {},
+            {"key": {"text": "Submission period"}, "value": {"text": submissionPeriodText} },
+            {"key": {"text": "Submissions"}, "value": {"html": submissionsHtml} },
+            {"key": {"text": "Created by"}, "value": {"text": collection.created_by.email} },
+        ],
+    })
+  }}
+{% endmacro %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/pre_award/list_pre_award_forms.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/pre_award/list_pre_award_forms.html
@@ -5,8 +5,8 @@
 {% from "common/macros/status.html" import grantStatusDescription with context %}
 {% from "deliver_grant_funding/macros/collection_card.html" import collection_card with context %}
 
-{% set page_title = "Reports" %}
-{% set active_item_identifier = "reports" %}
+{% set page_title = "Forms" %}
+{% set active_item_identifier = "pre_award" %}
 {% set grant_admin = authorisation_helper.is_deliver_grant_admin(grant.id, current_user) %}
 
 {% block content %}
@@ -21,12 +21,12 @@
 
       {% if delete_form %}
         {% set banner_html %}
-          <p class="govuk-body govuk-!-font-weight-bold">Are you sure you want to delete the report ‘{{ delete_report.name }}’?</p>
+          <p class="govuk-body govuk-!-font-weight-bold">Are you sure you want to delete the form ‘{{ delete_pre_award_form.name }}’?</p>
           <form method="post" novalidate>
             {{ delete_form.csrf_token }}
             <div class="govuk-button-group govuk-!-margin-bottom-0">
-              {{ delete_form.confirm_deletion(params={"text": "Yes, delete this report", "classes": "govuk-button--secondary govuk-!-margin-bottom-0"}) }}
-              <a class="govuk-link govuk-link--no-visited-state govuk-!-margin-bottom-0" href="{{ url_for('deliver_grant_funding.list_reports', grant_id=grant.id) }}">Cancel</a>
+              {{ delete_form.confirm_deletion(params={"text": "Yes, delete this form", "classes": "govuk-button--secondary govuk-!-margin-bottom-0"}) }}
+              <a class="govuk-link govuk-link--no-visited-state govuk-!-margin-bottom-0" href="{{ url_for('deliver_grant_funding.list_pre_award_forms', grant_id=grant.id) }}">Cancel</a>
             </div>
           </form>
         {% endset %}
@@ -39,7 +39,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">
         <span class="govuk-caption-l">{{ grant.name }}</span>
-        Reports
+        Forms
       </h1>
 
       <p class="govuk-body"><strong>Grant status</strong>: {{ grantStatusTag(grant.status) }}</p>
@@ -48,19 +48,21 @@
   </div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      {% if not grant.reports %}
-        <p class="govuk-body">There are no monitoring reports for {{ grant.name }}.</p>
+      {% if not grant.pre_award_forms %}
+        <p class="govuk-body">There are no pre-award forms for {{ grant.name }}.</p>
       {% else %}
-        {% for report in grant.reports %}
-          {{ collection_card(report) }}
+        {% for form in grant.pre_award_forms %}
+          {{ collection_card(form) }}
         {% endfor %}
       {% endif %}
 
       {% if grant_admin %}
+
+        {# TODO: in the next commit the collection type will be included to any url for collection pages like add section, change name, etc. #}
         {{
           govukButton({
-            "text": "Add a monitoring report" if not grant.reports else "Add another monitoring report",
-            "classes": "" if not grant.reports else "govuk-button--secondary",
+            "text": "Add a form",
+            "classes": "" if not grant.pre_award_forms else "govuk-button--secondary",
             "href": url_for('deliver_grant_funding.set_up_report', grant_id=grant.id)
           })
         }}

--- a/tests/integration/common/auth/test_decorators.py
+++ b/tests/integration/common/auth/test_decorators.py
@@ -15,6 +15,7 @@ from app.common.auth.decorators import (
     has_access_grant_recipient_role,
     has_access_grant_role,
     has_deliver_grant_role,
+    has_feature_flag_enabled,
     is_access_org_member,
     is_deliver_grant_funding_user,
     is_deliver_org_admin,
@@ -24,6 +25,7 @@ from app.common.auth.decorators import (
 )
 from app.common.data import interfaces
 from app.common.data.types import AuthMethodEnum, CollectionStatusEnum, RoleEnum
+from app.common.helpers.feature_flags import FeatureFlag
 from tests.models import _get_grant_managing_organisation
 
 
@@ -967,3 +969,23 @@ class TestHasGrantRecipientRole:
         session["auth"] = AuthMethodEnum.MAGIC_LINK
 
         assert view_func() == "OK"
+
+
+class TestHasFeatureFlagEnabled:
+    def test_has_feature_flag_enabled(self, app, factories):
+        ENABLED_FLAG = FeatureFlag(description="Test feature flag", resolver=lambda: True)
+        DISABLED_FLAG = FeatureFlag(description="Test feature flag", resolver=lambda: False)
+
+        @has_feature_flag_enabled(ENABLED_FLAG)
+        def test_view_enabled():
+            return "OK"
+
+        @has_feature_flag_enabled(DISABLED_FLAG)
+        def test_view_disabled():
+            return "OK"
+
+        response = test_view_enabled()
+        assert response == "OK"
+
+        with pytest.raises(NotFound):
+            test_view_disabled()

--- a/tests/integration/deliver_grant_funding/routes/test_pre_award_forms.py
+++ b/tests/integration/deliver_grant_funding/routes/test_pre_award_forms.py
@@ -28,6 +28,7 @@ class TestListPreAwardForms:
         self, request: pytest.FixtureRequest, client_fixture: str, can_edit: bool, factories
     ):
         client = request.getfixturevalue(client_fixture)
+        client.grant.allow_pre_award = True
 
         response = client.get(url_for("deliver_grant_funding.list_pre_award_forms", grant_id=client.grant.id))
         assert response.status_code == 200
@@ -59,6 +60,7 @@ class TestListPreAwardForms:
     ):
         client = request.getfixturevalue(client_fixture)
         grant = client.grant or factories.grant.create()
+        grant.allow_pre_award = True
         factories.collection.create(grant=grant, type=CollectionType.APPLICATION)
 
         response = client.get(url_for("deliver_grant_funding.list_pre_award_forms", grant_id=grant.id))
@@ -94,6 +96,7 @@ class TestListPreAwardForms:
                 assert link.get("href") == expected_link[1]
 
     def test_get_with_delete_parameter_no_submissions(self, authenticated_grant_admin_client, factories):
+        authenticated_grant_admin_client.grant.allow_pre_award = True
         pre_award_form = factories.collection.create(
             grant=authenticated_grant_admin_client.grant, name="Test form", type=CollectionType.APPLICATION
         )
@@ -121,6 +124,7 @@ class TestListPreAwardForms:
         self, request: pytest.FixtureRequest, client_fixture: str, can_delete: bool, factories, db_session
     ):
         client = request.getfixturevalue(client_fixture)
+        client.grant.allow_pre_award = True
         pre_award_form = factories.collection.create(
             grant=client.grant, name="Test Form", type=CollectionType.APPLICATION
         )
@@ -149,6 +153,7 @@ class TestListPreAwardForms:
     ):
         client = request.getfixturevalue(client_fixture)
         grant = client.grant if client.grant else factories.grant.create()
+        grant.allow_pre_award = True
         factories.collection.create(
             grant=grant, name="Test Form", type=CollectionType.APPLICATION, status=collection_status
         )
@@ -163,3 +168,31 @@ class TestListPreAwardForms:
 
         assert change_name_link is None
         assert delete_link is None
+
+    def test_404_when_pre_award_flag_disabled(self, authenticated_grant_admin_client):
+        response = authenticated_grant_admin_client.get(
+            url_for("deliver_grant_funding.list_pre_award_forms", grant_id=authenticated_grant_admin_client.grant.id)
+        )
+        assert response.status_code == 404
+
+
+class TestPreAwardNavigation:
+    def test_nav_shows_pre_award_link_when_flag_enabled(self, authenticated_grant_admin_client):
+        authenticated_grant_admin_client.grant.allow_pre_award = True
+
+        response = authenticated_grant_admin_client.get(
+            url_for("deliver_grant_funding.grant_details", grant_id=authenticated_grant_admin_client.grant.id)
+        )
+
+        assert response.status_code == 200
+        soup = BeautifulSoup(response.data, "html.parser")
+        assert page_has_link(soup, "Pre-award") is not None
+
+    def test_nav_hides_pre_award_link_when_flag_disabled(self, authenticated_grant_admin_client):
+        response = authenticated_grant_admin_client.get(
+            url_for("deliver_grant_funding.grant_details", grant_id=authenticated_grant_admin_client.grant.id)
+        )
+
+        assert response.status_code == 200
+        soup = BeautifulSoup(response.data, "html.parser")
+        assert page_has_link(soup, "Pre-award") is None

--- a/tests/integration/deliver_grant_funding/routes/test_pre_award_forms.py
+++ b/tests/integration/deliver_grant_funding/routes/test_pre_award_forms.py
@@ -1,0 +1,165 @@
+import uuid
+
+import pytest
+from bs4 import BeautifulSoup
+from flask import url_for
+
+from app.common.data.models import Collection
+from app.common.data.types import CollectionStatusEnum, CollectionType
+from app.common.forms import GenericConfirmDeletionForm
+from tests.utils import AnyStringMatching, get_form_data, page_has_button, page_has_link
+
+
+class TestListPreAwardForms:
+    def test_404(self, authenticated_grant_member_client):
+        response = authenticated_grant_member_client.get(
+            url_for("deliver_grant_funding.list_pre_award_forms", grant_id=uuid.uuid4())
+        )
+        assert response.status_code == 404
+
+    @pytest.mark.parametrize(
+        "client_fixture, can_edit",
+        (
+            ("authenticated_grant_member_client", False),
+            ("authenticated_grant_admin_client", True),
+        ),
+    )
+    def test_grant_member_get_no_forms(
+        self, request: pytest.FixtureRequest, client_fixture: str, can_edit: bool, factories
+    ):
+        client = request.getfixturevalue(client_fixture)
+
+        response = client.get(url_for("deliver_grant_funding.list_pre_award_forms", grant_id=client.grant.id))
+        assert response.status_code == 200
+
+        soup = BeautifulSoup(response.data, "html.parser")
+        assert client.grant.name in soup.text
+
+        # todo: replace report specific actions with pre-award when pages are made generic for collections
+        expected_links = [
+            ("Add a form", AnyStringMatching(r"/deliver/grant/[a-z0-9-]{36}/set-up-report")),
+        ]
+        for expected_link in expected_links:
+            button = page_has_link(soup, expected_link[0])
+            assert (button is not None) is can_edit
+
+            if can_edit:
+                assert button.get("href") == expected_link[1]
+
+    @pytest.mark.parametrize(
+        "client_fixture, can_edit",
+        (
+            ("authenticated_grant_member_client", False),
+            ("authenticated_grant_admin_client", True),
+            ("authenticated_platform_admin_client", True),
+        ),
+    )
+    def test_grant_member_get_with_forms(
+        self, request: pytest.FixtureRequest, client_fixture: str, can_edit: bool, factories
+    ):
+        client = request.getfixturevalue(client_fixture)
+        grant = client.grant or factories.grant.create()
+        factories.collection.create(grant=grant, type=CollectionType.APPLICATION)
+
+        response = client.get(url_for("deliver_grant_funding.list_pre_award_forms", grant_id=grant.id))
+        assert response.status_code == 200
+
+        soup = BeautifulSoup(response.data, "html.parser")
+        assert grant.name in soup.text
+
+        test_submission_links = page_has_link(soup, "0 test submissions")
+        assert test_submission_links is not None
+        assert test_submission_links.get("href") == AnyStringMatching(
+            r"/deliver/grant/[a-z0-9-]{36}/report/[a-z0-9-]{36}/submissions/test"
+        )
+
+        live_submissions_links = page_has_link(soup, "0 live submissions")
+        assert live_submissions_links is not None
+        assert live_submissions_links.get("href") == AnyStringMatching(
+            r"/deliver/grant/[a-z0-9-]{36}/report/[a-z0-9-]{36}/submissions/live"
+        )
+
+        # todo: replace report specific actions with pre-award when pages are made generic for collections
+        expected_links = [
+            ("Add a form", AnyStringMatching(r"/deliver/grant/[a-z0-9-]{36}/set-up-report")),
+            ("Add sections", AnyStringMatching(r"/deliver/grant/[a-z0-9-]{36}/report/[a-z0-9-]{36}/add-section")),
+            ("Change name", AnyStringMatching(r"/deliver/grant/[a-z0-9-]{36}/report/[a-z0-9-]{36}/change-name")),
+            ("Delete", AnyStringMatching(r"/deliver/grant/[a-z0-9-]{36}/pre-award\?delete")),
+        ]
+        for expected_link in expected_links:
+            link = page_has_link(soup, expected_link[0])
+            assert (link is not None) is can_edit
+
+            if can_edit:
+                assert link.get("href") == expected_link[1]
+
+    def test_get_with_delete_parameter_no_submissions(self, authenticated_grant_admin_client, factories):
+        pre_award_form = factories.collection.create(
+            grant=authenticated_grant_admin_client.grant, name="Test form", type=CollectionType.APPLICATION
+        )
+
+        response = authenticated_grant_admin_client.get(
+            url_for(
+                "deliver_grant_funding.list_pre_award_forms",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                delete=pre_award_form.id,
+            )
+        )
+
+        assert response.status_code == 200
+        soup = BeautifulSoup(response.data, "html.parser")
+        assert page_has_button(soup, "Yes, delete this form")
+
+    @pytest.mark.parametrize(
+        "client_fixture, can_delete",
+        (
+            ("authenticated_grant_member_client", False),
+            ("authenticated_grant_admin_client", True),
+        ),
+    )
+    def test_post_delete(
+        self, request: pytest.FixtureRequest, client_fixture: str, can_delete: bool, factories, db_session
+    ):
+        client = request.getfixturevalue(client_fixture)
+        pre_award_form = factories.collection.create(
+            grant=client.grant, name="Test Form", type=CollectionType.APPLICATION
+        )
+
+        form = GenericConfirmDeletionForm(data={"confirm_deletion": True})
+        response = client.post(
+            url_for("deliver_grant_funding.list_pre_award_forms", grant_id=client.grant.id, delete=pre_award_form.id),
+            data=get_form_data(form),
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 302
+        assert response.location == AnyStringMatching("^/deliver/grant/[a-z0-9-]{36}/pre-award$")
+
+        deleted_form = db_session.get(Collection, pre_award_form.id)
+        assert (deleted_form is None) == can_delete
+
+    @pytest.mark.parametrize(
+        "collection_status", [status for status in CollectionStatusEnum if status != CollectionStatusEnum.DRAFT]
+    )
+    @pytest.mark.parametrize(
+        "client_fixture", ("authenticated_grant_admin_client", "authenticated_platform_admin_client")
+    )
+    def test_get_no_change_or_delete_links_when_form_not_draft(
+        self, factories, collection_status, client_fixture, request
+    ):
+        client = request.getfixturevalue(client_fixture)
+        grant = client.grant if client.grant else factories.grant.create()
+        factories.collection.create(
+            grant=grant, name="Test Form", type=CollectionType.APPLICATION, status=collection_status
+        )
+
+        response = client.get(url_for("deliver_grant_funding.list_pre_award_forms", grant_id=grant.id))
+
+        assert response.status_code == 200
+        soup = BeautifulSoup(response.data, "html.parser")
+
+        change_name_link = page_has_link(soup, "Change name")
+        delete_link = page_has_link(soup, "Delete")
+
+        assert change_name_link is None
+        assert delete_link is None

--- a/tests/unit/common/helpers/test_feature_flags.py
+++ b/tests/unit/common/helpers/test_feature_flags.py
@@ -1,6 +1,5 @@
 from unittest.mock import patch
 
-import pytest
 from flask import Flask
 
 from app.common.data.types import RoleEnum
@@ -41,10 +40,11 @@ class TestCheckGrantAllowsPreAward:
             with patch("app.common.helpers.feature_flags.get_grant", return_value=grant):
                 assert self.flag.is_enabled is False
 
-    def test_raises(self, app: Flask) -> None:
+    def test_disabled_without_grant_id(self, app: Flask, factories) -> None:
+        grant = factories.grant.build(allow_pre_award=True)
         with app.test_request_context("/"):
-            with pytest.raises(ValueError, match="grant_id required"):
-                assert self.flag.is_enabled
+            with patch("app.common.helpers.feature_flags.get_grant", return_value=grant):
+                assert self.flag.is_enabled is False
 
 
 class TestCheckUserIsPlatformMember:

--- a/tests/unit/test_all_routes_access.py
+++ b/tests/unit/test_all_routes_access.py
@@ -124,6 +124,7 @@ routes_with_expected_member_only_access = [
     "deliver_grant_funding.list_users_for_grant",
     "deliver_grant_funding.grant_details",
     "deliver_grant_funding.list_reports",
+    "deliver_grant_funding.list_pre_award_forms",
     "deliver_grant_funding.list_report_sections",
     "deliver_grant_funding.start_test_grant_recipient_journey",
     "deliver_grant_funding.list_section_questions",


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-1369

## 📝 Description
Adds the pre-award tab to Deliver grant funding. The naming on this
navigation and headings may change as pages are put in front of users
and language is refined.

For now the pre-award tab is only shown to to grants with the feature
flag enabled, this will let us push incomplete journeys (i.e only the
list application page without the full CRUD functionality) without
interrupting existing monitoring users. When the Deliver/ Access pages
are all updated we can decide when to turn this on for all grants.

This commit only implements the list collections page which allows us
to:
- list "APPLICATION" collection types
- delete "APPLICATION" collection types (as the functionality is also
  the responsibility of the list page

This page is separately implemented from listing monitoring collections
as it should allow these pages to more easily have separate designs and
functionality as we have business requirements for those, for example:
- showing a progress overview for your assessments on applications
- showing which monitoring reports are schduled
- showing the number of applicants for open collections

The next task/ commit will update all of collection management pages
which should be able to work for monitoring report and pre-award
contexts without any significant differences (present or future):
- adding a collection
- renaming a collection
- managing collection sections
- managing section questions and question groups

Note that this doesn't enforce the feature flag to be enable to actually access
the pages, happy to implement that if useful.

## 📸 Show the thing (screenshots, gifs)
<img width="667" height="856" alt="Screenshot 2026-05-18 at 09 32 25" src="https://github.com/user-attachments/assets/86a29e69-259f-4e4c-8621-715a4629b154" />
<img width="801" height="853" alt="Screenshot 2026-05-18 at 09 32 14" src="https://github.com/user-attachments/assets/44101fea-89a0-4876-89db-e9e1c9f2c41d" />
<img width="1010" height="730" alt="Screenshot 2026-05-18 at 09 31 45" src="https://github.com/user-attachments/assets/ab69f132-312e-4356-a3c2-4e8cbc417a0a" />


## 🧪 Testing
<!-- Describe how you've tested this change, and how a reviewer can test it -->

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- [x] No N+1 query problems introduced
- [-] Any new DB queries include appropriate where clauses based on the user's permissions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [-] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested

