### PR TITLE
Allow mapping a column as British pounds directly

### DIFF
--- a/app/common/data/types.py
+++ b/app/common/data/types.py
@@ -69,6 +69,8 @@ class AuthMethodEnum(str, enum.Enum):
 
 
 class QuestionDataType(enum.StrEnum):
+    # NOTE: Changing any of the values here may require a database migration due to the text forming part of
+    # the config on `DataSource.schema` for eg grant recipient data sources
     TEXT_SINGLE_LINE = "Single line of text"
     TEXT_MULTI_LINE = "Multiple lines of text"
     EMAIL = "Email address"

--- a/app/deliver_grant_funding/forms.py
+++ b/app/deliver_grant_funding/forms.py
@@ -1106,19 +1106,20 @@ class ColumnDataTypeMappingForm(FlaskForm):
         csrf = False
 
     column_name = HiddenField()
-    data_type = SelectField(
+    column_type = SelectField(
         "Data type",
         choices=[
             ("", "Select data type"),
-            ("TEXT", "Text"),
-            ("INTEGER", "Whole number"),
+            ("BRITISH_POUNDS", "British pounds"),
             ("DECIMAL", "Decimal number"),
+            ("INTEGER", "Whole number"),
+            ("TEXT", "Text"),
         ],
         validators=[],
         widget=GovSelect(),
     )
 
-    def validate_data_type(self, field: Field) -> None:
+    def validate_column_type(self, field: Field) -> None:
         if not field.data or field.data == "":
             raise ValidationError(f"Select a data type for {self.column_name.data}")
 
@@ -1143,41 +1144,31 @@ class MapDataSetColumnsForm(FlaskForm):
     def get_column_mappings(self) -> list[DataSetColumnMapping]:
         mappings = []
         for idx, column in enumerate(self.data_columns):
-            selected_value = self.columns.entries[idx].form.data_type.data
+            selected_value = self.columns.entries[idx].form.column_type.data
             match selected_value:
-                case "TEXT":
+                case "BRITISH_POUNDS":
                     mapping = DataSetColumnMapping(
                         column_name=column,
-                        data_type=QuestionDataType.TEXT_SINGLE_LINE,
+                        column_type=selected_value,
+                        prefix="£",
+                        max_decimal_places=2,
                     )
-                case "INTEGER":
+                case "TEXT" | "INTEGER" | "DECIMAL" | _:
                     mapping = DataSetColumnMapping(
                         column_name=column,
-                        data_type=QuestionDataType.NUMBER,
-                        number_type=NumberTypeEnum.INTEGER,
-                    )
-                case "DECIMAL":
-                    mapping = DataSetColumnMapping(
-                        column_name=column,
-                        data_type=QuestionDataType.NUMBER,
-                        number_type=NumberTypeEnum.DECIMAL,
-                    )
-                case _:
-                    mapping = DataSetColumnMapping(
-                        column_name=column,
-                        data_type=QuestionDataType.TEXT_SINGLE_LINE,
+                        column_type=selected_value,
                     )
             mappings.append(mapping)
         return mappings
 
     def has_numerical_columns(self) -> bool:
-        return any(entry.form.data_type.data in ["DECIMAL", "INTEGER"] for entry in self.columns.entries)
+        return any(entry.form.column_type.data in ["DECIMAL", "INTEGER"] for entry in self.columns.entries)
 
     def get_numerical_columns(self) -> list[str]:
         return [
             column
             for idx, column in enumerate(self.data_columns)
-            if self.columns.entries[idx].form.data_type.data in ["DECIMAL", "INTEGER"]
+            if self.columns.entries[idx].form.column_type.data in ["DECIMAL", "INTEGER"]
         ]
 
 

--- a/app/deliver_grant_funding/routes/reports.py
+++ b/app/deliver_grant_funding/routes/reports.py
@@ -3422,15 +3422,7 @@ def map_data_set_columns(grant_id: UUID, report_id: UUID) -> ResponseReturnValue
 
     if not form.is_submitted() and data_set_data.column_mappings:
         for idx, mapping in enumerate(data_set_data.column_mappings):
-            form.columns.entries[idx].form.data_type.data = (
-                "TEXT"
-                if mapping.data_type == QuestionDataType.TEXT_SINGLE_LINE
-                else "INTEGER"
-                if mapping.number_type == NumberTypeEnum.INTEGER
-                else "DECIMAL"
-                if mapping.number_type == NumberTypeEnum.DECIMAL
-                else ""
-            )
+            form.columns.entries[idx].form.column_type.data = mapping.column_type
 
     if form.validate_on_submit():
         data_set_data.column_mappings = form.get_column_mappings()
@@ -3521,9 +3513,7 @@ def map_data_set_number_columns(grant_id: UUID, report_id: UUID) -> ResponseRetu
     if not data_set_data:
         return redirect(url_for("deliver_grant_funding.upload_data_set", grant_id=grant_id, report_id=report_id))
 
-    number_columns = [
-        mapping for mapping in data_set_data.column_mappings if mapping.data_type == QuestionDataType.NUMBER
-    ]
+    number_columns = [mapping for mapping in data_set_data.column_mappings if mapping.requires_manual_formatting]
 
     form = MapNumberColumnsForm(numerical_columns=number_columns, data_set_data=data_set_data)
 

--- a/app/deliver_grant_funding/session_models.py
+++ b/app/deliver_grant_funding/session_models.py
@@ -129,11 +129,36 @@ class AddContextToExpressionsModel(_ReferenceDataSessionModel):
 
 class DataSetColumnMapping(BaseModel):
     column_name: str
-    data_type: Literal[QuestionDataType.TEXT_SINGLE_LINE, QuestionDataType.NUMBER]
-    number_type: NumberTypeEnum | None = None
-    prefix: str | None = None
+    column_type: Literal["TEXT", "BRITISH_POUNDS", "INTEGER", "DECIMAL"]
+    prefix: str | None = Field(default_factory=lambda o: "£" if o["column_type"] == "BRITISH_POUNDS" else None)
     suffix: str | None = None
-    max_decimal_places: int | None = None
+    max_decimal_places: int | None = Field(
+        default_factory=lambda o: 2 if o["column_type"] == "BRITISH_POUNDS" else None
+    )
+
+    @property
+    def data_type(self) -> Literal[QuestionDataType.TEXT_SINGLE_LINE, QuestionDataType.NUMBER]:
+        match self.column_type:
+            case "TEXT":
+                return QuestionDataType.TEXT_SINGLE_LINE
+            case "BRITISH_POUNDS" | "INTEGER" | "DECIMAL":
+                return QuestionDataType.NUMBER
+            case _:
+                raise ValueError(f"Unknown column type: {self.column_type}")
+
+    @property
+    def number_type(self) -> NumberTypeEnum | None:
+        match self.column_type:
+            case "INTEGER":
+                return NumberTypeEnum.INTEGER
+            case "BRITISH_POUNDS" | "DECIMAL":
+                return NumberTypeEnum.DECIMAL
+            case _:
+                return None
+
+    @property
+    def requires_manual_formatting(self) -> bool:
+        return self.column_type in ["INTEGER", "DECIMAL"]
 
 
 class DataSetUploadSessionModel(BaseModel):

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/data_sets/map_columns.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/data_sets/map_columns.html
@@ -33,7 +33,7 @@
           {% endfor %}
           {% set preview_html = preview_values | join(', ') %}
           {% set select_html %}
-            {{ form.columns[idx].form.data_type(params={"label": {"html": "Data type <span class='govuk-visually-hidden'>for " ~ column ~ "</span>" } }) }}
+            {{ form.columns[idx].form.column_type(params={"label": {"html": "Data type <span class='govuk-visually-hidden'>for " ~ column ~ "</span>" } }) }}
           {% endset %}
           {%
             do rows.append([

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/data_sets/map_number_columns.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/data_sets/map_number_columns.html
@@ -25,7 +25,7 @@
         {{ form.csrf_token }}
 
         {% set rows = [] %}
-        {% for mapping in session_data.column_mappings if mapping.data_type == enum.question_type.NUMBER %}
+        {% for mapping in session_data.column_mappings if mapping.requires_manual_formatting %}
           {% set idx = loop.index0 %}
           {% set preview_values = [] %}
           {% for row in session_data.preview_rows %}

--- a/tests/integration/common/data/interfaces/test_data_sets.py
+++ b/tests/integration/common/data/interfaces/test_data_sets.py
@@ -41,8 +41,7 @@ class TestCreateUploadedDataSourceGrantRecipient:
         column_mappings = [
             DataSetColumnMapping(
                 column_name="Capital allocation",
-                data_type=QuestionDataType.NUMBER,
-                number_type=NumberTypeEnum.INTEGER,
+                column_type="INTEGER",
             ),
         ]
         all_rows = [
@@ -88,16 +87,8 @@ class TestCreateUploadedDataSourceGrantRecipient:
         user = factories.user.create()
 
         column_mappings = [
-            DataSetColumnMapping(
-                column_name="Capital allocation",
-                data_type=QuestionDataType.NUMBER,
-                number_type=NumberTypeEnum.INTEGER,
-                prefix="£",
-            ),
-            DataSetColumnMapping(
-                column_name="Additional info",
-                data_type=QuestionDataType.TEXT_SINGLE_LINE,
-            ),
+            DataSetColumnMapping(column_name="Capital allocation", column_type="INTEGER", prefix="£"),
+            DataSetColumnMapping(column_name="Additional info", column_type="TEXT"),
         ]
         all_rows = [
             {
@@ -135,11 +126,7 @@ class TestCreateUploadedDataSourceGrantRecipient:
         user = factories.user.create()
 
         column_mappings = [
-            DataSetColumnMapping(
-                column_name="Capital allocation",
-                data_type=QuestionDataType.NUMBER,
-                number_type=NumberTypeEnum.INTEGER,
-            ),
+            DataSetColumnMapping(column_name="Capital allocation", column_type="INTEGER"),
         ]
         all_rows = [
             {
@@ -184,15 +171,8 @@ class TestCreateUploadedDataSourceGrantRecipient:
         user = factories.user.create()
 
         column_mappings = [
-            DataSetColumnMapping(
-                column_name="Capital allocation",
-                data_type=QuestionDataType.NUMBER,
-                number_type=NumberTypeEnum.INTEGER,
-            ),
-            DataSetColumnMapping(
-                column_name="Description",
-                data_type=QuestionDataType.TEXT_SINGLE_LINE,
-            ),
+            DataSetColumnMapping(column_name="Capital allocation", column_type="INTEGER"),
+            DataSetColumnMapping(column_name="Description", column_type="TEXT"),
         ]
         all_rows = [
             {
@@ -228,12 +208,7 @@ class TestCreateUploadedDataSourceGrantRecipient:
 
         column_mappings = [
             DataSetColumnMapping(
-                column_name="Amount",
-                data_type=QuestionDataType.NUMBER,
-                number_type=NumberTypeEnum.DECIMAL,
-                prefix="£",
-                suffix="m",
-                max_decimal_places=2,
+                column_name="Amount", column_type="DECIMAL", prefix="£", suffix="m", max_decimal_places=2
             ),
         ]
         all_rows = [
@@ -266,11 +241,7 @@ class TestCreateUploadedDataSourceGrantRecipient:
         user = factories.user.create()
 
         column_mappings = [
-            DataSetColumnMapping(
-                column_name="Capital allocation",
-                data_type=QuestionDataType.NUMBER,
-                number_type=NumberTypeEnum.INTEGER,
-            ),
+            DataSetColumnMapping(column_name="Capital allocation", column_type="INTEGER"),
         ]
         all_rows = [
             {
@@ -303,10 +274,7 @@ class TestCreateUploadedDataSourceGrantRecipient:
         user = factories.user.create()
 
         column_mappings = [
-            DataSetColumnMapping(
-                column_name="Notes",
-                data_type=QuestionDataType.TEXT_SINGLE_LINE,
-            ),
+            DataSetColumnMapping(column_name="Notes", column_type="TEXT"),
         ]
         all_rows = [
             {
@@ -340,15 +308,8 @@ class TestCreateUploadedDataSourceProjectLevel:
         user = factories.user.create()
 
         column_mappings = [
-            DataSetColumnMapping(
-                column_name="Project name",
-                data_type=QuestionDataType.TEXT_SINGLE_LINE,
-            ),
-            DataSetColumnMapping(
-                column_name="Allocation",
-                data_type=QuestionDataType.NUMBER,
-                number_type=NumberTypeEnum.INTEGER,
-            ),
+            DataSetColumnMapping(column_name="Project name", column_type="TEXT"),
+            DataSetColumnMapping(column_name="Allocation", column_type="INTEGER"),
         ]
         all_rows = [
             {
@@ -399,15 +360,8 @@ class TestCreateUploadedDataSourceProjectLevel:
         user = factories.user.create()
 
         column_mappings = [
-            DataSetColumnMapping(
-                column_name="Project name",
-                data_type=QuestionDataType.TEXT_SINGLE_LINE,
-            ),
-            DataSetColumnMapping(
-                column_name="Allocation",
-                data_type=QuestionDataType.NUMBER,
-                number_type=NumberTypeEnum.INTEGER,
-            ),
+            DataSetColumnMapping(column_name="Project name", column_type="TEXT"),
+            DataSetColumnMapping(column_name="Allocation", column_type="INTEGER"),
         ]
         all_rows = [
             {
@@ -451,10 +405,7 @@ class TestCreateUploadedDataSourceProjectLevel:
         user = factories.user.create()
 
         column_mappings = [
-            DataSetColumnMapping(
-                column_name="Project name",
-                data_type=QuestionDataType.TEXT_SINGLE_LINE,
-            ),
+            DataSetColumnMapping(column_name="Project name", column_type="TEXT"),
         ]
         all_rows = [
             {
@@ -489,14 +440,8 @@ class TestCreateUploadedDataSourceStatic:
         user = factories.user.create()
 
         column_mappings = [
-            DataSetColumnMapping(
-                column_name="Code",
-                data_type=QuestionDataType.TEXT_SINGLE_LINE,
-            ),
-            DataSetColumnMapping(
-                column_name="Label",
-                data_type=QuestionDataType.TEXT_SINGLE_LINE,
-            ),
+            DataSetColumnMapping(column_name="Code", column_type="TEXT"),
+            DataSetColumnMapping(column_name="Label", column_type="TEXT"),
         ]
         all_rows = [
             {"Code": "UK", "Label": "United Kingdom"},
@@ -543,8 +488,8 @@ class TestCreateUploadedDataSourceStatic:
         user = factories.user.create()
 
         column_mappings = [
-            DataSetColumnMapping(column_name="Code", data_type=QuestionDataType.TEXT_SINGLE_LINE),
-            DataSetColumnMapping(column_name="Label", data_type=QuestionDataType.TEXT_SINGLE_LINE),
+            DataSetColumnMapping(column_name="Code", column_type="TEXT"),
+            DataSetColumnMapping(column_name="Label", column_type="TEXT"),
         ]
         all_rows = [{"Code": "UK", "Label": "United Kingdom"}]
 
@@ -570,8 +515,8 @@ class TestCreateUploadedDataSourceStatic:
         user = factories.user.create()
 
         column_mappings = [
-            DataSetColumnMapping(column_name="Code", data_type=QuestionDataType.TEXT_SINGLE_LINE),
-            DataSetColumnMapping(column_name="Label", data_type=QuestionDataType.TEXT_SINGLE_LINE),
+            DataSetColumnMapping(column_name="Code", column_type="TEXT"),
+            DataSetColumnMapping(column_name="Label", column_type="TEXT"),
         ]
         all_rows = [{"Code": "UK", "Label": "United Kingdom"}, {"Code": "UK", "Label": "Another one"}]
 
@@ -597,8 +542,8 @@ class TestCreateUploadedDataSourceErrors:
         user = factories.user.create()
 
         column_mappings = [
-            DataSetColumnMapping(column_name="Code", data_type=QuestionDataType.TEXT_SINGLE_LINE),
-            DataSetColumnMapping(column_name="Label", data_type=QuestionDataType.TEXT_SINGLE_LINE),
+            DataSetColumnMapping(column_name="Code", column_type="TEXT"),
+            DataSetColumnMapping(column_name="Label", column_type="TEXT"),
         ]
 
         with pytest.raises(ValueError, match="Unsupported data source type"):
@@ -644,11 +589,7 @@ class TestCreateUploadedDataSourceSchemaOptions:
         column_mappings = [
             DataSetColumnMapping(
                 column_name="Amount",
-                data_type=QuestionDataType.NUMBER,
-                number_type=NumberTypeEnum.DECIMAL,
-                prefix="£",
-                suffix="",
-                max_decimal_places=2,
+                column_type="BRITISH_POUNDS",
             ),
         ]
         all_rows = [
@@ -684,10 +625,7 @@ class TestCreateUploadedDataSourceSchemaOptions:
         user = factories.user.create()
 
         column_mappings = [
-            DataSetColumnMapping(
-                column_name="Description",
-                data_type=QuestionDataType.TEXT_SINGLE_LINE,
-            ),
+            DataSetColumnMapping(column_name="Description", column_type="TEXT"),
         ]
         all_rows = [
             {
@@ -724,11 +662,7 @@ class TestCreateUploadedDataSourceSchemaOptions:
         user = factories.user.create()
 
         column_mappings = [
-            DataSetColumnMapping(
-                column_name="Capital Allocation (£)",
-                data_type=QuestionDataType.NUMBER,
-                number_type=NumberTypeEnum.INTEGER,
-            ),
+            DataSetColumnMapping(column_name="Capital Allocation (£)", column_type="BRITISH_POUNDS"),
         ]
         all_rows = [
             {
@@ -968,17 +902,8 @@ class TestDataSourceOrganisationItemDataProperty:
             grant_id=grant.id,
             collection_id=report.id,
             column_mappings=[
-                DataSetColumnMapping(
-                    column_name="Capital allocation",
-                    data_type=QuestionDataType.NUMBER,
-                    number_type=NumberTypeEnum.DECIMAL,
-                    prefix="£",
-                    max_decimal_places=2,
-                ),
-                DataSetColumnMapping(
-                    column_name="Additional notes",
-                    data_type=QuestionDataType.TEXT_SINGLE_LINE,
-                ),
+                DataSetColumnMapping(column_name="Capital allocation", column_type="BRITISH_POUNDS"),
+                DataSetColumnMapping(column_name="Additional notes", column_type="TEXT"),
             ],
             all_rows=[
                 {
@@ -1019,15 +944,8 @@ class TestDataSourceOrganisationItemDataProperty:
             grant_id=grant.id,
             collection_id=report.id,
             column_mappings=[
-                DataSetColumnMapping(
-                    column_name="Project name",
-                    data_type=QuestionDataType.TEXT_SINGLE_LINE,
-                ),
-                DataSetColumnMapping(
-                    column_name="Headcount",
-                    data_type=QuestionDataType.NUMBER,
-                    number_type=NumberTypeEnum.INTEGER,
-                ),
+                DataSetColumnMapping(column_name="Project name", column_type="TEXT"),
+                DataSetColumnMapping(column_name="Headcount", column_type="INTEGER"),
             ],
             all_rows=[
                 {
@@ -1071,17 +989,8 @@ class TestDataSourceOrganisationItemDataProperty:
             grant_id=grant.id,
             collection_id=report.id,
             column_mappings=[
-                DataSetColumnMapping(
-                    column_name="Notes",
-                    data_type=QuestionDataType.TEXT_SINGLE_LINE,
-                ),
-                DataSetColumnMapping(
-                    column_name="Capital allocation",
-                    data_type=QuestionDataType.NUMBER,
-                    number_type=NumberTypeEnum.DECIMAL,
-                    prefix="£",
-                    max_decimal_places=2,
-                ),
+                DataSetColumnMapping(column_name="Notes", column_type="TEXT"),
+                DataSetColumnMapping(column_name="Capital allocation", column_type="BRITISH_POUNDS"),
             ],
             all_rows=[
                 {
@@ -1119,15 +1028,8 @@ class TestDataSourceOrganisationItemDataProperty:
             grant_id=grant.id,
             collection_id=report.id,
             column_mappings=[
-                DataSetColumnMapping(
-                    column_name="Project name",
-                    data_type=QuestionDataType.TEXT_SINGLE_LINE,
-                ),
-                DataSetColumnMapping(
-                    column_name="Headcount",
-                    data_type=QuestionDataType.NUMBER,
-                    number_type=NumberTypeEnum.INTEGER,
-                ),
+                DataSetColumnMapping(column_name="Project name", column_type="TEXT"),
+                DataSetColumnMapping(column_name="Headcount", column_type="INTEGER"),
             ],
             all_rows=[
                 {

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -9636,7 +9636,7 @@ class TestMapDataSetColumns:
                 assert row[col] in soup.text
         for idx, col in enumerate(data_set_session_data["data_columns"]):
             assert col in soup.text
-            select = soup.find("select", {"name": f"columns-{idx}-data_type"})
+            select = soup.find("select", {"name": f"columns-{idx}-column_type"})
             assert select is not None
 
     def test_get_repopulates_form_from_session(self, authenticated_grant_admin_client, factories):
@@ -9654,16 +9654,8 @@ class TestMapDataSetColumns:
                     {"Capital allocation": "£2000", "Revenue allocation": "£30000"},
                 ],
                 column_mappings=[
-                    {
-                        "column_name": "Capital allocation",
-                        "data_type": QuestionDataType.NUMBER,
-                        "number_type": NumberTypeEnum.INTEGER,
-                    },
-                    {
-                        "column_name": "Revenue allocation",
-                        "data_type": QuestionDataType.NUMBER,
-                        "number_type": NumberTypeEnum.DECIMAL,
-                    },
+                    DataSetColumnMapping(column_name="Capital allocation", column_type="INTEGER"),
+                    DataSetColumnMapping(column_name="Revenue allocation", column_type="DECIMAL"),
                 ],
                 data_source_id=uuid.uuid4(),
                 original_filename="test.csv",
@@ -9675,8 +9667,8 @@ class TestMapDataSetColumns:
         )
         soup = BeautifulSoup(response.data, "html.parser")
 
-        select_0 = soup.find("select", {"name": "columns-0-data_type"})
-        select_1 = soup.find("select", {"name": "columns-1-data_type"})
+        select_0 = soup.find("select", {"name": "columns-0-column_type"})
+        select_1 = soup.find("select", {"name": "columns-1-column_type"})
         assert select_0.find("option", {"selected": True})["value"] == "INTEGER"
         assert select_1.find("option", {"selected": True})["value"] == "DECIMAL"
 
@@ -9707,8 +9699,8 @@ class TestMapDataSetColumns:
             ).model_dump(mode="json")
 
         data = {
-            "columns-0-data_type": "INTEGER",
-            "columns-1-data_type": "TEXT",
+            "columns-0-column_type": "INTEGER",
+            "columns-1-column_type": "TEXT",
             "submit": "y",
         }
         response = authenticated_grant_admin_client.post(
@@ -9761,7 +9753,7 @@ class TestMapDataSetColumns:
         mocker.patch("app.services.s3.S3Service.download_file", return_value=_rows_to_csv_bytes(all_rows))
 
         data = {
-            "columns-0-data_type": "TEXT",
+            "columns-0-column_type": "TEXT",
             "submit": "y",
         }
         response = authenticated_grant_admin_client.post(
@@ -9815,7 +9807,7 @@ class TestMapDataSetColumns:
         mocker.patch("app.services.s3.S3Service.download_file", return_value=_rows_to_csv_bytes(all_rows))
 
         data = {
-            "columns-0-data_type": "TEXT",
+            "columns-0-column_type": "TEXT",
             "submit": "y",
         }
         response = authenticated_grant_admin_client.post(
@@ -9852,8 +9844,8 @@ class TestMapDataSetColumns:
             ).model_dump(mode="json")
 
         data = {
-            "columns-0-data_type": "",
-            "columns-1-data_type": "INTEGER",
+            "columns-0-column_type": "",
+            "columns-1-column_type": "INTEGER",
             "submit": "y",
         }
         response = authenticated_grant_admin_client.post(
@@ -9886,20 +9878,9 @@ class TestMapDataSetNumberColumns:
                     {"Additional info": "Some text", "Capital allocation": "£2000", "Revenue allocation": "£30000"},
                 ],
                 column_mappings=[
-                    DataSetColumnMapping(
-                        column_name="Additional info",
-                        data_type=QuestionDataType.TEXT_SINGLE_LINE,
-                    ),
-                    DataSetColumnMapping(
-                        column_name="Capital allocation",
-                        data_type=QuestionDataType.NUMBER,
-                        number_type=NumberTypeEnum.DECIMAL,
-                    ),
-                    DataSetColumnMapping(
-                        column_name="Revenue allocation",
-                        data_type=QuestionDataType.NUMBER,
-                        number_type=NumberTypeEnum.INTEGER,
-                    ),
+                    DataSetColumnMapping(column_name="Additional info", column_type="TEXT"),
+                    DataSetColumnMapping(column_name="Capital allocation", column_type="DECIMAL"),
+                    DataSetColumnMapping(column_name="Revenue allocation", column_type="INTEGER"),
                 ],
                 data_source_id=uuid.uuid4(),
                 original_filename="test.csv",
@@ -9937,24 +9918,10 @@ class TestMapDataSetNumberColumns:
                 ],
                 column_mappings=[
                     DataSetColumnMapping(
-                        column_name="Capital allocation",
-                        data_type=QuestionDataType.NUMBER,
-                        number_type=NumberTypeEnum.DECIMAL,
-                        prefix="£",
-                        suffix="",
-                        max_decimal_places=2,
+                        column_name="Capital allocation", column_type="DECIMAL", prefix="£", max_decimal_places=2
                     ),
-                    DataSetColumnMapping(
-                        column_name="Revenue allocation",
-                        data_type=QuestionDataType.NUMBER,
-                        number_type=NumberTypeEnum.INTEGER,
-                        prefix="",
-                        suffix="km",
-                    ),
-                    DataSetColumnMapping(
-                        column_name="Additional info",
-                        data_type=QuestionDataType.TEXT_SINGLE_LINE,
-                    ),
+                    DataSetColumnMapping(column_name="Revenue allocation", column_type="INTEGER", suffix="km"),
+                    DataSetColumnMapping(column_name="Additional info", column_type="TEXT"),
                 ],
                 data_source_id=uuid.uuid4(),
                 original_filename="test.csv",
@@ -9989,20 +9956,9 @@ class TestMapDataSetNumberColumns:
                     {"Capital allocation": "£2000", "Revenue allocation": "£30000", "Additional info": "Some text"},
                 ],
                 column_mappings=[
-                    DataSetColumnMapping(
-                        column_name="Capital allocation",
-                        data_type=QuestionDataType.NUMBER,
-                        number_type=NumberTypeEnum.DECIMAL,
-                    ),
-                    DataSetColumnMapping(
-                        column_name="Revenue allocation",
-                        data_type=QuestionDataType.NUMBER,
-                        number_type=NumberTypeEnum.INTEGER,
-                    ),
-                    DataSetColumnMapping(
-                        column_name="Additional info",
-                        data_type=QuestionDataType.TEXT_SINGLE_LINE,
-                    ),
+                    DataSetColumnMapping(column_name="Capital allocation", column_type="DECIMAL"),
+                    DataSetColumnMapping(column_name="Revenue allocation", column_type="INTEGER"),
+                    DataSetColumnMapping(column_name="Additional info", column_type="TEXT"),
                 ],
                 data_source_id=uuid.uuid4(),
                 original_filename="test.csv",
@@ -10074,11 +10030,7 @@ class TestMapDataSetNumberColumns:
                     }
                 ],
                 column_mappings=[
-                    DataSetColumnMapping(
-                        column_name="Capital allocation",
-                        data_type=QuestionDataType.NUMBER,
-                        number_type=NumberTypeEnum.INTEGER,
-                    ),
+                    DataSetColumnMapping(column_name="Capital allocation", column_type="INTEGER"),
                 ],
                 data_source_id=uuid.uuid4(),
                 original_filename="test.csv",
@@ -10129,16 +10081,8 @@ class TestMapDataSetNumberColumns:
                     {"Capital allocation": "£2000", "Revenue allocation": "£30000"},
                 ],
                 column_mappings=[
-                    DataSetColumnMapping(
-                        column_name="Capital allocation",
-                        data_type=QuestionDataType.NUMBER,
-                        number_type=NumberTypeEnum.DECIMAL,
-                    ),
-                    DataSetColumnMapping(
-                        column_name="Revenue allocation",
-                        data_type=QuestionDataType.NUMBER,
-                        number_type=NumberTypeEnum.INTEGER,
-                    ),
+                    DataSetColumnMapping(column_name="Capital allocation", column_type="DECIMAL"),
+                    DataSetColumnMapping(column_name="Revenue allocation", column_type="INTEGER"),
                 ],
                 data_source_id=uuid.uuid4(),
                 original_filename="test.csv",
@@ -10184,16 +10128,10 @@ class TestMapDataSetNumberColumns:
                 "original_filename": "test.csv",
                 "s3_key": "data-set-uploads/test.csv",
                 "column_mappings": [
-                    {
-                        "column_name": "Capital allocation",
-                        "data_type": QuestionDataType.NUMBER,
-                        "number_type": NumberTypeEnum.DECIMAL,
-                    },
-                    {
-                        "column_name": "Distance",
-                        "data_type": QuestionDataType.NUMBER,
-                        "number_type": NumberTypeEnum.INTEGER,
-                    },
+                    DataSetColumnMapping(column_name="Capital allocation", column_type="DECIMAL").model_dump(
+                        mode="json"
+                    ),
+                    DataSetColumnMapping(column_name="Distance", column_type="INTEGER").model_dump(mode="json"),
                 ],
             }
 
@@ -10269,13 +10207,9 @@ class TestDataSetMissingData:
                 "data_columns": ["Capital allocation"],
                 "preview_rows": [],
                 "column_mappings": [
-                    {
-                        "column_name": "Capital allocation",
-                        "data_type": QuestionDataType.NUMBER,
-                        "number_type": NumberTypeEnum.DECIMAL,
-                        "prefix": "£",
-                        "max_decimal_places": 2,
-                    }
+                    DataSetColumnMapping(column_name="Capital allocation", column_type="BRITISH_POUNDS").model_dump(
+                        mode="json"
+                    ),
                 ],
                 "data_source_id": uuid.uuid4(),
                 "original_filename": "test.csv",
@@ -10339,18 +10273,8 @@ class TestDataSetMissingData:
                     },
                 ],
                 column_mappings=[
-                    DataSetColumnMapping(
-                        column_name="Capital allocation",
-                        data_type=QuestionDataType.NUMBER,
-                        number_type=NumberTypeEnum.INTEGER,
-                    ),
-                    DataSetColumnMapping(
-                        column_name="Revenue allocation",
-                        data_type=QuestionDataType.NUMBER,
-                        number_type=NumberTypeEnum.DECIMAL,
-                        prefix="£",
-                        max_decimal_places=2,
-                    ),
+                    DataSetColumnMapping(column_name="Capital allocation", column_type="INTEGER"),
+                    DataSetColumnMapping(column_name="Revenue allocation", column_type="BRITISH_POUNDS"),
                 ],
                 data_source_id=uuid.uuid4(),
                 original_filename="test.csv",

--- a/tests/integration/deliver_grant_funding/test_data_sets.py
+++ b/tests/integration/deliver_grant_funding/test_data_sets.py
@@ -1,6 +1,6 @@
 import uuid
 
-from app.common.data.types import DataSourceType, NumberTypeEnum, QuestionDataType
+from app.common.data.types import DataSourceType
 from app.constants import DATA_SET_EXTERNAL_ID_COLUMN_HEADER, DATA_SET_GRANT_RECIPIENT_COLUMN_HEADER
 from app.deliver_grant_funding.data_sets import (
     DataTypeError,
@@ -36,18 +36,8 @@ class TestValidateDataSet:
         data_set = _make_data_set(
             data_columns=["Capital allocation", "Revenue allocation"],
             column_mappings=[
-                DataSetColumnMapping(
-                    column_name="Capital allocation",
-                    data_type=QuestionDataType.NUMBER,
-                    number_type=NumberTypeEnum.DECIMAL,
-                    prefix="£",
-                    max_decimal_places=2,
-                ),
-                DataSetColumnMapping(
-                    column_name="Revenue allocation",
-                    data_type=QuestionDataType.NUMBER,
-                    number_type=NumberTypeEnum.INTEGER,
-                ),
+                DataSetColumnMapping(column_name="Capital allocation", column_type="BRITISH_POUNDS"),
+                DataSetColumnMapping(column_name="Revenue allocation", column_type="INTEGER"),
             ],
         )
 
@@ -69,9 +59,7 @@ class TestValidateDataSet:
         gr = factories.grant_recipient.create(organisation__external_id="EC123")
         data_set = _make_data_set(
             data_columns=["Notes"],
-            column_mappings=[
-                DataSetColumnMapping(column_name="Notes", data_type=QuestionDataType.TEXT_SINGLE_LINE),
-            ],
+            column_mappings=[DataSetColumnMapping(column_name="Notes", column_type="TEXT")],
         )
 
         all_rows = [
@@ -94,8 +82,8 @@ class TestValidateDataSet:
         data_set = _make_data_set(
             data_columns=["Notes", "Summary"],
             column_mappings=[
-                DataSetColumnMapping(column_name="Notes", data_type=QuestionDataType.TEXT_SINGLE_LINE),
-                DataSetColumnMapping(column_name="Summary", data_type=QuestionDataType.TEXT_SINGLE_LINE),
+                DataSetColumnMapping(column_name="Notes", column_type="TEXT"),
+                DataSetColumnMapping(column_name="Summary", column_type="TEXT"),
             ],
         )
 
@@ -123,15 +111,7 @@ class TestValidateDataSet:
         gr = factories.grant_recipient.create(organisation__external_id="EC123")
         data_set = _make_data_set(
             data_columns=["Capital allocation"],
-            column_mappings=[
-                DataSetColumnMapping(
-                    column_name="Capital allocation",
-                    data_type=QuestionDataType.NUMBER,
-                    number_type=NumberTypeEnum.DECIMAL,
-                    prefix="£",
-                    max_decimal_places=2,
-                ),
-            ],
+            column_mappings=[DataSetColumnMapping(column_name="Capital allocation", column_type="BRITISH_POUNDS")],
         )
 
         all_rows = [
@@ -153,15 +133,7 @@ class TestValidateDataSet:
         gr = factories.grant_recipient.create(organisation__external_id="EC123")
         data_set = _make_data_set(
             data_columns=["Capital allocation"],
-            column_mappings=[
-                DataSetColumnMapping(
-                    column_name="Capital allocation",
-                    data_type=QuestionDataType.NUMBER,
-                    number_type=NumberTypeEnum.DECIMAL,
-                    prefix="£",
-                    max_decimal_places=2,
-                ),
-            ],
+            column_mappings=[DataSetColumnMapping(column_name="Capital allocation", column_type="BRITISH_POUNDS")],
         )
 
         all_rows = [
@@ -180,13 +152,7 @@ class TestValidateDataSet:
         data_set = _make_data_set(
             data_columns=["Rate"],
             column_mappings=[
-                DataSetColumnMapping(
-                    column_name="Rate",
-                    data_type=QuestionDataType.NUMBER,
-                    number_type=NumberTypeEnum.DECIMAL,
-                    suffix="%",
-                    max_decimal_places=2,
-                ),
+                DataSetColumnMapping(column_name="Rate", column_type="DECIMAL", suffix="%", max_decimal_places=2)
             ],
         )
 
@@ -205,15 +171,7 @@ class TestValidateDataSet:
         gr = factories.grant_recipient.create(organisation__external_id="EC123")
         data_set = _make_data_set(
             data_columns=["Capital allocation"],
-            column_mappings=[
-                DataSetColumnMapping(
-                    column_name="Capital allocation",
-                    data_type=QuestionDataType.NUMBER,
-                    number_type=NumberTypeEnum.DECIMAL,
-                    prefix="£",
-                    max_decimal_places=2,
-                ),
-            ],
+            column_mappings=[DataSetColumnMapping(column_name="Capital allocation", column_type="BRITISH_POUNDS")],
         )
 
         all_rows = [
@@ -233,13 +191,7 @@ class TestValidateDataSet:
         gr = factories.grant_recipient.create(organisation__external_id="EC123")
         data_set = _make_data_set(
             data_columns=["Revenue allocation"],
-            column_mappings=[
-                DataSetColumnMapping(
-                    column_name="Revenue allocation",
-                    data_type=QuestionDataType.NUMBER,
-                    number_type=NumberTypeEnum.INTEGER,
-                ),
-            ],
+            column_mappings=[DataSetColumnMapping(column_name="Revenue allocation", column_type="INTEGER")],
         )
         all_rows = [
             {
@@ -257,14 +209,7 @@ class TestValidateDataSet:
         gr = factories.grant_recipient.create(organisation__external_id="EC123")
         data_set = _make_data_set(
             data_columns=["Rate"],
-            column_mappings=[
-                DataSetColumnMapping(
-                    column_name="Rate",
-                    data_type=QuestionDataType.NUMBER,
-                    number_type=NumberTypeEnum.DECIMAL,
-                    max_decimal_places=2,
-                ),
-            ],
+            column_mappings=[DataSetColumnMapping(column_name="Rate", column_type="DECIMAL", max_decimal_places=2)],
         )
 
         all_rows = [
@@ -285,14 +230,8 @@ class TestValidateDataSet:
         data_set = _make_data_set(
             data_columns=["Capital allocation", "Notes"],
             column_mappings=[
-                DataSetColumnMapping(
-                    column_name="Capital allocation",
-                    data_type=QuestionDataType.NUMBER,
-                    number_type=NumberTypeEnum.DECIMAL,
-                    prefix="£",
-                    max_decimal_places=2,
-                ),
-                DataSetColumnMapping(column_name="Notes", data_type=QuestionDataType.TEXT_SINGLE_LINE),
+                DataSetColumnMapping(column_name="Capital allocation", column_type="BRITISH_POUNDS"),
+                DataSetColumnMapping(column_name="Notes", column_type="TEXT"),
             ],
         )
 
@@ -318,18 +257,8 @@ class TestValidateDataSet:
         data_set = _make_data_set(
             data_columns=["Capital allocation", "Revenue allocation"],
             column_mappings=[
-                DataSetColumnMapping(
-                    column_name="Capital allocation",
-                    data_type=QuestionDataType.NUMBER,
-                    number_type=NumberTypeEnum.DECIMAL,
-                    prefix="£",
-                    max_decimal_places=2,
-                ),
-                DataSetColumnMapping(
-                    column_name="Revenue allocation",
-                    data_type=QuestionDataType.NUMBER,
-                    number_type=NumberTypeEnum.INTEGER,
-                ),
+                DataSetColumnMapping(column_name="Capital allocation", column_type="BRITISH_POUNDS"),
+                DataSetColumnMapping(column_name="Revenue allocation", column_type="INTEGER"),
             ],
         )
 


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-1392

## 📝 Description
At the moment we force form designers to choose 'Decimal' and then enter a £ prefix and a 2 decimal place config when setting up a CSV column as being currency.

User research has shown this is confusing and laborious, and that users would prefer to just say the column is a 'currency' or 'finance' column.

This starts the process by adding a British pounds column type.

Error handling and tidying up navigation (eg backlinks) will come in a future commit.

## 📸 Show the thing (screenshots, gifs)
<img width="2106" height="2646" alt="2026-05-21 16 01 09" src="https://github.com/user-attachments/assets/67f5838a-dab7-49a4-bd02-daa97b15ec57" />


## 🧪 Testing
<!-- Describe how you've tested this change, and how a reviewer can test it -->

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [ ] End-to-end tests have been updated (if applicable)
- [ ] Edge cases and error conditions are tested