### PR TITLE
Join submission event users

### DIFF
--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -367,7 +367,7 @@ def get_all_submissions_with_mode_for_collection(
             .joinedload(Collection.forms)
             .selectinload(Form._all_components)
             .selectinload(Component.owned_component_references),
-            selectinload(Submission.events),
+            selectinload(Submission.events).joinedload(SubmissionEvent.created_by),
             selectinload(Submission.data_sources),
             joinedload(Submission.created_by),
         )

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -5161,6 +5161,44 @@ class TestGetSubmissions:
 
         assert len(iterate_queries) == baseline_queries
 
+    def test_get_all_submissions_with_mode_for_collection_with_full_schema_no_n_plus_one_for_event_users(
+        self, db_session, factories, track_sql_queries
+    ):
+        collection = factories.collection.create()
+        for _ in range(2):
+            submission = factories.submission.create(collection=collection, mode=SubmissionModeEnum.LIVE)
+            factories.submission_event.create(submission=submission)
+            factories.submission_event.create(submission=submission)
+
+        db_session.expire_all()
+        with track_sql_queries() as baseline_queries:
+            submissions = get_all_submissions_with_mode_for_collection(
+                collection_id=collection.id,
+                submission_mode=SubmissionModeEnum.LIVE,
+                with_full_schema=True,
+            )
+            for submission in submissions:
+                for event in submission.events:
+                    _ = event.created_by
+        baseline = len(baseline_queries)
+
+        submission = factories.submission.create(collection=collection, mode=SubmissionModeEnum.LIVE)
+        factories.submission_event.create(submission=submission)
+        factories.submission_event.create(submission=submission)
+
+        db_session.expire_all()
+        with track_sql_queries() as iterate_queries:
+            submissions = get_all_submissions_with_mode_for_collection(
+                collection_id=collection.id,
+                submission_mode=SubmissionModeEnum.LIVE,
+                with_full_schema=True,
+            )
+            for submission in submissions:
+                for event in submission.events:
+                    _ = event.created_by
+
+        assert len(iterate_queries) == baseline
+
 
 class TestResetTestSubmission:
     def test_reset_test_submission_only_deletes_specified_submission(self, db_session, factories):


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
We're seeing n+1 queries on `deliver_grant_funding.list_submissions` in Sentry, which is causing a lot of additional page latency when loading multiple submissions.

This eagerly loads a submission event's user in order to prevent n+1 queries.

Sentry trace: https://communitiesuk.sentry.io/explore/traces/trace/7c95dde559f248a58d146b7cf5b9065b

## 🧪 Testing
<!-- Describe how you've tested this change, and how a reviewer can test it -->

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [ ] PR title and description provide sufficient context for reviewers
- [ ] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- [ ] No N+1 query problems introduced
- [ ] Any new DB queries include appropriate where clauses based on the user's permissions

### Testing
- [ ] I have tested this change and it meets the acceptance criteria for the ticket
- [ ] I need the reviewer(s) to pull and run this change locally
- [ ] New (non-developer) functionality has appropriate unit and integration tests
- [ ] End-to-end tests have been updated (if applicable)
- [ ] Edge cases and error conditions are tested

## 📚 Additional Notes
<!-- Any additional context, concerns, or considerations for reviewers -->
