### PR TITLE
FSPT-1337: Drop unneeded data set type enum values

### DIFF
--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-063_submission_status_not_null
+064_remove_data_set_types

--- a/app/common/data/migrations/versions/064_remove_data_set_types.py
+++ b/app/common/data/migrations/versions/064_remove_data_set_types.py
@@ -1,0 +1,74 @@
+"""Remove redundant data set types
+
+Revision ID: 064_remove_data_set_types
+Revises: 063_submission_status_not_null
+Create Date: 2026-05-26 16:14:58.306592
+
+"""
+
+from alembic import op
+from alembic_postgresql_enum import TableReference
+
+revision = "064_remove_data_set_types"
+down_revision = "063_submission_status_not_null"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("data_source", schema=None) as batch_op:
+        batch_op.drop_constraint(
+            "ck_data_source_non_custom_requires_name_grant_collection_and_schema_and_file_metadata",
+            type_="check",
+        )
+
+    # I've checked and we only have GRANT_RECIPIENT and CUSTOM data sources in deployed envs, so this is for safety/
+    # local dev just in case people have STATIC or PROJECT_LEVEL data sources knocking around
+    op.execute(
+        "DELETE FROM data_source_item WHERE data_source_id IN (SELECT id FROM data_source WHERE type = 'STATIC')"
+    )
+    op.execute("DELETE FROM data_source WHERE type IN ('STATIC', 'PROJECT_LEVEL')")
+
+    op.sync_enum_values(  # ty: ignore[unresolved-attribute]
+        enum_schema="public",
+        enum_name="data_source_type_enum",
+        new_values=["CUSTOM", "GRANT_RECIPIENT"],
+        affected_columns=[TableReference(table_schema="public", table_name="data_source", column_name="type")],
+        enum_values_to_rename=[],
+    )
+
+    with op.batch_alter_table("data_source", schema=None) as batch_op:
+        batch_op.create_check_constraint(
+            "ck_data_source_non_custom_requires_name_grant_collection_and_schema_and_file_metadata",
+            (
+                "type = 'CUSTOM' OR "
+                "(name IS NOT NULL AND grant_id IS NOT NULL AND collection_id IS NOT NULL "
+                "AND schema IS NOT NULL AND file_metadata IS NOT NULL)"
+            ),
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("data_source", schema=None) as batch_op:
+        batch_op.drop_constraint(
+            "ck_data_source_non_custom_requires_name_grant_collection_and_schema_and_file_metadata",
+            type_="check",
+        )
+
+    op.sync_enum_values(  # ty: ignore[unresolved-attribute]
+        enum_schema="public",
+        enum_name="data_source_type_enum",
+        new_values=["CUSTOM", "STATIC", "GRANT_RECIPIENT", "PROJECT_LEVEL"],
+        affected_columns=[TableReference(table_schema="public", table_name="data_source", column_name="type")],
+        enum_values_to_rename=[],
+    )
+
+    with op.batch_alter_table("data_source", schema=None) as batch_op:
+        batch_op.create_check_constraint(
+            "ck_data_source_non_custom_requires_name_grant_collection_and_schema_and_file_metadata",
+            (
+                "type = 'CUSTOM' OR "
+                "(name IS NOT NULL AND grant_id IS NOT NULL AND collection_id IS NOT NULL "
+                "AND schema IS NOT NULL AND file_metadata IS NOT NULL)"
+            ),
+        )

--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -1202,22 +1202,18 @@ class DataSource(BaseModel, SafeDidMixin):
 
     def build_typed_org_item_data(
         self,
-        data: dict[str, str | int | float | None] | list[dict[str, str | int | float | None]],
-    ) -> dict[str, DataSourceAnswerTypes | None] | list[dict[str, DataSourceAnswerTypes | None]]:
+        data: dict[str, str | int | float | None],
+    ) -> dict[str, DataSourceAnswerTypes | None]:
         """
         Transform raw DataSourceOrganisationItem data into typed answer models.
 
-        2D (GRANT_RECIPIENT or STATIC, though STATIC is bit of a weird one): dict -> dict[str, DataSourceAnswerTypes]
-        3D (PROJECT_LEVEL): list[dict] -> list[dict[str, DataSourceAnswerTypes]]
+        2D (GRANT_RECIPIENT): dict -> dict[str, DataSourceAnswerTypes]
 
         The typed answers carry the presentation & data options (prefix, suffix etc.) so that we can call all the usual
         answer methods eg. get_value_for_interpolation().
         """
         if not self.schema:
