### PR TITLE
British pounds errors

### DIFF
--- a/app/deliver_grant_funding/data_sets.py
+++ b/app/deliver_grant_funding/data_sets.py
@@ -40,6 +40,10 @@ class DataTypeError(CellError):
     table_message: str = "Incorrect data type"
 
 
+class BritishPoundsError(CellError):
+    table_message: str = "Not valid British pounds"
+
+
 class RowValidationResult(BaseModel):
     row_number: int
     cell_errors: list[CellError] = Field(default_factory=list)
@@ -104,6 +108,9 @@ def _validate_cell(column: str, value: str, mapping: DataSetColumnMapping) -> li
 
     if mapping.number_type == NumberTypeEnum.DECIMAL:
         errors.extend(_validate_decimal(stripped, mapping, column))
+
+    if mapping.column_type == "BRITISH_POUNDS" and errors:
+        return [BritishPoundsError(column=column)]
 
     return errors
 

--- a/app/deliver_grant_funding/forms.py
+++ b/app/deliver_grant_funding/forms.py
@@ -53,7 +53,14 @@ from app.common.helpers.feature_flags import FeatureFlags
 from app.common.safe_ids import safe_column_id
 from app.common.utils import uppercase_first
 from app.constants import DATA_SET_IDENTIFIER_COLUMN_HEADERS
-from app.deliver_grant_funding.data_sets import CellError, DataTypeError, DecimalError, PrefixError, SuffixError
+from app.deliver_grant_funding.data_sets import (
+    BritishPoundsError,
+    CellError,
+    DataTypeError,
+    DecimalError,
+    PrefixError,
+    SuffixError,
+)
 from app.deliver_grant_funding.session_models import DataSetColumnMapping
 
 if TYPE_CHECKING:
@@ -1133,6 +1140,8 @@ class MapDataSetColumnsForm(FlaskForm):
             mappings.append(mapping)
         return mappings
 
+    def has_british_pounds_columns(self) -> bool:
+        return any(entry.form.column_type.data == "BRITISH_POUNDS" for entry in self.columns.entries)
 
     def get_numerical_columns(self) -> list[str]:
         return [
@@ -1140,6 +1149,30 @@ class MapDataSetColumnsForm(FlaskForm):
             for idx, column in enumerate(self.data_columns)
             if self.columns.entries[idx].form.column_type.data in ["DECIMAL", "INTEGER"]
         ]
+
+    def build_british_pounds_form_errors(
+        self,
+        column_errors: dict[str, list[CellError]],
+    ) -> list[dict[str, list[str]]]:
+        columns_error_list: list[dict[str, list[str]]] = []
+        for entry in self.columns.entries:
+            subform = entry.form
+            column_name = subform.column_name.data
+            col_errs = column_errors.get(column_name, []) if column_name else []
+            subform_errors: dict[str, list[str]] = {}
+
+            for error in col_errs:
+                if isinstance(error, BritishPoundsError):
+                    message = (
+                        f"One or more numbers in column '{column_name}' are not formatted as British pounds to 2 "
+                        f"decimal places with the '£' prefix. For example, £100.00"
+                    )
+                    subform.column_type.errors = list(subform.column_type.errors) + [message]
+                    subform_errors.setdefault("column_type", []).append(message)
+
+            columns_error_list.append(subform_errors)
+
+        return columns_error_list
 
 
 class NumberColumnOptionsForm(FlaskForm):

--- a/app/deliver_grant_funding/forms.py
+++ b/app/deliver_grant_funding/forms.py
@@ -1133,8 +1133,6 @@ class MapDataSetColumnsForm(FlaskForm):
             mappings.append(mapping)
         return mappings
 
