### PR TITLE
FSPT-1337:  grant recipient level datasets only

### DIFF
--- a/app/common/data/types.py
+++ b/app/common/data/types.py
@@ -488,6 +488,7 @@ class DataSourceFileMetadata(BaseModel):
 
 TUnvalidatedDataSetRow = dict[str, str]
 TUnvalidatedDataSetRows = list[TUnvalidatedDataSetRow]
+TDataSetPreviewData = dict[str, list[str]]
 
 
 class DataSourceFileMetadataPostgresType(TypeDecorator):

--- a/app/deliver_grant_funding/forms.py
+++ b/app/deliver_grant_funding/forms.py
@@ -33,7 +33,6 @@ from app.common.data.interfaces.grants import grant_code_exists, grant_name_exis
 from app.common.data.interfaces.user import get_user_by_email
 from app.common.data.types import (
     ConditionsOperator,
-    DataSourceType,
     ExpressionType,
     FileUploadTypes,
     GroupDisplayOptions,
@@ -997,17 +996,6 @@ class UploadDataSetForm(FlaskForm):
         validators=[DataRequired("Enter the name for this data set")],
     )
 
-    data_source_type = RadioField(
-        "Is this grant recipient level data?",
-        widget=GovRadioInput(),
-        choices=[
-            (DataSourceType.GRANT_RECIPIENT, "Yes, with one row for each grant recipient"),
-            (DataSourceType.PROJECT_LEVEL, "Yes, with more than one row for grant recipients"),
-            (DataSourceType.STATIC, "No"),
-        ],
-        validators=[DataRequired("Select grant recipient level")],
-    )
-
     file = FileField(
         "Upload a file",
         widget=GovFileInput(),
@@ -1067,29 +1055,13 @@ class UploadDataSetForm(FlaskForm):
                     "The CSV file contains rows which are longer or shorter than the number of columns"
                 )
 
-            if self.data_source_type.data in [DataSourceType.GRANT_RECIPIENT, DataSourceType.PROJECT_LEVEL]:
-                missing = [col for col in DATA_SET_IDENTIFIER_COLUMN_HEADERS if col not in fieldnames]
-                if missing:
-                    raise ValidationError(f"The CSV file must contain the columns: {', '.join(missing)}")
+            missing = [col for col in DATA_SET_IDENTIFIER_COLUMN_HEADERS if col not in fieldnames]
+            if missing:
+                raise ValidationError(f"The CSV file must contain the columns: {', '.join(missing)}")
 
-                data_columns = [
-                    col for col in fieldnames if col.strip() and col not in DATA_SET_IDENTIFIER_COLUMN_HEADERS
-                ]
-                if not data_columns:
-                    raise ValidationError("The CSV file must contain at least one column of data")
-
-            if self.data_source_type.data == DataSourceType.STATIC:
-                rows_with_missing = [
-                    idx + 2
-                    for idx, row in enumerate(rows)
-                    if any(not value or not value.strip() for value in row.values())
-                ]
-                if rows_with_missing:
-                    raise ValidationError(
-                        f"The file has missing data in row(s): {', '.join(str(r) for r in rows_with_missing)} "
-                    )
-                if len(fieldnames) != 2:
-                    raise ValidationError("Static data sets can only have two columns")
+            data_columns = [col for col in fieldnames if col.strip() and col not in DATA_SET_IDENTIFIER_COLUMN_HEADERS]
+            if not data_columns:
+                raise ValidationError("The CSV file must contain at least one column of data")
 
             row_count = len(rows)
             if row_count > 10000:

--- a/app/deliver_grant_funding/routes/reports.py
+++ b/app/deliver_grant_funding/routes/reports.py
@@ -3354,10 +3354,7 @@ def upload_data_set(grant_id: UUID, report_id: UUID) -> ResponseReturnValue:
         file: FileStorage = form.file.data
         columns, rows = _parse_data_set_csv(form.file.data)
 
-        if form.data_source_type.data in [DataSourceType.GRANT_RECIPIENT, DataSourceType.PROJECT_LEVEL]:
-            data_columns = [col for col in columns if col not in DATA_SET_IDENTIFIER_COLUMN_HEADERS]
-        else:
-            data_columns = columns
+        data_columns = [col for col in columns if col not in DATA_SET_IDENTIFIER_COLUMN_HEADERS]
 
         data_source_id = uuid.uuid4()
         s3_key = build_data_set_upload_s3_key(grant_id=grant_id, report_id=report_id, data_source_id=data_source_id)
