### PR TITLE
Platform admin page for reviewing certifiers

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -315,6 +315,7 @@ class _SharedConfig(_BaseConfig):
     ACCESS_SERVICE_DESK_URL: str = "https://mhclgdigital.atlassian.net/servicedesk/customer/portal/5/group/1344"
     DELIVER_SERVICE_DESK_URL: str = "https://mhclgdigital.atlassian.net/servicedesk/customer/portal/5/group/1343"
     DELTA_SERVICE_DESK_URL: str = "https://mhclgdigital.atlassian.net/servicedesk/customer/portal/6/group/12"
+    DELTA_S151_CSV_PATH_OR_KEY: str = "app/developers/data/s151-data.csv"
 
     # Feedback Surveys
     GRANT_RECIPIENT_GENERAL_FEEDBACK_URL: str = "https://forms.office.com/e/NpWGTr4AAa"

--- a/app/deliver_grant_funding/admin/__init__.py
+++ b/app/deliver_grant_funding/admin/__init__.py
@@ -31,7 +31,9 @@ def register_admin_views(flask_admin: Admin, db_: SQLAlchemy) -> None:
     flask_admin.add_view(
         PlatformAdminDataAnalysisView(name="Data analysis", endpoint="data_analysis", url="data-analysis")
     )
-    flask_admin.add_view(PlatformAdminDeltaCertifiersView(name="Certifiers", endpoint="certifiers", url="certifiers"))
+    flask_admin.add_view(
+        PlatformAdminDeltaCertifiersView(name="Delta certifiers", endpoint="delta_certifiers", url="delta-certifiers")
+    )
     flask_admin.add_view(PlatformAdminSubmissionView(db_))
     flask_admin.add_view(PlatformAdminSubmissionEventView(db_))
 

--- a/app/deliver_grant_funding/admin/__init__.py
+++ b/app/deliver_grant_funding/admin/__init__.py
@@ -16,6 +16,7 @@ from app.deliver_grant_funding.admin.entities import (
 )
 from app.deliver_grant_funding.admin.views import (
     PlatformAdminDataAnalysisView,
+    PlatformAdminDeltaCertifiersView,
     PlatformAdminDeveloperToolsView,
     PlatformAdminReportingLifecycleView,
 )
@@ -30,6 +31,7 @@ def register_admin_views(flask_admin: Admin, db_: SQLAlchemy) -> None:
     flask_admin.add_view(
         PlatformAdminDataAnalysisView(name="Data analysis", endpoint="data_analysis", url="data-analysis")
     )
+    flask_admin.add_view(PlatformAdminDeltaCertifiersView(name="Certifiers", endpoint="certifiers", url="certifiers"))
     flask_admin.add_view(PlatformAdminSubmissionView(db_))
     flask_admin.add_view(PlatformAdminSubmissionEventView(db_))
 

--- a/app/deliver_grant_funding/admin/views.py
+++ b/app/deliver_grant_funding/admin/views.py
@@ -1205,10 +1205,10 @@ def _build_delegated_rows(
 ) -> list[DelegatedRow]:
     fs_grant_certifiers_by_org: dict[Organisation, dict[str, _FSGrantCertifier]] = {}
     for grant in get_all_grants():
-        override_certifiers = get_grant_override_certifiers_by_organisation(grant_id=grant.id)
+        override_certifiers = get_grant_override_certifiers_by_organisation(
+            grant_id=grant.id, organisation_mode=OrganisationModeEnum.LIVE
+        )
         for fs_org, users in override_certifiers.items():
