### PR TITLE
BAU Validation allow expression context defaults

### DIFF
--- a/app/common/collections/forms.py
+++ b/app/common/collections/forms.py
@@ -262,7 +262,7 @@ class DynamicQuestionForm(FlaskForm):
                 # don't show referenced questions that the user hasn't had to answer
                 if (
                     self._submission_helper
-                    and referenced_question.id not in self._submission_helper.all_visible_questions.keys()
+                    and referenced_question.id not in self._submission_helper.all_visible_questions
                 ):
                     continue
 

--- a/app/common/collections/forms.py
+++ b/app/common/collections/forms.py
@@ -146,7 +146,7 @@ class DynamicQuestionForm(FlaskForm):
         # in this form by the user.
         submitted_evaluation_context = self._evaluation_context.with_question_form_context(
             self._extract_submission_answers()
-        )
+        ).with_default_context(self._submission_helper)
 
         for q in self._questions:
             # only add custom validators if that question hasn't already failed basic validation
@@ -183,7 +183,10 @@ class DynamicQuestionForm(FlaskForm):
         group = cast(Group, self._component)
 
         for validation in group.validations:
-            if evaluate(expression=validation, context=submitted_evaluation_context):
+            if evaluate(
+                expression=validation,
+                context=submitted_evaluation_context.with_default_context(self._submission_helper),
+            ):
                 emit_metric_count(
                     MetricEventName.SUBMISSION_MANAGED_VALIDATION_SUCCESS
                     if validation.is_managed
@@ -255,6 +258,14 @@ class DynamicQuestionForm(FlaskForm):
             else:
                 if referenced_question.id in seen_off_page:
                     continue
+
+                # don't show referenced questions that the user hasn't had to answer
+                if (
+                    self._submission_helper
+                    and referenced_question.id not in self._submission_helper.all_visible_questions.keys()
+                ):
+                    continue
+
                 seen_off_page.add(referenced_question.id)
 
                 display_value = "not answered"

--- a/app/common/collections/validation.py
+++ b/app/common/collections/validation.py
@@ -87,12 +87,12 @@ class SubmissionValidator:
         if add_another_index is not None:
             evaluation_context = self.helper.cached_evaluation_context.with_add_another_context(
                 group, self.helper.submission.data_manager, add_another_index=add_another_index, mode="evaluation"
-            )
+            ).with_default_context(self.helper)
             interpolation_context = self.helper.cached_interpolation_context.with_add_another_context(
                 group, self.helper.submission.data_manager, add_another_index=add_another_index, mode="interpolation"
             )
         else:
-            evaluation_context = self.helper.cached_evaluation_context
+            evaluation_context = self.helper.cached_evaluation_context.with_default_context(self.helper)
             interpolation_context = self.helper.cached_interpolation_context
 
         for validation_expr in group.validations:
@@ -133,7 +133,7 @@ class SubmissionValidator:
         if not question.validations:
             return errors
 
-        evaluation_context = self.helper.cached_evaluation_context
+        evaluation_context = self.helper.cached_evaluation_context.with_default_context(self.helper)
         if add_another_index is not None and question.add_another_container:
             evaluation_context = evaluation_context.with_add_another_context(
                 question.add_another_container,

--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-062_empty_default_values
+061_pre_award_collections

--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-061_pre_award_collections
+062_empty_default_values

--- a/app/common/expressions/__init__.py
+++ b/app/common/expressions/__init__.py
@@ -11,7 +11,7 @@ from markupsafe import Markup, escape
 from pydantic import BaseModel
 
 from app.common.data.submission_data_manager import SubmissionDataManager
-from app.common.data.types import ExpressionType, ManagedExpressionsEnum
+from app.common.data.types import ExpressionType, ManagedExpressionsEnum, QuestionDataType
 from app.common.exceptions import WTFormRenderableException
 from app.common.expressions.references import ExpressionReference
 from app.types import NOT_PROVIDED
@@ -188,12 +188,14 @@ class ExpressionContext(ChainMap[str, Any]):
         add_another_context: dict[str, Any] | None = None,
         data_source_context: dict[str, Any] | None = None,
         question_form_context: dict[str, Any] | None = None,
+        default_context: dict[str, Any] | None = None,
     ):
         self._submission_data = submission_data or {}
         self._expression_context = expression_context or {}
         self._add_another_context = add_another_context or {}
         self._data_source_context = data_source_context or {}
         self._question_form_context = question_form_context or {}