@@ -3375,7 +3372,7 @@ def upload_data_set(grant_id: UUID, report_id: UUID) -> ResponseReturnValue:
 
         session_data = DataSetUploadSessionModel(
             name=cast(str, form.name.data),
-            data_source_type=form.data_source_type.data,
+            data_source_type=DataSourceType.GRANT_RECIPIENT,
             data_columns=data_columns,
             preview_data=preview_data,
             s3_key=s3_key,
@@ -3385,17 +3382,16 @@ def upload_data_set(grant_id: UUID, report_id: UUID) -> ResponseReturnValue:
 
         session["data_set_upload"] = session_data.model_dump(mode="json")
 
-        if form.data_source_type.data != DataSourceType.STATIC:
-            grant_recipients = interfaces.grant_recipients.get_grant_recipients(report.grant, with_organisations=True)
-            gr_errors = validate_data_set_grant_recipients(session_data, grant_recipients, all_rows=rows)
-            if gr_errors:
-                return render_template(
-                    "deliver_grant_funding/reports/data_sets/upload_dataset.html",
-                    grant=report.grant,
-                    report=report,
-                    form=form,
-                    gr_errors=gr_errors,
-                )
+        grant_recipients = interfaces.grant_recipients.get_grant_recipients(report.grant, with_organisations=True)
+        gr_errors = validate_data_set_grant_recipients(session_data, grant_recipients, all_rows=rows)
+        if gr_errors:
+            return render_template(
+                "deliver_grant_funding/reports/data_sets/upload_dataset.html",
+                grant=report.grant,
+                report=report,
+                form=form,
+                gr_errors=gr_errors,
+            )
 
         return redirect(
             url_for(

--- a/app/deliver_grant_funding/routes/reports.py
+++ b/app/deliver_grant_funding/routes/reports.py
@@ -3364,11 +3364,20 @@ def upload_data_set(grant_id: UUID, report_id: UUID) -> ResponseReturnValue:
         file.stream.seek(0)
         s3_service.upload_file(file, s3_key, {"status": DataSourceFileTagEnum.PENDING})
 
+        preview_data: dict[str, list[str]] = {}
+        for column in data_columns:
+            values = []
+            for row in rows:
+                val = row.get(column, "")
+                if val and len(values) < 3:
+                    values.append(str(escape(val)))
+            preview_data[column] = values
+
         session_data = DataSetUploadSessionModel(
             name=cast(str, form.name.data),
             data_source_type=form.data_source_type.data,
             data_columns=data_columns,
-            preview_rows=rows[:5],
+            preview_data=preview_data,
             s3_key=s3_key,
             original_filename=secure_filename(file.filename),
             data_source_id=data_source_id,

--- a/app/deliver_grant_funding/session_models.py
+++ b/app/deliver_grant_funding/session_models.py
@@ -9,7 +9,7 @@ from app.common.data.types import (
     ManagedExpressionsEnum,
     NumberTypeEnum,
     QuestionDataType,
-    TUnvalidatedDataSetRows,
+    TDataSetPreviewData,
 )
 from app.common.expressions import ExpressionContext
 from app.common.expressions.references import ExpressionReference
@@ -168,7 +168,7 @@ class DataSetUploadSessionModel(BaseModel):
     data_source_id: UUID4
     original_filename: str
     s3_key: str
-    preview_rows: TUnvalidatedDataSetRows
+    preview_data: TDataSetPreviewData
     column_mappings: list[DataSetColumnMapping] = Field(default_factory=list)
 
     @classmethod

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/data_sets/map_columns.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/data_sets/map_columns.html
@@ -27,18 +27,14 @@
         {% set rows = [] %}
         {% for column in session_data.data_columns %}
           {% set idx = loop.index0 %}
-          {% set preview_values = [] %}
-          {% for row in session_data.preview_rows %}
-            {% do preview_values.append(row.get(column, "")) %}
-          {% endfor %}
-          {% set preview_html = preview_values | join(', ') %}
+          {% set preview_html = session_data.preview_data[column] | join('<br>') %}
           {% set select_html %}
             {{ form.columns[idx].form.column_type(params={"label": {"html": "Data type <span class='govuk-visually-hidden'>for " ~ column ~ "</span>" } }) }}
           {% endset %}
           {%
             do rows.append([
               {"text": column},
-              {"text": preview_html},
+              {"html": preview_html},
               {"html": select_html}
             ])
           %}
@@ -48,7 +44,7 @@
           govukTable({
             "head": [
               {"text": "Column name", "classes": "govuk-!-width-one-quarter"},
-              {"text": "Example data", "classes": "govuk-!-width-one-third"},
+              {"text": "Example data", "classes": "govuk-!-width-one-half"},
               {"text": "Data type"}
             ],
             "rows": rows

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/data_sets/map_number_columns.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/data_sets/map_number_columns.html
@@ -27,11 +27,7 @@
         {% set rows = [] %}
         {% for mapping in session_data.column_mappings if mapping.requires_manual_formatting %}
           {% set idx = loop.index0 %}
-          {% set preview_values = [] %}
-          {% for row in session_data.preview_rows %}
-            {% do preview_values.append(row.get(mapping.column_name, "")) %}
-          {% endfor %}
-          {% set preview_html = preview_values | join(', ') %}
+          {% set preview_html = session_data.preview_data[mapping.column_name] | join('<br>') %}
           {% set settings_html %}
             <div>{{ form.columns[idx].form.prefix(params={"label": {"html": "Prefix (optional) <span class='govuk-visually-hidden'> for " ~ mapping.column_name ~ "</span>" }, "classes": "govuk-input--width-10"}) }}</div>
             <div>{{ form.columns[idx].form.suffix(params={"label": {"html": "Suffix (optional) <span class='govuk-visually-hidden'> for " ~ mapping.column_name ~ "</span>" }, "classes": "govuk-input--width-10"}) }}</div>
@@ -42,7 +38,7 @@
           {%
             do rows.append([
               {"text": mapping.column_name},
-              {"text": preview_html},
+              {"html": preview_html},
               {"html": settings_html}
             ])
           %}
@@ -52,7 +48,7 @@
           govukTable({
             "head": [
               {"text": "Column name", "classes": "govuk-!-width-one-quarter"},
-              {"text": "Example data", "classes": "govuk-!-width-one-third"},
+              {"text": "Example data", "classes": "govuk-!-width-one-half"},
               {"text": "Formatting options"}
             ],
             "rows": rows

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/data_sets/upload_dataset.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/data_sets/upload_dataset.html
@@ -30,29 +30,19 @@
         <span class="govuk-caption-l">{{ report.name }}</span>
         Upload new data set
       </h1>
-      <p class="govuk-body">Upload data to reference in form guidance, questions, conditions and validation.</p>
+      <p class="govuk-body">
+        To upload a complete data set, <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.grant_details', grant_id=grant.id) }}">check the grant recipients</a> have been set up first before uploading
+        the file. The grant recipients will be reflected in the
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.download_grant_recipient_data_set_template', grant_id=grant.id, report_id=report.id) }}">data set template (CSV)</a>.
+      </p>
+      <p class="govuk-body">If you are missing some grant recipients or data, you can still upload the file and replace it later.</p>
       <form method="POST" enctype="multipart/form-data" novalidate>
         {{ form.csrf_token }}
         {{ form.name }}
-        {{
-          form.data_source_type(params={
-            "items": [
-              { "hint": {
-                  "text": "For example, grant allocation",
-                }
-              },
-              {
-                "hint": {
-                  "text": "For example, project details",
-                }
-              },
-              {},
-            ]
-          })
-        }}
         {{ form.file(params={"javascript": true}) }}
+        <p class="govuk-body">Only CSV (.csv) files can be uploaded for data sets.</p>
         <div class="govuk-button-group">
-          {{ form.submit(params={"text": "Continue and map columns" }) }}
+          {{ form.submit(params={"text": "Continue and format data" }) }}
           <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.list_report_data_sets', grant_id=grant.id, report_id=report.id) }}">Cancel</a>
         </div>
       </form>

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/data_sets/view_data_set.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/data_sets/view_data_set.html
@@ -71,10 +71,6 @@
       {%
         set summary_rows = [
           {
-            "key": {"text": "Data level"},
-            "value": {"text": data_source.type.value}
-          },
-          {
             "key": {"text": "Uploaded by"},
             "value": {"text": data_source.created_by.name if data_source.created_by else "Unknown"}
           },

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_data_sets.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_data_sets.html
@@ -2,6 +2,7 @@
 {% from "govuk_frontend_jinja/components/table/macro.html" import govukTable %}
 {% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
 {% from "deliver_grant_funding/macros/deliver_grant_funding_reports_breadcrumb.html" import deliver_grant_funding_reports_breadcrumb %}
+{% from 'govuk_frontend_jinja/components/details/macro.html' import govukDetails %}
 
 {% set page_title = "Data sets for " + report.name %}
 {% set active_item_identifier = "reports" %}
@@ -32,12 +33,25 @@
         <span class="govuk-caption-l">{{ report.name }}</span>
         Uploaded data sets
       </h1>
-      <p class="govuk-body">Data referenced in the grant form, uploaded as a CSV.</p>
-      <p class="govuk-body">
-        For uploading grant recipient level data like grant allocation, use the <br />
-        <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.download_grant_recipient_data_set_template', grant_id=grant.id, report_id=report.id) }}">grant recipient data upload template (CSV)</a>.
-        Grant recipients must be set up for the grant report before using the template and uploading grant recipient level data.
-      </p>
+      <p class="govuk-body">Upload data to reference in guidance, questions, conditions and validation.</p>
+      <p class="govuk-body">You can replace uploaded data sets to update missing or incorrect data.</p>
+
+      {% set dataSetUploadInstructionsHtml %}
+        <ol class="govuk-list govuk-list--number govuk-!-margin-bottom-0">
+          <li>
+            Check the <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.grant_details', grant_id=grant.id) }}">grant recipients</a> are set up to make sure they will be in the data set template.
+          </li>
+          <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.download_grant_recipient_data_set_template', grant_id=grant.id, report_id=report.id) }}">Download the data set template (CSV)</a>.</li>
+          <li>Name each column to describe the data in it, for example, “Funding”.</li>
+          <li>Upload the new data set by naming and formatting the data set.</li>
+        </ol>
+      {% endset %}
+      {{
+        govukDetails({
+          "summaryText": "Uploading a data set",
+          "html": dataSetUploadInstructionsHtml,
+        })
+      }}
     </div>
     <div class="govuk-grid-column-full">
       {% set rows = [] %}

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -9438,7 +9438,7 @@ class TestUploadDataSet:
         with authenticated_grant_admin_client.session_transaction() as session:
             session["data_set_upload"] = {
                 "name": "Test Data Set",
-                "data_source_type": DataSourceType.PROJECT_LEVEL,
+                "data_source_type": DataSourceType.GRANT_RECIPIENT,
                 "data_columns": ["Amount"],
                 "preview_data": {},
                 "column_mappings": [],
@@ -9455,10 +9455,6 @@ class TestUploadDataSet:
         soup = BeautifulSoup(response.text, "html.parser")
         name_input = soup.find("input", {"name": "name"})
         assert name_input["value"] == "Test Data Set"
-        assert (
-            soup.find("input", {"name": "data_source_type", "value": DataSourceType.PROJECT_LEVEL}).get("checked")
-            is not None
-        )
 
     def test_post_valid_csv_redirects_to_map_columns_with_session(
         self, authenticated_grant_admin_client, factories, mock_s3_service_calls
@@ -9582,31 +9578,6 @@ class TestUploadDataSet:
                 assert len(values) == 3
                 assert all(v != "" for v in values)
             assert session_data["preview_data"]["Amount"] == ["1000", "2000", "3000"]
-        assert len(mock_s3_service_calls.upload_file_calls) == 1
-
-    def test_post_static_csv_without_missing_data_proceeds(
-        self, authenticated_grant_admin_client, factories, mock_s3_service_calls
-    ):
-        grant = authenticated_grant_admin_client.grant
-        report = factories.collection.create(grant=grant)
-
-        csv_content = "theme id,theme name\nelectric,Electricity\nwater,Water supply"
-        data = {
-            "name": "Themes",
-            "data_source_type": DataSourceType.STATIC,
-            "file": (io.BytesIO(csv_content.encode("utf-8")), "themes.csv"),
-        }
-
-        response = authenticated_grant_admin_client.post(
-            url_for("deliver_grant_funding.upload_data_set", grant_id=grant.id, report_id=report.id),
-            data=data,
-            content_type="multipart/form-data",
-        )
-
-        assert response.status_code == 302
-        assert response.location == url_for(
-            "deliver_grant_funding.map_data_set_columns", grant_id=grant.id, report_id=report.id
-        )
         assert len(mock_s3_service_calls.upload_file_calls) == 1
 
 
@@ -10471,7 +10442,6 @@ class TestViewDataSource:
         assert response.status_code == 200
         soup = BeautifulSoup(response.data, "html.parser")
         assert user.name in soup.text
-        assert "Static" in soup.text
         assert "Test data set" in soup.text
 
     def test_get_shows_grant_recipient_table(self, authenticated_grant_member_client, factories):

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -9270,7 +9270,7 @@ class TestListReportDataSets:
                 "is_grant_recipient_data": True,
                 "is_grant_recipient_project_level_data": False,
                 "data_columns": ["Amount"],
-                "preview_rows": [],
+                "preview_data": {},
                 "all_rows": [],
                 "column_mappings": [],
             }
@@ -9440,7 +9440,7 @@ class TestUploadDataSet:
                 "name": "Test Data Set",
                 "data_source_type": DataSourceType.PROJECT_LEVEL,
                 "data_columns": ["Amount"],
-                "preview_rows": [],
+                "preview_data": {},
                 "column_mappings": [],
                 "data_source_id": uuid.uuid4(),
                 "original_filename": "test.csv",
@@ -9546,15 +9546,24 @@ class TestUploadDataSet:
         assert len(mock_s3_service_calls.upload_file_calls) == 1
         assert mock_s3_service_calls.upload_file_calls[0].args[2] == {"status": DataSourceFileTagEnum.PENDING}
 
-    def test_post_stores_preview_rows(self, authenticated_grant_admin_client, factories, mock_s3_service_calls):
+    def test_post_stores_preview_data(self, authenticated_grant_admin_client, factories, mock_s3_service_calls):
         grant = authenticated_grant_admin_client.grant
         report = factories.collection.create(grant=grant)
+        factories.grant_recipient.create(grant=grant, organisation__external_id="E123", organisation__name="Lothlorien")
+        factories.grant_recipient.create(grant=grant, organisation__external_id="E456", organisation__name="Numenor")
+        factories.grant_recipient.create(grant=grant, organisation__external_id="E789", organisation__name="Rivendell")
+        factories.grant_recipient.create(grant=grant, organisation__external_id="E000", organisation__name="Gondor")
 
-        rows = ["Col1,Col2"] + [f"val{i},data{i}" for i in range(10)]
-        csv_content = "\n".join(rows)
+        csv_content = (
+            "Organisation ID,Grant recipient,Amount,Category\n"
+            "E123,Lothlorien,,A\n"
+            "E456,Numenor,1000,A\n"
+            "E789,Rivendell,2000,A\n"
+            "E000,Gondor,3000,A"
+        )
         data = {
             "name": "Test Data Set",
-            "data_source_type": DataSourceType.STATIC,
+            "data_source_type": DataSourceType.GRANT_RECIPIENT,
             "file": (io.BytesIO(csv_content.encode("utf-8")), "test.csv"),
         }
 
@@ -9568,7 +9577,11 @@ class TestUploadDataSet:
 
         with authenticated_grant_admin_client.session_transaction() as sess:
             session_data = sess.get("data_set_upload")
-            assert len(session_data["preview_rows"]) == 5  # Only first 5 rows
+            assert set(session_data["preview_data"].keys()) == {"Amount", "Category"}
+            for values in session_data["preview_data"].values():
+                assert len(values) == 3
+                assert all(v != "" for v in values)
+            assert session_data["preview_data"]["Amount"] == ["1000", "2000", "3000"]
         assert len(mock_s3_service_calls.upload_file_calls) == 1
 
     def test_post_static_csv_without_missing_data_proceeds(
@@ -9612,10 +9625,11 @@ class TestMapDataSetColumns:
                 name="Test Data Set",
                 data_source_type=DataSourceType.GRANT_RECIPIENT,
                 data_columns=["Capital allocation", "Revenue allocation", "Notes"],
-                preview_rows=[
-                    {"Capital allocation": "£1000", "Revenue allocation": "£10000", "Notes": "First"},
-                    {"Capital allocation": "£2000", "Revenue allocation": "£30000", "Notes": "Second"},
-                ],
+                preview_data={
+                    "Capital allocation": ["£1000", "£2000"],
+                    "Revenue allocation": ["£10000", "£30000"],
+                    "Notes": ["First", "Second"],
+                },
                 data_source_id=uuid.uuid4(),
                 original_filename="test.csv",
                 s3_key="data-set-uploads/test.csv",
@@ -9631,9 +9645,9 @@ class TestMapDataSetColumns:
 
         assert f"Map {data_set_session_data['name']} data columns" in get_h1_text(soup)
 
-        for row in data_set_session_data["preview_rows"]:
-            for col in data_set_session_data["data_columns"]:
-                assert row[col] in soup.text
+        for _, values in data_set_session_data["preview_data"].items():
+            for value in values:
+                assert value in soup.text
         for idx, col in enumerate(data_set_session_data["data_columns"]):
             assert col in soup.text
             select = soup.find("select", {"name": f"columns-{idx}-column_type"})
@@ -9649,10 +9663,10 @@ class TestMapDataSetColumns:
                     "Capital allocation",
                     "Revenue allocation",
                 ],
-                preview_rows=[
-                    {"Capital allocation": "£1000", "Revenue allocation": "£10000"},
-                    {"Capital allocation": "£2000", "Revenue allocation": "£30000"},
-                ],
+                preview_data={
+                    "Capital allocation": ["£1000", "£2000"],
+                    "Revenue allocation": ["£10000", "£30000"],
+                },
                 column_mappings=[
                     DataSetColumnMapping(column_name="Capital allocation", column_type="INTEGER"),
                     DataSetColumnMapping(column_name="Revenue allocation", column_type="DECIMAL"),
@@ -9689,10 +9703,10 @@ class TestMapDataSetColumns:
                 name="Test Data Set",
                 data_source_type=DataSourceType.GRANT_RECIPIENT,
                 data_columns=["Capital allocation", "Additional info"],
-                preview_rows=[
-                    {"Capital allocation": "1000", "Additional info": "Some extra details"},
-                    {"Capital allocation": "2000", "Additional info": "Here are some finer details"},
-                ],
+                preview_data={
+                    "Capital allocation": ["£1000", "£2000"],
+                    "Additional info": ["Some extra details", "Here are some finer details"],
+                },
                 data_source_id=uuid.uuid4(),
                 original_filename="test.csv",
                 s3_key="data-set-uploads/test.csv",
@@ -9729,10 +9743,7 @@ class TestMapDataSetColumns:
                 name="Test Data Set",
                 data_source_type=DataSourceType.GRANT_RECIPIENT,
                 data_columns=["Area description"],
-                preview_rows=[
-                    {"Area description": "A fine place"},
-                    {"Area description": "A wonderful place"},
-                ],
+                preview_data={"Area description": ["A fine place", "A wonderful place"]},
                 data_source_id=uuid.uuid4(),
                 original_filename="test.csv",
                 s3_key="data-set-uploads/test.csv",
@@ -9783,10 +9794,7 @@ class TestMapDataSetColumns:
                 name="Test Data Set",
                 data_source_type=DataSourceType.PROJECT_LEVEL,
                 data_columns=["Area description"],
-                preview_rows=[
-                    {"Area description": "A fine place"},
-                    {"Area description": "A wonderful place"},
-                ],
+                preview_data={"Area description": ["A fine place", "A wonderful place"]},
                 data_source_id=uuid.uuid4(),
                 original_filename="test.csv",
                 s3_key="data-set-uploads/test.csv",
@@ -9834,10 +9842,10 @@ class TestMapDataSetColumns:
                     "Capital allocation",
                     "Revenue allocation",
                 ],
-                preview_rows=[
-                    {"Capital allocation": "£1000", "Revenue allocation": "£10000"},
-                    {"Capital allocation": "£2000", "Revenue allocation": "£30000"},
-                ],
+                preview_data={
+                    "Capital allocation": ["£1000", "£2000"],
+                    "Revenue allocation": ["£10000", "£30000"],
+                },
                 data_source_id=uuid.uuid4(),
                 original_filename="test.csv",
                 s3_key="data-set-uploads/test.csv",
@@ -9873,10 +9881,11 @@ class TestMapDataSetNumberColumns:
                 name="Test Data Set",
                 data_source_type=DataSourceType.GRANT_RECIPIENT,
                 data_columns=["Additional info", "Capital allocation", "Revenue allocation"],
-                preview_rows=[
-                    {"Additional info": "Some text", "Capital allocation": "£1000", "Revenue allocation": "£10000"},
-                    {"Additional info": "Some text", "Capital allocation": "£2000", "Revenue allocation": "£30000"},
-                ],
+                preview_data={
+                    "Additional info": ["Some text", "Some text"],
+                    "Capital allocation": ["£1000", "£2000"],
+                    "Revenue allocation": ["£10000", "£30000"],
+                },
                 column_mappings=[
                     DataSetColumnMapping(column_name="Additional info", column_type="TEXT"),
                     DataSetColumnMapping(column_name="Capital allocation", column_type="DECIMAL"),
@@ -9912,10 +9921,11 @@ class TestMapDataSetNumberColumns:
                 name="Test Data Set",
                 data_source_type=DataSourceType.GRANT_RECIPIENT,
                 data_columns=["Capital allocation", "Revenue allocation", "Additional info"],
-                preview_rows=[
-                    {"Capital allocation": "£1000", "Revenue allocation": "£10000", "Additional info": "Some text"},
-                    {"Capital allocation": "£2000", "Revenue allocation": "£30000", "Additional info": "Some text"},
-                ],
+                preview_data={
+                    "Additional info": ["Some text", "Some text"],
+                    "Capital allocation": ["£1000", "£2000"],
+                    "Revenue allocation": ["£10000", "£30000"],
+                },
                 column_mappings=[
                     DataSetColumnMapping(
                         column_name="Capital allocation", column_type="DECIMAL", prefix="£", max_decimal_places=2
@@ -9951,10 +9961,11 @@ class TestMapDataSetNumberColumns:
                 name="Test Data Set",
                 data_source_type=DataSourceType.GRANT_RECIPIENT,
                 data_columns=["Capital allocation", "Revenue allocation", "Additional info"],
-                preview_rows=[
-                    {"Capital allocation": "£1000", "Revenue allocation": "£10000", "Additional info": "Some text"},
-                    {"Capital allocation": "£2000", "Revenue allocation": "£30000", "Additional info": "Some text"},
-                ],
+                preview_data={
+                    "Additional info": ["Some text", "Some text"],
+                    "Capital allocation": ["£1000", "£2000"],
+                    "Revenue allocation": ["£10000", "£30000"],
+                },
                 column_mappings=[
                     DataSetColumnMapping(column_name="Capital allocation", column_type="DECIMAL"),
                     DataSetColumnMapping(column_name="Revenue allocation", column_type="INTEGER"),
@@ -10022,13 +10033,9 @@ class TestMapDataSetNumberColumns:
                 name="Test Data Set",
                 data_source_type=DataSourceType.GRANT_RECIPIENT,
                 data_columns=["Capital allocation"],
-                preview_rows=[
-                    {
-                        DATA_SET_EXTERNAL_ID_COLUMN_HEADER: "E123",
-                        DATA_SET_GRANT_RECIPIENT_COLUMN_HEADER: "Org",
-                        "Capital allocation": "",
-                    }
-                ],
+                preview_data={
+                    "Capital allocation": [],
+                },
                 column_mappings=[
                     DataSetColumnMapping(column_name="Capital allocation", column_type="INTEGER"),
                 ],
@@ -10076,10 +10083,10 @@ class TestMapDataSetNumberColumns:
                     "Capital allocation",
                     "Revenue allocation",
                 ],
-                preview_rows=[
-                    {"Capital allocation": "£1000", "Revenue allocation": "£10000"},
-                    {"Capital allocation": "£2000", "Revenue allocation": "£30000"},
-                ],
+                preview_data={
+                    "Capital allocation": ["£1000", "£2000"],
+                    "Revenue allocation": ["£10000", "£30000"],
+                },
                 column_mappings=[
                     DataSetColumnMapping(column_name="Capital allocation", column_type="DECIMAL"),
                     DataSetColumnMapping(column_name="Revenue allocation", column_type="INTEGER"),
@@ -10123,7 +10130,7 @@ class TestMapDataSetNumberColumns:
                 "name": "Test Data Set",
                 "data_source_type": DataSourceType.GRANT_RECIPIENT,
                 "data_columns": ["Capital allocation", "Distance"],
-                "preview_rows": [],
+                "preview_data": {},
                 "data_source_id": uuid.uuid4(),
                 "original_filename": "test.csv",
                 "s3_key": "data-set-uploads/test.csv",
@@ -10205,7 +10212,7 @@ class TestDataSetMissingData:
                 "name": "Test Data Set",
                 "data_source_type": DataSourceType.GRANT_RECIPIENT,
                 "data_columns": ["Capital allocation"],
-                "preview_rows": [],
+                "preview_data": {},
                 "column_mappings": [
                     DataSetColumnMapping(column_name="Capital allocation", column_type="BRITISH_POUNDS").model_dump(
                         mode="json"
@@ -10258,20 +10265,18 @@ class TestDataSetMissingData:
                 name="Test Data Set",
                 data_source_type=DataSourceType.GRANT_RECIPIENT,
                 data_columns=["Capital allocation", "Revenue allocation"],
-                preview_rows=[
-                    {
-                        DATA_SET_EXTERNAL_ID_COLUMN_HEADER: grant_recipient.organisation.external_id,
-                        DATA_SET_GRANT_RECIPIENT_COLUMN_HEADER: grant_recipient.organisation.name,
-                        "Capital allocation": "",
-                        "Revenue allocation": "",
-                    },
-                    {
-                        DATA_SET_EXTERNAL_ID_COLUMN_HEADER: grant_recipient_2.organisation.external_id,
-                        DATA_SET_GRANT_RECIPIENT_COLUMN_HEADER: grant_recipient_2.organisation.name,
-                        "Capital allocation": "",
-                        "Revenue allocation": "£200.00",
-                    },
-                ],
+                preview_data={
+                    DATA_SET_EXTERNAL_ID_COLUMN_HEADER: [
+                        grant_recipient.organisation.external_id,
+                        grant_recipient_2.organisation.external_id,
+                    ],
+                    DATA_SET_GRANT_RECIPIENT_COLUMN_HEADER: [
+                        grant_recipient.organisation.name,
+                        grant_recipient_2.organisation.name,
+                    ],
+                    "Capital allocation": [],
+                    "Revenue allocation": ["£200.00"],
+                },
                 column_mappings=[
                     DataSetColumnMapping(column_name="Capital allocation", column_type="INTEGER"),
                     DataSetColumnMapping(column_name="Revenue allocation", column_type="BRITISH_POUNDS"),

--- a/tests/integration/deliver_grant_funding/test_data_sets.py
+++ b/tests/integration/deliver_grant_funding/test_data_sets.py
@@ -22,7 +22,7 @@ def _make_data_set(
         name="Test Data Set",
         data_source_type=data_source_type,
         data_columns=data_columns or [],
-        preview_rows=[],
+        preview_data={},
         column_mappings=column_mappings or [],
         data_source_id=uuid.uuid4(),
         original_filename="test.csv",

--- a/tests/unit/deliver_grant_funding/test_forms.py
+++ b/tests/unit/deliver_grant_funding/test_forms.py
@@ -973,23 +973,3 @@ class TestUploadDataSetForm:
             f"The CSV file must contain the columns: {DATA_SET_EXTERNAL_ID_COLUMN_HEADER}, "
             f"{DATA_SET_GRANT_RECIPIENT_COLUMN_HEADER}"
         ) in form.file.errors[0]
-
-    def test_static_csv_with_missing_data_raises_error(self):
-        csv_content = "theme id,theme name\nelectric,Electricity\nwater,Water supply\ngarbage,"
-        file = FileStorage(
-            stream=io.BytesIO(csv_content.encode("utf-8")),
-            filename="test.csv",
-            content_type="text/csv",
-        )
-        data = MultiDict(
-            [
-                ("name", "Test Data Set"),
-                ("data_source_type", DataSourceType.STATIC),
-                ("file", file),
-            ]
-        )
-        form = UploadDataSetForm(existing_data_source_names=[])
-        form.process(data)
-
-        assert form.validate() is False
-        assert "The file has missing data in row(s): 4" in form.file.errors[0]


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-1337

## 📝 Description
Now that we've decided to restrict the data set upload to only Grant Recipient level data sets, Design have been able to hugely simplify the initial upload views and guidance.

This PR brings the views in line with these design changes, plus a couple of other small UI changes (line separating the 'example data' when mapping columns and removing the 'data level' metadata on the view data set page).

NB: Removing all of the remaining mentions/logic for static and project-level data sets will be done in a separate PR, along with a migration to remove these from the enum. Feels better to keep those separate to a) make this easier to review and b) make sure no one can upload either of the other data set types before we remove the options from the enum and logic entirely.

Other content changes on other pages in the flow (eg. page heading on 'Map columns', which has been changed in the designs) will be updated as part of a single pass content update PR.

## 📸 Show the thing (screenshots, gifs)

|  Before  |  After  |
| ---------|--------- |
|   <img width="1033" height="611" alt="image" src="https://github.com/user-attachments/assets/1c8368f9-fe05-4b50-82c5-f8bc3508800b" />   |   <img width="1048" height="777" alt="image" src="https://github.com/user-attachments/assets/69d09e7b-170d-4eb0-9ba4-17b46f250795" />   |
|  <img width="795" height="931" alt="image" src="https://github.com/user-attachments/assets/8631db85-a539-4857-9555-7e000713a65c" /> |  <img width="770" height="820" alt="image" src="https://github.com/user-attachments/assets/5adee899-fdef-43fa-b67b-c097dbb6af28" /> |
|  <img width="1049" height="790" alt="image" src="https://github.com/user-attachments/assets/2e5b8896-a99c-4fdd-b8b2-580fd2ecd7c9" /> |  <img width="1014" height="796" alt="image" src="https://github.com/user-attachments/assets/9cb768cf-fdc4-40a8-9275-908e6ece80c0" /> |
|  <img width="1062" height="951" alt="image" src="https://github.com/user-attachments/assets/c6906d73-1bfe-44e6-946b-7101199307dc" />  |  <img width="1030" height="943" alt="image" src="https://github.com/user-attachments/assets/de70bd42-6da7-46c2-8f51-4dc53808a7ed" />  |
| <img width="750" height="525" alt="image" src="https://github.com/user-attachments/assets/c6c99f86-9c86-4c8f-90b1-2c02ccb7064e" /> |  <img width="685" height="394" alt="image" src="https://github.com/user-attachments/assets/76014601-0513-4903-92ba-319f372fc496" />  |

## 🧪 Testing
Go through the data set upload flow - you should only be able to upload a grant recipient level data set and the UI and content should match what's in the designs, with the exception of what's called out in the PR description.

## 📋 Developer Checklist

### Review Readiness
- [X] PR title and description provide sufficient context for reviewers
- [X] Commits are logical, self-contained, and have clear descriptions

### Testing
- [X] I have tested this change and it meets the acceptance criteria for the ticket
- [X] I need the reviewer(s) to pull and run this change locally
- ~[ ] New (non-developer) functionality has appropriate unit and integration tests~
- ~[ ] End-to-end tests have been updated (if applicable)~
- ~[ ] Edge cases and error conditions are tested~