-            return {} if isinstance(data, dict) else []
-
-        if isinstance(data, list):
-            return [self._build_typed_data(row) for row in data]
+            return {}
 
         return self._build_typed_data(data)
 
@@ -1319,10 +1315,7 @@ class DataSourceOrganisationItem(BaseModel):
     data_source_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("data_source.id", ondelete="CASCADE"))
     external_id: Mapped[str]
 
-    # For 2D: dict[str, scalar], for 3D: list[dict[str, scalar]]
-    _data: Mapped[json_flat_scalars | list[json_flat_scalars]] = mapped_column(
-        "data", mutable_json_type(dbtype=JSONB, nested=True)
-    )
+    _data: Mapped[json_flat_scalars] = mapped_column("data", mutable_json_type(dbtype=JSONB, nested=True))
 
     data_source: Mapped[DataSource] = relationship("DataSource", back_populates="organisation_items")
 
@@ -1333,12 +1326,11 @@ class DataSourceOrganisationItem(BaseModel):
     )
 
     @property
-    def data(self) -> dict[str, DataSourceAnswerTypes | None] | list[dict[str, DataSourceAnswerTypes | None]]:
+    def data(self) -> dict[str, DataSourceAnswerTypes | None]:
         """
         Returns raw data as typed answer models via the parent DataSource schema.
 
-        2D (GRANT_RECIPIENT or STATIC): dict[str, DataSourceAnswerTypes]
-        3D (PROJECT_LEVEL): list[dict[str, DataSourceAnswerTypes]]
+        2D (GRANT_RECIPIENT): dict[str, DataSourceAnswerTypes]
         """
         return self.data_source.build_typed_org_item_data(self._data)
 

--- a/app/common/data/types.py
+++ b/app/common/data/types.py
@@ -472,9 +472,7 @@ class AuditEventType(enum.Enum):
 
 class DataSourceType(enum.StrEnum):
     CUSTOM = "Custom"
-    STATIC = "Static"
     GRANT_RECIPIENT = "Grant recipient"
-    PROJECT_LEVEL = "Project level"
 
 
 class DataSourceSchemaColumn(BaseModel):

--- a/tests/unit/common/data/test_models.py
+++ b/tests/unit/common/data/test_models.py
@@ -412,7 +412,7 @@ class TestDataSourceMakePydanticModel:
     def test_text_column_returns_text_single_line_answer(self, factories):
         data_source = factories.data_source.build(
             name="Test data set",
-            type=DataSourceType.STATIC,
+            type=DataSourceType.GRANT_RECIPIENT,
             schema=DataSourceSchema.model_validate({"theme-name": _text_col("Theme name")}),
         )
 


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-1337

## 📝 Description
We're not supporting STATIC or PROJECT_LEVEL data sets for the time being so now that all code and logic referencing these is removed from the service (https://github.com/communitiesuk/funding-service/pull/1673) and they can't be created we can safely drop the values from the enum and accompanying logic in our models.

## 📸 Show the thing (screenshots, gifs)
<!-- Include screenshots for UI changes, new features, or visual modifications -->
<!-- Use "Before" and "After" sections if showing changes to existing functionality -->

## 🧪 Testing
DB should be able to go up and down safely with this migration, any lingering STATIC or PROJECT_LEVEL data sources should be removed as part of the upgrade.

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [X] PR title and description provide sufficient context for reviewers
- [X] Commits are logical, self-contained, and have clear descriptions

### Testing
- [X] I have tested this change and it meets the acceptance criteria for the ticket
- [X] I need the reviewer(s) to pull and run this change locally
- ~[ ] New (non-developer) functionality has appropriate unit and integration tests~
- ~[ ] End-to-end tests have been updated (if applicable)~
- ~[ ] Edge cases and error conditions are tested~