### PR TITLE
Raise when deleting depended-upon section

### DIFF
--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -827,6 +827,50 @@ class DependencyOrderException(WTFormRenderableException, FlashableException):
         }
 
 
+class SectionComponentDependencyException(Exception, FlashableException):
+    def __init__(self, message: str, form: Form, component_references: list[ComponentReference]):
+        super().__init__(message)
+        self.message = message
+        self.form = form
+        self.component_references = component_references
+
+    def as_flash_context(self) -> dict[str, Any]:
+        seen_keys: set[tuple[UUID, str]] = set()
+        references: list[dict[str, Any]] = []
+        for ref in self.component_references:
+            component = ref.component
+            if ref.expression is not None:
+                reference_type = "validation" if ref.expression.type_ == ExpressionType.VALIDATION else "condition"
+            else:
+                reference_type = "group" if component.is_group else "question"
+
+            key = (component.id, reference_type)
+            if key in seen_keys:
+                continue
+            seen_keys.add(key)
+
+            references.append(
+                {
+                    "reference_type": reference_type,
+                    "component_id": str(component.id),
+                    "component_text": component.text or "",
+                    "is_group": component.is_group,
+                    "section_id": str(component.form_id),
+                    "section_title": component.form.title,
+                }
+            )
+
+        return {
+            "message": self.message,
+            "grant_id": str(self.form.collection.grant_id),  # Required for URL routing
+            "form_id": str(self.form.id),
+            "form_title": self.form.title,
+            "references": sorted(
+                references, key=lambda r: (r["section_title"], r["component_text"], r["reference_type"])
+            ),
+        }
+
+
 class SectionDependencyOrderException(Exception, FlashableException):
     def __init__(self, message: str, form: Form, depends_on_form: Form):
         super().__init__(message)
@@ -1115,9 +1159,11 @@ def is_component_dependency_order_valid(component: Component, depends_on_compone
     return form.cached_all_components.index(component) > form.cached_all_components.index(depends_on_component)
 
 
-def raise_if_question_has_any_dependencies(question: Question | Group) -> Never | None:
+def raise_if_component_or_section_has_any_dependencies(component_or_form: Question | Group | Form) -> Never | None:
     child_components_ids = [
-        c.id for c in [question] + (question.cached_all_components if isinstance(question, Group) else [])
+        c.id
+        for c in [component_or_form]
+        + (component_or_form.cached_all_components if isinstance(component_or_form, (Group, Form)) else [])
     ]
     # Only consider references whose dependent component is *outside* the subtree being deleted.
     # Internal references (e.g. a group validation that references its own child questions) will be
@@ -1129,10 +1175,18 @@ def raise_if_question_has_any_dependencies(question: Question | Group) -> Never 
         .all()
     )
     if component_reference:
+        if isinstance(component_or_form, Form):
+            raise SectionComponentDependencyException(
+                f"You cannot delete {component_or_form.title} because it is being referenced in another "
+                f"section's questions",
+                component_or_form,
+                component_reference,
+            )
+
         raise DependencyOrderException(
-            f"{question.id} cannot be deleted as it is depended on by {component_reference[0].component.id}",
+            f"{component_or_form.id} cannot be deleted as it is depended on by {component_reference[0].component.id}",
             component_reference[0].component,
-            question,  # TODO: this could be component_reference[0].depends_on_component?
+            component_or_form,  # TODO: this could be component_reference[0].depends_on_component?
             form_error_message="You cannot delete an answer that other questions depend on",
         )
 
@@ -1997,7 +2051,7 @@ def delete_form(form: Form) -> None:
 
 @flush_and_rollback_on_exceptions
 def delete_question(question: Question | Group) -> None:
-    raise_if_question_has_any_dependencies(question)
+    raise_if_component_or_section_has_any_dependencies(question)
     if question.data_source and question.data_source.type == DataSourceType.CUSTOM:
         db.session.delete(question.data_source)
     db.session.delete(question)

