### PR TITLE
FSPT-1349: Update data set fallback interpolation

### DIFF
--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -1184,6 +1184,11 @@ class DataSource(BaseModel, SafeDidMixin):
                     f"Unsupported data_type {column_schema.data_type} for column {column_schema.original_column_name}"
                 )
 
+    def column_reference_label(self, column: DataSourceSchemaColumn) -> str | None:
+        if self.type == DataSourceType.CUSTOM:
+            return None
+        return f"{column.original_column_name} from {self.name} data set"
+
 
 class DataSourceItem(BaseModel):
     __tablename__ = "data_source_item"

--- a/app/common/expressions/__init__.py
+++ b/app/common/expressions/__init__.py
@@ -362,7 +362,7 @@ class ExpressionContext(ChainMap[str, Any]):
                     )
                     for column_name, column_schema in data_source.schema.root.items():
                         data_source_context[data_source.safe_did].setdefault(
-                            column_name, f"(({data_source.name} → {column_schema.original_column_name}))"
+                            column_name, f"(({data_source.column_reference_label(column_schema)}))"
                         )
 
         return ExpressionContext(submission_data=submission_data, data_source_context=data_source_context)
@@ -429,7 +429,7 @@ class ExpressionContext(ChainMap[str, Any]):
             if org_item is None:
                 data_source_context[data_source.safe_did] = {
                     col_name: (
-                        None if mode == "evaluation" else f"(({data_source.name} → {col_schema.original_column_name}))"
+                        None if mode == "evaluation" else f"(({data_source.column_reference_label(col_schema)}))"
                     )
                     for col_name, col_schema in data_source.schema.root.items()
                 }

--- a/app/common/expressions/references.py
+++ b/app/common/expressions/references.py
@@ -156,7 +156,8 @@ class ExpressionReference(str):
             return question.data_reference_label
 
         if (column := self.data_source_column) and (data_source := self.data_source):
-            return f"{column.original_column_name} from {data_source.name} data set"
+            if label := data_source.column_reference_label(column):
+                return label
 
         raise ValueError(f"Can't resolve ExpressionReference {self!r} to a specific label; unknown reference shape")
 

--- a/tests/integration/common/expressions/test_init.py
+++ b/tests/integration/common/expressions/test_init.py
@@ -271,7 +271,7 @@ class TestExpressionContext:
             grant_recipient = factories.grant_recipient.create(grant=grant, organisation=organisation)
             submission = factories.submission.create(collection=collection, grant_recipient=grant_recipient)
             data_source = factories.data_source.create(
-                name="Test data set",
+                name="Allocations",
                 grant=grant,
                 collection=collection,
                 type=DataSourceType.GRANT_RECIPIENT,
@@ -291,7 +291,10 @@ class TestExpressionContext:
             context = ExpressionContext._build_data_source_context(mode="interpolation", submission_helper=helper)
 
             assert data_source.safe_did in context
-            assert context[data_source.safe_did]["capital_allocation"] == "((Test data set → Capital Allocation))"
+            assert (
+                context[data_source.safe_did]["capital_allocation"]
+                == "((Capital Allocation from Allocations data set))"
+            )
 
         def test_non_dict_typed_data_is_skipped(self, factories, mocker):
             grant = factories.grant.create()
@@ -946,6 +949,7 @@ class TestDataSourceInterpolation:
         grant_recipient = factories.grant_recipient.create(grant=grant, organisation=organisation)
         submission = factories.submission.create(collection=collection, grant_recipient=grant_recipient)
         data_source = factories.data_source.create(
+            name="Allocations",
             grant=grant,
             collection=collection,
             type=DataSourceType.GRANT_RECIPIENT,
@@ -966,7 +970,7 @@ class TestDataSourceInterpolation:
         context = ExpressionContext(data_source_context=ds_context)
 
         result = interpolate(f"(({data_source.safe_did}.capital_allocation))", context)
-        assert result == "((Test data set → Capital Allocation))"
+        assert result == "((Capital Allocation from Allocations data set))"
 
     def test_unknown_data_source_reference_renders_raw(self):
         context = ExpressionContext(data_source_context={})


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-1349

## 📝 Description
We weren't being consistent with how we referred to data set references in interpolation - we were using this new preferred format of '<column_name> from <data_set_name> data set' when referencing a data set column as a `depends on` label in a condition but weren't using it anywhere else consistently.

This change brings all the labels for data set references together consistently and makes the format be generated on the data source model itself rather than explicitly in 3 different places in the code.

## 📸 Show the thing (screenshots, gifs)

| Before      | After |
| ----------- | ----------- |
|  <img width="726" height="1018" alt="image" src="https://github.com/user-attachments/assets/3bb115b4-60da-460c-a261-a922fa13b89f" />  |  <img width="713" height="819" alt="image" src="https://github.com/user-attachments/assets/2cae7f93-2920-4a69-b820-cd99b6ecb7b1" />  |
| <img width="772" height="807" alt="image" src="https://github.com/user-attachments/assets/2324e955-5e0f-4297-9800-5e09dbac40a7" /> | <img width="742" height="664" alt="image" src="https://github.com/user-attachments/assets/b224b1cb-7c07-4b5d-90a6-9ea97cf70351" /> |
| <img width="689" height="988" alt="image" src="https://github.com/user-attachments/assets/8abae57a-d794-4e62-b4ff-1504b84da6a9" />  | <img width="701" height="948" alt="image" src="https://github.com/user-attachments/assets/a9a7d60f-3b48-41a5-82a4-aec839a3c965" /> |

## 🧪 Testing
Set up some data set references and switch between branch and main. The labels on the branch should all consistently be in the new format.

## 📋 Developer Checklist

### Review Readiness
- [X] PR title and description provide sufficient context for reviewers
- [X] Commits are logical, self-contained, and have clear descriptions

### Testing
- [X] I have tested this change and it meets the acceptance criteria for the ticket
- ~[ ] I need the reviewer(s) to pull and run this change locally~
- [X] New (non-developer) functionality has appropriate unit and integration tests
- ~[ ] End-to-end tests have been updated (if applicable)~
- ~[ ] Edge cases and error conditions are tested~