+        self._default_context = default_context or {}
 
         super().__init__(*self._ordered_contexts)
 
@@ -240,6 +242,7 @@ class ExpressionContext(ChainMap[str, Any]):
             expression_context=self._expression_context,
             question_form_context=self._question_form_context,
             data_source_context=self._data_source_context,
+            default_context=self._default_context,
         )
 
     @property
@@ -253,6 +256,7 @@ class ExpressionContext(ChainMap[str, Any]):
                     self._submission_data,
                     self._data_source_context,
                     self._expression_context,
+                    self._default_context,
                 ],
             )
         )
@@ -280,6 +284,43 @@ class ExpressionContext(ChainMap[str, Any]):
             add_another_context=self._add_another_context,
             data_source_context=self._data_source_context,
             question_form_context=submission_answers_from_form,
+            default_context=self._default_context,
+        )
+
+    def with_default_context(self, submission_helper: SubmissionHelper | None) -> ExpressionContext:
+        """To accommodate custom expressions that might reference questions that are
+        conditionally not required given the current answer state, we set default empty values
+        for any question that is not currently visible.
+
+        We won't default answers that should be visible, as anything unhandled here should
+        surface logical errors and defaults could lead to unpredictable failures.
+
+        This method is intentionally separated from building the initial expression context
+        so that any initial visibility checks and interpolation don't worry about default edge cases,
+        this should only be used when evaluating custom validations.
+
+        The scope of this could be expanded to other data sources and other data types
+        as required.
+        """
+        if not submission_helper:
+            return self
+
+        default_context: dict[str, Any] = {}
+
+        for form in submission_helper.collection.forms:
+            visible_questions = submission_helper.cached_get_ordered_visible_questions(form)
+            for question in form.cached_questions:
+                if question not in visible_questions:
+                    if question.data_type == QuestionDataType.NUMBER:
+                        default_context[question.safe_qid] = 0
+
+        return ExpressionContext(
+            submission_data=self._submission_data,
+            expression_context=self._expression_context,
+            add_another_context=self._add_another_context,
+            data_source_context=self._data_source_context,
+            question_form_context=self._question_form_context,
+            default_context=default_context,
         )
 
     @staticmethod

--- a/app/common/expressions/__init__.py
+++ b/app/common/expressions/__init__.py
@@ -252,11 +252,11 @@ class ExpressionContext(ChainMap[str, Any]):
                 None,
                 [
                     self._question_form_context,
+                    self._default_context,
                     self._add_another_context,
                     self._submission_data,
                     self._data_source_context,
                     self._expression_context,
-                    self._default_context,
                 ],
             )
         )

--- a/tests/integration/common/collections/test_forms.py
+++ b/tests/integration/common/collections/test_forms.py
@@ -8,6 +8,7 @@ from wtforms.fields.choices import SelectField
 from wtforms.validators import DataRequired
 
 from app.common.collections.forms import build_question_form
