### PR TITLE
Collection dependency graph visibility

### DIFF
--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -53,6 +53,7 @@ from app.common.expressions.custom import CustomExpression, get_custom_expressio
 from app.common.expressions.managed import (
     get_managed_expression,
 )
+from app.common.helpers.visibility import CollectionDependencyGraph
 from app.common.safe_ids import SafeDidMixin, SafeQidMixin
 from app.common.utils import comma_join_items
 
@@ -352,6 +353,10 @@ class Collection(BaseModel):
         # TODO: link to the grants/ collection public sign up page when registered as an endpoint in Access
         # url is just a placeholder for now
         return url_for("auth.request_a_link_to_sign_in", _external=True)
+
+    @property
+    def dependency_graph(self) -> CollectionDependencyGraph:
+        return CollectionDependencyGraph(self)
 
 
 class Submission(BaseModel):

--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -4,14 +4,17 @@ import uuid
 from collections.abc import Callable, Sequence
 from datetime import datetime
 from functools import cached_property, lru_cache, partial
+from graphlib import CycleError
 from io import StringIO
 from itertools import chain
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, NamedTuple, cast
 from uuid import UUID
 
+import sentry_sdk
 from flask import current_app, url_for
 from pydantic import BaseModel as PydanticBaseModel
+from sentry_sdk.tracing import NoOpSpan
 from werkzeug.datastructures import FileStorage
 from werkzeug.utils import secure_filename
 
@@ -56,6 +59,7 @@ from app.common.data.types import (
     SubmissionModeEnum,
     SubmissionStatusEnum,
     TasklistSectionStatusEnum,
+    TraceLevelEnum,
 )
 from app.common.exceptions import SubmissionAnswerConflict
 from app.common.expressions import (
@@ -67,7 +71,9 @@ from app.common.expressions import (
     evaluate,
     interpolate,
 )
+from app.common.helpers.request_tracing import get_tracing_levels
 from app.common.helpers.submission_events import SubmissionEventHelper
+from app.common.helpers.visibility import VisibilityResolver
 from app.extensions import notification_service, s3_service
 
 if TYPE_CHECKING:
@@ -191,6 +197,18 @@ class SubmissionHelper:
             data_manager=self.submission.data_manager,
             mode="interpolation",
         )
+
+    @cached_property
+    def resolver(self) -> VisibilityResolver | None:
+        try:
+            resolver = VisibilityResolver(
+                self.collection.dependency_graph, self.cached_evaluation_context, self.submission.data_manager
+            )
+        except CycleError as e:
+            sentry_sdk.capture_exception(e)
+            return None
+
+        return resolver
 
     @property
     def submission_name(self) -> str:
@@ -345,6 +363,9 @@ class SubmissionHelper:
 
         if "cached_interpolation_context" in self.__dict__:
             del self.cached_interpolation_context
+
+        if "resolver" in self.__dict__:
+            del self.resolver
 
     def _update_submission_status(self):
         self.clear_caches()
