### PR TITLE
FSPT-1347: Add data set ref to group validation error

### DIFF
--- a/app/common/collections/forms.py
+++ b/app/common/collections/forms.py
@@ -77,10 +77,21 @@ class ErrorListEntry:
 
 
 @dataclass
+class DataSetReferenceEntry:
+    column_name: str
+    value: str
+
+    @property
+    def error_message(self) -> str:
+        return f"{self.column_name} ({self.value})"
+
+
+@dataclass
 class GroupValidationError:
     message: str
     on_page_entries: list[ErrorListEntry] = dataclass_field(default_factory=list)
     off_page_entries: list[ErrorListEntry] = dataclass_field(default_factory=list)
+    data_set_entries: list[DataSetReferenceEntry] = dataclass_field(default_factory=list)
 
 
 # FIXME: Ideally this would do an intersection between FlaskForm and QuestionFormProtocol, but type hinting in
@@ -258,6 +269,33 @@ class DynamicQuestionForm(FlaskForm):
                     input_href=f"#{referenced_question.safe_qid}",
                 )
                 error.off_page_entries.append(error_entry)
+
+        for reference in validation.component_references:
+            data_source = reference.depends_on_data_source
+            column_name = reference.depends_on_column_name
+
+            if not (data_source and column_name):
+                continue
+            if not data_source.schema or not (column := data_source.schema.root.get(column_name)):
+                raise ValueError(
+                    f"ComponentReference {reference.id} in validation {validation.id} points to column {column_name} "
+                    f"on data source {data_source.id} but column does not exist in the schema."
+                )
+
+            assert self._submission_helper is not None
+            data_source_org_item = data_source.get_filtered_organisation_item(
+                self._submission_helper.submission.grant_recipient.organisation.external_id
+            )
+            assert data_source_org_item is not None and isinstance(data_source_org_item.data, dict)
+            org_item_column_value = data_source_org_item.data.get(column_name)
+            assert org_item_column_value is not None
+
+            error.data_set_entries.append(
+                DataSetReferenceEntry(
+                    column_name=column.original_column_name,
+                    value=org_item_column_value.get_value_for_text_export(),
+                )
+            )
 
         return error
 

--- a/app/common/templates/common/macros/ask-a-question-error-summary.html
+++ b/app/common/templates/common/macros/ask-a-question-error-summary.html
@@ -29,6 +29,15 @@
                   {% endfor %}
                 </ul>
               {% endif %}
+
+              {% if form.group_validation_error.data_set_entries %}
+                <p class="govuk-body">Other information referenced:</p>
+                <ul class="govuk-list govuk-error-summary__list govuk-list--bullet">
+                  {% for entry in form.group_validation_error.data_set_entries %}
+                    <li>{{ entry.error_message }}</li>
+                  {% endfor %}
+                </ul>
+              {% endif %}
             </div>
           </div>
         </div>

--- a/tests/integration/deliver_grant_funding/routes/test_runner.py
+++ b/tests/integration/deliver_grant_funding/routes/test_runner.py
@@ -8,8 +8,13 @@ from flask import url_for
 from app.common.collections.types import FileUploadAnswer, IntegerAnswer, TextSingleLineAnswer, YesNoAnswer
 from app.common.data.interfaces.collections import add_component_validation
 from app.common.data.types import (
+    DataSourceSchema,
+    DataSourceSchemaColumn,
+    DataSourceType,
     ExpressionType,
     ManagedExpressionsEnum,
+    NumberTypeEnum,
+    QuestionDataOptions,
     QuestionDataType,
     QuestionPresentationOptions,
     SubmissionModeEnum,
@@ -912,15 +917,44 @@ class TestGroupValidation:
     ):
         client = authenticated_grant_admin_client
         group, capital, revenue = self._make_same_page_group_with_two_numbers(factories, client.grant)
+        organisation = factories.organisation.create()
+        grant_recipient = factories.grant_recipient.create(grant=client.grant, organisation=organisation)
+
+        data_source = factories.data_source.create(
+            name="Allocations",
+            grant=client.grant,
+            collection=group.form.collection,
+            type=DataSourceType.GRANT_RECIPIENT,
+            schema=DataSourceSchema.model_validate(
+                {
+                    "c_allocation": DataSourceSchemaColumn(
+                        data_type=QuestionDataType.NUMBER,
+                        presentation_options=QuestionPresentationOptions(prefix="£"),
+                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
+                        original_column_name="Capital Allocation",
+                    )
+                }
+            ),
+        )
+        factories.data_source_organisation_item.create(
+            data_source=data_source,
+            external_id=organisation.external_id,
+            _data={"c_allocation": 1000},
+        )
+
         add_component_validation(
             group,
             client.user,
             CustomExpression(
-                custom_expression=f"(({capital.safe_qid})) + (({revenue.safe_qid})) == 1000",
+                custom_expression=(
+                    f"(({capital.safe_qid})) + (({revenue.safe_qid})) == (({data_source.safe_did}.c_allocation))"
+                ),
                 custom_message="Capital plus revenue must equal 1000",
             ),
         )
-        submission = factories.submission.create(collection=group.form.collection, created_by=client.user)
+        submission = factories.submission.create(
+            collection=group.form.collection, created_by=client.user, grant_recipient=grant_recipient
+        )
 
         response = client.post(
             url_for(
@@ -942,6 +976,9 @@ class TestGroupValidation:
         assert "Capital plus revenue must equal 1000" in error_summary.text
         assert "On this page:" in error_summary.text
         assert "On a different page:" not in error_summary.text
+        assert "Other information referenced:" in error_summary.text
+        assert "Capital Allocation" in error_summary.text
+        assert "£1,000" in error_summary.text
 
         on_page_links = error_summary.find_all("a")
         on_page_link_texts = [a.text.strip() for a in on_page_links]


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-1347

## 📝 Description
The original designs for the group validation errors included a mention of data sets if a data set reference was part of the custom expression. The group validation error was built before the data set referencing work was completed so this was never included.

This adds it in, checking for data set references when building the group validation error message and including these at the end of the error summary in the structure specified in the designs.

## 📸 Show the thing (screenshots, gifs)
<!-- Include screenshots for UI changes, new features, or visual modifications -->
<!-- Use "Before" and "After" sections if showing changes to existing functionality -->

### Validation set up
<img width="556" height="606" alt="image" src="https://github.com/user-attachments/assets/b414e09f-1f2f-42e7-9741-0262b4c5ec98" />

### Before
<img width="637" height="820" alt="image" src="https://github.com/user-attachments/assets/36427e53-d284-4a0d-a3ee-b6c0d6885217" />

### After
<img width="837" height="1073" alt="image" src="https://github.com/user-attachments/assets/d01cb40c-2f72-460b-8eba-c977aa31b894" />


## 🧪 Testing
Set up group validation which includes data set references. On the branch, triggering the validation error should include a mention of the referenced column name and the relevant value.

## 📋 Developer Checklist

### Review Readiness
- [X] PR title and description provide sufficient context for reviewers
- [X] Commits are logical, self-contained, and have clear descriptions

### Testing
- [X] I have tested this change and it meets the acceptance criteria for the ticket
- [X] I need the reviewer(s) to pull and run this change locally
- [X] New (non-developer) functionality has appropriate unit and integration tests
- ~[ ] End-to-end tests have been updated (if applicable)~
- [X] Edge cases and error conditions are tested