### PR TITLE
Use interface for fetching org's grant recipients / fix global certifier revoke

### DIFF
--- a/app/common/audit.py
+++ b/app/common/audit.py
@@ -3,13 +3,10 @@ import enum
 from typing import Any, Literal
 from uuid import UUID
 
-from flask import current_app
 from pydantic import BaseModel, Field
 from sqlalchemy import inspect
-from sqlalchemy.orm import Session, scoped_session
 
 from app.common.data.base import BaseModel as SQLAlchemyBaseModel
-from app.common.data.models_audit import AuditEvent as AuditEventModel
 from app.common.data.models_user import User
 from app.common.data.types import AuditEventType
 
@@ -147,25 +144,4 @@ def create_system_event_for_delete(
         action="delete",
         changes=snapshot,
         context=context,
-    )
-
-
-def track_audit_event(session: scoped_session[Session] | Session, event: AuditEvent, user: User) -> None:
-    audit_record = AuditEventModel(
-        event_type=event.event_type,
-        user_id=event.user_id,
-        data=event.model_dump(mode="json"),
-    )
-    session.add(audit_record)
-
-    current_app.logger.info(
-        "audit_event: %(event_type)s by %(user_email)s",
-        {"event_type": event.event_type, "user_email": user.email},
-        extra={
-            "audit": True,
-            "event_type": event.event_type,
-            "user_id": str(event.user_id),
-            "user_email": user.email,
-            "event_data": event.model_dump(mode="json"),
-        },
     )

--- a/app/common/data/interfaces/audit.py
+++ b/app/common/data/interfaces/audit.py
@@ -1,0 +1,29 @@
+from flask import current_app
+
+from app.common.audit import AuditEvent
+from app.common.data.interfaces.exceptions import flush_and_rollback_on_exceptions
+from app.common.data.models_audit import AuditEvent as AuditEventModel
+from app.common.data.models_user import User
+from app.extensions import db
+
+
+@flush_and_rollback_on_exceptions
+def track_audit_event(event: AuditEvent, user: User) -> None:
+    audit_record = AuditEventModel(
+        event_type=event.event_type,
+        user_id=event.user_id,
+        data=event.model_dump(mode="json"),
+    )
+    db.session.add(audit_record)
+
+    current_app.logger.info(
+        "audit_event: %(event_type)s by %(user_email)s",
+        {"event_type": event.event_type, "user_email": user.email},
+        extra={
+            "audit": True,
+            "event_type": event.event_type,
+            "user_id": str(event.user_id),
+            "user_email": user.email,
+            "event_data": event.model_dump(mode="json"),
+        },
+    )