@@ -647,9 +668,33 @@ class SubmissionHelper:
         that question's visibility. If the referenced question is HIDDEN, it will
         never be answered, so this component is also HIDDEN.
         """
-        return self._get_component_visibility_state_internal(
-            component, context, add_another_index=add_another_index, visited=None, check_undetermined=check_undetermined
-        )
+        trace_component_visibility = TraceLevelEnum.TRACE in get_tracing_levels()
+        start_span = sentry_sdk.start_span if trace_component_visibility else NoOpSpan
+
+        with start_span(op="get-component-visibility-state[old]", name=str(component.id)):
+            state = self._get_component_visibility_state_internal(
+                component,
+                context,
+                add_another_index=add_another_index,
+                visited=None,
+                check_undetermined=check_undetermined,
+            )
+
+        if self.resolver:
+            with start_span(op="get-component-visibility-state[new]", name=str(component.id)):
+                if add_another_index is not None:
+                    resolver_state = self.resolver.get_visibility_for_add_another(component, add_another_index)
+                else:
+                    resolver_state = self.resolver.get_visibility(component)
+
+            if state != resolver_state:
+                current_app.logger.error(
+                    "Old SubmissionHelper visibility mismatch with new VisibilityResolver visibility on "
+                    "%(component)s [add_another_index=%(add_another_index)s]: old=%(old)s new=%(new)s",
+                    dict(component=component.id, add_another_index=add_another_index, old=state, new=resolver_state),
+                )
+
+        return state
 
     def _check_reference_visibility(
         self,

--- a/app/common/helpers/visibility.py
+++ b/app/common/helpers/visibility.py
@@ -1,0 +1,436 @@
+from graphlib import TopologicalSorter
+from typing import TYPE_CHECKING, cast
+from uuid import UUID
+
+from app.common.data.submission_data_manager import SubmissionDataManager
+from app.common.data.types import ComponentVisibilityState, ConditionsOperator, ExpressionType
+from app.common.expressions import (
+    DisallowedExpression,
+    ExpressionContext,
+    UndefinedFunctionInExpression,
+    UndefinedOperatorInExpression,
+    UndefinedVariableInExpression,
+    evaluate,
+)
+
+if TYPE_CHECKING:
+    from app.common.data.models import Collection, Component, ComponentReference, Expression, Question
+
+
+class CollectionDependencyGraph:
+    """A directed acyclic graph of component dependencies with topological ordering.
+
+    Built from a Collection's schema (no answers involved). Components are ordered
+    such that dependencies come before dependents, enabling a single forward pass
+    to resolve visibility.
+    """
+
+    def __init__(self, collection: Collection):
+        self._components: dict[UUID, Component] = {}
+        self._dependencies: dict[UUID, set[UUID]] = {}
+        self._is_conditional_ignoring_parents: dict[UUID, bool] = {}
+        self._sorted_ids: list[UUID] = []
+        self._build(collection)
+
+    def _build(self, collection: Collection) -> None:
+
+        for form in collection.forms:
+            for component in form.cached_all_components:
+                self._components[component.id] = component
+                self._dependencies[component.id] = set()
+                self._is_conditional_ignoring_parents[component.id] = False
+
+        for component_id, component in self._components.items():
+            parent_id = component.parent_id or (component.parent.id if component.parent else None)
+            if parent_id and parent_id in self._components:
+                self._dependencies[component_id].add(parent_id)
+
+            for ref in component.owned_component_references:
+                # Only check references where the component is depending on another component; specifically here we are
+                # ignoring where a component references a data set, which won't affect dependencies within the
+                # collection itself
+                dep = ref.depends_on_component
+                dep_id = dep.id if dep else ref.depends_on_component_id
+                if not dep_id or dep_id == component_id or dep_id not in self._components:
+                    continue
+
+                # Ignore group validation - the group comes 'before' its children, but it validates the values of its
+                # children. Group validation does not affect the rendering order or dependencies of a collection in
+                # any way.
+                if component.is_group and ref.expression and ref.expression.type_ == ExpressionType.VALIDATION:
+                    continue
+
+                # Record that `component` has a dependency on `dep`
+                self._dependencies[component_id].add(dep_id)
+
+                # A helper cache to track whether this component itself specifically has some condition on it; this
+                # powers the 'Conditional' tag in Deliver.
+                self._is_conditional_ignoring_parents[component_id] = bool(
+                    self._is_conditional_ignoring_parents[component_id]
+                    or self._is_conditional_ignoring_parents[dep_id]
+                    or (ref.expression and ref.expression.type_ == ExpressionType.CONDITION)
+                )
+
+        self._topological_sort()
+
+    def _topological_sort(self) -> None:
+        sorter = TopologicalSorter(self._dependencies)
+        self._sorted_ids = list(sorter.static_order())
+
+    @property
+    def sorted_components(self) -> list[Component]:
+        return [self._components[cid] for cid in self._sorted_ids]
+
+    @property
+    def components(self) -> dict[UUID, Component]:
+        return self._components
+
+    def dependencies_of(self, component: Component) -> set[UUID]:
+        dependencies = set(self._dependencies[component.id])
+
+        return dependencies
+
+    def is_conditional_ignoring_parents(self, component: Component):
+        """
+        Returns True if this component has direct conditional requirements, either from self-owned
+        conditions or from direct component references on components that are conditional.
+
+        It does *not* check conditions on its parent chain. This is used to show the 'Conditional' tag on the
+        `list questions` page; if we checked parents then every single question inside a conditional group would show
+        the tag, which is not useful.
+
+        This returns True if the component has conditions itself, or it references a question which is itself
+        conditional.
+        """
+        return self._is_conditional_ignoring_parents[component.id]
+
+
+class VisibilityResolver:
+    """Resolves visibility for all components in a single topological pass.
+
+    Walks the topological order from the graph, evaluating each component's own
+    conditions and checking cached dependency visibility, to build a lookup table
+    of ComponentVisibilityState for every component.
+
+    A future optimisation might allow restricting the resolution of the graph to only a subset of questions so that
+    we don't analyse the full collection dependency graph when eg we only want to render a single question on the page.
+    This is left as an exercise for a future developer.
+    """
+
+    def __init__(
+        self,
+        graph: CollectionDependencyGraph,
+        context: ExpressionContext,
+        data_manager: SubmissionDataManager,
+    ):
+        self._graph = graph
+        self._context = context
+        self._data_manager = data_manager
+        self._cache: dict[UUID, ComponentVisibilityState] = {}
+        self._add_another_cache: dict[tuple[UUID, int], ComponentVisibilityState] = {}
+
+        self._resolve()
+
+    def _resolve(self) -> None:
+        container_counts: dict[UUID, int] = {}
+        for component in self._graph.sorted_components:
+            self._resolve_component(component)
+
+            container = component.add_another_container
+            if container is None:
+                continue
+
+            if container.id not in container_counts:
+                container_counts[container.id] = self._data_manager.get_count_for_add_another(container)
+
+            for index in range(container_counts[container.id]):
+                self.get_visibility_for_add_another(component.id, index)
+
+    def _resolve_component(self, component: Component) -> ComponentVisibilityState:
+        if component.id in self._cache:
+            return self._cache[component.id]
+
+        state = self._compute_visibility(component)
+        self._cache[component.id] = state
+        return state
+
+    @staticmethod
+    def _component_reference_is_skippable(component: Component, ref: ComponentReference):
+        depends_on_component = ref.depends_on_component
+
+        # Non-component references, eg data sources
+        if depends_on_component is None:
+            return True
+
+        # There is nothing to check if a component 'depends on' itself; we no longer record these in
+        # ComponentReferences, but here for extra guarantee
+        if depends_on_component.id == component.id:
+            return True
+
+        # Group validation references do not affect the group's visibility; they validate the values of other
+        # components. These are excluded from the dependency graph (see CollectionDependencyGraph._build), so the
+        # depended-on component may not be resolved yet when we resolve the group.
+        if component.is_group and ref.expression and ref.expression.type_ == ExpressionType.VALIDATION:
+            return True
+
+        # We don't check references where the depended-on thing is a child of this component; this can happen
+        # where a question group has validation on its children.
+        if depends_on_component.is_descendant_of(component):
+            return True
+
+        return False
+
+    def _compute_visibility(self, component: Component) -> ComponentVisibilityState:
+        parent_id = component.parent_id or (component.parent.id if component.parent else None)
+        if parent_id:
+            parent_state = self._cache[parent_id]
+            if parent_state != ComponentVisibilityState.VISIBLE:
+                return parent_state
+
+        ref_state = self._check_references(component)
+
+        conditions = component.conditions
+
+        # For ALL operator (or no conditions), a HIDDEN dependency means the component is definitely
+        # HIDDEN — all conditions must pass, and a condition with a HIDDEN dep can never pass.
+        # For ANY operator with conditions, we can't short-circuit: a HIDDEN dep only invalidates
+        # the conditions that reference it, while other conditions may still evaluate to True.
+        if ref_state == ComponentVisibilityState.HIDDEN:
+            if not conditions or component.conditions_operator != ConditionsOperator.ANY:
+                return ComponentVisibilityState.HIDDEN
+
+        if not conditions:
+            return ref_state  # VISIBLE or UNDETERMINED based on references
+
+        condition_result = self._evaluate_conditions(
+            component.conditions_operator, conditions, self._context, component
+        )
+
+        if condition_result == ComponentVisibilityState.HIDDEN:
+            return ComponentVisibilityState.HIDDEN
+        if condition_result == ComponentVisibilityState.UNDETERMINED:
+            return ComponentVisibilityState.UNDETERMINED
+
+        # For ALL: an unanswered ref means a condition can't be evaluated yet → UNDETERMINED.
+        # For ANY: condition evaluation already accounts for per-condition ref states, so if it
+        # returned VISIBLE, the successful condition's deps are satisfied regardless of other refs.
+        if (
+            component.conditions_operator != ConditionsOperator.ANY
+            and ref_state == ComponentVisibilityState.UNDETERMINED
+        ):
+            return ComponentVisibilityState.UNDETERMINED
+
+        return ComponentVisibilityState.VISIBLE
+
+    def _check_references(self, component: Component) -> ComponentVisibilityState:
+        result = ComponentVisibilityState.VISIBLE
+
+        for ref in component.owned_component_references:
+            dep = ref.depends_on_component
+
+            if self._component_reference_is_skippable(component, ref):
+                continue
+
+            # _component_reference_is_skipped checks that `dep` is not None
+            dep = cast("Component", dep)
+
+            if component.add_another_container:
+                # We cannot check references here for anything in an 'add another' container; that needs to use
+                # `_check_references_for_add_another` to check the correct index.
+                continue
+
+            dep_state = self._cache[dep.id]
+            if dep_state == ComponentVisibilityState.HIDDEN:
+                return ComponentVisibilityState.HIDDEN
+
+            if not dep.is_question:
+                raise RuntimeError(f"Components can only depend on questions, but got a non-question {dep.id}")
+
+            if self._data_manager.get(cast("Question", dep)) is None:
+                result = ComponentVisibilityState.UNDETERMINED
+
+        return result
+
+    def _evaluate_conditions(
+        self,
+        operator: ConditionsOperator,
+        conditions: list[Expression],
+        context: ExpressionContext,
+        component: Component,
+    ) -> ComponentVisibilityState:
+        undefined_expression_ids: set[UUID] = set()
+        undefined_resolution: ComponentVisibilityState | None = None
+        results: list[ComponentVisibilityState] = []
+
+        for condition in conditions:
+            try:
+                results.append(
+                    ComponentVisibilityState.VISIBLE
+                    if evaluate(condition, context)
+                    else ComponentVisibilityState.HIDDEN
+                )
+
+            except (
+                UndefinedVariableInExpression,
+                DisallowedExpression,
+                UndefinedFunctionInExpression,
+                UndefinedOperatorInExpression,
+            ):
+                undefined_expression_ids.add(condition.id)
+
+        if undefined_expression_ids:
+            undefined_resolution = self._resolve_undetermined(component, undefined_expression_ids)
+            results.append(undefined_resolution)
+
+        if operator not in {ConditionsOperator.ALL, ConditionsOperator.ANY}:
+            raise RuntimeError(f"Invalid conditions operator: {operator}")
+
+        aggregator = all if operator == ConditionsOperator.ALL else any
+        if aggregator(result == ComponentVisibilityState.VISIBLE for result in results):
+            return ComponentVisibilityState.VISIBLE
+
+        return undefined_resolution or ComponentVisibilityState.HIDDEN
+
+    def _resolve_undetermined(
+        self,
+        component: Component,
+        undefined_expression_ids: set[UUID],
+    ) -> ComponentVisibilityState:
+        for ref in component.owned_component_references:
+            dep = ref.depends_on_component
+
+            if self._component_reference_is_skippable(component, ref):
+                continue
+
+            # _component_reference_is_skipped checks that `dep` is not None
+            dep = cast("Component", dep)
+
+            ref_expr_id = ref.expression_id or (ref.expression.id if ref.expression else None)
+            if ref_expr_id not in undefined_expression_ids:
+                continue
+            dep_state = self._cache[dep.id]
+            if dep_state != ComponentVisibilityState.HIDDEN:
+                return ComponentVisibilityState.UNDETERMINED
+        return ComponentVisibilityState.HIDDEN
+
+    def is_visible(self, component_or_id: Component | UUID, add_another_index: int | None = None) -> bool:
+        component_id = component_or_id if isinstance(component_or_id, UUID) else component_or_id.id
+
+        if add_another_index is not None:
+            state = self.get_visibility_for_add_another(component_id, add_another_index=add_another_index)
+        else:
+            state = self.get_visibility(component_id)
+
+        return state == ComponentVisibilityState.VISIBLE
+
+    def get_visibility(self, component_or_id: Component | UUID) -> ComponentVisibilityState:
+        component_id = component_or_id if isinstance(component_or_id, UUID) else component_or_id.id
+
+        return self._cache[component_id]
+
+    def get_visibility_for_add_another(
+        self, component_or_id: Component | UUID, add_another_index: int
+    ) -> ComponentVisibilityState:
+        component_id = component_or_id if isinstance(component_or_id, UUID) else component_or_id.id
+        cache_key = (component_id, add_another_index)
+        if cache_key in self._add_another_cache:
+            return self._add_another_cache[cache_key]
+
+        component = self._graph.components.get(component_id)
+        if component is None:
+            return ComponentVisibilityState.UNDETERMINED
+
+        if not component.add_another_container:
+            state = self._cache[component_id]
+            self._add_another_cache[cache_key] = state
+            return state
+
+        add_another_context = self._context.with_add_another_context(
+            component,
+            data_manager=self._data_manager,
+            add_another_index=add_another_index,
+        )
+
+        state = self._compute_visibility_for_add_another(component, add_another_context, add_another_index)
+        self._add_another_cache[cache_key] = state
+        return state
+
+    def _get_dep_state_for_add_another(
+        self,
+        dep: Component,
+        add_another_index: int,
+    ) -> ComponentVisibilityState:
+        if dep.add_another_container:
+            return self.get_visibility_for_add_another(dep.id, add_another_index)
+        return self._cache[dep.id]
+
+    def _compute_visibility_for_add_another(
+        self,
+        component: Component,
+        context: ExpressionContext,
+        add_another_index: int,
+    ) -> ComponentVisibilityState:
+        parent_id = component.parent_id or (component.parent.id if component.parent else None)
+        parent = self._graph.components.get(parent_id) if parent_id else None
+        if parent is not None:
+            if parent.add_another_container is not None:
+                parent_state = self.get_visibility_for_add_another(parent.id, add_another_index)
+            else:
+                parent_state = self._cache[parent.id]
+            if parent_state == ComponentVisibilityState.HIDDEN:
+                return ComponentVisibilityState.HIDDEN
+
+        ref_state = self._check_references_for_add_another(component, add_another_index)
+
+        conditions = component.conditions
+
+        if ref_state == ComponentVisibilityState.HIDDEN:
+            if not conditions or component.conditions_operator != ConditionsOperator.ANY:
+                return ComponentVisibilityState.HIDDEN
+
+        if not conditions:
+            return ref_state
+
+        condition_result = self._evaluate_conditions(component.conditions_operator, conditions, context, component)
+
+        if condition_result == ComponentVisibilityState.HIDDEN:
+            return ComponentVisibilityState.HIDDEN
+        if condition_result == ComponentVisibilityState.UNDETERMINED:
+            return ComponentVisibilityState.UNDETERMINED
+
+        if (
+            component.conditions_operator != ConditionsOperator.ANY
+            and ref_state == ComponentVisibilityState.UNDETERMINED
+        ):
+            return ComponentVisibilityState.UNDETERMINED
+
+        return ComponentVisibilityState.VISIBLE
+
+    def _check_references_for_add_another(
+        self,
+        component: Component,
+        add_another_index: int,
+    ) -> ComponentVisibilityState:
+        result = ComponentVisibilityState.VISIBLE
+
+        for ref in component.owned_component_references:
+            dep = ref.depends_on_component
+
+            if self._component_reference_is_skippable(component, ref):
+                continue
+
+            # _component_reference_is_skipped checks that `dep` is not None
+            dep = cast("Component", dep)
+
+            if not dep.is_question:
+                raise RuntimeError(f"Components can only depend on questions, but got a non-question {dep.id}")
+
+            dep_state = self._get_dep_state_for_add_another(dep, add_another_index)
+            if dep_state == ComponentVisibilityState.HIDDEN:
+                return ComponentVisibilityState.HIDDEN
+
+            if dep.is_question:
+                if self._data_manager.get(cast("Question", dep), add_another_index=add_another_index) is None:
+                    result = ComponentVisibilityState.UNDETERMINED
+
+        return result

--- a/tests/unit/common/helpers/test_collections.py
+++ b/tests/unit/common/helpers/test_collections.py
@@ -777,14 +777,15 @@ class TestSubmissionHelper:
             assert helper.is_component_visible(q1, helper.cached_evaluation_context) is True
             assert helper.is_component_visible(q2, helper.cached_evaluation_context) is True
 
-        def test_is_component_visible_ignores_references_to_groups(self, factories):
+        def test_is_component_visible_doesnt_understand_references_to_groups(self, factories):
             group = factories.group.build()
             q1 = factories.question.build(form=group.form)
             q1.owned_component_references = [ComponentReference(component=q1, depends_on_component=group)]
             submission = factories.submission.build(collection=group.form.collection)
             helper = SubmissionHelper(submission)
 
-            assert helper.is_component_visible(q1, helper.cached_evaluation_context) is True
+            with pytest.raises(RuntimeError, match="Components can only depend on questions"):
+                helper.is_component_visible(q1, helper.cached_evaluation_context)
 
         def test_is_component_visible_ignores_self_references(self, factories):
             q1 = factories.question.build()

--- a/tests/unit/common/helpers/test_visibility.py
+++ b/tests/unit/common/helpers/test_visibility.py
@@ -1,0 +1,743 @@
+import uuid
+from graphlib import CycleError
+from typing import TYPE_CHECKING
+
+import pytest
+
+from app.common.collections.types import IntegerAnswer, YesNoAnswer
+from app.common.data.models import ComponentReference
+from app.common.data.types import (
+    ComponentVisibilityState,
+    ConditionsOperator,
+    ExpressionType,
+    QuestionDataType,
+)
+from app.common.helpers.collections import SubmissionHelper
+from app.common.helpers.visibility import CollectionDependencyGraph, VisibilityResolver
+from tests.models import FactoryAnswer
+
+if TYPE_CHECKING:
+    from app.common.data.models import Submission
+
+
+class TestComponentDependencyGraph:
+    def test_no_dependencies_preserves_form_order(self, factories):
+        form = factories.form.build()
+        q1 = factories.question.build(form=form, order=0)
+        q2 = factories.question.build(form=form, order=1)
+        q3 = factories.question.build(form=form, order=2)
+
+        graph = CollectionDependencyGraph(form.collection)
+
+        ids = [c.id for c in graph.sorted_components]
+        assert ids == [q1.id, q2.id, q3.id]
+
+    def test_linear_chain_dependency_order(self, factories):
+        form = factories.form.build()
+        q1 = factories.question.build(form=form, order=0)
+        q2 = factories.question.build(form=form, order=1)
+        q3 = factories.question.build(form=form, order=2)
+
+        cond_q2 = factories.expression.build(
+            question=q2, type_=ExpressionType.CONDITION, statement=f"{q1.safe_qid} == 'yes'"
+        )
+        q2.owned_component_references = [ComponentReference(component=q2, expression=cond_q2, depends_on_component=q1)]
+
+        cond_q3 = factories.expression.build(
+            question=q3, type_=ExpressionType.CONDITION, statement=f"{q2.safe_qid} == 'go'"
+        )
+        q3.owned_component_references = [ComponentReference(component=q3, expression=cond_q3, depends_on_component=q2)]
+
+        graph = CollectionDependencyGraph(form.collection)
+
+        ids = [c.id for c in graph.sorted_components]
+        assert ids.index(q1.id) < ids.index(q2.id)
+        assert ids.index(q2.id) < ids.index(q3.id)
+
+    def test_parent_child_dependency(self, factories):
+        group = factories.group.build()
+        q1 = factories.question.build(form=group.form, parent=group, order=0)
+
+        graph = CollectionDependencyGraph(group.form.collection)
+
+        ids = [c.id for c in graph.sorted_components]
+        assert ids.index(group.id) < ids.index(q1.id)
+
+    def test_diamond_dependency(self, factories):
+        form = factories.form.build()
+        q1 = factories.question.build(form=form, order=0)
+        q2 = factories.question.build(form=form, order=1)
+        q3 = factories.question.build(form=form, order=2)
+        q4 = factories.question.build(form=form, order=3)
+
+        cond_q2 = factories.expression.build(question=q2, type_=ExpressionType.CONDITION, statement="True")
+        q2.owned_component_references = [ComponentReference(component=q2, expression=cond_q2, depends_on_component=q1)]
+
+        cond_q3 = factories.expression.build(question=q3, type_=ExpressionType.CONDITION, statement="True")
+        q3.owned_component_references = [ComponentReference(component=q3, expression=cond_q3, depends_on_component=q1)]
+
+        cond_q4 = factories.expression.build(question=q4, type_=ExpressionType.CONDITION, statement="True")
+        q4.owned_component_references = [
+            ComponentReference(component=q4, expression=cond_q4, depends_on_component=q2),
+            ComponentReference(component=q4, expression=cond_q4, depends_on_component=q3),
+        ]
+
+        graph = CollectionDependencyGraph(form.collection)
+
+        ids = [c.id for c in graph.sorted_components]
+        assert ids.index(q1.id) < ids.index(q2.id)
+        assert ids.index(q1.id) < ids.index(q3.id)
+        assert ids.index(q2.id) < ids.index(q4.id)
+        assert ids.index(q3.id) < ids.index(q4.id)
+
+    def test_cycle_raises(self, factories):
+        form = factories.form.build()
+        q1 = factories.question.build(form=form, order=0)
+        q2 = factories.question.build(form=form, order=1)
+
+        cond_q1 = factories.expression.build(question=q1, type_=ExpressionType.CONDITION, statement="True")
+        q1.owned_component_references = [ComponentReference(component=q1, expression=cond_q1, depends_on_component=q2)]
+
+        cond_q2 = factories.expression.build(question=q2, type_=ExpressionType.CONDITION, statement="True")
+        q2.owned_component_references = [ComponentReference(component=q2, expression=cond_q2, depends_on_component=q1)]
+
+        with pytest.raises(CycleError):
+            CollectionDependencyGraph(form.collection)
+
+    def test_cross_form_dependencies(self, factories):
+        collection = factories.collection.build()
+        form1 = factories.form.build(collection=collection, order=0)
+        form2 = factories.form.build(collection=collection, order=1)
+        q1 = factories.question.build(form=form1, order=0)
+        q2 = factories.question.build(form=form2, order=0)
+
+        cond_q2 = factories.expression.build(question=q2, type_=ExpressionType.CONDITION, statement="True")
+        q2.owned_component_references = [ComponentReference(component=q2, expression=cond_q2, depends_on_component=q1)]
+
+        graph = CollectionDependencyGraph(collection)
+
+        ids = [c.id for c in graph.sorted_components]
+        assert ids.index(q1.id) < ids.index(q2.id)
+
+    def test_group_validation_referencing_child_is_not_a_dependency(self, factories):
+        group = factories.group.build()
+        q1 = factories.question.build(form=group.form, parent=group, order=0)
+
+        group_validation = factories.expression.build(
+            question=group, type_=ExpressionType.VALIDATION, statement=f"{q1.safe_qid} > 0"
+        )
+        group.owned_component_references = [
+            ComponentReference(component=group, expression=group_validation, depends_on_component=q1)
+        ]
+
+        graph = CollectionDependencyGraph(group.form.collection)
+
+        ids = [c.id for c in graph.sorted_components]
+        assert ids.index(group.id) < ids.index(q1.id)
+        assert q1.id not in graph.dependencies_of(group)
+
+    def test_is_conditional_ignoring_parents(self, factories):
+        form = factories.form.build()
+        q1, q2, q3 = factories.question.build_batch(3, form=form)
+        g1 = factories.group.build(form=form)
+        q4, q5 = factories.question.build_batch(2, form=form, parent=g1)
+
+        cond_q2 = factories.expression.build(question=q2, type_=ExpressionType.CONDITION, statement="True")
+        q2.owned_component_references = [ComponentReference(component=q2, expression=cond_q2, depends_on_component=q1)]
+
+        cond_q3 = factories.expression.build(question=q3, type_=ExpressionType.CONDITION, statement="True")
+        q3.owned_component_references = [ComponentReference(component=q3, expression=cond_q3, depends_on_component=q2)]
+
+        cond_g1 = factories.expression.build(question=g1, type_=ExpressionType.CONDITION, statement="True")
+        g1.owned_component_references = [ComponentReference(component=g1, expression=cond_g1, depends_on_component=q2)]
+
+        cond_q5 = factories.expression.build(question=q5, type_=ExpressionType.CONDITION, statement="True")
+        q5.owned_component_references = [ComponentReference(component=q5, expression=cond_q5, depends_on_component=q4)]
+
+        graph = CollectionDependencyGraph(form.collection)
+
+        assert graph.is_conditional_ignoring_parents(q1) is False
+        assert graph.is_conditional_ignoring_parents(q2) is True
+        assert graph.is_conditional_ignoring_parents(q3) is True
+        assert graph.is_conditional_ignoring_parents(g1) is True
+        assert graph.is_conditional_ignoring_parents(q4) is False
+        assert graph.is_conditional_ignoring_parents(q5) is True
+
+
+class TestVisibilityResolver:
+    @staticmethod
+    def _get_resolver(submission: "Submission") -> VisibilityResolver:
+        dependency_graph = CollectionDependencyGraph(submission.collection)
+        helper = SubmissionHelper(submission)
+        context = helper.cached_evaluation_context
+        data_manager = submission.data_manager
+        resolver = VisibilityResolver(dependency_graph, context, data_manager)
+        return resolver
+
+    def test_no_conditions_all_visible(self, factories):
+        form = factories.form.build()
+        q1 = factories.question.build(form=form, order=0)
+        q2 = factories.question.build(form=form, order=1)
+        submission = factories.submission.build(collection=form.collection)
+        resolver = TestVisibilityResolver._get_resolver(submission)
+
+        assert resolver.is_visible(q1) is True
+        assert resolver.is_visible(q2) is True
+        assert resolver.get_visibility(q1) == ComponentVisibilityState.VISIBLE
+        assert resolver.get_visibility(q2) == ComponentVisibilityState.VISIBLE
+
+    def test_static_false_condition_hidden(self, factories):
+        form = factories.form.build()
+        q1 = factories.question.build(form=form, order=0)
+        factories.expression.build(question=q1, type_=ExpressionType.CONDITION, statement="False")
+        submission = factories.submission.build(collection=form.collection)
+        resolver = TestVisibilityResolver._get_resolver(submission)
+
+        assert resolver.is_visible(q1) is False
+        assert resolver.get_visibility(q1) == ComponentVisibilityState.HIDDEN
+
+    def test_static_true_condition_visible(self, factories):
+        form = factories.form.build()
+        q1 = factories.question.build(form=form, order=0)
+        factories.expression.build(question=q1, type_=ExpressionType.CONDITION, statement="True")
+        submission = factories.submission.build(collection=form.collection)
+        resolver = TestVisibilityResolver._get_resolver(submission)
+
+        assert resolver.is_visible(q1) is True
+        assert resolver.get_visibility(q1) == ComponentVisibilityState.VISIBLE
+
+    def test_undetermined_when_reference_unanswered(self, factories):
+        form = factories.form.build()
+        q1 = factories.question.build(form=form, order=0, data_type=QuestionDataType.YES_NO)
+        q2 = factories.question.build(form=form, order=1)
+
+        cond_q2 = factories.expression.build(
+            question=q2, type_=ExpressionType.CONDITION, statement=f"{q1.safe_qid} == 'yes'"
+        )
+        q2.owned_component_references = [ComponentReference(component=q2, expression=cond_q2, depends_on_component=q1)]
+
+        submission = factories.submission.build(collection=form.collection)
+        resolver = TestVisibilityResolver._get_resolver(submission)
+
+        assert resolver.is_visible(q1) is True
+        assert resolver.is_visible(q2) is False
+        assert resolver.get_visibility(q1) == ComponentVisibilityState.VISIBLE
+        assert resolver.get_visibility(q2) == ComponentVisibilityState.UNDETERMINED
+
+    def test_parent_hidden_hides_children(self, factories):
+        group = factories.group.build()
+        q1 = factories.question.build(form=group.form, parent=group, order=0)
+
+        factories.expression.build(question=group, type_=ExpressionType.CONDITION, statement="False")
+
+        submission = factories.submission.build(collection=group.form.collection)
+        resolver = TestVisibilityResolver._get_resolver(submission)
+
+        assert resolver.is_visible(group) is False
+        assert resolver.is_visible(q1) is False
+        assert resolver.get_visibility(group) == ComponentVisibilityState.HIDDEN
+        assert resolver.get_visibility(q1) == ComponentVisibilityState.HIDDEN
+
+    class TestNonConditionReferences:
+        def test_is_component_visible_doesnt_understand_references_to_groups(self, factories):
+            group = factories.group.build()
+            q1 = factories.question.build(form=group.form)
+            q1.owned_component_references = [ComponentReference(component=q1, depends_on_component=group)]
+            submission = factories.submission.build(collection=group.form.collection)
+
+            with pytest.raises(RuntimeError, match="Components can only depend on questions"):
+                TestVisibilityResolver._get_resolver(submission)
+
+        def test_is_component_visible_ignores_self_references(self, factories):
+            q1 = factories.question.build()
+            q1.owned_component_references = [ComponentReference(component=q1, depends_on_component=q1)]
+            submission = factories.submission.build(collection=q1.form.collection)
+            resolver = TestVisibilityResolver._get_resolver(submission)
+
+            assert resolver.is_visible(q1) is True
+            assert resolver.get_visibility(q1) == ComponentVisibilityState.VISIBLE
+
+        def test_is_component_visible_ignores_data_source_column_references(self, factories):
+            q1 = factories.question.build()
+            q1.owned_component_references = [
+                ComponentReference(component=q1, depends_on_data_source_id=uuid.uuid4(), depends_on_column_name="c_x")
+            ]
+            submission = factories.submission.build(collection=q1.form.collection)
+            resolver = TestVisibilityResolver._get_resolver(submission)
+
+            assert resolver.is_visible(q1) is True
+            assert resolver.get_visibility(q1) == ComponentVisibilityState.VISIBLE
+
+    class TestConditionsOperator:
+        def test_any_operator_one_true_is_visible(self, factories):
+            form = factories.form.build()
+            q1 = factories.question.build(form=form, order=0, conditions_operator=ConditionsOperator.ANY)
+
+            factories.expression.build(question=q1, type_=ExpressionType.CONDITION, statement="False")
+            factories.expression.build(question=q1, type_=ExpressionType.CONDITION, statement="True")
+
+            submission = factories.submission.build(collection=form.collection)
+            resolver = TestVisibilityResolver._get_resolver(submission)
+
+            assert resolver.is_visible(q1) is True
+            assert resolver.get_visibility(q1) == ComponentVisibilityState.VISIBLE
+
+        def test_any_operator_all_false_is_hidden(self, factories):
+            form = factories.form.build()
+            q1 = factories.question.build(form=form, order=0, conditions_operator=ConditionsOperator.ANY)
+
+            factories.expression.build(question=q1, type_=ExpressionType.CONDITION, statement="False")
+            factories.expression.build(question=q1, type_=ExpressionType.CONDITION, statement="False")
+
+            submission = factories.submission.build(collection=form.collection)
+            resolver = TestVisibilityResolver._get_resolver(submission)
+
+            assert resolver.is_visible(q1) is False
+            assert resolver.get_visibility(q1) == ComponentVisibilityState.HIDDEN
+
+        def test_all_operator_requires_all_true(self, factories):
+            form = factories.form.build()
+            q1 = factories.question.build(form=form, order=0, conditions_operator=ConditionsOperator.ALL)
+
+            factories.expression.build(question=q1, type_=ExpressionType.CONDITION, statement="True")
+            factories.expression.build(question=q1, type_=ExpressionType.CONDITION, statement="False")
+
+            submission = factories.submission.build(collection=form.collection)
+            resolver = TestVisibilityResolver._get_resolver(submission)
+
+            assert resolver.is_visible(q1) is False
+            assert resolver.get_visibility(q1) == ComponentVisibilityState.HIDDEN
+
+        def test_is_component_visible_with_nested_groups_different_operators(self, factories):
+            group = factories.group.build(conditions_operator=ConditionsOperator.ANY)
+            question = factories.question.build(
+                form=group.form, parent=group, conditions_operator=ConditionsOperator.ALL
+            )
+
+            # Group has ANY operator with one True and one False condition
+            factories.expression.build(question=group, type_=ExpressionType.CONDITION, statement="True")
+            factories.expression.build(question=group, type_=ExpressionType.CONDITION, statement="False")
+
+            # Question has ALL operator with all True conditions
+            factories.expression.build(question=question, type_=ExpressionType.CONDITION, statement="True")
+            factories.expression.build(question=question, type_=ExpressionType.CONDITION, statement="True")
+
+            submission = factories.submission.build(collection=group.form.collection)
+            resolver = TestVisibilityResolver._get_resolver(submission)
+
+            assert resolver.is_visible(group) is True
+            assert resolver.is_visible(question) is True
+            assert resolver.get_visibility(group) is ComponentVisibilityState.VISIBLE
+            assert resolver.get_visibility(question) is ComponentVisibilityState.VISIBLE
+
+        def test_is_component_visible_child_hidden_when_parent_hidden_regardless_of_operator(self, factories):
+            group = factories.group.build(conditions_operator=ConditionsOperator.ALL)
+            question = factories.question.build(
+                form=group.form, parent=group, conditions_operator=ConditionsOperator.ANY
+            )
+
+            # Group has ALL operator with one False condition (so hidden)
+            factories.expression.build(question=group, type_=ExpressionType.CONDITION, statement="False")
+
+            # Question has ANY operator with one True condition
+            factories.expression.build(question=question, type_=ExpressionType.CONDITION, statement="True")
+
+            submission = factories.submission.build(collection=group.form.collection)
+            resolver = TestVisibilityResolver._get_resolver(submission)
+
+            assert resolver.is_visible(group) is False
+            assert resolver.is_visible(question) is False
+            assert resolver.get_visibility(group) is ComponentVisibilityState.HIDDEN
+            assert resolver.get_visibility(question) is ComponentVisibilityState.HIDDEN
+
+        def test_any_condition_visibility(self, factories):
+            form = factories.form.build()
+            q1 = factories.question.build(form=form, order=0, data_type=QuestionDataType.YES_NO)
+            q2 = factories.question.build(form=form, order=1, data_type=QuestionDataType.YES_NO)
+            q3 = factories.question.build(form=form, order=1, data_type=QuestionDataType.YES_NO)
+            q4 = factories.question.build(
+                form=form,
+                order=2,
+                data_type=QuestionDataType.TEXT_SINGLE_LINE,
+                conditions_operator=ConditionsOperator.ANY,
+            )
+
+            cond_q2 = factories.expression.build(
+                question=q2, type_=ExpressionType.CONDITION, statement=f"{q1.safe_qid} is True"
+            )
+            q2.owned_component_references = [
+                ComponentReference(component=q2, expression=cond_q2, depends_on_component=q1)
+            ]
+
+            cond_q4_q2 = factories.expression.build(
+                question=q4, type_=ExpressionType.CONDITION, statement=f"{q2.safe_qid} is True"
+            )
+            cond_q4_q3 = factories.expression.build(
+                question=q4, type_=ExpressionType.CONDITION, statement=f"{q3.safe_qid} is True"
+            )
+            q4.owned_component_references = [
+                ComponentReference(component=q4, expression=cond_q4_q2, depends_on_component=q2),
+                ComponentReference(component=q4, expression=cond_q4_q3, depends_on_component=q3),
+            ]
+
+            submission = factories.submission.build(collection=form.collection)
+            resolver = TestVisibilityResolver._get_resolver(submission)
+
+            assert resolver.is_visible(q1) is True
+            assert resolver.is_visible(q2) is False
+            assert resolver.is_visible(q3) is True
+            assert resolver.is_visible(q4) is False
+            assert resolver.get_visibility(q1) is ComponentVisibilityState.VISIBLE
+            assert resolver.get_visibility(q2) is ComponentVisibilityState.UNDETERMINED
+            assert resolver.get_visibility(q3) is ComponentVisibilityState.VISIBLE
+            assert resolver.get_visibility(q4) is ComponentVisibilityState.UNDETERMINED
+
+            submission = factories.submission.build(
+                collection=form.collection, answers=[FactoryAnswer(q1, YesNoAnswer(False))]
+            )
+            resolver = TestVisibilityResolver._get_resolver(submission)
+
+            assert resolver.is_visible(q1) is True
+            assert resolver.is_visible(q2) is False
+            assert resolver.is_visible(q3) is True
+            assert resolver.is_visible(q4) is False
+            assert resolver.get_visibility(q1) is ComponentVisibilityState.VISIBLE
+            assert resolver.get_visibility(q2) is ComponentVisibilityState.HIDDEN
+            assert resolver.get_visibility(q3) is ComponentVisibilityState.VISIBLE
+            assert resolver.get_visibility(q4) is ComponentVisibilityState.UNDETERMINED
+
+            submission = factories.submission.build(
+                collection=form.collection,
+                answers=[FactoryAnswer(q1, YesNoAnswer(False)), FactoryAnswer(q3, YesNoAnswer(True))],
+            )
+            resolver = TestVisibilityResolver._get_resolver(submission)
+
+            assert resolver.is_visible(q1) is True
+            assert resolver.is_visible(q2) is False
+            assert resolver.is_visible(q3) is True
+            assert resolver.is_visible(q4) is True
+            assert resolver.get_visibility(q1) is ComponentVisibilityState.VISIBLE
+            assert resolver.get_visibility(q2) is ComponentVisibilityState.HIDDEN
+            assert resolver.get_visibility(q3) is ComponentVisibilityState.VISIBLE
+            assert resolver.get_visibility(q4) is ComponentVisibilityState.VISIBLE
+
+            submission = factories.submission.build(
+                collection=form.collection,
+                answers=[FactoryAnswer(q1, YesNoAnswer(False)), FactoryAnswer(q3, YesNoAnswer(True))],
+            )
+            resolver = TestVisibilityResolver._get_resolver(submission)
+
+            assert resolver.is_visible(q1) is True
+            assert resolver.is_visible(q2) is False
+            assert resolver.is_visible(q3) is True
+            assert resolver.is_visible(q4) is True
+            assert resolver.get_visibility(q1) is ComponentVisibilityState.VISIBLE
+            assert resolver.get_visibility(q2) is ComponentVisibilityState.HIDDEN
+            assert resolver.get_visibility(q3) is ComponentVisibilityState.VISIBLE
+            assert resolver.get_visibility(q4) is ComponentVisibilityState.VISIBLE
+
+            submission = factories.submission.build(
+                collection=form.collection,
+                answers=[FactoryAnswer(q1, YesNoAnswer(False)), FactoryAnswer(q3, YesNoAnswer(False))],
+            )
+            resolver = TestVisibilityResolver._get_resolver(submission)
+
+            assert resolver.is_visible(q1) is True
+            assert resolver.is_visible(q2) is False
+            assert resolver.is_visible(q3) is True
+            assert resolver.is_visible(q4) is False
+            assert resolver.get_visibility(q1) is ComponentVisibilityState.VISIBLE
+            assert resolver.get_visibility(q2) is ComponentVisibilityState.HIDDEN
+            assert resolver.get_visibility(q3) is ComponentVisibilityState.VISIBLE
+            assert resolver.get_visibility(q4) is ComponentVisibilityState.HIDDEN
+
+            submission = factories.submission.build(
+                collection=form.collection,
+                answers=[FactoryAnswer(q1, YesNoAnswer(True))],
+            )
+            resolver = TestVisibilityResolver._get_resolver(submission)
+
+            assert resolver.is_visible(q1) is True
+            assert resolver.is_visible(q2) is True
+            assert resolver.is_visible(q3) is True
+            assert resolver.is_visible(q4) is False
+            assert resolver.get_visibility(q1) is ComponentVisibilityState.VISIBLE
+            assert resolver.get_visibility(q2) is ComponentVisibilityState.VISIBLE
+            assert resolver.get_visibility(q3) is ComponentVisibilityState.VISIBLE
+            assert resolver.get_visibility(q4) is ComponentVisibilityState.UNDETERMINED
+
+            submission = factories.submission.build(
+                collection=form.collection,
+                answers=[
+                    FactoryAnswer(q1, YesNoAnswer(True)),
+                    FactoryAnswer(q2, YesNoAnswer(True)),
+                ],
+            )
+            resolver = TestVisibilityResolver._get_resolver(submission)
+
+            assert resolver.is_visible(q1) is True
+            assert resolver.is_visible(q2) is True
+            assert resolver.is_visible(q3) is True
+            assert resolver.is_visible(q4) is True
+            assert resolver.get_visibility(q1) is ComponentVisibilityState.VISIBLE
+            assert resolver.get_visibility(q2) is ComponentVisibilityState.VISIBLE
+            assert resolver.get_visibility(q3) is ComponentVisibilityState.VISIBLE
+            assert resolver.get_visibility(q4) is ComponentVisibilityState.VISIBLE
+
+    class TestAddAnother:
+        def test_add_another_per_index_visibility(self, factories):
+            group = factories.group.build(add_another=True)
+            q1 = factories.question.build(form=group.form, parent=group, data_type=QuestionDataType.NUMBER, order=0)
+            q2 = factories.question.build(form=group.form, parent=group, order=1)
+
+            cond = factories.expression.build(
+                question=q2, type_=ExpressionType.CONDITION, statement=f"{q1.safe_qid} > 50"
+            )
+            q2.owned_component_references = [ComponentReference(component=q2, expression=cond, depends_on_component=q1)]
+
+            submission = factories.submission.build(collection=group.form.collection)
+            submission.data_manager.set(q1, IntegerAnswer(value=55), add_another_index=0)
+            submission.data_manager.set(q1, IntegerAnswer(value=20), add_another_index=1)
+            resolver = TestVisibilityResolver._get_resolver(submission)
+
+            assert resolver.is_visible(q2, add_another_index=0) is True
+            assert resolver.is_visible(q2, add_another_index=1) is False
+            assert resolver.get_visibility_for_add_another(q2, add_another_index=0) == ComponentVisibilityState.VISIBLE
+            assert resolver.get_visibility_for_add_another(q2, add_another_index=1) == ComponentVisibilityState.HIDDEN
+
+        def test_nested_group_condition_inside_add_another(self, factories):
+            outer = factories.group.build(add_another=True)
+            show_nested = factories.question.build(
+                form=outer.form, parent=outer, order=0, data_type=QuestionDataType.YES_NO
+            )
+            nested = factories.group.build(form=outer.form, parent=outer, order=1)
+            q_nested = factories.question.build(form=outer.form, parent=nested, order=0)
+
+            cond = factories.expression.build(
+                question=nested, type_=ExpressionType.CONDITION, statement=f"{show_nested.safe_qid} is True"
+            )
+            nested.owned_component_references = [
+                ComponentReference(component=nested, expression=cond, depends_on_component=show_nested)
+            ]
+
+            submission = factories.submission.build(collection=outer.form.collection)
+            submission.data_manager.set(show_nested, YesNoAnswer(True), add_another_index=0)
+            submission.data_manager.set(show_nested, YesNoAnswer(False), add_another_index=1)
+            resolver = TestVisibilityResolver._get_resolver(submission)
+
+            assert resolver.is_visible(q_nested, add_another_index=0) is True
+            assert resolver.is_visible(q_nested, add_another_index=1) is False
+            assert (
+                resolver.get_visibility_for_add_another(q_nested, add_another_index=0)
+                == ComponentVisibilityState.VISIBLE
+            )
+            assert (
+                resolver.get_visibility_for_add_another(q_nested, add_another_index=1)
+                == ComponentVisibilityState.HIDDEN
+            )
+
+    def test_chained_hide_propagation(self, factories):
+        form = factories.form.build()
+        q1 = factories.question.build(form=form, order=0, data_type=QuestionDataType.YES_NO)
+        q2 = factories.question.build(form=form, order=1)
+        q3 = factories.question.build(form=form, order=2)
+
+        factories.expression.build(question=q1, type_=ExpressionType.CONDITION, statement="False")
+
+        cond_q2 = factories.expression.build(
+            question=q2, type_=ExpressionType.CONDITION, statement=f"{q1.safe_qid} is True"
+        )
+        q2.owned_component_references = [ComponentReference(component=q2, expression=cond_q2, depends_on_component=q1)]
+
+        cond_q3 = factories.expression.build(
+            question=q3, type_=ExpressionType.CONDITION, statement=f"{q2.safe_qid} == 'go'"
+        )
+        q3.owned_component_references = [ComponentReference(component=q3, expression=cond_q3, depends_on_component=q2)]
+
+        submission = factories.submission.build(collection=form.collection)
+        resolver = TestVisibilityResolver._get_resolver(submission)
+        assert resolver.is_visible(q1) is False
+        assert resolver.is_visible(q2) is False
+        assert resolver.is_visible(q3) is False
+        assert resolver.get_visibility(q1) == ComponentVisibilityState.HIDDEN
+        assert resolver.get_visibility(q2) == ComponentVisibilityState.HIDDEN
+        assert resolver.get_visibility(q3) == ComponentVisibilityState.HIDDEN
+
+    def test_nested_hide_propagation(self, factories):
+        form = factories.form.build()
+        q1 = factories.question.build(form=form, order=0, data_type=QuestionDataType.YES_NO)
+        group = factories.group.build(form=form, order=1)
+        cond_group = factories.expression.build(
+            question=group, type_=ExpressionType.CONDITION, statement=f"{q1.safe_qid} is True"
+        )
+        group.owned_component_references = [
+            ComponentReference(component=group, expression=cond_group, depends_on_component=q1)
+        ]
+        q2 = factories.question.build(form=form, parent=group, order=0, data_type=QuestionDataType.YES_NO)
+        subgroup = factories.group.build(form=form, parent=group, order=1)
+        cond_subgroup = factories.expression.build(
+            question=subgroup, type_=ExpressionType.CONDITION, statement=f"{q2.safe_qid} is True"
+        )
+        subgroup.owned_component_references = [
+            ComponentReference(component=subgroup, expression=cond_subgroup, depends_on_component=q2)
+        ]
+        q3 = factories.question.build(form=form, parent=subgroup, order=0)
+
+        submission = factories.submission.build(collection=form.collection)
+        resolver = TestVisibilityResolver._get_resolver(submission)
+        assert resolver.is_visible(q1) is True
+        assert resolver.is_visible(q2) is False
+        assert resolver.is_visible(q3) is False
+        assert resolver.get_visibility(q1) == ComponentVisibilityState.VISIBLE
+        assert resolver.get_visibility(q2) == ComponentVisibilityState.UNDETERMINED
+        assert resolver.get_visibility(q3) == ComponentVisibilityState.UNDETERMINED
+
+        submission = factories.submission.build(
+            collection=form.collection, answers=[FactoryAnswer(q1, YesNoAnswer(True))]
+        )
+        resolver = TestVisibilityResolver._get_resolver(submission)
+        assert resolver.is_visible(q1) is True
+        assert resolver.is_visible(q2) is True
+        assert resolver.is_visible(q3) is False
+        assert resolver.get_visibility(q1) == ComponentVisibilityState.VISIBLE
+        assert resolver.get_visibility(q2) == ComponentVisibilityState.VISIBLE
+        assert resolver.get_visibility(q3) == ComponentVisibilityState.UNDETERMINED
+
+        submission = factories.submission.build(
+            collection=form.collection, answers=[FactoryAnswer(q1, YesNoAnswer(False))]
+        )
+        resolver = TestVisibilityResolver._get_resolver(submission)
+        assert resolver.is_visible(q1) is True
+        assert resolver.is_visible(q2) is False
+        assert resolver.is_visible(q3) is False
+        assert resolver.get_visibility(q1) == ComponentVisibilityState.VISIBLE
+        assert resolver.get_visibility(q2) == ComponentVisibilityState.HIDDEN
+        assert resolver.get_visibility(q3) == ComponentVisibilityState.HIDDEN
+
+        submission = factories.submission.build(
+            collection=form.collection,
+            answers=[FactoryAnswer(q1, YesNoAnswer(True)), FactoryAnswer(q2, YesNoAnswer(True))],
+        )
+        resolver = TestVisibilityResolver._get_resolver(submission)
+        assert resolver.is_visible(q1) is True
+        assert resolver.is_visible(q2) is True
+        assert resolver.is_visible(q3) is True
+        assert resolver.get_visibility(q1) == ComponentVisibilityState.VISIBLE
+        assert resolver.get_visibility(q2) == ComponentVisibilityState.VISIBLE
+        assert resolver.get_visibility(q3) == ComponentVisibilityState.VISIBLE
+
+    def test_group_validation_referencing_child_does_not_affect_visibility(self, factories):
+        group = factories.group.build()
+        q1 = factories.question.build(form=group.form, parent=group, order=0, data_type=QuestionDataType.NUMBER)
+
+        group_validation = factories.expression.build(
+            question=group, type_=ExpressionType.VALIDATION, statement=f"{q1.safe_qid} > 0"
+        )
+        group.owned_component_references = [
+            ComponentReference(component=group, expression=group_validation, depends_on_component=q1)
+        ]
+
+        submission = factories.submission.build(collection=group.form.collection)
+        resolver = TestVisibilityResolver._get_resolver(submission)
+
+        assert resolver.is_visible(group) is True
+        assert resolver.is_visible(q1) is True
+        assert resolver.get_visibility(group) == ComponentVisibilityState.VISIBLE
+        assert resolver.get_visibility(q1) == ComponentVisibilityState.VISIBLE
+
+    def test_hidden_propagation_with_multiple_refs(self, factories):
+        form = factories.form.build()
+        q1 = factories.question.build(form=form, order=0, data_type=QuestionDataType.YES_NO)
+        q2 = factories.question.build(form=form, order=1)
+        q3 = factories.question.build(form=form, order=2)
+        q4 = factories.question.build(form=form, order=3)
+
+        cond_q2 = factories.expression.build(
+            question=q2, type_=ExpressionType.CONDITION, statement=f"{q1.safe_qid} is True"
+        )
+        q2.owned_component_references = [ComponentReference(component=q2, expression=cond_q2, depends_on_component=q1)]
+
+        factories.expression.build(question=q3, type_=ExpressionType.CONDITION, statement="False")
+
+        q4.owned_component_references = [
+            ComponentReference(component=q4, depends_on_component=q2),
+            ComponentReference(component=q4, depends_on_component=q3),
+        ]
+
+        submission = factories.submission.build(collection=form.collection)
+        resolver = TestVisibilityResolver._get_resolver(submission)
+
+        assert resolver.get_visibility(q1) == ComponentVisibilityState.VISIBLE
+        assert resolver.get_visibility(q2) == ComponentVisibilityState.UNDETERMINED
+        assert resolver.get_visibility(q3) == ComponentVisibilityState.HIDDEN
+        assert resolver.get_visibility(q4) == ComponentVisibilityState.HIDDEN
+
+    def test_any_operator_with_hidden_referenced_question(self, factories):
+        """Scenario: Q1 yes/no, Q2 yes/no (show if Q1=yes), Q3 text (show if Q1=no OR Q2=yes).
+
+        When Q1="no": Q2 is hidden (its condition Q1=="yes" fails). Q3 should be VISIBLE
+        because ANY only needs one condition — Q1=="no" is True.
+        When Q1="yes", Q2 unanswered: Q3 should be UNDETERMINED (Q1=="no" is False, Q2=="yes"
+        can't be evaluated yet).
+        When Q1="yes", Q2="yes": Q3 should be VISIBLE (Q2=="yes" passes).
+        When Q1="yes", Q2="no": Q3 should be HIDDEN (both conditions fail).
+        """
+        q1 = factories.question.build(order=0, data_type=QuestionDataType.YES_NO)
+        q2 = factories.question.build(form=q1.form, order=1, data_type=QuestionDataType.YES_NO)
+        q2_expr1 = factories.expression.build(
+            question=q2, type_=ExpressionType.CONDITION, statement=f"{q1.safe_qid} is True"
+        )
+        q2.owned_component_references = [ComponentReference(component=q2, depends_on_component=q1, expression=q2_expr1)]
+
+        q3 = factories.question.build(form=q1.form, order=2, conditions_operator=ConditionsOperator.ANY)
+        q3_expr1 = factories.expression.build(
+            question=q3, type_=ExpressionType.CONDITION, statement=f"{q1.safe_qid} is False"
+        )
+        q3_expr2 = factories.expression.build(
+            question=q3, type_=ExpressionType.CONDITION, statement=f"{q2.safe_qid} is True"
+        )
+        q3.owned_component_references = [
+            ComponentReference(component=q3, depends_on_component=q1, expression=q3_expr1),
+            ComponentReference(component=q3, depends_on_component=q2, expression=q3_expr2),
+        ]
+
+        # Case 1: Q1="no" → Q2 hidden, Q3 visible (Q1=="no" is True)
+        submission = factories.submission.build(
+            collection=q1.form.collection, answers=[FactoryAnswer(q1, YesNoAnswer(False))]
+        )
+        resolver = TestVisibilityResolver._get_resolver(submission)
+        assert resolver.is_visible(q2) is False
+        assert resolver.is_visible(q3) is True
+        assert resolver.get_visibility(q2) == ComponentVisibilityState.HIDDEN
+        assert resolver.get_visibility(q3) == ComponentVisibilityState.VISIBLE
+
+        # Case 2: Q1="yes", Q2 not answered → Q3 undetermined
+        submission = factories.submission.build(
+            collection=q1.form.collection, answers=[FactoryAnswer(q1, YesNoAnswer(True))]
+        )
+        resolver = TestVisibilityResolver._get_resolver(submission)
+        assert resolver.is_visible(q2) is True
+        assert resolver.is_visible(q3) is False
+        assert resolver.get_visibility(q2) == ComponentVisibilityState.VISIBLE
+        assert resolver.get_visibility(q3) == ComponentVisibilityState.UNDETERMINED
+
+        # Case 3: Q1="yes", Q2="yes" → Q3 visible
+        submission = factories.submission.build(
+            collection=q1.form.collection,
+            answers=[
+                FactoryAnswer(q1, YesNoAnswer(True)),
+                FactoryAnswer(q2, YesNoAnswer(True)),
+            ],
+        )
+        resolver = TestVisibilityResolver._get_resolver(submission)
+        assert resolver.is_visible(q3) is True
+        assert resolver.get_visibility(q3) == ComponentVisibilityState.VISIBLE
+
+        # Case 4: Q1="yes", Q2="no" → Q3 hidden
+        submission = factories.submission.build(
+            collection=q1.form.collection,
+            answers=[FactoryAnswer(q1, YesNoAnswer(True)), FactoryAnswer(q2, YesNoAnswer(False))],
+        )
+        resolver = TestVisibilityResolver._get_resolver(submission)
+        assert resolver.is_visible(q3) is False
+        assert resolver.get_visibility(q3) == ComponentVisibilityState.HIDDEN


### PR DESCRIPTION
## 🎫 Ticket


## 📝 Description
Our existing logic for working out which components (questions/groups) should be shown to users is currently all on the SubmissionHelper class and uses a lot of recursion, which has proven hard to follow and validate, and relatively little caching, which causes a lot of repeated work and minor performance issues.

The purpose of this PR is to re-implement component visibility checks to use a single forward pass and cache results for the request to reduce duplicative processing. We also move it off the SubmissionHelper onto its own dedicated class which should make it easier to read, understand, and test in some isolation.

This is staged work which just provides the implementation and runs it in parallel with the existing component visibility resolving logic. It will log an error to Sentry if if ever resolves differently to the existing logic. Deeper tracing can be enabled by developers to assess performance.

## 📸 Show the thing (screenshots, gifs)
N/A

## 🧪 Testing
Run through a bunch of submissions with tracing enabled - review traces in Sentry to check timing and scan logs for any ERROR messages that indicate visibility results don't match between the old and new logic.

I'll follow this up with some manual testing in production across a few reports to check matching behaviour in some real reports.

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- [x] No N+1 query problems introduced
- [x] Any new DB queries include appropriate where clauses based on the user's permissions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [ ] End-to-end tests have been updated (if applicable)
- [ ] Edge cases and error conditions are tested