-            if fs_org.mode != OrganisationModeEnum.LIVE:
-                continue
             for user in users:
                 email = user.email.lower()
                 entry = fs_grant_certifiers_by_org.setdefault(fs_org, {}).setdefault(
@@ -1262,7 +1262,7 @@ class PlatformAdminDeltaCertifiersView(FlaskAdminPlatformAdminGrantLifecycleMana
         certifiers_by_org = get_certifiers_by_organisation()
 
         return self.render(
-            "deliver_grant_funding/admin/certifiers.html",
+            "deliver_grant_funding/admin/delta-certifiers.html",
             org_rows=_build_org_certifier_rows(delta_officers, certifiers_by_org),
             delegated_rows=_build_delegated_rows(delta_officers, certifiers_by_org),
             delta_last_updated_at=delta_last_updated_at,

--- a/app/deliver_grant_funding/admin/views.py
+++ b/app/deliver_grant_funding/admin/views.py
@@ -1,10 +1,16 @@
 import csv
+import datetime
+import os
+import zipfile
+from dataclasses import dataclass
 from io import BytesIO, StringIO
-from typing import Any
+from typing import TYPE_CHECKING, Any, Literal, Sequence, TypedDict, cast
 from uuid import UUID
 
+import boto3
 import markupsafe
 from flask import abort, current_app, flash, make_response, redirect, send_file, url_for
+from flask.typing import ResponseReturnValue
 from flask_admin import AdminIndexView, BaseView, expose
 from sqlalchemy import text
 
@@ -85,6 +91,10 @@ from app.deliver_grant_funding.admin.mixins import (
     FlaskAdminPlatformMemberAccessibleMixin,
 )
 from app.extensions import auto_commit_after_request, db, notification_service
+
+if TYPE_CHECKING:
+    from app.common.data.models import Grant, Organisation
+    from app.common.data.models_user import User
 
 
 class PlatformAdminIndexView(FlaskAdminPlatformMemberAccessibleMixin, AdminIndexView):
@@ -1086,3 +1096,174 @@ class PlatformAdminDeveloperToolsView(FlaskAdminPlatformAdminAccessibleMixin, Ba
             return response
 
         return redirect(url_for("developer_tools.index"))
+
+
+@dataclass(frozen=True)
+class DeltaS151Officer:
+    organisation_code: str
+    organisation_name: str
+    officer_type: Literal["s151-officer", "deputy-s151-officer", "delegated-s151-officer"]
+    email: str
+    name: str
+    delegated_access_groups: str
+    last_modified_date: datetime.datetime
+
+
+class OrgCertifierRow(TypedDict):
+    organisation: Organisation
+    our_certifiers: Sequence[User]
+    delta_officers: Sequence[DeltaS151Officer]
+    has_diff: bool
+
+
+class DelegatedEntry(TypedDict):
+    email: str
+    name: str
+    delegated_access_groups: str
+    our_grants: list[Grant]
+
+
+class DelegatedRow(TypedDict):
+    organisation: Organisation
+    entries: list[DelegatedEntry]
+
+
+class _FSGrantCertifier(TypedDict):
+    user: User
+    grants: list[Grant]
+
+
+def _load_delta_s151_officers() -> tuple[list[DeltaS151Officer], datetime.datetime]:
+    path_or_key = current_app.config["DELTA_S151_CSV_PATH_OR_KEY"]
+    if path_or_key.startswith("s3://"):
+        bucket, _, key = path_or_key.removeprefix("s3://").partition("/")
+        s3_object = boto3.client("s3").get_object(Bucket=bucket, Key=key)
+        last_updated_at = s3_object["LastModified"]
+        zip_bytes = s3_object["Body"].read()
+        with zipfile.ZipFile(BytesIO(zip_bytes)) as archive:
+            csv_name = next(n for n in archive.namelist() if n.endswith(".csv"))
+            csv_text = archive.read(csv_name).decode("utf-8-sig")
+    else:
+        last_updated_at = datetime.datetime.fromtimestamp(os.path.getmtime(path_or_key), tz=datetime.UTC)
+        with open(path_or_key, encoding="utf-8-sig") as f:
+            csv_text = f.read()
+
+    reader = csv.DictReader(csv_text.splitlines())
+    officers = [
+        DeltaS151Officer(
+            organisation_code=row["organisation-code"],
+            organisation_name=row["organisation-name"],
+            officer_type=cast(
+                Literal["s151-officer", "deputy-s151-officer", "delegated-s151-officer"],
+                row["officer-type"],
+            ),
+            email=row["officer-user-email"],
+            name=row["officer-name"],
+            delegated_access_groups=row["delegated-access-groups"],
+            last_modified_date=datetime.datetime.fromisoformat(row["last-modified-date"]),
+        )
+        for row in reader
+        if row["officer-type"] in ("s151-officer", "deputy-s151-officer", "delegated-s151-officer")
+        and row["status"] == "approved"
+        and row["account-status"] == "enabled"
+    ]
+    return officers, last_updated_at
+
+
+def _build_org_certifier_rows(
+    delta_officers: list[DeltaS151Officer],
+    certifiers_by_org: dict[Organisation, Sequence[User]],
+) -> list[OrgCertifierRow]:
+    delta_by_org_code: dict[str, list[DeltaS151Officer]] = {}
+    for officer in delta_officers:
+        if officer.officer_type == "delegated-s151-officer":
+            continue
+        delta_by_org_code.setdefault(officer.organisation_code, []).append(officer)
+
+    rows = []
+    for organisation, our_certifiers in certifiers_by_org.items():
+        delta_for_org = delta_by_org_code.get(organisation.external_id, [])
+        our_emails = {user.email.lower() for user in our_certifiers}
+        delta_emails = {officer.email.lower() for officer in delta_for_org}
+        rows.append(
+            {
+                "organisation": organisation,
+                "our_certifiers": sorted(our_certifiers, key=lambda u: u.email),
+                "delta_officers": sorted(
+                    delta_for_org, key=lambda o: (0 if o.officer_type == "s151-officer" else 1, o.email)
+                ),
+                "has_diff": our_emails != delta_emails,
+            }
+        )
+    rows.sort(key=lambda row: row["organisation"].name)
+    return rows
+
+
+def _build_delegated_rows(
+    delta_officers: list[DeltaS151Officer],
+    certifiers_by_org: dict[Organisation, Sequence[User]],
+) -> list[DelegatedRow]:
+    fs_grant_certifiers_by_org: dict[Organisation, dict[str, _FSGrantCertifier]] = {}
+    for grant in get_all_grants():
+        override_certifiers = get_grant_override_certifiers_by_organisation(grant_id=grant.id)
+        for fs_org, users in override_certifiers.items():
+            if fs_org.mode != OrganisationModeEnum.LIVE:
+                continue
+            for user in users:
+                email = user.email.lower()
+                entry = fs_grant_certifiers_by_org.setdefault(fs_org, {}).setdefault(
+                    email, {"user": user, "grants": []}
+                )
+                entry["grants"].append(grant)
+
+    org_by_external_id = {org.external_id: org for org in certifiers_by_org}
+
+    delta_delegated_by_org: dict[Organisation, dict[str, DeltaS151Officer]] = {}
+    for officer in delta_officers:
+        if officer.officer_type != "delegated-s151-officer":
+            continue
+        organisation = org_by_external_id.get(officer.organisation_code)
+        if organisation is None:
+            continue
+        delta_delegated_by_org.setdefault(organisation, {})[officer.email.lower()] = officer
+
+    rows = []
+    for organisation in certifiers_by_org:
+        delta_map = delta_delegated_by_org.get(organisation, {})
+        fs_map = fs_grant_certifiers_by_org.get(organisation, {})
+        entries = []
+        for email in sorted(set(delta_map) | set(fs_map)):
+            delta_officer = delta_map.get(email)
+            fs_data = fs_map.get(email)
+            if delta_officer is not None:
+                name = delta_officer.name
+                delegated_access_groups = delta_officer.delegated_access_groups
+            else:
+                assert fs_data is not None
+                name = fs_data["user"].name
+                delegated_access_groups = ""
+            entries.append(
+                {
+                    "email": email,
+                    "name": name,
+                    "delegated_access_groups": delegated_access_groups,
+                    "our_grants": sorted(fs_data["grants"], key=lambda g: g.name) if fs_data else [],
+                }
+            )
+        rows.append({"organisation": organisation, "entries": entries})
+    rows.sort(key=lambda row: row["organisation"].name)
+    return rows
+
+
+class PlatformAdminDeltaCertifiersView(FlaskAdminPlatformAdminGrantLifecycleManagerAccessibleMixin, BaseView):
+    @expose("/", methods=["GET"])
+    def index(self) -> ResponseReturnValue:
+        delta_officers, delta_last_updated_at = _load_delta_s151_officers()
+        certifiers_by_org = get_certifiers_by_organisation()
+
+        return self.render(
+            "deliver_grant_funding/admin/certifiers.html",
+            org_rows=_build_org_certifier_rows(delta_officers, certifiers_by_org),
+            delegated_rows=_build_delegated_rows(delta_officers, certifiers_by_org),
+            delta_last_updated_at=delta_last_updated_at,
+        )

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/admin/certifiers.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/admin/certifiers.html
@@ -1,0 +1,148 @@
+{% extends "admin/master.html" %}
+{% import 'admin/layout.html' as layout with context %}
+{% from 'govuk_frontend_jinja/components/tag/macro.html' import govukTag %}
+{% from 'common/govuk/tabs/macro.html' import govukTabs %}
+
+{% macro noneHint() %}
+  <span class="govuk-hint">None</span>
+{% endmacro %}
+
+{% macro statusTag(has_diff) %}
+  {% if has_diff %}
+    {{ govukTag({"text": "Out of sync", "classes": "govuk-tag--red"}) }}
+  {% else %}
+    {{ govukTag({"text": "OK", "classes": "govuk-tag--green"}) }}
+  {% endif %}
+{% endmacro %}
+
+{% macro userList(users) %}
+  {% if users %}
+    <ul class="govuk-list">
+      {% for user in users %}
+        <li>{{ user.name }} ({{ user.email }})</li>
+      {% endfor %}
+    </ul>
+  {% else %}
+    {{ noneHint() }}
+  {% endif %}
+{% endmacro %}
+
+{% macro deltaOfficerList(officers) %}
+  {% if officers %}
+    <ul class="govuk-list">
+      {% for officer in officers %}
+        <li>
+          {{ officer.name }} ({{ officer.email }})
+          <br />
+          <span class="govuk-hint govuk-!-font-size-16"> {{ officer.officer_type }} &middot; last modified {{ format_datetime_short(officer.last_modified_date) }} </span>
+        </li>
+      {% endfor %}
+    </ul>
+  {% else %}
+    {{ noneHint() }}
+  {% endif %}
+{% endmacro %}
+
+{% macro certifierLine(name, email) %}
+  {{ name }}<br />
+  <span class="govuk-hint govuk-!-font-size-16">{{ email }}</span>
+{% endmacro %}
+
+{% macro accessGroupsList(groups_str) %}
+  {% if groups_str %}
+    {{ groups_str.split(';') | map('trim') | sort | join('<br>' | safe) }}
+  {% else %}
+    {{ noneHint() }}
+  {% endif %}
+{% endmacro %}
+
+{% macro grantsList(grants) %}
+  {% if grants %}
+    <ul class="govuk-list">
+      {% for grant in grants %}
+        <li>{{ grant.name }}</li>
+      {% endfor %}
+    </ul>
+  {% else %}
+    {{ noneHint() }}
+  {% endif %}
+{% endmacro %}
+
+
+{% set orgTabPanel %}
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header">Organisation</th>
+        <th scope="col" class="govuk-table__header">Delta certifiers</th>
+        <th scope="col" class="govuk-table__header">Funding Service certifiers</th>
+        <th scope="col" class="govuk-table__header">Status</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      {% for row in org_rows %}
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">{{ row.organisation.name }}</th>
+          <td class="govuk-table__cell">{{ deltaOfficerList(row.delta_officers) }}</td>
+          <td class="govuk-table__cell">{{ userList(row.our_certifiers) }}</td>
+          <td class="govuk-table__cell">{{ statusTag(row.has_diff) }}</td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+{% endset %}
+
+
+{% set delegatedTabPanel %}
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header">Organisation</th>
+        <th scope="col" class="govuk-table__header">Delegated certifier</th>
+        <th scope="col" class="govuk-table__header">Delta access groups</th>
+        <th scope="col" class="govuk-table__header">Funding Service grants</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      {% for row in delegated_rows %}
+        {% if row.entries %}
+          {% for entry in row.entries %}
+            <tr class="govuk-table__row">
+              {% if loop.first %}
+                <th scope="row" rowspan="{{ row.entries | length }}" class="govuk-table__header">{{ row.organisation.name }}</th>
+              {% endif %}
+              <td class="govuk-table__cell">{{ certifierLine(entry.name, entry.email) }}</td>
+              <td class="govuk-table__cell">{{ accessGroupsList(entry.delegated_access_groups) }}</td>
+              <td class="govuk-table__cell">{{ grantsList(entry.our_grants) }}</td>
+            </tr>
+          {% endfor %}
+        {% else %}
+          <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header">{{ row.organisation.name }}</th>
+            <td class="govuk-table__cell">{{ noneHint() }}</td>
+            <td class="govuk-table__cell">{{ noneHint() }}</td>
+            <td class="govuk-table__cell">{{ noneHint() }}</td>
+          </tr>
+        {% endif %}
+      {% endfor %}
+    </tbody>
+  </table>
+{% endset %}
+
+{% block action_panel %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      {{ layout.messages() }}
+
+      <h1 class="govuk-heading-l">Certifiers</h1>
+      <p class="govuk-body">Compare certifiers configured in Delta against the certifiers set up in the Funding Service. The Delta export was last updated on {{ format_datetime_short(delta_last_updated_at) }}.</p>
+
+      {{
+        govukTabs({
+        "items": [
+          {"label": "Certifiers", "id": "certifiers-by-organisation", "panel": {"html": orgTabPanel
+      }},
+      {"label": "Delegated certifiers", "id": "delegated-certifiers", "panel": {"html": delegatedTabPanel}} ] }) }}
+    </div>
+  </div>
+{% endblock %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/admin/delta-certifiers.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/admin/delta-certifiers.html
@@ -134,7 +134,7 @@
     <div class="govuk-grid-column-full">
       {{ layout.messages() }}
 
-      <h1 class="govuk-heading-l">Certifiers</h1>
+      <h1 class="govuk-heading-l">Delta certifiers</h1>
       <p class="govuk-body">Compare certifiers configured in Delta against the certifiers set up in the Funding Service. The Delta export was last updated on {{ format_datetime_short(delta_last_updated_at) }}.</p>
 
       {{

--- a/app/developers/data/s151-data.csv
+++ b/app/developers/data/s151-data.csv
@@ -1,0 +1,4 @@
+"organisation-code","organisation-name","officer-type","officer-user-email","officer-name","delegated-access-groups","status","account-status","created-date","last-modified-date"
+"T0001","Ministry of Testing","s151-officer","s151@testing.gov.uk","S151","","approved","enabled","2022-03-14T09:34:31.200491Z","2022-05-10T15:22:53.069613Z"
+"T0001","Ministry of Testing","deputy-s151-officer","deputy-s151@testing.gov.uk","Deputy","","approved","enabled","2022-02-22T15:28:42.595885Z","2022-02-22T15:28:42.649231Z"
+"T0001","Ministry of Testing","delegated-s151-officer","delegated-s151@testing.gov.uk","Delegated","cheeseboards-in-parks","approved","enabled","2022-08-05T12:21:16.674833Z","2022-08-05T09:46:56.478107Z"

--- a/tests/fixtures/s151-data-sample.csv
+++ b/tests/fixtures/s151-data-sample.csv
@@ -1,0 +1,9 @@
+organisation-code,organisation-name,officer-type,officer-user-email,officer-name,delegated-access-groups,status,account-status,created-date,last-modified-date
+ORG-MATCH,Matching Council,s151-officer,matching@example.gov.uk,Matt Match,,approved,enabled,2024-01-01T09:00:00.000000Z,2024-05-01T10:15:30.123456Z
+ORG-DIFF,Different Council,s151-officer,delta-only@example.gov.uk,Della Onlyone,,approved,enabled,2024-02-01T09:00:00.000000Z,2024-06-15T14:22:00.000000Z
+ORG-EMPTY,Empty Council,s151-officer,empty-delta-only@example.gov.uk,Eve Empty,,approved,enabled,2024-03-01T09:00:00.000000Z,2024-07-01T08:00:00.000000Z
+ORG-MATCH,Matching Council,deputy-s151-officer,deputy@example.gov.uk,Daphne Deputy,,approved,enabled,2024-04-01T09:00:00.000000Z,2024-08-01T16:45:12.000000Z
+ORG-FILTER,Filtered Council,s151-officer,not-approved@example.gov.uk,Norma Pending,,pending,enabled,2024-01-01T09:00:00.000000Z,2024-05-01T10:15:30.000000Z
+ORG-FILTER,Filtered Council,s151-officer,not-enabled@example.gov.uk,Dan Disabled,,approved,disabled,2024-01-01T09:00:00.000000Z,2024-05-01T10:15:30.000000Z
+ORG-DELEGATED,Delegated Council,delegated-s151-officer,delegated@example.gov.uk,Doris Delegated,grant-alpha;grant-beta,approved,enabled,2024-01-01T09:00:00.000000Z,2024-09-01T11:30:45.000000Z
+ORG-DELEGATED,Delegated Council,delegated-s151-officer,delegated-deputy@example.gov.uk,Dirk Deputy,grant-alpha,approved,enabled,2024-02-01T09:00:00.000000Z,2024-09-15T13:00:00.000000Z

--- a/tests/integration/deliver_grant_funding/admin/test_delta_certifiers_view.py
+++ b/tests/integration/deliver_grant_funding/admin/test_delta_certifiers_view.py
@@ -1,0 +1,238 @@
+import datetime
+import zipfile
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+from bs4 import BeautifulSoup
+
+from app.common.data.types import OrganisationModeEnum, RoleEnum
+
+FIXTURE_CSV = Path(__file__).resolve().parents[3] / "fixtures" / "s151-data-sample.csv"
+
+
+@pytest.fixture
+def delta_csv_path(app, monkeypatch):
+    monkeypatch.setitem(app.config, "DELTA_S151_CSV_PATH_OR_KEY", str(FIXTURE_CSV))
+    return FIXTURE_CSV
+
+
+@pytest.fixture
+def delta_test_data(factories, db_session):
+    # The data here lines up with the FIXTURE_CSV data
+    org_match = factories.organisation.create(external_id="ORG-MATCH", name="Matching Council")
+    org_diff = factories.organisation.create(external_id="ORG-DIFF", name="Different Council")
+    factories.organisation.create(external_id="ORG-EMPTY", name="Empty Council")
+    org_delegated = factories.organisation.create(external_id="ORG-DELEGATED", name="Delegated Council")
+
+    match_certifier = factories.user.create(email="matching@example.gov.uk", name="Matt Match")
+    match_deputy = factories.user.create(email="deputy@example.gov.uk", name="Daphne Deputy")
+    local_only_certifier = factories.user.create(email="local-only@example.gov.uk", name="Lily Local")
+
+    factories.user_role.create(user=match_certifier, permissions=[RoleEnum.CERTIFIER], organisation=org_match)
+    factories.user_role.create(user=match_deputy, permissions=[RoleEnum.CERTIFIER], organisation=org_match)
+    factories.user_role.create(user=local_only_certifier, permissions=[RoleEnum.CERTIFIER], organisation=org_diff)
+
+    grant = factories.grant.create(name="Alpha grant")
+    delegated_user = factories.user.create(email="delegated@example.gov.uk", name="Doris Delegated")
+    fs_only_delegated_user = factories.user.create(email="fs-only-delegated@example.gov.uk", name="Fred FS-Only")
+    factories.user_role.create(
+        user=delegated_user, permissions=[RoleEnum.CERTIFIER], grant=grant, organisation=org_delegated
+    )
+    factories.user_role.create(
+        user=fs_only_delegated_user, permissions=[RoleEnum.CERTIFIER], grant=grant, organisation=org_delegated
+    )
+
+    test_org = factories.organisation.create(
+        external_id="ORG-TEST", name="Test Mode Council", mode=OrganisationModeEnum.TEST
+    )
+    test_org_user = factories.user.create(email="test-org-user@example.gov.uk", name="Tina Test")
+    factories.user_role.create(user=test_org_user, permissions=[RoleEnum.CERTIFIER], grant=grant, organisation=test_org)
+
+
+@pytest.fixture
+def page_soup(authenticated_platform_grant_lifecycle_manager_client, delta_csv_path, delta_test_data):
+    response = authenticated_platform_grant_lifecycle_manager_client.get("/deliver/admin/certifiers/")
+    assert response.status_code == 200
+    return BeautifulSoup(response.data, "html.parser")
+
+
+def _rows_by_org(soup, panel_selector):
+    panel = soup.select_one(panel_selector)
+    assert panel is not None, f"Panel {panel_selector!r} not found"
+    clusters: dict[str, list] = {}
+    current_org: str | None = None
+    for row in panel.select("tbody tr"):
+        th = row.find("th", attrs={"scope": "row"})
+        if th:
+            current_org = th.get_text(strip=True)
+            clusters[current_org] = []
+        assert current_org is not None, "First row in a certifiers table must have a row-header"
+        clusters[current_org].append(row)
+    return clusters
+
+
+class TestDeltaCertifiersAdminAccess:
+    @pytest.mark.parametrize(
+        "client_fixture, expected_code",
+        [
+            ("authenticated_platform_admin_client", 200),
+            ("authenticated_platform_grant_lifecycle_manager_client", 200),
+            ("authenticated_platform_data_analyst_client", 403),
+            ("authenticated_platform_member_client", 403),
+            ("authenticated_grant_admin_client", 403),
+            ("authenticated_grant_member_client", 403),
+            ("authenticated_no_role_client", 403),
+            ("anonymous_client", 302),
+        ],
+    )
+    def test_page_access(self, client_fixture, expected_code, request, delta_csv_path):
+        client = request.getfixturevalue(client_fixture)
+        response = client.get("/deliver/admin/certifiers/")
+        assert response.status_code == expected_code
+
+
+class TestCertifiersTable:
+    expected_orgs = {"Delegated Council", "Different Council", "Empty Council", "Matching Council"}
+
+    def test_lists_every_live_grant_recipient_org(self, page_soup):
+        rows = _rows_by_org(page_soup, "#certifiers-by-organisation")
+        assert set(rows) == self.expected_orgs
+
+    def test_matching_council_in_sync_with_s151_before_deputy(self, page_soup):
+        cells = _rows_by_org(page_soup, "#certifiers-by-organisation")["Matching Council"][0].find_all("td")
+        delta_cell, fs_cell, status_cell = (c.get_text(" ", strip=True) for c in cells)
+
+        assert "OK" in status_cell
+        assert delta_cell.index("matching@example.gov.uk") < delta_cell.index("deputy@example.gov.uk")
+        assert "matching@example.gov.uk" in fs_cell
+        assert "deputy@example.gov.uk" in fs_cell
+
+    def test_different_council_shows_mismatch_with_one_email_per_side(self, page_soup):
+        cells = _rows_by_org(page_soup, "#certifiers-by-organisation")["Different Council"][0].find_all("td")
+        delta_cell, fs_cell, status_cell = (c.get_text(" ", strip=True) for c in cells)
+
+        assert "Out of sync" in status_cell
+        assert "delta-only@example.gov.uk" in delta_cell
+        assert "local-only@example.gov.uk" in fs_cell
+
+    def test_empty_council_shows_mismatch_with_no_funding_service_certifiers(self, page_soup):
+        cells = _rows_by_org(page_soup, "#certifiers-by-organisation")["Empty Council"][0].find_all("td")
+        delta_cell, fs_cell, status_cell = (c.get_text(" ", strip=True) for c in cells)
+
+        assert "Out of sync" in status_cell
+        assert "empty-delta-only@example.gov.uk" in delta_cell
+        assert fs_cell == "None"
+
+    def test_delegated_council_in_sync_with_no_org_level_certifiers(self, page_soup):
+        cells = _rows_by_org(page_soup, "#certifiers-by-organisation")["Delegated Council"][0].find_all("td")
+        delta_cell, fs_cell, status_cell = (c.get_text(" ", strip=True) for c in cells)
+
+        assert "OK" in status_cell
+        assert delta_cell == "None"
+        assert fs_cell == "None"
+
+
+class TestDelegatedCertifiersTable:
+    expected_orgs = {"Delegated Council", "Different Council", "Empty Council", "Matching Council"}
+
+    def test_lists_every_live_grant_recipient_org(self, page_soup):
+        rows = _rows_by_org(page_soup, "#delegated-certifiers")
+        assert set(rows) == self.expected_orgs
+
+    def test_delegated_council_clusters_three_certifiers_under_one_org_header(self, page_soup):
+        delegated = _rows_by_org(page_soup, "#delegated-certifiers")["Delegated Council"]
+        assert len(delegated) == 3
+        assert delegated[0].find("th").get("rowspan") == "3"
+
+    def test_delta_only_certifier_shows_none_for_funding_service_grants(self, page_soup):
+        delegated = _rows_by_org(page_soup, "#delegated-certifiers")["Delegated Council"]
+        cells = delegated[0].find_all("td")
+        certifier_cell, groups_cell, grants_cell = (c.get_text(" ", strip=True) for c in cells)
+
+        assert "Dirk Deputy" in certifier_cell
+        assert "delegated-deputy@example.gov.uk" in certifier_cell
+        assert "grant-alpha" in groups_cell
+        assert grants_cell == "None"
+
+    def test_certifier_in_both_systems_shows_groups_and_grants(self, page_soup):
+        delegated = _rows_by_org(page_soup, "#delegated-certifiers")["Delegated Council"]
+        cells = delegated[1].find_all("td")
+        certifier_cell, groups_cell, grants_cell = (c.get_text(" ", strip=True) for c in cells)
+
+        assert "Doris Delegated" in certifier_cell
+        assert "delegated@example.gov.uk" in certifier_cell
+        assert "grant-alpha" in groups_cell
+        assert "grant-beta" in groups_cell
+        assert "Alpha grant" in grants_cell
+
+    def test_funding_service_only_certifier_shows_none_for_delta_groups(self, page_soup):
+        delegated = _rows_by_org(page_soup, "#delegated-certifiers")["Delegated Council"]
+        cells = delegated[2].find_all("td")
+        certifier_cell, groups_cell, grants_cell = (c.get_text(" ", strip=True) for c in cells)
+
+        assert "Fred FS-Only" in certifier_cell
+        assert "fs-only-delegated@example.gov.uk" in certifier_cell
+        assert groups_cell == "None"
+        assert "Alpha grant" in grants_cell
+
+    @pytest.mark.parametrize("org_name", ["Different Council", "Empty Council", "Matching Council"])
+    def test_orgs_without_delegated_entries_show_single_none_row(self, page_soup, org_name):
+        rows = _rows_by_org(page_soup, "#delegated-certifiers")[org_name]
+        assert len(rows) == 1
+        cells = rows[0].find_all("td")
+        assert [c.get_text(strip=True) for c in cells] == ["None", "None", "None"]
+
+
+class TestExcludedData:
+    @pytest.mark.parametrize(
+        "excluded",
+        [
+            "test-org-user@example.gov.uk",
+            "Test Mode Council",
+            "not-approved@example.gov.uk",
+            "not-enabled@example.gov.uk",
+            "other@example.gov.uk",
+        ],
+    )
+    def test_excluded_from_page(self, page_soup, excluded):
+        assert excluded not in page_soup.get_text(" ", strip=True)
+
+
+class TestCsvLoadFailure:
+    def test_missing_csv_surfaces_to_caller(
+        self, authenticated_platform_grant_lifecycle_manager_client, app, monkeypatch
+    ):
+        monkeypatch.setitem(app.config, "DELTA_S151_CSV_PATH_OR_KEY", "/nonexistent/path/s151-data.csv")
+        with pytest.raises(FileNotFoundError):
+            authenticated_platform_grant_lifecycle_manager_client.get("/deliver/admin/certifiers/")
+
+
+class TestS3ZipSource:
+    def test_s3_uri_downloads_and_unzips_csv(
+        self, authenticated_platform_grant_lifecycle_manager_client, app, monkeypatch, mocker, factories, db_session
+    ):
+        factories.organisation.create(external_id="ORG-DELEGATED", name="Delegated Council")
+
+        zip_bytes = BytesIO()
+        with zipfile.ZipFile(zip_bytes, mode="w") as archive:
+            archive.write(FIXTURE_CSV, arcname="s151-data.csv")
+
+        last_modified = datetime.datetime(2026, 5, 26, 9, 30, tzinfo=datetime.UTC)
+        s3_client = mocker.MagicMock()
+        s3_client.get_object.return_value = {
+            "Body": BytesIO(zip_bytes.getvalue()),
+            "LastModified": last_modified,
+        }
+        boto3_client_mock = mocker.patch("app.deliver_grant_funding.admin.views.boto3.client", return_value=s3_client)
+        monkeypatch.setitem(app.config, "DELTA_S151_CSV_PATH_OR_KEY", "s3://delta-exports/s151/s151-data.zip")
+
+        response = authenticated_platform_grant_lifecycle_manager_client.get("/deliver/admin/certifiers/")
+
+        assert response.status_code == 200
+        boto3_client_mock.assert_called_once_with("s3")
+        s3_client.get_object.assert_called_once_with(Bucket="delta-exports", Key="s151/s151-data.zip")
+        body = response.get_data(as_text=True)
+        assert "Delegated Council" in body
+        assert "delegated@example.gov.uk" in body
+        assert "Delta export was last updated on 26 May 2026 at 10:30am" in body

--- a/tests/integration/deliver_grant_funding/admin/test_delta_certifiers_view.py
+++ b/tests/integration/deliver_grant_funding/admin/test_delta_certifiers_view.py
@@ -52,7 +52,7 @@ def delta_test_data(factories, db_session):
 
 @pytest.fixture
 def page_soup(authenticated_platform_grant_lifecycle_manager_client, delta_csv_path, delta_test_data):
-    response = authenticated_platform_grant_lifecycle_manager_client.get("/deliver/admin/certifiers/")
+    response = authenticated_platform_grant_lifecycle_manager_client.get("/deliver/admin/delta-certifiers/")
     assert response.status_code == 200
     return BeautifulSoup(response.data, "html.parser")
 
@@ -88,7 +88,7 @@ class TestDeltaCertifiersAdminAccess:
     )
     def test_page_access(self, client_fixture, expected_code, request, delta_csv_path):
         client = request.getfixturevalue(client_fixture)
-        response = client.get("/deliver/admin/certifiers/")
+        response = client.get("/deliver/admin/delta-certifiers/")
         assert response.status_code == expected_code
 
 
@@ -205,7 +205,7 @@ class TestCsvLoadFailure:
     ):
         monkeypatch.setitem(app.config, "DELTA_S151_CSV_PATH_OR_KEY", "/nonexistent/path/s151-data.csv")
         with pytest.raises(FileNotFoundError):
-            authenticated_platform_grant_lifecycle_manager_client.get("/deliver/admin/certifiers/")
+            authenticated_platform_grant_lifecycle_manager_client.get("/deliver/admin/delta-certifiers/")
 
 
 class TestS3ZipSource:
@@ -227,7 +227,7 @@ class TestS3ZipSource:
         boto3_client_mock = mocker.patch("app.deliver_grant_funding.admin.views.boto3.client", return_value=s3_client)
         monkeypatch.setitem(app.config, "DELTA_S151_CSV_PATH_OR_KEY", "s3://delta-exports/s151/s151-data.zip")
 
-        response = authenticated_platform_grant_lifecycle_manager_client.get("/deliver/admin/certifiers/")
+        response = authenticated_platform_grant_lifecycle_manager_client.get("/deliver/admin/delta-certifiers/")
 
         assert response.status_code == 200
         boto3_client_mock.assert_called_once_with("s3")

--- a/tests/unit/test_all_routes_access.py
+++ b/tests/unit/test_all_routes_access.py
@@ -333,7 +333,7 @@ routes_with_access_controlled_by_flask_admin = [
     "question.edit_view",
     "question.export",
     "question.index_view",
-    "certifiers.index",
+    "delta_certifiers.index",
 ]
 
 

--- a/tests/unit/test_all_routes_access.py
+++ b/tests/unit/test_all_routes_access.py
@@ -333,6 +333,7 @@ routes_with_access_controlled_by_flask_admin = [
     "question.edit_view",
     "question.export",
     "question.index_view",
+    "certifiers.index",
 ]
 
 


### PR DESCRIPTION
## 🎫 Ticket
N/A

## 📝 Description
Requires https://github.com/communitiesuk/funding-service-terraform/pull/107

We maintain our own list of certifiers seeded initially from Delta's list.

Delta maintains their list actively and makes an export available nightly. This patch loads their export and provides a platform admin page to compare their list of certifiers with our own to aid in keeping our list up-to-date and reviewing incoming support requests to check whether people should be authorised to certify reports.

This page is a bare MVP and could be improved in multiple ways:

- Sorting 
- Filtering 
- An action to easily sync/set up certifiers from Delta's list

But these are left for future work to keep this a simple readonly page for now, as there are other priorities.

This purposely avoids a lot of thinking around the processes for updating certifiers, instead choosing to just expose the raw information. We can't easily automate the process until it's well known, understood and defined. Hopefully this will enable us to get that more closely locked down and facilitate future automation. It's also likely to be somewhat unperformant in deployed environments because of doing a lot of work (pull from S3, unzip, read+process the full list, etc). Improvements left for the future due to other priorities and the limited blast radius of this change (internal to our team only).

## 📸 Show the thing (screenshots, gifs)
<img width="1274" height="892" alt="image" src="https://github.com/user-attachments/assets/d7d13517-1ef9-40eb-8b35-4691011f4d2b" />

<img width="1281" height="906" alt="image" src="https://github.com/user-attachments/assets/e4276fb8-b8a0-46e0-9cb1-7d177d4d60fe" />


## 🧪 Testing
Should be able to test this locally (albeit rubbish data) and as of 8am 27th May it's deployed on dev where it can check against Delta's (rubbish) staging data. The table will be full of rubbish but you can validate that it loads and see the diffs.

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [ ] End-to-end tests have been updated (if applicable)
- [ ] Edge cases and error conditions are tested