+from app.common.collections.types import IntegerAnswer, YesNoAnswer
 from app.common.data import interfaces
 from app.common.data.interfaces.collections import create_question
 from app.common.data.types import (
@@ -16,13 +17,16 @@ from app.common.data.types import (
     NumberTypeEnum,
     QuestionDataOptions,
     QuestionDataType,
+    QuestionPresentationOptions,
 )
 from app.common.expressions import ExpressionContext
 from app.common.expressions.custom import CustomExpression
-from app.common.expressions.managed import GreaterThan, IsAfter, LessThan
+from app.common.expressions.managed import GreaterThan, IsAfter, IsYes, LessThan
 from app.common.expressions.references import ExpressionReference
 from app.common.forms.fields import MHCLGAccessibleAutocomplete
+from app.common.helpers.collections import SubmissionHelper
 from app.metrics import MetricEventName
+from tests.models import FactoryAnswer
 
 EC = ExpressionContext
 
@@ -554,3 +558,119 @@ class TestValidationMetrics:
         assert valid is False
         assert mock_sentry_metrics.call_count == 2
         assert mock_sentry_metrics.call_args[0] == (MetricEventName.SUBMISSION_CUSTOM_VALIDATION_ERROR, 1)
+
+
+class TestGroupValidationWithDefaultContext:
+    def test_group_validation_passes_when_conditional_number_question_answer_is_missing(
+        self, factories, mock_sentry_metrics
+    ):
+        user = factories.user.create()
+        is_yes_question = factories.question.create(data_type=QuestionDataType.YES_NO, order=0)
+        group = factories.group.create(
+            form=is_yes_question.form,
+            order=1,
+            presentation_options=QuestionPresentationOptions(show_questions_on_the_same_page=True),
+        )
+        question_number_one = factories.question.create(
+            form=is_yes_question.form, parent=group, data_type=QuestionDataType.NUMBER, order=0
+        )
+        question_number_two = factories.question.create(
+            form=is_yes_question.form, parent=group, data_type=QuestionDataType.NUMBER, order=1
+        )
+        interfaces.collections.add_component_condition(
+            question_number_two,
+            user,
+            IsYes(subject_reference=ExpressionReference.from_question(is_yes_question)),
+        )
+        interfaces.collections.add_component_validation(
+            group,
+            user,
+            CustomExpression(
+                custom_expression=f"(({question_number_two.safe_qid})) + (({question_number_one.safe_qid})) == 50",
+                custom_message="Total must be 50",
+            ),
+        )
+
+        submission = factories.submission.create(
+            collection=is_yes_question.form.collection,
+            answers=[FactoryAnswer(is_yes_question, YesNoAnswer(False))],
+        )
+        helper = SubmissionHelper(submission)
+
+        _FormClass = build_question_form(
+            [question_number_one],
+            evaluation_context=helper.cached_evaluation_context,
+            interpolation_context=helper.cached_interpolation_context,
+            component=group,
+            submission_helper=helper,
+        )
+        form_instance = _FormClass(formdata=MultiDict({question_number_one.safe_qid: "50"}))
+
+        valid = form_instance.validate()
+
+        assert valid is True
+        assert form_instance.group_validation_error is None
+
+    def test_group_validation_error_excludes_invisible_referenced_questions(self, factories, mock_sentry_metrics):
+        user = factories.user.create()
+        is_yes_question = factories.question.create(data_type=QuestionDataType.YES_NO, order=0)
+        question_off_page_hidden = factories.question.create(
+            form=is_yes_question.form, data_type=QuestionDataType.NUMBER, order=1
+        )
+        question_off_page_visible = factories.question.create(
+            form=is_yes_question.form, data_type=QuestionDataType.NUMBER, order=2
+        )
+        interfaces.collections.add_component_condition(
+            question_off_page_hidden,
+            user,
+            IsYes(subject_reference=ExpressionReference.from_question(is_yes_question)),
+        )
+        group = factories.group.create(
+            form=is_yes_question.form,
+            order=3,
+            presentation_options=QuestionPresentationOptions(show_questions_on_the_same_page=True),
+        )
+        question_on_page = factories.question.create(
+            form=is_yes_question.form, parent=group, data_type=QuestionDataType.NUMBER, order=0
+        )
+        interfaces.collections.add_component_validation(
+            group,
+            user,
+            CustomExpression(
+                custom_expression=f"(({question_on_page.safe_qid})) + (({question_off_page_visible.safe_qid})) "
+                + f"+ (({question_off_page_hidden.safe_qid})) == 150",
+                custom_message="Total must be 150",
+            ),
+        )
+
+        submission = factories.submission.create(
+            collection=is_yes_question.form.collection,
+            answers=[
+                FactoryAnswer(is_yes_question, YesNoAnswer(False)),
+                FactoryAnswer(question_off_page_visible, IntegerAnswer(value=50)),
+            ],
+        )
+        helper = SubmissionHelper(submission)
+
+        _FormClass = build_question_form(
+            [question_on_page],
+            evaluation_context=helper.cached_evaluation_context,
+            interpolation_context=helper.cached_interpolation_context,
+            component=group,
+            submission_helper=helper,
+        )
+        form_instance = _FormClass(formdata=MultiDict({question_on_page.safe_qid: "50"}))
+
+        valid = form_instance.validate()
+
+        # the condition was safely allowed to run, and fails
+        assert valid is False
+        # on_page_entries includes q_on_page (it's a visible field on this form)
+        on_page_ids = {e.question.id for e in form_instance.group_validation_error.on_page_entries}
+        off_page_ids = {e.question.id for e in form_instance.group_validation_error.off_page_entries}
+
+        # errors off page includes visible question but don't include the question that is hidden
+        # by a condition
+        assert question_on_page.id in on_page_ids
+        assert question_off_page_hidden.id not in off_page_ids
+        assert question_off_page_visible.id in off_page_ids

--- a/tests/integration/common/collections/test_forms.py
+++ b/tests/integration/common/collections/test_forms.py
@@ -674,3 +674,58 @@ class TestGroupValidationWithDefaultContext:
         assert question_on_page.id in on_page_ids
         assert question_off_page_hidden.id not in off_page_ids
         assert question_off_page_visible.id in off_page_ids
+
+    def test_group_validation_passes_when_hidden_question_has_stale_persisted_answer(
+        self, factories, mock_sentry_metrics
+    ):
+        user = factories.user.create()
+        is_yes_question = factories.question.create(data_type=QuestionDataType.YES_NO, order=0)
+        group = factories.group.create(
+            form=is_yes_question.form,
+            order=1,
+            presentation_options=QuestionPresentationOptions(show_questions_on_the_same_page=True),
+        )
+        question_number_one = factories.question.create(
+            form=is_yes_question.form, parent=group, data_type=QuestionDataType.NUMBER, order=0
+        )
+        question_number_two = factories.question.create(
+            form=is_yes_question.form, parent=group, data_type=QuestionDataType.NUMBER, order=1
+        )
+        interfaces.collections.add_component_condition(
+            question_number_two,
+            user,
+            IsYes(subject_reference=ExpressionReference.from_question(is_yes_question)),
+        )
+        interfaces.collections.add_component_validation(
+            group,
+            user,
+            CustomExpression(
+                custom_expression=f"(({question_number_two.safe_qid})) + (({question_number_one.safe_qid})) == 50",
+                custom_message="Total must be 50",
+            ),
+        )
+
+        # question_number_two was answered earlier (when is_yes was True)
+        # is_yes to False so question_number_two is now hidden
+        submission = factories.submission.create(
+            collection=is_yes_question.form.collection,
+            answers=[
+                FactoryAnswer(is_yes_question, YesNoAnswer(False)),
+                FactoryAnswer(question_number_two, IntegerAnswer(value=100)),
+            ],
+        )
+        helper = SubmissionHelper(submission)
+
+        _FormClass = build_question_form(
+            [question_number_one],
+            evaluation_context=helper.cached_evaluation_context,
+            interpolation_context=helper.cached_interpolation_context,
+            component=group,
+            submission_helper=helper,
+        )
+        form_instance = _FormClass(formdata=MultiDict({question_number_one.safe_qid: "50"}))
+
+        valid = form_instance.validate()
+
+        assert valid is True
+        assert form_instance.group_validation_error is None

--- a/tests/integration/common/expressions/test_init.py
+++ b/tests/integration/common/expressions/test_init.py
@@ -5,7 +5,7 @@ from unittest.mock import PropertyMock
 
 import pytest
 
-from app.common.collections.types import TextSingleLineAnswer
+from app.common.collections.types import IntegerAnswer, TextSingleLineAnswer
 from app.common.data.models import Expression
 from app.common.data.types import (
     DataSourceSchema,
@@ -30,6 +30,7 @@ class TestExpressionContext:
             submission_data={"a": 1, "b": 1, "e": 1},
             expression_context={"a": 2, "c": 2, "d": 2},
             question_form_context={"a": 3, "f": 3, "g": 3},
+            default_context={"a": 0, "h": 0},
         )
         assert ex["a"] == 3
         assert ex["b"] == 1
@@ -38,9 +39,10 @@ class TestExpressionContext:
         assert ex["e"] == 1
         assert ex["f"] == 3
         assert ex["g"] == 3
+        assert ex["h"] == 0
 
         with pytest.raises(KeyError):
-            assert ex["h"]
+            assert ex["i"]
 
     def test_get(self):
         ex = ExpressionContext(
@@ -905,6 +907,43 @@ class TestExtendingWithQuestionFormContext:
             )
 
             assert new_context["d_abc"]["capital_allocation"] == 1000
+
+
+class TestWithDefaultContext:
+    def test_returns_unchanged_with_no_submission_helper(self):
+        ctx = ExpressionContext(submission_data={"qid": 5})
+        result = ctx.with_default_context(None)
+        assert result is ctx
+
+    def test_defaults_answers_set_based_on_visibility(self, factories):
+        visible_question_with_answer = factories.question.create(data_type=QuestionDataType.NUMBER)
+        visible_question_without_answer = factories.question.create(
+            form=visible_question_with_answer.form, data_type=QuestionDataType.NUMBER
+        )
+        hidden_question = factories.question.create(
+            form=visible_question_with_answer.form, data_type=QuestionDataType.NUMBER
+        )
+        factories.expression.create(
+            question=hidden_question,
+            statement="False",
+            type_=ExpressionType.CONDITION,
+        )
+        submission = factories.submission.create(
+            collection=visible_question_with_answer.form.collection,
+            answers=[FactoryAnswer(visible_question_with_answer, IntegerAnswer(value=123))],
+        )
+        helper = SubmissionHelper(submission)
+
+        result = ExpressionContext.build_expression_context(
+            collection=visible_question_with_answer.form.collection,
+            mode="evaluation",
+            submission_helper=helper,
+            data_manager=helper.submission.data_manager,
+        ).with_default_context(helper)
+
+        assert result.get(visible_question_with_answer.safe_qid) == 123
+        assert result.get(visible_question_without_answer.safe_qid) is None
+        assert result.get(hidden_question.safe_qid) == 0
 
 
 class TestDataSourceInterpolation:

--- a/tests/integration/common/expressions/test_init.py
+++ b/tests/integration/common/expressions/test_init.py
@@ -27,10 +27,10 @@ from tests.models import FactoryAnswer
 class TestExpressionContext:
     def test_layering(self):
         ex = ExpressionContext(
-            submission_data={"a": 1, "b": 1, "e": 1},
+            submission_data={"a": 1, "b": 1, "e": 1, "j": 1},
             expression_context={"a": 2, "c": 2, "d": 2},
             question_form_context={"a": 3, "f": 3, "g": 3},
-            default_context={"a": 0, "h": 0},
+            default_context={"a": 0, "h": 0, "j": 0},
         )
         assert ex["a"] == 3
         assert ex["b"] == 1
@@ -40,6 +40,10 @@ class TestExpressionContext:
         assert ex["f"] == 3
         assert ex["g"] == 3
         assert ex["h"] == 0
+
+        # for now default context is above submission data to avoid
+        # stale data (on now hidden questions) being used in validations
+        assert ex["j"] == 0
 
         with pytest.raises(KeyError):
             assert ex["i"]

--- a/tests/unit/common/collections/test_validation.py
+++ b/tests/unit/common/collections/test_validation.py
@@ -401,3 +401,48 @@ class TestSubmissionValidator:
         assert errors[0].question_id == inner_group.id
         assert errors[0].form_id == form.id
         assert errors[0].error_message == "Total must be 100"
+
+    def test_group_validation_passes_when_referenced_number_question_is_conditionally_hidden(self, factories):
+        is_yes_question = factories.question.build(id=uuid.uuid4(), data_type=QuestionDataType.YES_NO, order=0)
+        group = factories.group.build(
+            form=is_yes_question.form,
+            id=uuid.uuid4(),
+            order=1,
+            presentation_options=QuestionPresentationOptions(show_questions_on_the_same_page=True),
+        )
+        question_number_one = factories.question.build(
+            form=is_yes_question.form, parent=group, id=uuid.uuid4(), data_type=QuestionDataType.NUMBER, order=0
+        )
+        factories.expression.build(
+            question=question_number_one,
+            type_=ExpressionType.CONDITION,
+            managed_name=ManagedExpressionsEnum.IS_YES,
+            statement=f"{is_yes_question.safe_qid} is True",
+            context={"subject_reference": ExpressionReference.from_question(is_yes_question)},
+        )
+        question_number_two = factories.question.build(
+            form=is_yes_question.form, parent=group, id=uuid.uuid4(), data_type=QuestionDataType.NUMBER, order=1
+        )
+        custom = CustomExpression(
+            custom_expression=f"(({question_number_one.safe_qid})) + (({question_number_two.safe_qid})) == 50",
+            custom_message="Total must be 50",
+        )
+        factories.expression.build(
+            question=group,
+            type_=ExpressionType.VALIDATION,
+            statement=custom.statement,
+            context=custom.model_dump(mode="json"),
+        )
+
+        submission = factories.submission.build(
+            collection=is_yes_question.form.collection,
+            answers=[
+                FactoryAnswer(is_yes_question, YesNoAnswer(False)),
+                FactoryAnswer(question_number_two, IntegerAnswer(value=50)),
+            ],
+        )
+
+        helper = SubmissionHelper(submission)
+        validator = SubmissionValidator(helper)
+
+        assert validator.validate_all_reachable_questions() is None


### PR DESCRIPTION
## 📝 Description
Add an optional default value context to the expresion context builder,
this can be used when validations might be referencing values that could
be optional and would have no impact on the validation/ calculation. For
example a number might be 0 or a text value "".

Fow now the scope is limited to the questions in the current collection
and only number values (defaulting to 0).

We'll only add default values to questions that are not
currently visible based on the expression context, this should mean that
any out of order or logical code failures where a question should have
been answered to get to this point are still raised as failures.

Note that for single components partial validations are still not
practically possible because the question won't be conditionally shown
if the questions it refers to are not answered - this isn't the case for
group validations as visibility is based on the questions in the group.

I've checked this against the propose change to a single directional
graph through condition visibility checking and it still works as
expected - we should sense check that our conditional checks and
referencing for group validations work as we expect.

One last thing it would be helpful for someone to sense check is that
its appropriate that a validation on a single question with references
that aren't yet populated will cause the question to not show but
validation on a group with references that aren't yet populated will
allow the group to be navigated to - I don't think this is a problem but
we should make the behaviour explicit or we'll end up with something
unexpected later on down the line.

## 🧪 Testing

Set up a form scenario as follows (reflects a real required scenario): 
- checkbox question "category", option A and option B
- number question "total"
- question group (validation "total A" + "total B" == "total")
  - number question "total A" (conditional on option A)
  - number question "total B" (conditional on option B)

Previewing the form
- the validation for the group should work appropriately if only A, B, or A and B are selected 
- the group validation should only show the relevantly shown questions
- if the "total" is then changed before submitting the tasklist should fail to submit with a helpful error message

## 📋 Developer Checklist


### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- [-] No N+1 query problems introduced
- [-] Any new DB queries include appropriate where clauses based on the user's permissions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [-] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested