### PR TITLE
Allow developers to trace requests

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,6 @@
 import datetime
+import os
+import secrets
 import typing as t
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -8,6 +10,7 @@ from flask.typing import ResponseReturnValue
 from flask_admin import Admin
 from flask_babel import Babel
 from flask_sqlalchemy_lite import SQLAlchemy
+from flask_wtf.csrf import generate_csrf
 from govuk_frontend_wtf.main import WTFormsHelpers
 from jinja2 import ChoiceLoader, PackageLoader, PrefixLoader
 from sqlalchemy.exc import NoResultFound, ProgrammingError
@@ -54,6 +57,7 @@ from app.common.filters import (
 )
 from app.common.helpers.collections import SubmissionAuthorisationError
 from app.common.helpers.feature_flags import FeatureFlags
+from app.common.helpers.request_tracing import get_tracing_state
 from app.common.utils import comma_join_items, uppercase_first
 from app.config import get_settings
 from app.constants import DATA_SET_EXTERNAL_ID_COLUMN_HEADER, DATA_SET_GRANT_RECIPIENT_COLUMN_HEADER
@@ -78,7 +82,7 @@ from app.types import FlashMessageType
 if TYPE_CHECKING:
     from app.common.data.models_user import User
 
-init_sentry()
+init_sentry(os.environ.get("SECRET_KEY", secrets.token_urlsafe(32)))
 
 
 def _register_global_error_handlers(app: Flask) -> None:
@@ -286,6 +290,7 @@ def create_app() -> Flask:  # noqa: C901
 
     app.jinja_env.filters["comma_join_items"] = comma_join_items
     app.jinja_env.filters["uppercase_first"] = uppercase_first
+    app.jinja_env.globals["csrf_token"] = generate_csrf  # ty: ignore[invalid-assignment]
 
     @app.context_processor
     def _jinja_template_context() -> dict[str, Any]:
@@ -330,6 +335,7 @@ def create_app() -> Flask:  # noqa: C901
                 data_source_type_enum=DataSourceType,
             ),
             feature_flags=FeatureFlags,
+            request_tracing_state=get_tracing_state(),
         )
 
     # TODO: Remove our basic auth application code when the app is deployed behind CloudFront and the app is not

--- a/app/access_grant_funding/templates/access_grant_funding/base.html
+++ b/app/access_grant_funding/templates/access_grant_funding/base.html
@@ -2,7 +2,7 @@
 {% from "common/partials/mhclg-header.html" import mhclgHeader %}
 {% from "common/macros/navigation.html" import accessGrantFundingServiceNavigation %}
 {% from "govuk_frontend_jinja/components/footer/macro.html" import govukFooter %}
-{% from "common/partials/mhclg-test-banner.html" import mhclgTestBanner %}
+{% from "common/partials/mhclg-test-banner.html" import mhclgTestBanner, mhclgRequestTracingBanner with context %}
 {% from "govuk_frontend_jinja/components/cookie-banner/macro.html" import govukCookieBanner %}
 
 {% set nav_items = nav_items or [] %}
@@ -32,6 +32,7 @@
   </script>
 {% endblock head %}
 {% block header %}