--- a/app/common/data/interfaces/grant_recipients.py
+++ b/app/common/data/interfaces/grant_recipients.py
@@ -66,6 +66,19 @@ def get_grant_recipients_with_outstanding_submissions_for_collection(
     return grant_recipients_with_outstanding_submissions
 
 
+def get_grant_recipients_for_organisation(
+    organisation_id: uuid.UUID,
+    *,
+    mode: GrantRecipientModeEnum = GrantRecipientModeEnum.LIVE,
+) -> Sequence[GrantRecipient]:
+    stmt = (
+        select(GrantRecipient)
+        .where(GrantRecipient.organisation_id == organisation_id, GrantRecipient.mode == mode)
+        .options(joinedload(GrantRecipient.grant))
+    )
+    return db.session.scalars(stmt).all()
+
+
 def get_grant_recipient(grant_id: uuid.UUID, organisation_id: uuid.UUID) -> GrantRecipient:
     statement = (
         select(GrantRecipient)

--- a/app/deliver_grant_funding/admin/entities.py
+++ b/app/deliver_grant_funding/admin/entities.py
@@ -21,9 +21,9 @@ from app.common.audit import (
     create_database_model_change_for_create,
     create_database_model_change_for_delete,
     create_database_model_change_for_update,
-    track_audit_event,
 )
 from app.common.data.base import BaseModel
+from app.common.data.interfaces.audit import track_audit_event
 from app.common.data.interfaces.user import get_current_user
 from app.common.data.models import (
     Collection,
@@ -103,10 +103,10 @@ class PlatformAdminModelView(XGovukModelView):
         user = get_current_user()
         if is_created:
             event = create_database_model_change_for_create(model, user)
-            track_audit_event(self.session.session, event, user)
+            track_audit_event(event, user)
             self.session.session.commit()
         elif pending_event := g.pop("audit_event", None):
-            track_audit_event(self.session.session, pending_event, user)
+            track_audit_event(pending_event, user)
             self.session.session.commit()
 
         return super().after_model_change(form, model, is_created)
@@ -120,7 +120,7 @@ class PlatformAdminModelView(XGovukModelView):
         needs to be responsible for committing itself, as flask-admin won't commit again automatically.
         """
         if audit_event := g.pop("audit_event", None):
-            track_audit_event(self.session.session, audit_event, get_current_user())
+            track_audit_event(audit_event, get_current_user())
             self.session.session.commit()
 
         return super().after_model_delete(model)
@@ -400,7 +400,7 @@ class PlatformAdminInvitationView(FlaskAdminPlatformAdminGrantLifecycleManagerAc
                 audit_event = create_database_model_change_for_update(invitation, get_current_user())
                 if not audit_event:
                     raise RuntimeError("Expected an audit event")
-                track_audit_event(self.session.session, audit_event, get_current_user())
+                track_audit_event(audit_event, get_current_user())
 
             self.session.session.commit()
 

--- a/app/deliver_grant_funding/routes/api/callbacks.py
+++ b/app/deliver_grant_funding/routes/api/callbacks.py
@@ -8,10 +8,11 @@ import sentry_sdk
 from flask import current_app, jsonify, request
 from flask.typing import ResponseReturnValue
 from pydantic import BaseModel, ValidationError
-from sqlalchemy import select
 
-from app.common.audit import create_system_event_for_delete, track_audit_event
+from app.common.audit import create_system_event_for_delete
 from app.common.auth.authorisation_helper import AuthorisationHelper
+from app.common.data.interfaces.audit import track_audit_event
+from app.common.data.interfaces.grant_recipients import get_grant_recipients_for_organisation
 from app.common.data.interfaces.user import (
     get_or_create_system_user,
     get_user_by_email,
@@ -20,10 +21,10 @@ from app.common.data.interfaces.user import (
 )
 from app.common.data.types import GrantRecipientModeEnum, OrganisationModeEnum, RoleEnum
 from app.deliver_grant_funding.routes.api import deliver_grant_funding_api_blueprint
-from app.extensions import auto_commit_after_request, db
+from app.extensions import auto_commit_after_request
 
 if TYPE_CHECKING:
-    from app.common.data.models import Grant, GrantRecipient, Organisation
+    from app.common.data.models import Grant, Organisation
     from app.common.data.models_user import User
 
 
@@ -85,7 +86,7 @@ def handle_permanent_email_failure(notification_id: uuid.UUID, recipient_email: 
     remove_all_roles_from_user(user)
 
     for event in audit_events:
-        track_audit_event(db.session, event, system_user)
+        track_audit_event(event, system_user)
 
     _log_error_for_access_grant_funding_roles_with_no_alternate_users(
         access_grant_funding_roles, exclude_user_id=None, reason="permanent failure"
@@ -136,12 +137,7 @@ def _get_access_grant_funding_roles_for_user(
         else:
             grants = [
                 gr.grant
-                for gr in db.session.scalars(
-                    select(GrantRecipient).where(
-                        GrantRecipient.organisation_id == ur.organisation_id,
-                        GrantRecipient.mode == GrantRecipientModeEnum.LIVE,
-                    )
-                ).all()
+                for gr in get_grant_recipients_for_organisation(ur.organisation.id, mode=GrantRecipientModeEnum.LIVE)
             ]
 
         for grant in grants:

--- a/tests/integration/common/data/interfaces/test_grant_recipients.py
+++ b/tests/integration/common/data/interfaces/test_grant_recipients.py
@@ -10,10 +10,11 @@ from app.common.data.interfaces.grant_recipients import (
     get_grant_recipient_data_providers_count,
     get_grant_recipients,
     get_grant_recipients_count,
+    get_grant_recipients_for_organisation,
     get_grant_recipients_with_outstanding_submissions_for_collection,
 )
 from app.common.data.models import GrantRecipient
-from app.common.data.types import RoleEnum, SubmissionEventType, SubmissionModeEnum
+from app.common.data.types import GrantRecipientModeEnum, RoleEnum, SubmissionEventType, SubmissionModeEnum
 from tests.models import FactoryAnswer
 
 
@@ -389,6 +390,42 @@ class TestGetGrantRecipientsWithOutstandingReports:
 
         assert len(result) == 3
         assert {gr.organisation_id for gr in result} == {org1.id, org3.id, org4.id}
+
+
+class TestGetGrantRecipientsForOrganisation:
+    def test_returns_all_grant_recipients_for_organisation(self, factories, db_session):
+        organisation = factories.organisation.create()
+        other_organisation = factories.organisation.create()
+        grant_a = factories.grant.create()
+        grant_b = factories.grant.create()
+        grant_c = factories.grant.create()
+
+        factories.grant_recipient.create(grant=grant_a, organisation=organisation)
+        factories.grant_recipient.create(grant=grant_b, organisation=organisation)
+        factories.grant_recipient.create(grant=grant_c, organisation=other_organisation)
+
+        result = get_grant_recipients_for_organisation(organisation.id)
+
+        assert {gr.grant_id for gr in result} == {grant_a.id, grant_b.id}
+
+    def test_filters_by_mode(self, factories, db_session):
+        organisation = factories.organisation.create()
+        grant_a = factories.grant.create()
+        grant_b = factories.grant.create()
+
+        factories.grant_recipient.create(grant=grant_a, organisation=organisation, mode=GrantRecipientModeEnum.LIVE)
+        factories.grant_recipient.create(grant=grant_b, organisation=organisation, mode=GrantRecipientModeEnum.TEST)
+
+        live = get_grant_recipients_for_organisation(organisation.id)
+        test = get_grant_recipients_for_organisation(organisation.id, mode=GrantRecipientModeEnum.TEST)
+
+        assert {gr.grant_id for gr in live} == {grant_a.id}
+        assert {gr.grant_id for gr in test} == {grant_b.id}
+
+    def test_returns_empty_when_no_recipients(self, factories, db_session):
+        organisation = factories.organisation.create()
+
+        assert get_grant_recipients_for_organisation(organisation.id) == []
 
 
 class TestGetGrantRecipient:

--- a/tests/integration/deliver_grant_funding/routes/api/test_callbacks.py
+++ b/tests/integration/deliver_grant_funding/routes/api/test_callbacks.py
@@ -292,6 +292,32 @@ class TestGovukNotifyCallback:
             logs = _manual_intervention_logs(caplog)
             assert any(str(recipient_org_a.id) in msg and "DATA_PROVIDER" in msg for msg in logs)
 
+        def test_permanent_failure_with_org_wide_affected_role_flags_each_grant(
+            self, anonymous_client, factories, caplog
+        ) -> None:
+            grant_a = factories.grant.create(status=GrantStatusEnum.LIVE)
+            grant_b = factories.grant.create(status=GrantStatusEnum.LIVE)
+            recipient_org = factories.organisation.create(can_manage_grants=False)
+            factories.grant_recipient.create(grant=grant_a, organisation=recipient_org)
+            factories.grant_recipient.create(grant=grant_b, organisation=recipient_org)
+
+            affected_user = factories.user.create(email="bouncer@example.com")
+            factories.user_role.create(
+                user=affected_user, organisation=recipient_org, grant=None, permissions=[RoleEnum.CERTIFIER]
+            )
+
+            with caplog.at_level(logging.ERROR, logger="app"):
+                response, _ = self._post(anonymous_client, status="permanent-failure", to="bouncer@example.com")
+
+            assert response.status_code == 202
+
+            remaining = db.session.scalars(select(UserRole).where(UserRole.user_id == affected_user.id)).all()
+            assert remaining == []
+
+            logs = _manual_intervention_logs(caplog)
+            assert any("CERTIFIER" in msg and str(grant_a.id) in msg and str(recipient_org.id) in msg for msg in logs)
+            assert any("CERTIFIER" in msg and str(grant_b.id) in msg and str(recipient_org.id) in msg for msg in logs)
+
         def test_permanent_failure_unknown_email_logs_error_and_no_db_changes(self, anonymous_client, caplog) -> None:
             response, _ = self._post(anonymous_client, status="permanent-failure", to="not-a-user@example.com")
 
@@ -391,6 +417,29 @@ class TestGovukNotifyCallback:
 
             assert response.status_code == 202
             assert _manual_intervention_logs(caplog) == []
+
+        def test_temporary_failure_with_org_wide_affected_role_flags_each_grant(
+            self, anonymous_client, factories, caplog
+        ) -> None:
+            grant_a = factories.grant.create(status=GrantStatusEnum.LIVE)
+            grant_b = factories.grant.create(status=GrantStatusEnum.LIVE)
+            recipient_org = factories.organisation.create(can_manage_grants=False)
+            factories.grant_recipient.create(grant=grant_a, organisation=recipient_org)
+            factories.grant_recipient.create(grant=grant_b, organisation=recipient_org)
+
+            affected_user = factories.user.create(email="bouncer@example.com")
+            factories.user_role.create(
+                user=affected_user, organisation=recipient_org, grant=None, permissions=[RoleEnum.CERTIFIER]
+            )
+
+            with caplog.at_level(logging.ERROR, logger="app"):
+                response, _ = self._post(anonymous_client, to="bouncer@example.com")
+
+            assert response.status_code == 202
+
+            logs = _manual_intervention_logs(caplog)
+            assert any("CERTIFIER" in msg and str(grant_a.id) in msg and str(recipient_org.id) in msg for msg in logs)
+            assert any("CERTIFIER" in msg and str(grant_b.id) in msg and str(recipient_org.id) in msg for msg in logs)
 
         def test_unknown_email_logs_error_and_no_db_changes(self, anonymous_client, caplog) -> None:
             with caplog.at_level(logging.ERROR, logger="app"):


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-1356 / https://github.com/communitiesuk/funding-service/pull/1626

## 📝 Description
I slipped up last week and put some DB queries directly in our app code instead of using a proper interface, and this then slipped through our import linters and type checkers because GrantRecipient was only imported in the type checking block and the test coverage didn't check this quite narrow code path revoking perms for a global certifier.

## 🧪 Testing
- Manually create some user roles for seeded users giving them Access grant funding permissions (eg for darin.lewis@test.communities.gov.uk with certifier for Ministry of Testing+no grant).
- Comment out this line:
    ```python
            if callback_data.to.endswith(current_app.config["GOVUK_NOTIFY_IGNORE_CALLBACK_DOMAINS"]):
                return jsonify(), 202
    ```
- POST to the /deliver/api/v1/govuk-notify-callback endpoint with `Authorisation: Bearer local-use-secret` header and payload:
    ```
    {
    "completed_at": "2026-05-12T07:46:45.250646Z",
    "created_at": "2026-05-12T07:46:44.422635Z",
    "id": "1fdbe5d2-f7e4-4a8e-af8d-592c943cfd0f",
    "notification_type": "email",
    "reference": null,
    "sent_at": "2026-05-12T07:46:44.564077Z",
    "status": "permanent-failure",
    "template_id": "e511c0d0-2ac8-4ded-80a2-13b79023c5d5",
    "template_version": 13,
    "to": "darin.lewis@test.communities.gov.uk"
    }
    ```
- Check that user role for that user was dropped.
- Check that error log messages were emitted.


## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [ ] End-to-end tests have been updated (if applicable)
- [ ] Edge cases and error conditions are tested

## 📚 Additional Notes
<!-- Any additional context, concerns, or considerations for reviewers -->