--- a/app/deliver_grant_funding/routes/reports.py
+++ b/app/deliver_grant_funding/routes/reports.py
@@ -29,6 +29,7 @@ from app.common.data.interfaces.collections import (
     IncompatibleDataTypeInCalculationException,
     NestedGroupDisplayTypeSamePageException,
     NestedGroupException,
+    SectionComponentDependencyException,
     SectionDependencyOrderException,
     create_collection,
     create_form,
@@ -48,9 +49,9 @@ from app.common.data.interfaces.collections import (
     move_component_up,
     move_form_down,
     move_form_up,
+    raise_if_component_or_section_has_any_dependencies,
     raise_if_data_source_has_references,
     raise_if_nested_group_creation_not_valid_here,
-    raise_if_question_has_any_dependencies,
     remove_question_expression,
     reset_all_test_submissions,
     reset_test_submission,
@@ -835,15 +836,28 @@ def list_section_questions(grant_id: UUID, form_id: UUID) -> ResponseReturnValue
             abort(403)
 
         if delete_wtform.validate_on_submit():
-            delete_form(db_form)
+            try:
+                raise_if_component_or_section_has_any_dependencies(db_form)
 
-            return redirect(
-                url_for(
-                    "deliver_grant_funding.list_report_sections",
-                    grant_id=grant_id,
-                    report_id=db_form.collection_id,
+                delete_form(db_form)
+
+                return redirect(
+                    url_for(
+                        "deliver_grant_funding.list_report_sections",
+                        grant_id=grant_id,
+                        report_id=db_form.collection_id,
+                    )
                 )
-            )
+
+            except SectionComponentDependencyException as e:
+                flash(e.as_flash_context(), FlashMessageType.SECTION_COMPONENT_DEPENDENCY_ERROR.value)  # type:ignore [arg-type]
+                return redirect(
+                    url_for(
+                        "deliver_grant_funding.list_section_questions",
+                        grant_id=grant_id,
+                        form_id=form_id,
+                    )
+                )
 
     return render_template(
         "deliver_grant_funding/reports/list_section_questions.html",
@@ -869,7 +883,7 @@ def list_group_questions(grant_id: UUID, group_id: UUID) -> ResponseReturnValue:
             return redirect(url_for("deliver_grant_funding.list_group_questions", grant_id=grant_id, group_id=group_id))
 
         try:
-            raise_if_question_has_any_dependencies(group)
+            raise_if_component_or_section_has_any_dependencies(group)
             if delete_wtform.validate_on_submit() and delete_wtform.confirm_deletion.data:
                 delete_question(group)
                 if group.parent and group.parent.is_group:
@@ -1870,7 +1884,7 @@ def edit_question(grant_id: UUID, question_id: UUID) -> ResponseReturnValue:  # 
     confirm_deletion_form = GenericConfirmDeletionForm()
     if "delete" in request.args:
         try:
-            raise_if_question_has_any_dependencies(question)
+            raise_if_component_or_section_has_any_dependencies(question)
 
             if confirm_deletion_form.validate_on_submit() and confirm_deletion_form.confirm_deletion.data:
                 delete_question(question)

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/macros/dependency_banner.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/macros/dependency_banner.html
@@ -42,3 +42,24 @@
 
   {{ govukNotificationBanner(params={"role": "alert", "titleText": "Error", "classes": "app-notification-banner--destructive", "html": banner_html}) }}
 {% endmacro %}
+
+{% macro section_component_dependency_banner(error, interpolate) %}
+  {% set banner_html %}
+    <p class="govuk-body govuk-!-font-weight-bold">{{ error.message }}:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      {% for ref in error.references %}
+        {% set component_link = url_for("deliver_grant_funding.edit_question", grant_id=error.grant_id, question_id=ref.component_id) if not ref.is_group else url_for("deliver_grant_funding.list_group_questions", grant_id=error.grant_id, group_id=ref.component_id) %}
+        {% set section_link = url_for("deliver_grant_funding.list_section_questions", grant_id=error.grant_id, form_id=ref.section_id) %}
+        <li class="govuk-body govuk-!-font-weight-bold">
+          {% if ref.reference_type in ("validation", "condition") %}{{ ref.reference_type | uppercase_first }} for{% endif %}
+          <a class="govuk-notification-banner__link" href="{{ component_link }}">{{ interpolate(ref.component_text) }}</a>
+          in
+          <a class="govuk-notification-banner__link" href="{{ section_link }}">{{ ref.section_title }}</a>
+        </li>
+      {% endfor %}
+    </ul>
+    <p class="govuk-body govuk-!-font-weight-bold">Delete the other section references to delete this section.</p>
+  {% endset %}
+
+  {{ govukNotificationBanner(params={"role": "alert", "titleText": "Error", "classes": "app-notification-banner--destructive", "html": banner_html}) }}
+{% endmacro %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_section_questions.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_section_questions.html
@@ -2,6 +2,7 @@
 {% from "deliver_grant_funding/macros/deliver_grant_funding_reports_breadcrumb.html" import deliver_grant_funding_reports_breadcrumb %}
 {% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
 {% from "deliver_grant_funding/macros/dependency_banner.html" import dependency_banner %}
+{% from "deliver_grant_funding/macros/dependency_banner.html" import section_component_dependency_banner %}
 {% from "deliver_grant_funding/macros/question_table.html" import question_table %}
 
 {% set page_title = db_form.title %}
@@ -25,6 +26,11 @@
           {{ govukNotificationBanner(params={"titleText": "Preview complete", "text": flashes[0]}) }}
         {% endif %}
         {% set errors = None %}
+      {% endwith %}
+      {% with flashes = get_flashed_messages(category_filter=[enum.flash_message_type.SECTION_COMPONENT_DEPENDENCY_ERROR.value]) %}
+        {% if flashes %}
+          {{ section_component_dependency_banner(flashes[0], interpolate=interpolate) }}
+        {% endif %}
       {% endwith %}
       {% if delete_form %}
         {% set banner_html %}

--- a/app/types.py
+++ b/app/types.py
@@ -16,6 +16,7 @@ NOT_PROVIDED = TNotProvided.token
 class FlashMessageType(StrEnum):
     DEPENDENCY_ORDER_ERROR = "dependency_order_error"
     SECTION_DEPENDENCY_ORDER_ERROR = "section_dependency_order_error"
+    SECTION_COMPONENT_DEPENDENCY_ERROR = "section_component_dependency_error"
     DATA_SOURCE_ITEM_DEPENDENCY_ERROR = "data_source_item_dependency_error"
     DATA_SOURCE_REFERENCE_ERROR = "data_source_reference_error"
     SUBMISSION_TESTING_COMPLETE = "submission_testing_complete"

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -15,6 +15,7 @@ from app.common.data.interfaces.collections import (
     IncompatibleDataTypeException,
     NestedGroupDisplayTypeSamePageException,
     NestedGroupException,
+    SectionComponentDependencyException,
     _validate_and_sync_component_references,
     _validate_and_sync_expression_references,
     _validate_reference,
@@ -46,10 +47,10 @@ from app.common.data.interfaces.collections import (
     move_component_up,
     move_form_down,
     move_form_up,
+    raise_if_component_or_section_has_any_dependencies,
     raise_if_data_source_item_reference_dependency,
     raise_if_group_questions_depend_on_each_other,
     raise_if_nested_group_creation_not_valid_here,
-    raise_if_question_has_any_dependencies,
     remove_question_expression,
     reset_all_test_submissions,
     reset_test_submission,
@@ -2597,10 +2598,10 @@ class TestDependencyExceptionHelpers:
             ],
         )
 
-        assert raise_if_question_has_any_dependencies(q2) is None
+        assert raise_if_component_or_section_has_any_dependencies(q2) is None
 
         with pytest.raises(DependencyOrderException) as e:
-            raise_if_question_has_any_dependencies(q1)
+            raise_if_component_or_section_has_any_dependencies(q1)
         assert e.value.question == q2  # ty: ignore[unresolved-attribute]
         assert e.value.depends_on_question == q1  # ty: ignore[unresolved-attribute]
 
@@ -2623,13 +2624,40 @@ class TestDependencyExceptionHelpers:
         )
 
         with pytest.raises(DependencyOrderException) as e:
-            raise_if_question_has_any_dependencies(nested_question)
+            raise_if_component_or_section_has_any_dependencies(nested_question)
 
         with pytest.raises(DependencyOrderException) as e:
-            raise_if_question_has_any_dependencies(group)
+            raise_if_component_or_section_has_any_dependencies(group)
 
         assert e.value.question == q2  # ty: ignore[unresolved-attribute]
         assert e.value.depends_on_question == group  # ty: ignore[unresolved
+
+    def test_raise_if_section_has_any_dependencies(db_session, factories):
+        collection = factories.collection.create()
+        user = factories.user.create()
+        section_with_depended_on_question = factories.form.create(collection=collection)
+        dependent_section = factories.form.create(collection=collection)
+
+        depended_on_question = factories.question.create(form=section_with_depended_on_question)
+        dependent_question = factories.question.create(
+            form=dependent_section,
+            expressions=[
+                Expression.from_evaluatable_expression(
+                    GreaterThan(
+                        subject_reference=ExpressionReference.from_question(depended_on_question), minimum_value=1000
+                    ),
+                    ExpressionType.CONDITION,
+                    user,
+                )
+            ],
+        )
+
+        assert raise_if_component_or_section_has_any_dependencies(dependent_section) is None
+
+        with pytest.raises(SectionComponentDependencyException) as e:
+            raise_if_component_or_section_has_any_dependencies(section_with_depended_on_question)
+        assert e.value.form == section_with_depended_on_question
+        assert [ref.component for ref in e.value.component_references] == [dependent_question]
 
     def test_raise_if_group_questions_depend_on_each_other(db_session, factories):
         form = factories.form.create()

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -2341,6 +2341,65 @@ class TestListSectionQuestions:
             for message in caplog.messages
         )
 
+    def test_cannot_delete_section_with_questions_depended_on_by_other_section(
+        self, authenticated_grant_admin_client, factories, db_session
+    ):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant, name="Test Report")
+        section_to_delete = factories.form.create(collection=report, title="Section being deleted")
+        dependent_section = factories.form.create(collection=report, title="Dependent section")
+
+        depended_on_question = factories.question.create(form=section_to_delete, data_type=QuestionDataType.YES_NO)
+        dependent_question = factories.question.create(
+            form=dependent_section,
+            text="Do you want a biscuit?",
+            expressions=[
+                Expression.from_evaluatable_expression(
+                    IsYes(subject_reference=ExpressionReference.from_question(depended_on_question)),
+                    ExpressionType.CONDITION,
+                    authenticated_grant_admin_client.user,
+                )
+            ],
+        )
+
+        confirm_form = GenericConfirmDeletionForm(data={"confirm_deletion": True})
+        response = authenticated_grant_admin_client.post(
+            url_for(
+                "deliver_grant_funding.list_section_questions",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                form_id=section_to_delete.id,
+                delete="",
+            ),
+            data=get_form_data(confirm_form),
+            follow_redirects=True,
+        )
+
+        assert response.status_code == 200
+        assert db_session.get(Form, section_to_delete.id) is not None
+
+        soup = BeautifulSoup(response.data, "html.parser")
+        banner = soup.select_one(".govuk-notification-banner.app-notification-banner--destructive")
+        assert banner is not None
+        banner_text = " ".join(banner.text.split())
+        assert (
+            "You cannot delete Section being deleted because it is being referenced in another section's questions"
+            in banner_text
+        )
+        assert "Condition for Do you want a biscuit? in Dependent section" in banner_text
+        assert "Delete the other section references to delete this section." in banner_text
+
+        banner_links = banner.select("a.govuk-notification-banner__link")
+        assert [link.text for link in banner_links] == ["Do you want a biscuit?", "Dependent section"]
+        assert banner_links[0].get("href") == url_for(
+            "deliver_grant_funding.edit_question",
+            grant_id=authenticated_grant_admin_client.grant.id,
+            question_id=dependent_question.id,
+        )
+        assert banner_links[1].get("href") == url_for(
+            "deliver_grant_funding.list_section_questions",
+            grant_id=authenticated_grant_admin_client.grant.id,
+            form_id=dependent_section.id,
+        )
+
     @pytest.mark.parametrize(
         "client_fixture, can_preview",
         (


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-1301

## 📝 Description
If a form designer tries to delete a section that contains questions which are depended on by questions in other sections, we currently raise a 500 from DB integrity checks.

Let's catch this nicely and render a dependency banner error instead.


## 📸 Show the thing (screenshots, gifs)
<img width="1028" height="1491" alt="image" src="https://github.com/user-attachments/assets/1fefcc73-5cb6-47c7-903e-d6fa2c557f48" />



## 🧪 Testing
<!-- Describe how you've tested this change, and how a reviewer can test it -->

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [ ] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [ ] End-to-end tests have been updated (if applicable)
- [ ] Edge cases and error conditions are tested