+  {{ mhclgRequestTracingBanner() }}
   {{
     mhclgHeader(
       params={

--- a/app/assets/admin.scss
+++ b/app/assets/admin.scss
@@ -7,6 +7,7 @@
 );
 
 @use "components/metadata";
+@use "components/test-data-banner";
 @use "tweaks";
 
 .app-\!-align-vertically {

--- a/app/assets/components/test-data-banner/_index.scss
+++ b/app/assets/components/test-data-banner/_index.scss
@@ -35,3 +35,50 @@
     background-color: govuk.govuk-colour("orange");
     padding: 15px 15px;
 }
+
+.app-request-tracing-banner {
+    background-color: govuk.govuk-colour("brown");
+
+    &--container {
+        padding: 7px 0;
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+
+        @include govuk.govuk-media-query($until: tablet) {
+            flex-direction: column;
+            align-items: stretch;
+            gap: 5px;
+        }
+    }
+}
+
+.app-request-tracing-banner__tag {
+    color: white;
+    flex-grow: 1;
+}
+
+.app-request-tracing-banner__link-button {
+    background: none;
+    border: 0;
+    padding: 0;
+    margin: 0;
+    color: white;
+    cursor: pointer;
+    text-decoration: underline;
+    font: inherit;
+
+    &:hover {
+        text-decoration: none;
+    }
+
+    &:focus {
+        color: govuk.govuk-colour("black");
+        background-color: govuk.govuk-colour("yellow");
+        outline: 3px solid transparent;
+        box-shadow:
+            0 -2px govuk.govuk-colour("yellow"),
+            0 4px govuk.govuk-colour("black");
+        text-decoration: none;
+    }
+}

--- a/app/common/data/types.py
+++ b/app/common/data/types.py
@@ -172,6 +172,12 @@ class ExpressionType(enum.StrEnum):
     VALIDATION = "VALIDATION"
 
 
+class TraceLevelEnum(enum.StrEnum):
+    TRACE = "sentry tracing"
+    PROFILE = "sentry profiling"
+    DEBUG_LOGGING = "debug logging"
+
+
 class ComponentVisibilityState(enum.Enum):
     VISIBLE = "visible"  # Conditions evaluated to True
     HIDDEN = "hidden"  # Conditions evaluated to False (definitive)

--- a/app/common/helpers/request_tracing.py
+++ b/app/common/helpers/request_tracing.py
@@ -1,0 +1,102 @@
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from http.cookies import SimpleCookie
+
+from flask import current_app, request
+from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
+
+from app.common.data.types import TraceLevelEnum
+
+REQUEST_TRACING_COOKIE_NAME = "request_tracing"
+REQUEST_TRACING_TTL = 15 * 60  # Number of seconds that tracing gets enabled for
+
+
+@dataclass(frozen=True)
+class RequestTracingState:
+    levels: list[TraceLevelEnum]
+    expires_in: str
+
+
+def _serializer(secret: str) -> URLSafeTimedSerializer:
+    # The salt here is for namespacing, not for cryptographic security, so it can be a static public string.
+    return URLSafeTimedSerializer(secret, salt="request-tracing")
+
+
+def _parse_payload(payload: object) -> list[TraceLevelEnum]:
+    if not isinstance(payload, str):
+        return []
+
+    levels: list[TraceLevelEnum] = []
+    for raw in payload.split("\n"):
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            levels.append(TraceLevelEnum(raw))
+        except ValueError:
+            continue
+    return levels
+
+
+def encode_levels(levels: list[TraceLevelEnum], secret: str) -> str:
+    payload = "\n".join([level.value for level in levels])
+    return _serializer(secret).dumps(payload)
+
+
+def decode_levels(token: str, secret: str) -> list[TraceLevelEnum]:
+    try:
+        payload = _serializer(secret).loads(token, max_age=REQUEST_TRACING_TTL)
+    except BadSignature, SignatureExpired:
+        return []
+
+    return _parse_payload(payload)
+
+
+def _decode_with_expiry(token: str, secret: str) -> tuple[list[TraceLevelEnum], datetime] | None:
+    try:
+        payload, signed_at = _serializer(secret).loads(token, max_age=REQUEST_TRACING_TTL, return_timestamp=True)
+    except BadSignature, SignatureExpired:
+        return None
+
+    levels = _parse_payload(payload)
+    if not levels:
+        return None
+    return levels, signed_at + timedelta(seconds=REQUEST_TRACING_TTL)
+
+
+def get_tracing_levels_from_environ(wsgi_environ: dict[str, str], secret: str) -> list[TraceLevelEnum]:
+    cookie_header = wsgi_environ.get("HTTP_COOKIE")
+    if not cookie_header:
+        return []
+
+    cookies: SimpleCookie = SimpleCookie()
+    cookies.load(cookie_header)
+    morsel = cookies.get(REQUEST_TRACING_COOKIE_NAME)
+    if morsel is None:
+        return []
+
+    return decode_levels(morsel.value, secret)
+
+
+def get_tracing_levels() -> list[TraceLevelEnum]:
+    token = request.cookies.get(REQUEST_TRACING_COOKIE_NAME)
+    if not token:
+        return []
+    return decode_levels(token, current_app.config["SECRET_KEY"])
+
+
+def get_tracing_state() -> RequestTracingState | None:
+    token = request.cookies.get(REQUEST_TRACING_COOKIE_NAME)
+    if not token:
+        return None
+    decoded = _decode_with_expiry(token, current_app.config["SECRET_KEY"])
+    if decoded is None:
+        return None
+    levels, expires_at = decoded
+
+    seconds_remaining = max(int((expires_at - datetime.now(UTC)).total_seconds()), 0)
+    minutes, seconds = divmod(seconds_remaining, 60)
+
+    expires_in = f"{minutes}m {seconds:02d}s"
+
+    return RequestTracingState(levels=levels, expires_in=expires_in)

--- a/app/common/templates/common/base.html
+++ b/app/common/templates/common/base.html
@@ -1,5 +1,6 @@
 {% extends "govuk_frontend_jinja/template.html" %}
 {% from "common/partials/mhclg-header.html" import mhclgHeader %}
+{% from "common/partials/mhclg-test-banner.html" import mhclgRequestTracingBanner with context %}
 {% from "govuk_frontend_jinja/components/footer/macro.html" import govukFooter %}
 {% from "common/macros/standard-error-summary.html" import standardErrorSummary with context %}
 
@@ -27,6 +28,7 @@
 {% endblock head %}
 
 {% block header %}
+  {{ mhclgRequestTracingBanner() }}
   {# todo: have this header read a homepageUrl variable, then any subclasses can just use super() calls #}
   {{
     mhclgHeader(

--- a/app/common/templates/common/partials/mhclg-test-banner.html
+++ b/app/common/templates/common/partials/mhclg-test-banner.html
@@ -41,3 +41,24 @@
     </div>
   </div>
 {% endmacro %}
+
+{% macro mhclgRequestTracingBanner() %}
+  {% if request_tracing_state %}
+    {% set label = "Request tracing enabled for " ~ request_tracing_state.expires_in ~ ": " ~ (request_tracing_state.levels | join(", ")) %}
+    <div class="app-request-tracing-banner govuk-body govuk-!-margin-bottom-0">
+      <div class="govuk-width-container">
+        <div class="app-request-tracing-banner--container">
+          <div class="app-request-tracing-banner__tag">
+            <strong>{{ label }}</strong>
+          </div>
+          <div>
+            <form method="post" action="{{ url_for('developer_tools.stop') }}" class="govuk-!-margin-bottom-0">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+              <button type="submit" class="app-request-tracing-banner__link-button">Stop tracing</button>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  {% endif %}
+{% endmacro %}

--- a/app/deliver_grant_funding/admin/__init__.py
+++ b/app/deliver_grant_funding/admin/__init__.py
@@ -16,6 +16,7 @@ from app.deliver_grant_funding.admin.entities import (
 )
 from app.deliver_grant_funding.admin.views import (
     PlatformAdminDataAnalysisView,
+    PlatformAdminDeveloperToolsView,
     PlatformAdminReportingLifecycleView,
 )
 
@@ -41,3 +42,9 @@ def register_admin_views(flask_admin: Admin, db_: SQLAlchemy) -> None:
     flask_admin.add_view(PlatformAdminQuestionView(db_))
     flask_admin.add_view(PlatformAdminInvitationView(db_))
     flask_admin.add_view(PlatformAdminAuditEventView(db_))
+
+    flask_admin.add_view(
+        PlatformAdminDeveloperToolsView(
+            name="Developer tools", endpoint="developer_tools", url="developer-tools", category="Developer tools"
+        )
+    )

--- a/app/deliver_grant_funding/admin/forms.py
+++ b/app/deliver_grant_funding/admin/forms.py
@@ -1,12 +1,13 @@
 import csv
 import datetime
 from collections.abc import Mapping, Sequence
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import email_validator
 from flask import current_app, flash
 from flask_wtf import FlaskForm
 from govuk_frontend_wtf.wtforms_widgets import (
+    GovCheckboxesInput,
     GovCheckboxInput,
     GovDateInput,
     GovSubmitInput,
@@ -23,7 +24,10 @@ from xgovuk_flask_admin import GovSelectWithSearch
 from app.common.data.types import (
     OrganisationData,
     OrganisationType,
+    TraceLevelEnum,
 )
+from app.common.helpers.request_tracing import REQUEST_TRACING_TTL
+from app.common.utils import uppercase_first
 
 if TYPE_CHECKING:
     from app.common.data.models import Collection, Grant, GrantRecipient, Organisation
@@ -596,3 +600,17 @@ class PlatformAdminSetPrivacyPolicyForm(FlaskForm):
         widget=GovTextArea(),
     )
     submit = SubmitField("Save privacy policy", widget=GovSubmitInput())
+
+
+class PlatformAdminForceTracingForm(FlaskForm):
+    levels = SelectMultipleField(
+        "Request tracing",
+        choices=[(e.value, cast(str, uppercase_first(e.value))) for e in TraceLevelEnum],
+        widget=GovCheckboxesInput(),
+        validators=[Optional()],
+        description=(
+            "Enable more detailed logs and tracing to be emitted for requests from your browser "
+            f"for the next {REQUEST_TRACING_TTL // 60} minutes"
+        ),
+    )
+    submit = SubmitField("Apply", widget=GovSubmitInput())

--- a/app/deliver_grant_funding/admin/views.py
+++ b/app/deliver_grant_funding/admin/views.py
@@ -4,7 +4,7 @@ from typing import Any
 from uuid import UUID
 
 import markupsafe
-from flask import abort, current_app, flash, redirect, send_file, url_for
+from flask import abort, current_app, flash, make_response, redirect, send_file, url_for
 from flask_admin import AdminIndexView, BaseView, expose
 from sqlalchemy import text
 
@@ -46,10 +46,17 @@ from app.common.data.types import (
     RoleEnum,
     SubmissionEventType,
     SubmissionModeEnum,
+    TraceLevelEnum,
 )
 from app.common.filters import format_date
 from app.common.forms import GenericSubmitForm
 from app.common.helpers.collections import SubmissionHelper
+from app.common.helpers.request_tracing import (
+    REQUEST_TRACING_COOKIE_NAME,
+    REQUEST_TRACING_TTL,
+    encode_levels,
+    get_tracing_levels,
+)
 from app.deliver_grant_funding.admin.forms import (
     PlatformAdminAddSingleDataProviderForm,
     PlatformAdminAddTestGrantRecipientUserForm,
@@ -58,6 +65,7 @@ from app.deliver_grant_funding.admin.forms import (
     PlatformAdminCreateCertifiersForm,
     PlatformAdminCreateGrantOverrideCertifiersForm,
     PlatformAdminCreateGrantRecipientDataProvidersForm,
+    PlatformAdminForceTracingForm,
     PlatformAdminMakeGrantLiveForm,
     PlatformAdminMakeReportLiveForm,
     PlatformAdminMarkAsOnboardingForm,
@@ -71,6 +79,7 @@ from app.deliver_grant_funding.admin.forms import (
     PlatformAdminSetPrivacyPolicyForm,
 )
 from app.deliver_grant_funding.admin.mixins import (
+    FlaskAdminPlatformAdminAccessibleMixin,
     FlaskAdminPlatformAdminDataAnalystAccessibleMixin,
     FlaskAdminPlatformAdminGrantLifecycleManagerAccessibleMixin,
     FlaskAdminPlatformMemberAccessibleMixin,
@@ -1037,3 +1046,43 @@ class PlatformAdminDataAnalysisView(FlaskAdminPlatformAdminDataAnalystAccessible
             as_attachment=True,
             download_name="certification-events.csv",
         )
+
+
+class PlatformAdminDeveloperToolsView(FlaskAdminPlatformAdminAccessibleMixin, BaseView):
+    @expose("/", methods=["GET", "POST"])
+    def index(self) -> Any:
+        current_levels = get_tracing_levels()
+        form = PlatformAdminForceTracingForm(levels=[level.value for level in current_levels])
+
+        if form.validate_on_submit():
+            selected = [TraceLevelEnum(value) for value in (form.levels.data or [])]
+            response = make_response(redirect(url_for("developer_tools.index")))
+            if selected:
+                token = encode_levels(selected, current_app.config["SECRET_KEY"])
+                response.set_cookie(
+                    REQUEST_TRACING_COOKIE_NAME,
+                    token,
+                    max_age=REQUEST_TRACING_TTL,
+                    httponly=True,
+                    secure=True,
+                    samesite="Lax",
+                )
+            else:
+                response.delete_cookie(REQUEST_TRACING_COOKIE_NAME)
+            return response
+
+        return self.render(
+            "deliver_grant_funding/admin/developer_tools.html",
+            form=form,
+            current_levels=current_levels,
+        )
+
+    @expose("/stop", methods=["POST"])
+    def stop(self) -> Any:
+        form = GenericSubmitForm()
+        if form.validate_on_submit():
+            response = make_response(redirect(url_for("developer_tools.index")))
+            response.delete_cookie(REQUEST_TRACING_COOKIE_NAME)
+            return response
+
+        return redirect(url_for("developer_tools.index"))

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/admin/developer_tools.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/admin/developer_tools.html
@@ -1,0 +1,27 @@
+{% extends "admin/master.html" %}
+{% import 'admin/layout.html' as layout with context %}
+{% from 'govuk_frontend_jinja/components/error-summary/macro.html' import govukErrorSummary %}
+
+{% block action_panel %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ layout.messages() }}
+
+      {% if form.errors %}
+        {{ govukErrorSummary(wtforms_errors(form)) }}
+      {% endif %}
+
+      <h1 class="govuk-heading-l">Developer tools</h1>
+
+      {% set levels_html %}
+        <h2 class="govuk-heading-m">{{ form.levels.label.text }}</h2>
+      {% endset %}
+
+      <form method="post" novalidate>
+        {{ form.csrf_token }}
+        {{ form.levels(params={"fieldset": {"legend": {"classes": "govuk-!-font-weight-bold", "html": levels_html} } }) }}
+        {{ form.submit }}
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/admin/mhclg_base.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/admin/mhclg_base.html
@@ -1,4 +1,5 @@
 {% extends "admin/base.html" %}
+{% from "common/partials/mhclg-test-banner.html" import mhclgRequestTracingBanner with context %}
 
 {% block pageTitle %}Admin panel - MHCLG Funding Service{% endblock %}
 
@@ -9,6 +10,7 @@
 {% endblock %}
 
 {% block headerRow %}
+  {{ mhclgRequestTracingBanner() }}
   <header class="govuk-header" data-module="govuk-header">
     <div class="govuk-header__container govuk-width-container">
       <div class="govuk-header__logo app-header__logo">

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/base.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/base.html
@@ -1,5 +1,6 @@
 {% extends "common/base.html" %}
 {% from "common/partials/mhclg-header.html" import mhclgHeader %}
+{% from "common/partials/mhclg-test-banner.html" import mhclgRequestTracingBanner with context %}
 {% from "common/macros/navigation.html" import deliverGrantFundingServiceNavigation %}
 {% from "govuk_frontend_jinja/components/footer/macro.html" import govukFooter %}
 {% from "common/macros/standard-error-summary.html" import standardErrorSummary with context %}
@@ -29,6 +30,7 @@
   {{ super() }}
 {% endblock %}
 {% block header %}
+  {{ mhclgRequestTracingBanner() }}
   {{
     mhclgHeader(
       params={

--- a/app/sentry.py
+++ b/app/sentry.py
@@ -4,17 +4,35 @@ import sentry_sdk
 from sentry_sdk.integrations.logging import LoggingIntegration, ignore_logger
 from sentry_sdk.types import Event, Hint
 
+from app.common.data.types import TraceLevelEnum
+from app.common.helpers.request_tracing import get_tracing_levels_from_environ
 from app.config import Environment
+
+_secret_key: str | None = None
 
 
 def errors_sampler(event: Event, sampling_context: Hint) -> float:
     return float(os.getenv("SENTRY_ERRORS_SAMPLE_RATE", "1"))
 
 
+def _tracing_levels_from_context(sampling_context: Hint) -> list[TraceLevelEnum]:
+    if not _secret_key:
+        raise ValueError("Flask application secret key not configured for sentry")
+
+    wsgi_environ = sampling_context.get("wsgi_environ")
+    if not wsgi_environ:
+        return []
+
+    return get_tracing_levels_from_environ(wsgi_environ, _secret_key)
+
+
 def traces_sampler(sampling_context: Hint) -> float:
     wsgi_environ = sampling_context.get("wsgi_environ")
     if wsgi_environ and wsgi_environ.get("PATH_INFO") == "/healthcheck":
         return 0
+
+    if TraceLevelEnum.TRACE in _tracing_levels_from_context(sampling_context):
+        return 1.0
 
     return float(os.getenv("SENTRY_TRACES_SAMPLE_RATE", "0.02"))
 
@@ -24,10 +42,17 @@ def profiles_sampler(sampling_context: Hint) -> float:
     if wsgi_environ and wsgi_environ.get("PATH_INFO") == "/healthcheck":
         return 0
 
+    if TraceLevelEnum.PROFILE in _tracing_levels_from_context(sampling_context):
+        return 1.0
+
     return float(os.getenv("SENTRY_PROFILES_SAMPLE_RATE", "0.02"))
 
 
-def init_sentry() -> None:
+def init_sentry(secret_key: str) -> None:
+    global _secret_key
+
+    _secret_key = secret_key
+
     if os.getenv("SENTRY_DSN"):
         # Assume `production` here so that we 'fail closed', ie don't send PII/etc if this is unset or set incorrectly.
         env = Environment(os.getenv("FLASK_ENV", Environment.PROD.value))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,6 @@ services:
       FLASK_APP: "stubs.sso:create_sso_stub_app"
       WERKZEUG_DEBUG_PIN: off
       ASSETS_VITE_LIVE_ENABLED: ${ASSETS_VITE_LIVE_ENABLED:-true}
-      FLASK_ENV: local
     networks:
       ofs:
         aliases:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,7 +177,8 @@ forbidden_modules = [
 env = [
     "FLASK_ENV=unit_test",
     "DATABASE_URL=postgresql+psycopg://overridden-by-fixture",
-    "PGGSSENCMODE=disable" #https://github.com/ged/ruby-pg/issues/538#issuecomment-1591629049
+    "PGGSSENCMODE=disable", #https://github.com/ged/ruby-pg/issues/538#issuecomment-1591629049
+    "SECRET_KEY=unsafe"  # pragma: allowlist secret
 ]
 markers = [
     "e2e: Run E2E (browser) tests using playwright",

--- a/tests/integration/deliver_grant_funding/admin/test_developer_tools.py
+++ b/tests/integration/deliver_grant_funding/admin/test_developer_tools.py
@@ -1,0 +1,109 @@
+import pytest
+
+from app.common.data.types import TraceLevelEnum
+from app.common.helpers.request_tracing import (
+    REQUEST_TRACING_COOKIE_NAME,
+    REQUEST_TRACING_TTL,
+    decode_levels,
+    encode_levels,
+)
+from app.common.utils import uppercase_first
+
+
+def _set_cookie_to_levels(client, app, levels: list[TraceLevelEnum]) -> None:
+    token = encode_levels(levels, app.config["SECRET_KEY"])
+    client.set_cookie(REQUEST_TRACING_COOKIE_NAME, token, domain="funding.communities.gov.localhost", max_age=900)
+
+
+def _force_trace_cookie_from_response(response) -> str:
+    return next(h for h in response.headers.getlist("Set-Cookie") if h.startswith(f"{REQUEST_TRACING_COOKIE_NAME}="))
+
+
+def _is_deleted_cookie(cookie: str) -> bool:
+    return "Max-Age=0" in cookie or "Expires=Thu, 01 Jan 1970" in cookie
+
+
+class TestDeveloperToolsAdminAccess:
+    @pytest.mark.parametrize(
+        "client_fixture, expected_code",
+        [
+            ("authenticated_platform_admin_client", 200),
+            ("authenticated_platform_grant_lifecycle_manager_client", 403),
+            ("authenticated_platform_data_analyst_client", 403),
+            ("authenticated_platform_member_client", 403),
+            ("authenticated_grant_admin_client", 403),
+            ("authenticated_grant_member_client", 403),
+            ("authenticated_no_role_client", 403),
+            ("anonymous_client", 302),
+        ],
+    )
+    def test_developer_tools_page_access(self, client_fixture, expected_code, request):
+        client = request.getfixturevalue(client_fixture)
+        response = client.get("/deliver/admin/developer-tools/")
+        assert response.status_code == expected_code
+
+
+class TestDeveloperToolsAdminPage:
+    def test_get_renders_form_with_a_choice_per_tracing_level(self, authenticated_platform_admin_client):
+        response = authenticated_platform_admin_client.get("/deliver/admin/developer-tools/")
+        assert response.status_code == 200
+        assert "Developer tools" in response.text
+        assert "Request tracing" in response.text
+        for level in TraceLevelEnum:
+            assert uppercase_first(level.value) in response.text
+
+    def test_post_with_levels_sets_signed_cookie_with_full_ttl(self, authenticated_platform_admin_client, app):
+        selected_levels = {TraceLevelEnum.TRACE, TraceLevelEnum.PROFILE}
+        response = authenticated_platform_admin_client.post(
+            "/deliver/admin/developer-tools/",
+            data={"levels": sorted(level.value for level in selected_levels)},
+        )
+        assert response.status_code == 302
+
+        cookie = _force_trace_cookie_from_response(response)
+        assert f"Max-Age={REQUEST_TRACING_TTL}" in cookie
+
+        token = cookie.split("=", 1)[1].split(";", 1)[0]
+        assert set(decode_levels(token, app.config["SECRET_KEY"])) == selected_levels
+
+    def test_post_with_no_levels_deletes_cookie(self, authenticated_platform_admin_client):
+        response = authenticated_platform_admin_client.post("/deliver/admin/developer-tools/", data={"levels": []})
+        assert response.status_code == 302
+        cookie = _force_trace_cookie_from_response(response)
+        assert "Max-Age=0" in cookie or "Expires=Thu, 01 Jan 1970" in cookie
+
+    def test_stop_endpoint_deletes_cookie(self, authenticated_platform_admin_client, app):
+        _set_cookie_to_levels(authenticated_platform_admin_client, app, [TraceLevelEnum.TRACE])
+        response = authenticated_platform_admin_client.post("/deliver/admin/developer-tools/stop")
+        assert response.status_code == 302
+        cookie = _force_trace_cookie_from_response(response)
+        assert "Max-Age=0" in cookie or "Expires=Thu, 01 Jan 1970" in cookie
+
+
+class TestRequestTracingBanner:
+    @pytest.mark.freeze_time("2026-01-01 12:00:00")
+    def test_banner_appears_when_cookie_set(self, authenticated_platform_admin_client, app):
+        _set_cookie_to_levels(authenticated_platform_admin_client, app, [TraceLevelEnum.TRACE])
+        response = authenticated_platform_admin_client.get("/deliver/grants")
+        assert response.status_code == 200
+        assert "Stop tracing" in response.text
+        assert ": sentry tracing" in response.text
+
+    @pytest.mark.freeze_time("2026-01-01 12:00:00")
+    def test_banner_lists_all_enabled_levels_comma_separated(self, authenticated_platform_admin_client, app):
+        _set_cookie_to_levels(authenticated_platform_admin_client, app, [TraceLevelEnum.TRACE, TraceLevelEnum.PROFILE])
+        response = authenticated_platform_admin_client.get("/deliver/grants")
+        expected_label = ": sentry tracing, sentry profiling"
+        assert expected_label in response.text
+
+    @pytest.mark.freeze_time("2026-01-01 12:00:00")
+    def test_banner_shows_time_remaining_until_cookie_expiry(self, authenticated_platform_admin_client, app):
+        _set_cookie_to_levels(authenticated_platform_admin_client, app, [TraceLevelEnum.TRACE])
+        response = authenticated_platform_admin_client.get("/deliver/grants")
+        assert "enabled for 15m 00s" in response.text
+
+    @pytest.mark.freeze_time("2026-01-01 12:00:00")
+    def test_banner_absent_when_no_cookie(self, authenticated_platform_admin_client):
+        response = authenticated_platform_admin_client.get("/deliver/grants")
+        assert response.status_code == 200
+        assert "Stop tracing" not in response.text

--- a/tests/unit/common/helpers/test_request_tracing.py
+++ b/tests/unit/common/helpers/test_request_tracing.py
@@ -1,0 +1,69 @@
+from app.common.data.types import TraceLevelEnum
+from app.common.helpers.request_tracing import (
+    REQUEST_TRACING_COOKIE_NAME,
+    REQUEST_TRACING_TTL,
+    decode_levels,
+    encode_levels,
+    get_tracing_levels_from_environ,
+)
+
+
+class TestEncodeAndDecodeLevels:
+    def test_round_trip_single_level(self):
+        token = encode_levels([TraceLevelEnum.TRACE], "secret")
+        assert decode_levels(token, "secret") == [TraceLevelEnum.TRACE]
+
+    def test_empty_round_trips_to_empty_list(self):
+        token = encode_levels([], "secret")
+        assert decode_levels(token, "secret") == []
+
+    def test_wrong_secret_returns_empty_list(self):
+        token = encode_levels([TraceLevelEnum.TRACE], "secret")
+        assert decode_levels(token, "different-secret") == []
+
+    def test_tampered_token_returns_empty_list(self):
+        token = encode_levels([TraceLevelEnum.TRACE], "secret")
+        tampered = token[:-1] + ("a" if token[-1] != "a" else "b")
+        assert decode_levels(tampered, "secret") == []
+
+    def test_malformed_token_returns_empty_list(self):
+        assert decode_levels("not-a-real-token", "secret") == []
+
+    def test_expired_token_returns_empty_list(self, monkeypatch):
+        import itsdangerous.timed as itsdangerous_timed
+
+        signing_time = 1_735_732_800  # Jan 1 2025 noon
+        monkeypatch.setattr(itsdangerous_timed.time, "time", lambda: signing_time)
+        token = encode_levels([TraceLevelEnum.TRACE], "secret")
+
+        monkeypatch.setattr(itsdangerous_timed.time, "time", lambda: signing_time + REQUEST_TRACING_TTL + 1)
+        assert decode_levels(token, "secret") == []
+
+    def test_token_just_inside_ttl_still_valid(self, monkeypatch):
+        import itsdangerous.timed as itsdangerous_timed
+
+        signing_time = 1_735_732_800  # Jan 1 2025 noon
+        monkeypatch.setattr(itsdangerous_timed.time, "time", lambda: signing_time)
+        token = encode_levels([TraceLevelEnum.TRACE], "secret")
+
+        monkeypatch.setattr(itsdangerous_timed.time, "time", lambda: signing_time + REQUEST_TRACING_TTL - 1)
+        assert decode_levels(token, "secret") == [TraceLevelEnum.TRACE]
+
+
+class TestGetTracingLevelsFromEnviron:
+    def test_returns_empty_list_when_no_cookie_header(self):
+        assert get_tracing_levels_from_environ({}, "secret") == []
+
+    def test_returns_empty_list_when_tracing_cookie_missing(self):
+        environ = {"HTTP_COOKIE": "session=abc; other=xyz"}
+        assert get_tracing_levels_from_environ(environ, "secret") == []
+
+    def test_extracts_levels_from_cookie_header(self):
+        token = encode_levels([TraceLevelEnum.TRACE, TraceLevelEnum.PROFILE], "secret")
+        environ = {"HTTP_COOKIE": f"session=abc; {REQUEST_TRACING_COOKIE_NAME}={token}; other=xyz"}
+        assert get_tracing_levels_from_environ(environ, "secret") == [TraceLevelEnum.TRACE, TraceLevelEnum.PROFILE]
+
+    def test_wrong_secret_returns_empty_list(self):
+        token = encode_levels([TraceLevelEnum.TRACE], "secret")
+        environ = {"HTTP_COOKIE": f"{REQUEST_TRACING_COOKIE_NAME}={token}"}
+        assert get_tracing_levels_from_environ(environ, "different-secret") == []

--- a/tests/unit/test_all_routes_access.py
+++ b/tests/unit/test_all_routes_access.py
@@ -303,6 +303,8 @@ routes_with_access_controlled_by_flask_admin = [
     "reporting_lifecycle.close_report",
     "data_analysis.index",
     "data_analysis.download_certification_events_csv",
+    "developer_tools.index",
+    "developer_tools.stop",
     "submission.action_view",
     "submission.ajax_lookup",
     "submission.ajax_update",

--- a/tests/unit/test_sentry.py
+++ b/tests/unit/test_sentry.py
@@ -1,0 +1,96 @@
+import pytest
+
+from app.common.data.types import TraceLevelEnum
+from app.common.helpers.request_tracing import REQUEST_TRACING_COOKIE_NAME, encode_levels
+from app.sentry import profiles_sampler, traces_sampler
+
+
+def _cookie_environ(secret: str, levels: list[TraceLevelEnum], path_info: str = "/anything") -> dict[str, str]:
+    token = encode_levels(levels, secret)
+    return {"PATH_INFO": path_info, "HTTP_COOKIE": f"{REQUEST_TRACING_COOKIE_NAME}={token}"}
+
+
+class TestSentry:
+    class TestTracesSampler:
+        def test_healthcheck_is_never_sampled(self, app):
+            assert traces_sampler({"wsgi_environ": {"PATH_INFO": "/healthcheck"}}) == 0
+
+        def test_default_sample_rate_when_no_environ(self, app):
+            assert traces_sampler({}) == 0.02
+
+        def test_raises_when_secret_key_not_configured(self, app, monkeypatch):
+            import app.sentry as sentry_module
+
+            monkeypatch.setattr(sentry_module, "_secret_key", None)
+            wsgi_environ = _cookie_environ(app.config["SECRET_KEY"], [TraceLevelEnum.TRACE])
+            with pytest.raises(ValueError, match="Flask application secret key not configured for sentry"):
+                traces_sampler({"wsgi_environ": wsgi_environ})
+
+        def test_default_sample_rate_when_cookie_absent(self, app):
+            assert traces_sampler({"wsgi_environ": {"PATH_INFO": "/anything"}}) == 0.02
+
+        def test_default_sample_rate_when_cookie_signed_with_wrong_secret(self, app):
+            wsgi_environ = _cookie_environ("not-the-secret", [TraceLevelEnum.TRACE])
+            assert traces_sampler({"wsgi_environ": wsgi_environ}) == 0.02
+
+        def test_default_sample_rate_when_cookie_only_has_profile_level(self, app):
+            wsgi_environ = _cookie_environ(app.config["SECRET_KEY"], [TraceLevelEnum.PROFILE])
+            assert traces_sampler({"wsgi_environ": wsgi_environ}) == 0.02
+
+        def test_default_sample_rate_when_cookie_only_has_debug_logging_level(self, app):
+            wsgi_environ = _cookie_environ(app.config["SECRET_KEY"], [TraceLevelEnum.DEBUG_LOGGING])
+            assert traces_sampler({"wsgi_environ": wsgi_environ}) == 0.02
+
+        def test_force_sampled_when_cookie_has_trace_level(self, app):
+            wsgi_environ = _cookie_environ(app.config["SECRET_KEY"], [TraceLevelEnum.TRACE])
+            assert traces_sampler({"wsgi_environ": wsgi_environ}) == 1.0
+
+        def test_force_sampled_when_cookie_has_all_levels(self, app):
+            wsgi_environ = _cookie_environ(app.config["SECRET_KEY"], list(TraceLevelEnum))
+            assert traces_sampler({"wsgi_environ": wsgi_environ}) == 1.0
+
+        def test_healthcheck_takes_precedence_over_trace_cookie(self, app):
+            wsgi_environ = _cookie_environ(app.config["SECRET_KEY"], [TraceLevelEnum.TRACE], path_info="/healthcheck")
+            assert traces_sampler({"wsgi_environ": wsgi_environ}) == 0
+
+    class TestProfilesSampler:
+        def test_healthcheck_is_never_sampled(self, app):
+            assert profiles_sampler({"wsgi_environ": {"PATH_INFO": "/healthcheck"}}) == 0
+
+        def test_default_sample_rate_when_no_environ(self, app):
+            assert profiles_sampler({}) == 0.02
+
+        def test_raises_when_secret_key_not_configured(self, app, monkeypatch):
+            import app.sentry as sentry_module
+
+            monkeypatch.setattr(sentry_module, "_secret_key", None)
+            wsgi_environ = _cookie_environ(app.config["SECRET_KEY"], [TraceLevelEnum.PROFILE])
+            with pytest.raises(ValueError, match="Flask application secret key not configured for sentry"):
+                profiles_sampler({"wsgi_environ": wsgi_environ})
+
+        def test_default_sample_rate_when_cookie_absent(self, app):
+            assert profiles_sampler({"wsgi_environ": {"PATH_INFO": "/anything"}}) == 0.02
+
+        def test_default_sample_rate_when_cookie_signed_with_wrong_secret(self, app):
+            wsgi_environ = _cookie_environ("not-the-secret", [TraceLevelEnum.PROFILE])
+            assert profiles_sampler({"wsgi_environ": wsgi_environ}) == 0.02
+
+        def test_default_sample_rate_when_cookie_only_has_trace_level(self, app):
+            wsgi_environ = _cookie_environ(app.config["SECRET_KEY"], [TraceLevelEnum.TRACE])
+            assert profiles_sampler({"wsgi_environ": wsgi_environ}) == 0.02
+
+        def test_default_sample_rate_when_cookie_only_has_debug_logging_level(self, app):
+            wsgi_environ = _cookie_environ(app.config["SECRET_KEY"], [TraceLevelEnum.DEBUG_LOGGING])
+            assert profiles_sampler({"wsgi_environ": wsgi_environ}) == 0.02
+
+        def test_force_sampled_when_cookie_has_profile_level(self, app):
+            wsgi_environ = _cookie_environ(app.config["SECRET_KEY"], [TraceLevelEnum.PROFILE])
+            assert profiles_sampler({"wsgi_environ": wsgi_environ}) == 1.0
+
+        def test_force_sampled_when_cookie_has_all_levels(self, app):
+            wsgi_environ = _cookie_environ(app.config["SECRET_KEY"], list(TraceLevelEnum))
+            assert profiles_sampler({"wsgi_environ": wsgi_environ}) == 1.0
+
+        def test_healthcheck_takes_precedence_over_trace_cookie(self, app):
+            wsgi_environ = _cookie_environ(app.config["SECRET_KEY"], [TraceLevelEnum.PROFILE], path_info="/healthcheck")
+            assert profiles_sampler({"wsgi_environ": wsgi_environ}) == 0


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
Adds a platform admin developer tools page to toggle request tracing on. This emits more detailed information to Sentry to help debug slow page loads or trace what's happening under the hood.

We could use this to enable debug logging per request or toggle sentry profiling on for even more information. But this is left to the future for now.

## 📸 Show the thing (screenshots, gifs)
<img width="1312" height="935" alt="image" src="https://github.com/user-attachments/assets/a3bb066d-9f7b-4d6e-b539-dc68639435ca" />

<img width="1285" height="954" alt="image" src="https://github.com/user-attachments/assets/34c15e8a-2371-4089-b695-dc83e47596ea" />

<img width="1024" height="874" alt="image" src="https://github.com/user-attachments/assets/0f2f8695-ea46-41c9-b5dc-272e4c1f77e2" />

## 🧪 Testing
- Enable sentry DSN locally
- Check that most requests are not traced by default (2% trace defaults): https://communitiesuk.sentry.io/explore/traces/?environment=local&project=4511038202445904&statsPeriod=5m
- Use the new platform admin page to enable sentry tracing for 15 mins.
- Visit a few pages and see your requests get traced: https://communitiesuk.sentry.io/explore/traces/?environment=local&project=4511038202445904&statsPeriod=5m

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [ ] End-to-end tests have been updated (if applicable)
- [ ] Edge cases and error conditions are tested