-    def has_numerical_columns(self) -> bool:
-        return any(entry.form.column_type.data in ["DECIMAL", "INTEGER"] for entry in self.columns.entries)
 
     def get_numerical_columns(self) -> list[str]:
         return [

--- a/app/deliver_grant_funding/routes/reports.py
+++ b/app/deliver_grant_funding/routes/reports.py
@@ -114,6 +114,8 @@ from app.constants import (
     DATA_SET_IDENTIFIER_COLUMN_HEADERS,
 )
 from app.deliver_grant_funding.data_sets import (
+    BritishPoundsError,
+    DataSetValidationResult,
     build_data_set_upload_s3_key,
     validate_data_set,
     validate_data_set_grant_recipients,
@@ -3326,6 +3328,15 @@ def _parse_data_set_csv(file_storage: FileStorage) -> tuple[list[str], TUnvalida
     return columns, rows
 
 
+def _load_and_validate_data_set(
+    data_set_data: DataSetUploadSessionModel,
+) -> tuple[TUnvalidatedDataSetRows, DataSetValidationResult]:
+    file_bytes = s3_service.download_file(data_set_data.s3_key)
+    file_storage = FileStorage(stream=io.BytesIO(file_bytes), filename=data_set_data.original_filename)
+    _, rows = _parse_data_set_csv(file_storage)
+    return rows, validate_data_set(data_set_data, rows)
+
+
 def _extract_data_set_data_from_session() -> DataSetUploadSessionModel | None:
     if session_data := session.get("data_set_upload"):
         try:
@@ -3433,6 +3444,24 @@ def map_data_set_columns(grant_id: UUID, report_id: UUID) -> ResponseReturnValue
         data_set_data.column_mappings = form.get_column_mappings()
         session["data_set_upload"] = data_set_data.model_dump(mode="json")
 
+        rows: TUnvalidatedDataSetRows | None = None
+        validation_result: DataSetValidationResult | None = None
+
+        if form.has_british_pounds_columns():
+            rows, validation_result = _load_and_validate_data_set(data_set_data)
+            british_pounds_errors = [e for e in validation_result.blocking_errors if isinstance(e, BritishPoundsError)]
+            if british_pounds_errors:
+                errors = sorted(british_pounds_errors, key=lambda e: e.column)
+                column_errors = {col: list(errs) for col, errs in groupby(errors, key=lambda e: e.column)}
+                form.columns.errors = form.build_british_pounds_form_errors(column_errors)
+                return render_template(
+                    "deliver_grant_funding/reports/data_sets/map_columns.html",
+                    grant=report.grant,
+                    report=report,
+                    form=form,
+                    session_data=data_set_data,
+                )
+
         if data_set_data.has_columns_requiring_manual_formatting():
             return redirect(
                 url_for(
@@ -3442,11 +3471,8 @@ def map_data_set_columns(grant_id: UUID, report_id: UUID) -> ResponseReturnValue
                 )
             )
 
-        file_bytes = s3_service.download_file(data_set_data.s3_key)
-        file_storage = FileStorage(stream=io.BytesIO(file_bytes), filename=data_set_data.original_filename)
-        _, rows = _parse_data_set_csv(file_storage)
-
-        validation_result = validate_data_set(data_set_data, rows)
+        if validation_result is None:
+            rows, validation_result = _load_and_validate_data_set(data_set_data)
 
         if validation_result.blocking_errors or validation_result.has_missing_data:
             return redirect(
@@ -3540,11 +3566,7 @@ def map_data_set_number_columns(grant_id: UUID, report_id: UUID) -> ResponseRetu
                     mapping.max_decimal_places = settings[mapping.column_name]["max_decimal_places"]
         session["data_set_upload"] = data_set_data.model_dump(mode="json")
 
-        file_bytes = s3_service.download_file(data_set_data.s3_key)
-        file_storage = FileStorage(stream=io.BytesIO(file_bytes), filename=data_set_data.original_filename)
-        _, rows = _parse_data_set_csv(file_storage)
-
-        validation_result = validate_data_set(data_set_data, rows)
+        rows, validation_result = _load_and_validate_data_set(data_set_data)
 
         if validation_result.blocking_errors:
             errors = sorted(validation_result.blocking_errors, key=lambda e: e.column)
@@ -3615,11 +3637,7 @@ def data_set_missing_data(grant_id: UUID, report_id: UUID) -> ResponseReturnValu
     if not data_set_data:
         return redirect(url_for("deliver_grant_funding.upload_data_set", grant_id=grant_id, report_id=report_id))
 
-    file_bytes = s3_service.download_file(data_set_data.s3_key)
-    file_storage = FileStorage(stream=io.BytesIO(file_bytes), filename=data_set_data.original_filename)
-    _, rows = _parse_data_set_csv(file_storage)
-
-    validation_result = validate_data_set(data_set_data, rows)
+    rows, validation_result = _load_and_validate_data_set(data_set_data)
 
     form = GenericSubmitForm()
 

--- a/app/deliver_grant_funding/routes/reports.py
+++ b/app/deliver_grant_funding/routes/reports.py
@@ -3433,7 +3433,7 @@ def map_data_set_columns(grant_id: UUID, report_id: UUID) -> ResponseReturnValue
         data_set_data.column_mappings = form.get_column_mappings()
         session["data_set_upload"] = data_set_data.model_dump(mode="json")
 
-        if form.has_numerical_columns():
+        if data_set_data.has_columns_requiring_manual_formatting():
             return redirect(
                 url_for(
                     "deliver_grant_funding.map_data_set_number_columns",

--- a/app/deliver_grant_funding/session_models.py
+++ b/app/deliver_grant_funding/session_models.py
@@ -177,3 +177,6 @@ class DataSetUploadSessionModel(BaseModel):
 
     def get_column_mapping(self, column_name: str) -> DataSetColumnMapping | None:
         return next((mapping for mapping in self.column_mappings if mapping.column_name == column_name), None)
+
+    def has_columns_requiring_manual_formatting(self) -> bool:
+        return any(mapping.requires_manual_formatting for mapping in self.column_mappings)

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -9836,6 +9836,101 @@ class TestMapDataSetColumns:
         soup = BeautifulSoup(response.data, "html.parser")
         assert page_has_error(soup, f"Select a data type for {session['data_set_upload']['data_columns'][0]}")
 
+    def test_post_british_pounds_with_bad_data_shows_inline_error(
+        self, authenticated_grant_admin_client, factories, mock_s3_service_calls, mocker
+    ):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant)
+        grant_recipient = factories.grant_recipient.create(
+            grant=authenticated_grant_admin_client.grant, organisation__external_id="EC123"
+        )
+
+        with authenticated_grant_admin_client.session_transaction() as session:
+            session["data_set_upload"] = DataSetUploadSessionModel(
+                name="Test Data Set",
+                data_source_type=DataSourceType.GRANT_RECIPIENT,
+                data_columns=["Capital allocation"],
+                preview_data={"Capital allocation": ["100", "£200.5"]},
+                data_source_id=uuid.uuid4(),
+                original_filename="test.csv",
+                s3_key="data-set-uploads/test.csv",
+            ).model_dump(mode="json")
+
+        all_rows = [
+            {
+                DATA_SET_EXTERNAL_ID_COLUMN_HEADER: grant_recipient.organisation.external_id,
+                DATA_SET_GRANT_RECIPIENT_COLUMN_HEADER: grant_recipient.organisation.name,
+                "Capital allocation": "£200.555",
+            },
+        ]
+        mocker.patch("app.services.s3.S3Service.download_file", return_value=_rows_to_csv_bytes(all_rows))
+
+        data = {
+            "columns-0-column_type": "BRITISH_POUNDS",
+            "submit": "y",
+        }
+        response = authenticated_grant_admin_client.post(
+            url_for("deliver_grant_funding.map_data_set_columns", grant_id=report.grant.id, report_id=report.id),
+            data=data,
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 200
+        soup = BeautifulSoup(response.data, "html.parser")
+        expected_message = (
+            "One or more numbers in column 'Capital allocation' are not formatted as British pounds to 2 "
+            "decimal places with the '£' prefix. For example, £100.00"
+        )
+        assert page_has_error(soup, expected_message)
+        select = soup.find("select", {"name": "columns-0-column_type"})
+        error_id = select.get("aria-describedby", "").split()[-1] if select else ""
+        error_element = soup.find(id=error_id) if error_id else None
+        assert error_element is not None
+        assert expected_message in error_element.get_text()
+
+    def test_post_british_pounds_clean_data_proceeds(
+        self, authenticated_grant_admin_client, factories, db_session, mock_s3_service_calls, mocker
+    ):
+        report = factories.collection.create(grant=authenticated_grant_admin_client.grant)
+        grant_recipient = factories.grant_recipient.create(
+            grant=authenticated_grant_admin_client.grant, organisation__external_id="EC123"
+        )
+
+        with authenticated_grant_admin_client.session_transaction() as session:
+            session["data_set_upload"] = DataSetUploadSessionModel(
+                name="Test Data Set",
+                data_source_type=DataSourceType.GRANT_RECIPIENT,
+                data_columns=["Capital allocation"],
+                preview_data={"Capital allocation": ["£100.00"]},
+                data_source_id=uuid.uuid4(),
+                original_filename="test.csv",
+                s3_key="data-set-uploads/test.csv",
+            ).model_dump(mode="json")
+
+        all_rows = [
+            {
+                DATA_SET_EXTERNAL_ID_COLUMN_HEADER: grant_recipient.organisation.external_id,
+                DATA_SET_GRANT_RECIPIENT_COLUMN_HEADER: grant_recipient.organisation.name,
+                "Capital allocation": "£100.00",
+            },
+        ]
+        mocker.patch("app.services.s3.S3Service.download_file", return_value=_rows_to_csv_bytes(all_rows))
+
+        data = {
+            "columns-0-column_type": "BRITISH_POUNDS",
+            "submit": "y",
+        }
+        response = authenticated_grant_admin_client.post(
+            url_for("deliver_grant_funding.map_data_set_columns", grant_id=report.grant.id, report_id=report.id),
+            data=data,
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 302
+        assert response.location.endswith(
+            url_for("deliver_grant_funding.list_report_data_sets", grant_id=report.grant.id, report_id=report.id)
+        )
+        assert db_session.scalar(select(func.count()).select_from(DataSource)) == 1
+
 
 class TestMapDataSetNumberColumns:
     def test_404_for_non_admin(self, authenticated_grant_member_client):

--- a/tests/integration/deliver_grant_funding/test_data_sets.py
+++ b/tests/integration/deliver_grant_funding/test_data_sets.py
@@ -3,9 +3,8 @@ import uuid
 from app.common.data.types import DataSourceType
 from app.constants import DATA_SET_EXTERNAL_ID_COLUMN_HEADER, DATA_SET_GRANT_RECIPIENT_COLUMN_HEADER
 from app.deliver_grant_funding.data_sets import (
+    BritishPoundsError,
     DataTypeError,
-    DecimalError,
-    PrefixError,
     validate_data_set,
     validate_data_set_grant_recipients,
 )
@@ -107,7 +106,7 @@ class TestValidateDataSet:
         assert result.missing_columns_by_row[0] == ["Notes"]
         assert result.missing_columns_by_row[1] == ["Notes", "Summary"]
 
-    def test_wrong_prefix_symbol_is_incorrect_data_type(self, factories):
+    def test_wrong_prefix_symbol_for_british_pounds_collapses_to_single_error(self, factories):
         gr = factories.grant_recipient.create(organisation__external_id="EC123")
         data_set = _make_data_set(
             data_columns=["Capital allocation"],
@@ -124,10 +123,8 @@ class TestValidateDataSet:
 
         result = validate_data_set(data_set, all_rows)
 
-        assert result.blocking_errors
-        assert len(result.blocking_errors) == 2
-        assert any(isinstance(error, PrefixError) for error in result.blocking_errors)
-        assert any(isinstance(error, DataTypeError) for error in result.blocking_errors)
+        assert len(result.blocking_errors) == 1
+        assert isinstance(result.blocking_errors[0], BritishPoundsError)
 
     def test_missing_prefix_is_valid(self, factories):
         gr = factories.grant_recipient.create(organisation__external_id="EC123")
@@ -167,7 +164,7 @@ class TestValidateDataSet:
         result = validate_data_set(data_set, all_rows)
         assert not result.blocking_errors
 
-    def test_too_many_decimal_places_is_blocking_cell_error(self, factories):
+    def test_too_many_decimal_places_in_british_pounds_is_blocking_error(self, factories):
         gr = factories.grant_recipient.create(organisation__external_id="EC123")
         data_set = _make_data_set(
             data_columns=["Capital allocation"],
@@ -184,8 +181,8 @@ class TestValidateDataSet:
 
         result = validate_data_set(data_set, all_rows)
 
-        assert result.blocking_errors
-        assert any(isinstance(error, DecimalError) for error in result.blocking_errors)
+        assert len(result.blocking_errors) == 1
+        assert isinstance(result.blocking_errors[0], BritishPoundsError)
 
     def test_incorrect_data_type_integer(self, factories):
         gr = factories.grant_recipient.create(organisation__external_id="EC123")
@@ -248,7 +245,7 @@ class TestValidateDataSet:
 
         assert result.blocking_errors
         assert result.has_missing_data
-        assert any(isinstance(e, DataTypeError) for e in result.blocking_errors)
+        assert any(isinstance(e, BritishPoundsError) for e in result.blocking_errors)
         assert result.missing_columns_by_row[0] == ["Notes"]
 
     def test_multiple_errors_across_rows(self, factories):
@@ -281,11 +278,10 @@ class TestValidateDataSet:
 
         assert result.blocking_errors
         assert len(result.row_results) == 2
-        assert len(result.blocking_errors) == 4
+        assert len(result.blocking_errors) == 3
 
-        assert any(isinstance(e, PrefixError) for e in result.blocking_errors)
-        assert any(isinstance(e, DecimalError) for e in result.blocking_errors)
-        assert any(isinstance(e, DataTypeError) for e in result.blocking_errors)
+        assert sum(isinstance(e, BritishPoundsError) for e in result.blocking_errors) == 2
+        assert sum(isinstance(e, DataTypeError) for e in result.blocking_errors) == 1
 
 
 class TestValidateDataSetGrantRecipients:


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-1392

## 📝 Description
Properly catch errors when formatting a column as 'British pounds'.

## 📸 Show the thing (screenshots, gifs)
<img width="529" height="838" alt="image" src="https://github.com/user-attachments/assets/d07af02c-3bcb-4344-86c3-03edd71e21ea" />

## 🧪 Testing
Upload a dataset with some invalid (eg text) data in a column that you choose to format as British pounds.

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [ ] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [ ] End-to-end tests have been updated (if applicable)
- [ ] Edge cases and error conditions are tested

## 📚 Additional Notes
<!-- Any additional context, concerns, or considerations for reviewers -->
