### PR TITLE
Save submission status

### DIFF
--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -135,6 +135,11 @@ def update_collection(  # noqa: C901
     submission_name_question_id: uuid.UUID | None | TNotProvided = NOT_PROVIDED,
     submission_guidance: str | None | TNotProvided = NOT_PROVIDED,
 ) -> Collection:
+    """Update the various attributes of a collection.
+
+    NOTE: When transitioning a collection's status, this may need to update the status for all of its submissions, eg
+    when closing a report to change any unsubmitted submissions statuses to NOT_SUBMITTED.
+    """
     if name is not NOT_PROVIDED:
         collection.name = name
         collection.slug = slugify(name)
@@ -296,6 +301,17 @@ def update_collection(  # noqa: C901
                         f"You cannot close the report for submissions before "
                         f"the submission period end date of {collection.submission_period_end_date}"
                     )
+
+                from app.common.helpers.collections import SubmissionHelper
+
+                # TODO don't do this here but we need it for _update_submission_status to calculate the new status below
+                collection.status = status
+
+                for submission in collection._submissions:
+                    # TODO replace this with add_submission_event to record that the colleciton was closed
+                    #   But for expediency now, just call _update_submission_status which will calculate the new status
+                    #   based on the collection now being closed
+                    SubmissionHelper(submission)._update_submission_status()
 
             case _:
                 raise StateTransitionError("Collection", collection.status, status)

--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -51,6 +51,7 @@ from app.common.data.types import (
     QuestionPresentationOptions,
     SubmissionEventType,
     SubmissionModeEnum,
+    SubmissionStatusEnum,
 )
 from app.common.data.utils import generate_submission_reference
 from app.common.exceptions import WTFormRenderableException
@@ -314,12 +315,24 @@ def update_collection(  # noqa: C901
 
 @flush_and_rollback_on_exceptions
 def update_submission_data(submission: Submission) -> None:
+    """Update the submission data with the data from the helper.
+
+    NOTE: the submission's status probably needs updating after this; SubmissionHelper owns the status of a submission.
+    This interface should only be called by the SubmissionHelper, and it must make sure that the status of the
+    submission is updated appropriately (after clearing appropriate caches).
+    """
     # We make a deepcopy here so that if any changes are made to `submission.data_manager.data` after this is flushed,
     # the changes are not reflected on the submission.
     submission._data = deepcopy(submission.data_manager.data)
 
     # Bust the DataManager cached property so that it reads the new submission data
     del submission.data_manager
+
+
+@flush_and_rollback_on_exceptions
+def update_submission(submission: Submission, *, status: SubmissionStatusEnum | TNotProvided = NOT_PROVIDED) -> None:
+    if status is not NOT_PROVIDED:
+        submission.status = status
 
 
 def get_all_submissions_with_mode_for_collection(
@@ -495,6 +508,7 @@ def create_submission(
         created_by=created_by,
         mode=mode,
         grant_recipient=grant_recipient,
+        status=SubmissionStatusEnum.NOT_STARTED,
     )
     db.session.add(submission)
     emit_metric_count(MetricEventName.SUBMISSION_CREATED, submission=submission)
@@ -1505,46 +1519,55 @@ def update_question(
 
 
 @overload
-def add_submission_event(
+def _add_submission_event(
     submission: Submission,
     *,
     event_type: Literal[SubmissionEventType.SUBMISSION_DECLINED_BY_CERTIFIER],
     user: User,
     related_entity_id: UUID | None = None,
     **kwargs: Unpack[DeclinedByCertifierKwargs],
-) -> Submission: ...
+) -> None: ...
 
 
 @overload
-def add_submission_event(
+def _add_submission_event(
     submission: Submission,
     *,
     event_type: Literal[SubmissionEventType.SUBMISSION_REOPENED],
     user: User,
     related_entity_id: UUID | None = None,
     **kwargs: Unpack[ReopenedKwargs],
-) -> Submission: ...
+) -> None: ...
 
 
 @overload
-def add_submission_event(
+def _add_submission_event(
     submission: Submission,
     *,
     event_type: SubmissionEventType,
     user: User,
     related_entity_id: UUID | None = None,
-) -> Submission: ...
+) -> None: ...
 
 
 @flush_and_rollback_on_exceptions
-def add_submission_event(
+def _add_submission_event(
     submission: Submission,
     *,
     event_type: SubmissionEventType,
     user: User,
     related_entity_id: UUID | None = None,
     **kwargs: Any,
-) -> Submission:
+) -> None:
+    """Records an immutable submission event.
+
+    NOTE: the submission's status probably needs updating after this; SubmissionHelper owns the status of a submission.
+    This interface should only be called by the SubmissionHelper, and it must make sure that the status of the
+    submission is updated appropriately (after clearing appropriate caches).
+
+    You almost certainly want to use SubmissionHelper.add_submission_event instead of using this directly.
+    """
+
     submission.events.append(
         SubmissionEvent(
             event_type=event_type,
@@ -1578,13 +1601,12 @@ def add_submission_event(
 
         case SubmissionEventType.SUBMISSION_REOPENED:
             emit_metric_count(MetricEventName.SUBMISSION_REOPENED, submission=submission)
+
         case _:
             current_app.logger.error(
                 "No metric configured for submission event %(event_type)s for submission %(submission_id)s",
                 {"event_type": event_type, "submission_id": submission.id},
             )
-
-    return submission
 
 
 def get_referenced_data_source_items_by_managed_expression(

--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-061_pre_award_collections
+062_add_submission_status

--- a/app/common/data/migrations/versions/062_add_submission_status.py
+++ b/app/common/data/migrations/versions/062_add_submission_status.py
@@ -1,0 +1,46 @@
+"""add a submission status column
+
+Revision ID: 062_add_submission_status
+Revises: 061_pre_award_collections
+Create Date: 2026-06-01 11:36:07.895477
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "062_add_submission_status"
+down_revision = "061_pre_award_collections"
+branch_labels = None
+depends_on = None
+
+submission_status_enum = sa.Enum(
+    "NOT_STARTED",
+    "IN_PROGRESS",
+    "READY_TO_SUBMIT",
+    "AWAITING_SIGN_OFF",
+    "SUBMITTED",
+    "NOT_SUBMITTED",
+    "PARTIALLY_SUBMITTED",
+    name="submission_status_enum",
+)
+
+
+def upgrade() -> None:
+    submission_status_enum.create(op.get_bind())
+    with op.batch_alter_table("submission", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "status",
+                submission_status_enum,
+                nullable=True,
+            )
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("submission", schema=None) as batch_op:
+        batch_op.drop_column("status")
+
+    submission_status_enum.drop(op.get_bind())

--- a/app/common/data/migrations/versions/062_add_submission_status.py
+++ b/app/common/data/migrations/versions/062_add_submission_status.py
@@ -8,7 +8,6 @@ Create Date: 2026-06-01 11:36:07.895477
 
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.dialects import postgresql
 
 revision = "062_add_submission_status"
 down_revision = "061_pre_award_collections"

--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -44,6 +44,7 @@ from app.common.data.types import (
     RoleEnum,
     SubmissionEventType,
     SubmissionModeEnum,
+    SubmissionStatusEnum,
     json_flat_scalars,
     json_scalars,
 )
@@ -383,6 +384,15 @@ class Submission(BaseModel):
         "DataSource",
         primaryjoin=lambda: Submission.collection_id == foreign(DataSource.collection_id),
         viewonly=True,
+    )
+
+    status: Mapped[SubmissionStatusEnum | None] = mapped_column(
+        SqlEnum(
+            SubmissionStatusEnum,
+            name="submission_status_enum",
+            validate_strings=True,
+        ),
+        nullable=True,
     )
 
     @property

--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -37,6 +37,7 @@ from app.common.data import interfaces
 from app.common.data.interfaces.collections import (
     get_all_submissions_with_mode_for_collection,
     get_submission,
+    update_submission,
     update_submission_data,
 )
 from app.common.data.interfaces.grant_recipients import get_grant_recipients
@@ -129,6 +130,9 @@ class SubmissionHelper:
 
     It wraps a Submission instance from the DB and encapsulates the business logic that will make it easy to deal with
     conditionals, routing, storing+retrieving data, etc in one place, consistently.
+
+    The SubmissionHelper is responsible for keeping a submission's status in sync and correct; any changes to a
+    submission should go through this helper class to ensure it is kept in a consistent state.
     """
 
     def __init__(self, submission: Submission):
@@ -342,8 +346,38 @@ class SubmissionHelper:
 
         return SubmissionHelper(submission).status
 
-    @property
-    def status(self) -> SubmissionStatusEnum:
+    def clear_caches(self):
+        self.cached_get_answer_for_question.cache_clear()
+        self.cached_get_all_questions_are_answered_for_form.cache_clear()
+        self.cached_get_ordered_visible_questions.cache_clear()
+
+        if "cached_evaluation_context" in self.__dict__:
+            del self.cached_evaluation_context
+
+        if "cached_interpolation_context" in self.__dict__:
+            del self.cached_interpolation_context
+
+    def _update_submission_status(self):
+        self.clear_caches()
+        update_submission(self.submission, status=self._calculate_submission_status())
+
+    def add_submission_event(self, event_type: SubmissionEventType, user: User, related_entity_id: UUID, **kwargs: Any):
+        interfaces.collections._add_submission_event(
+            self.submission,
+            event_type=event_type,
+            user=user,
+            related_entity_id=related_entity_id,
+            **kwargs,
+        )
+
+        self._update_submission_status()
+
+    def _sync_submission_data_and_status(self):
+        update_submission_data(self.submission)
+
+        self._update_submission_status()
+
+    def _calculate_submission_status(self) -> SubmissionStatusEnum:
         submission_state = self.events.submission_state
 
         form_statuses = {self.get_status_for_form(form) for form in self.collection.forms}
@@ -373,6 +407,10 @@ class SubmissionHelper:
             return SubmissionStatusEnum.NOT_STARTED
         else:
             return SubmissionStatusEnum.IN_PROGRESS
+
+    @property
+    def status(self) -> SubmissionStatusEnum:
+        return self._calculate_submission_status()
 
     @property
     def submitted_at_utc(self) -> datetime | None:
@@ -822,13 +860,14 @@ class SubmissionHelper:
     def _emit_submission_events_for_forms_reset_to_in_progress(
         self, current_form: Form, previous_form_statuses: dict[Form, TasklistSectionStatusEnum], user: User
     ) -> None:
+        has_reset = False
         if previous_form_statuses[current_form] == TasklistSectionStatusEnum.COMPLETED:
-            interfaces.collections.add_submission_event(
-                self.submission,
+            self.add_submission_event(
                 event_type=SubmissionEventType.FORM_RUNNER_FORM_RESET_TO_IN_PROGRESS,
                 user=user,
                 related_entity_id=current_form.id,
             )
+            has_reset = True
             del previous_form_statuses[current_form]
 
         for form, old_form_status in previous_form_statuses.items():
@@ -836,12 +875,16 @@ class SubmissionHelper:
                 old_form_status == TasklistSectionStatusEnum.COMPLETED
                 and self.get_status_for_form(form) == TasklistSectionStatusEnum.IN_PROGRESS
             ):
-                interfaces.collections.add_submission_event(
-                    self.submission,
+                self.add_submission_event(
                     event_type=SubmissionEventType.FORM_RUNNER_FORM_RESET_TO_IN_PROGRESS,
                     user=user,
                     related_entity_id=form.id,
                 )
+            has_reset = True
+
+        if has_reset:
+            self.clear_caches()
+            update_submission(self.submission, status=SubmissionStatusEnum.IN_PROGRESS)
 
     def _get_answer_for_question(
         self, question_id: UUID, add_another_index: int | None = None
@@ -911,16 +954,7 @@ class SubmissionHelper:
             data.key = key
 
         self.submission.data_manager.set(question, data, add_another_index=add_another_index)
-        update_submission_data(self.submission)
-
-        self.cached_get_answer_for_question.cache_clear()
-        self.cached_get_all_questions_are_answered_for_form.cache_clear()
-        del self.cached_evaluation_context
-
-        # FIXME: work out why end to end tests aren't happy without this here
-        #        I've made it work but not happy with not clearly pointing to where
-        #        an instance was failing to route (next_url) appropriately without it
-        self.cached_get_ordered_visible_questions.cache_clear()
+        self._sync_submission_data_and_status()
 
         self._emit_submission_events_for_forms_reset_to_in_progress(current_form, current_form_statuses, user)
 
@@ -942,15 +976,10 @@ class SubmissionHelper:
         self.submission.data_manager.remove_add_another_entry(
             add_another_container, add_another_index=add_another_index
         )
-        update_submission_data(self.submission)
+        self._sync_submission_data_and_status()
 
         for key in keys_to_delete:
             s3_service.delete_file(key)
-
-        self.cached_get_answer_for_question.cache_clear()
-        self.cached_get_all_questions_are_answered_for_form.cache_clear()
-        del self.cached_evaluation_context
-        self.cached_get_ordered_visible_questions.cache_clear()
 
     def remove_answer_for_question(self, question_id: UUID, *, add_another_index: int | None = None) -> None:
         if self.in_answers_locked_state:
@@ -968,15 +997,10 @@ class SubmissionHelper:
                 keys_to_delete.append(answer.key)
 
         self.submission.data_manager.remove(question, add_another_index=add_another_index)
-        update_submission_data(self.submission)
+        self._sync_submission_data_and_status()
 
         for key in keys_to_delete:
             s3_service.delete_file(key)
-
-        self.cached_get_answer_for_question.cache_clear()
-        self.cached_get_all_questions_are_answered_for_form.cache_clear()
-        del self.cached_evaluation_context
-        self.cached_get_ordered_visible_questions.cache_clear()
 
     def _data_providers_for_lifecycle_emails(self, user: User) -> Sequence[User]:
         if self.is_preview:
@@ -1052,8 +1076,7 @@ class SubmissionHelper:
 
         SubmissionValidator(self).validate_all_reachable_questions()
 
-        interfaces.collections.add_submission_event(
-            self.submission,
+        self.add_submission_event(
             event_type=SubmissionEventType.SUBMISSION_SUBMITTED,
             user=user,
             related_entity_id=self.submission.id,
@@ -1083,8 +1106,10 @@ class SubmissionHelper:
         SubmissionValidator(self).validate_all_reachable_questions()
 
         if self.all_needed_forms_are_completed:
-            interfaces.collections.add_submission_event(
-                self.submission, event_type=SubmissionEventType.SUBMISSION_SENT_FOR_CERTIFICATION, user=user
+            self.add_submission_event(
+                event_type=SubmissionEventType.SUBMISSION_SENT_FOR_CERTIFICATION,
+                user=user,
+                related_entity_id=self.id,
             )
 
             for data_provider in self._data_providers_for_lifecycle_emails(user):
@@ -1124,15 +1149,14 @@ class SubmissionHelper:
             )
 
         if self.status == SubmissionStatusEnum.AWAITING_SIGN_OFF:
-            interfaces.collections.add_submission_event(
-                self.submission,
+            self.add_submission_event(
                 event_type=SubmissionEventType.SUBMISSION_DECLINED_BY_CERTIFIER,
                 user=user,
                 declined_reason=declined_reason,
+                related_entity_id=self.id,
             )
             for form in self.collection.forms:
-                interfaces.collections.add_submission_event(
-                    self.submission,
+                self.add_submission_event(
                     event_type=SubmissionEventType.FORM_RUNNER_FORM_RESET_BY_CERTIFIER,
                     user=user,
                     related_entity_id=form.id,
@@ -1181,8 +1205,10 @@ class SubmissionHelper:
                 f"Could not approve certification for submission id={self.id} because it is not awaiting sign off."
             )
 
-        interfaces.collections.add_submission_event(
-            self.submission, event_type=SubmissionEventType.SUBMISSION_APPROVED_BY_CERTIFIER, user=user
+        self.add_submission_event(
+            event_type=SubmissionEventType.SUBMISSION_APPROVED_BY_CERTIFIER,
+            user=user,
+            related_entity_id=self.id,
         )
 
     def can_be_reopened_by_user(self, user: User) -> bool:
@@ -1219,16 +1245,15 @@ class SubmissionHelper:
                 f"Could not reopen submission id={self.id} because it is not submitted."
             )
 
-        interfaces.collections.add_submission_event(
-            self.submission,
+        self.add_submission_event(
             event_type=SubmissionEventType.SUBMISSION_REOPENED,
             user=user,
             reopened_reason=reopened_reason,
             submission_data=self.submission.data_manager.data,
+            related_entity_id=self.id,
         )
         for form in self.collection.forms:
-            interfaces.collections.add_submission_event(
-                self.submission,
+            self.add_submission_event(
                 event_type=SubmissionEventType.FORM_RUNNER_FORM_RESET_TO_IN_PROGRESS,
                 user=user,
                 related_entity_id=form.id,
@@ -1258,15 +1283,13 @@ class SubmissionHelper:
                     f"Could not mark form id={form.id} as complete because not all questions have been answered."
                 )
 
-            interfaces.collections.add_submission_event(
-                self.submission,
+            self.add_submission_event(
                 event_type=SubmissionEventType.FORM_RUNNER_FORM_COMPLETED,
                 user=user,
                 related_entity_id=form.id,
             )
         else:
-            interfaces.collections.add_submission_event(
-                self.submission,
+            self.add_submission_event(
                 event_type=SubmissionEventType.FORM_RUNNER_FORM_RESET_TO_IN_PROGRESS,
                 user=user,
                 related_entity_id=form.id,

--- a/app/developers/commands.py
+++ b/app/developers/commands.py
@@ -938,3 +938,23 @@ def check_managed_statements(ctx: click.Context, output: str, s3_key: str | None
 
     if mismatches or errors:
         raise click.exceptions.Exit(1)
+
+
+@developers_blueprint.cli.command(
+    "populate-status-for-all-submissions",
+    help="Load each submission, calculate the status and write this back to the status column on the submission table",
+)
+def populate_status_for_all_submissions() -> None:
+    count = db.session.query(Submission).filter(Submission.status.is_(None)).count()
+    updated = 0
+
+    click.echo(f"Found {count} submissions with no existing status")
+
+    while submission_id := db.session.scalars(select(Submission.id).where(Submission.status.is_(None))).first():
+        helper = SubmissionHelper.load(submission_id)
+        helper.submission.status = helper._calculate_submission_status()
+        db.session.commit()
+        updated += 1
+        click.echo(f"Submission {helper.submission.id} updated with status {helper.submission.status}")
+
+    click.echo(f"Updated {updated} submissions with saved statuses")

--- a/tests/integration/access_grant_funding/routes/test_reports.py
+++ b/tests/integration/access_grant_funding/routes/test_reports.py
@@ -1,3 +1,4 @@
+import datetime
 from datetime import date
 
 import pytest
@@ -8,6 +9,7 @@ from pytest import FixtureRequest
 from app import CollectionStatusEnum, GrantStatusEnum, TasklistSectionStatusEnum
 from app.access_grant_funding.forms import DeclineSignOffForm
 from app.common.collections.types import IntegerAnswer, TextSingleLineAnswer
+from app.common.data.interfaces.collections import update_collection
 from app.common.data.types import (
     ExpressionType,
     ManagedExpressionsEnum,
@@ -936,7 +938,12 @@ class TestDeclineSignOff:
         grant_recipient,
         submission_awaiting_sign_off,
     ):
-        submission_awaiting_sign_off.collection.status = CollectionStatusEnum.CLOSED
+        update_collection(
+            submission_awaiting_sign_off.collection,
+            submission_period_start_date=datetime.date.today() - datetime.timedelta(days=1),
+            submission_period_end_date=datetime.date.today(),
+            status=CollectionStatusEnum.CLOSED,
+        )
         helper = SubmissionHelper(submission_awaiting_sign_off)
         assert not helper.is_awaiting_sign_off
         assert helper.in_immutable_state

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -16,12 +16,12 @@ from app.common.data.interfaces.collections import (
     NestedGroupDisplayTypeSamePageException,
     NestedGroupException,
     SectionComponentDependencyException,
+    _add_submission_event,
     _validate_and_sync_component_references,
     _validate_and_sync_expression_references,
     _validate_reference,
     add_component_condition,
     add_component_validation,
-    add_submission_event,
     components_in_same_group_and_on_same_page,
     create_collection,
     create_form,
@@ -105,6 +105,7 @@ from app.common.expressions.custom import CustomExpression
 from app.common.expressions.managed import AnyOf, Between, GreaterThan, LessThan, Specifically
 from app.common.expressions.references import ExpressionReference
 from app.common.forms.helpers import components_in_valid_add_another_combination
+from app.common.helpers.collections import SubmissionHelper
 from app.metrics import MetricEventName
 from tests.models import FactoryAnswer
 
@@ -2933,13 +2934,13 @@ class TestAddSubmissionEvent:
         submission = factories.submission.create(collection=form.collection)
         db_session.add(submission)
 
-        add_submission_event(
-            submission=submission,
+        _add_submission_event(
+            submission,
             user=user,
             event_type=SubmissionEventType.FORM_RUNNER_FORM_COMPLETED,
             related_entity_id=form.id,
         )
-        add_submission_event(submission=submission, user=user, event_type=SubmissionEventType.SUBMISSION_SUBMITTED)
+        _add_submission_event(submission, user=user, event_type=SubmissionEventType.SUBMISSION_SUBMITTED)
 
         # pull it back out of the database to also check all of the serialisation/ enums are mapped appropriately
         from_db = get_submission(submission.id, with_full_schema=True)
@@ -2950,7 +2951,7 @@ class TestAddSubmissionEvent:
         assert from_db.events[0].data == {}
 
         assert from_db.events[1].event_type == SubmissionEventType.SUBMISSION_SUBMITTED
-        assert from_db.events[1].related_entity_id is submission.id
+        assert from_db.events[1].related_entity_id == submission.id
         assert from_db.events[1].data == {}
 
     def test_add_certification_and_submission_event(self, db_session, factories):
@@ -2959,21 +2960,25 @@ class TestAddSubmissionEvent:
         submission = factories.submission.create(collection=form.collection)
         db_session.add(submission)
 
-        add_submission_event(
-            submission=submission,
+        _add_submission_event(
+            submission,
             user=user,
             event_type=SubmissionEventType.FORM_RUNNER_FORM_COMPLETED,
             related_entity_id=form.id,
         )
-        add_submission_event(
-            submission=submission, user=user, event_type=SubmissionEventType.SUBMISSION_SENT_FOR_CERTIFICATION
+        _add_submission_event(
+            submission,
+            user=user,
+            event_type=SubmissionEventType.SUBMISSION_SENT_FOR_CERTIFICATION,
         )
-        add_submission_event(
-            submission=submission, user=user, event_type=SubmissionEventType.SUBMISSION_APPROVED_BY_CERTIFIER
+        _add_submission_event(
+            submission,
+            user=user,
+            event_type=SubmissionEventType.SUBMISSION_APPROVED_BY_CERTIFIER,
         )
-        add_submission_event(submission=submission, user=user, event_type=SubmissionEventType.SUBMISSION_SUBMITTED)
-        add_submission_event(
-            submission=submission,
+        _add_submission_event(submission, user=user, event_type=SubmissionEventType.SUBMISSION_SUBMITTED)
+        _add_submission_event(
+            submission,
             user=user,
             event_type=SubmissionEventType.SUBMISSION_DECLINED_BY_CERTIFIER,
             declined_reason="inaccurate data",
@@ -3014,8 +3019,8 @@ class TestAddSubmissionEvent:
         submission._data = test_data
         db_session.add(submission)
 
-        add_submission_event(
-            submission=submission,
+        _add_submission_event(
+            submission,
             user=user,
             event_type=SubmissionEventType.SUBMISSION_REOPENED,
             reopened_reason="Test reason",
@@ -3031,7 +3036,6 @@ class TestAddSubmissionEvent:
     def test_reopen_submission_event_with_helpers(self, db_session, factories):
 
         from app.common.collections.forms import build_question_form
-        from app.common.helpers.collections import SubmissionHelper
 
         user = factories.user.create()
         form = factories.form.create()
@@ -3046,8 +3050,8 @@ class TestAddSubmissionEvent:
 
         db_session.add(submission)
 
-        add_submission_event(
-            submission=submission,
+        _add_submission_event(
+            submission,
             user=user,
             event_type=SubmissionEventType.SUBMISSION_REOPENED,
             reopened_reason="Test reason",
@@ -3071,30 +3075,46 @@ class TestAddSubmissionEvent:
         assert state.reopened_by == user
 
     @pytest.mark.parametrize(
-        "event_type,exp_metric",
+        "event_type,is_form_event,exp_metric",
         [
-            (SubmissionEventType.SUBMISSION_SENT_FOR_CERTIFICATION, MetricEventName.SUBMISSION_SENT_FOR_CERTIFICATION),
-            (SubmissionEventType.SUBMISSION_SUBMITTED, MetricEventName.SUBMISSION_SUBMITTED),
-            (SubmissionEventType.FORM_RUNNER_FORM_RESET_TO_IN_PROGRESS, MetricEventName.SECTION_RESET_TO_IN_PROGRESS),
-            (SubmissionEventType.FORM_RUNNER_FORM_COMPLETED, MetricEventName.SECTION_MARKED_COMPLETE),
+            (
+                SubmissionEventType.SUBMISSION_SENT_FOR_CERTIFICATION,
+                False,
+                MetricEventName.SUBMISSION_SENT_FOR_CERTIFICATION,
+            ),
+            (SubmissionEventType.SUBMISSION_SUBMITTED, False, MetricEventName.SUBMISSION_SUBMITTED),
+            (
+                SubmissionEventType.FORM_RUNNER_FORM_RESET_TO_IN_PROGRESS,
+                True,
+                MetricEventName.SECTION_RESET_TO_IN_PROGRESS,
+            ),
+            (SubmissionEventType.FORM_RUNNER_FORM_COMPLETED, True, MetricEventName.SECTION_MARKED_COMPLETE),
             (
                 SubmissionEventType.FORM_RUNNER_FORM_RESET_BY_CERTIFIER,
+                True,
                 MetricEventName.SECTION_RESET_TO_IN_PROGRESS_BY_CERTIFIER,
             ),
-            (SubmissionEventType.SUBMISSION_APPROVED_BY_CERTIFIER, MetricEventName.SUBMISSION_CERTIFIED),
-            (SubmissionEventType.SUBMISSION_DECLINED_BY_CERTIFIER, MetricEventName.SUBMISSION_CERTIFICATION_DECLINED),
-            (SubmissionEventType.SUBMISSION_REOPENED, MetricEventName.SUBMISSION_REOPENED),
+            (SubmissionEventType.SUBMISSION_APPROVED_BY_CERTIFIER, False, MetricEventName.SUBMISSION_CERTIFIED),
+            (
+                SubmissionEventType.SUBMISSION_DECLINED_BY_CERTIFIER,
+                False,
+                MetricEventName.SUBMISSION_CERTIFICATION_DECLINED,
+            ),
+            (SubmissionEventType.SUBMISSION_REOPENED, False, MetricEventName.SUBMISSION_REOPENED),
         ],
     )
-    def test_add_submission_event_metrics(self, db_session, factories, mock_sentry_metrics, event_type, exp_metric):
+    def test_add_submission_event_metrics(
+        self, db_session, factories, mock_sentry_metrics, event_type, is_form_event, exp_metric
+    ):
 
         user = factories.user.create()
         form = factories.form.create()
         submission = factories.submission.create(collection=form.collection)
 
-        add_submission_event(
-            submission=submission,
+        _add_submission_event(
+            submission,
             user=user,
+            related_entity_id=form.id if is_form_event else submission.id,
             event_type=event_type,
         )
 

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -99,6 +99,7 @@ from app.common.data.types import (
     RoleEnum,
     SubmissionEventType,
     SubmissionModeEnum,
+    SubmissionStatusEnum,
 )
 from app.common.expressions import ExpressionContext
 from app.common.expressions.custom import CustomExpression
@@ -760,6 +761,29 @@ class TestUpdateCollection:
             f"You cannot close the report for submissions before the submission period "
             f"end date of {collection.submission_period_end_date}"
         ) in str(exc_info.value)
+
+    @pytest.mark.freeze_time("2025-03-30 10:00:00")
+    def test_close_collection_updates_submission_status(self, db_session, factories):
+        collection = factories.collection.create(
+            status=CollectionStatusEnum.OPEN,
+            reporting_period_start_date=datetime.date(2024, 1, 1),
+            reporting_period_end_date=datetime.date(2024, 12, 31),
+            submission_period_start_date=datetime.date(2025, 1, 1),
+            submission_period_end_date=datetime.date(2025, 1, 31),
+        )
+
+        factories.question.create(form__collection=collection)
+
+        submission_not_started = factories.submission.create(collection=collection)
+        assert submission_not_started.status == SubmissionStatusEnum.NOT_STARTED
+
+        update_collection(
+            collection,
+            status=CollectionStatusEnum.CLOSED,
+        )
+
+        from_db = db_session.get(Submission, submission_not_started.id)
+        assert from_db.status == SubmissionStatusEnum.NOT_SUBMITTED
 
 
 class TestGetSubmission:

--- a/tests/integration/common/helpers/test_collections.py
+++ b/tests/integration/common/helpers/test_collections.py
@@ -833,6 +833,8 @@ class TestSubmissionHelper:
             helper = SubmissionHelper(submission)
 
             assert helper.status == SubmissionStatusEnum.NOT_STARTED
+            # TODO: remove redundant status check after full migration to DB submission.status
+            assert helper.submission.status == SubmissionStatusEnum.NOT_STARTED
 
             helper.submit_answer_for_question(
                 question.id,
@@ -846,6 +848,8 @@ class TestSubmissionHelper:
             assert helper.get_status_for_form(question.form) == TasklistSectionStatusEnum.COMPLETED
             assert helper.get_tasklist_status_for_form(question.form) == TasklistSectionStatusEnum.COMPLETED
             assert helper.status == SubmissionStatusEnum.IN_PROGRESS
+            # TODO: remove redundant status check after full migration to DB submission.status
+            assert helper.submission.status == SubmissionStatusEnum.IN_PROGRESS
 
             helper.submit_answer_for_question(
                 question_two.id,
@@ -860,6 +864,8 @@ class TestSubmissionHelper:
             assert helper.get_tasklist_status_for_form(question_two.form) == TasklistSectionStatusEnum.COMPLETED
 
             assert helper.status == SubmissionStatusEnum.READY_TO_SUBMIT
+            # TODO: remove redundant status check after full migration to DB submission.status
+            assert helper.submission.status == SubmissionStatusEnum.READY_TO_SUBMIT
 
             helper.mark_as_sent_for_certification(submission.created_by)
 
@@ -870,6 +876,8 @@ class TestSubmissionHelper:
             helper.decline_certification(certifier, "Reason for declining")
 
             assert helper.status == SubmissionStatusEnum.IN_PROGRESS
+            # TODO: remove redundant status check after full migration to DB submission.status
+            assert helper.submission.status == SubmissionStatusEnum.IN_PROGRESS
             assert helper.events.submission_state.sent_for_certification_by is submission.created_by
             assert helper.events.submission_state.is_awaiting_sign_off is False
             assert helper.events.submission_state.declined_by == certifier
@@ -882,10 +890,14 @@ class TestSubmissionHelper:
             helper.toggle_form_completed(question_two.form, submission.created_by, True)
 
             assert helper.status == SubmissionStatusEnum.READY_TO_SUBMIT
+            # TODO: remove redundant status check after full migration to DB submission.status
+            assert helper.submission.status == SubmissionStatusEnum.READY_TO_SUBMIT
 
             helper.mark_as_sent_for_certification(submission.created_by)
 
             assert helper.status == SubmissionStatusEnum.AWAITING_SIGN_OFF
+            # TODO: remove redundant status check after full migration to DB submission.status
+            assert helper.submission.status == SubmissionStatusEnum.AWAITING_SIGN_OFF
 
             helper.certify(certifier)
 
@@ -894,10 +906,14 @@ class TestSubmissionHelper:
             assert helper.events.submission_state.certified_by == certifier
 
             assert helper.status == SubmissionStatusEnum.READY_TO_SUBMIT
+            # TODO: remove redundant status check after full migration to DB submission.status
+            assert helper.submission.status == SubmissionStatusEnum.READY_TO_SUBMIT
 
             helper.submit(certifier)
 
             assert helper.status == SubmissionStatusEnum.SUBMITTED
+            # TODO: remove redundant status check after full migration to DB submission.status
+            assert helper.submission.status == SubmissionStatusEnum.SUBMITTED
             assert helper.events.submission_state.submitted_by == certifier
             assert helper.events.submission_state.is_approved is True
             assert helper.events.submission_state.is_awaiting_sign_off is False

--- a/tests/integration/common/helpers/test_collections.py
+++ b/tests/integration/common/helpers/test_collections.py
@@ -346,19 +346,16 @@ class TestSubmissionHelper:
             assert helper.submission.data_manager.get_count_for_add_another(add_another_container) == 1
 
         def test_remove_entry_for_add_another_clears_file_uploads(self, db_session, factories, mock_s3_service_calls):
-            collection = factories.collection.create(
-                create_completed_submissions_add_another_nested_group__test=1,
-                create_completed_submissions_add_another_nested_group__use_random_data=False,
-                create_completed_submissions_add_another_nested_group__number_of_add_another_answers=2,
-            )
-            questions = collection.forms[0].cached_questions
-            add_another_container = questions[2].add_another_container
+
+            add_another_container = factories.group.create(add_another=True)
             file_upload = factories.question.create(
-                form=collection.forms[0],
+                form=add_another_container.form,
                 data_type=QuestionDataType.FILE_UPLOAD,
                 parent=add_another_container,
             )
-            submission = collection.test_submissions[0]
+            submission = factories.submission.create(
+                collection=add_another_container.form.collection,
+            )
             for i in range(2):
                 submission.data_manager.set(
                     file_upload,

--- a/tests/integration/deliver_grant_funding/admin/test_views.py
+++ b/tests/integration/deliver_grant_funding/admin/test_views.py
@@ -4683,15 +4683,16 @@ class TestCloseReport:
     @pytest.mark.freeze_time("2024-05-01 10:00:00")
     def test_post_closes_report(self, authenticated_platform_grant_lifecycle_manager_client, factories, db_session):
         grant = factories.grant.create(name="Test Grant", status=GrantStatusEnum.LIVE)
-        collection = factories.collection.create(
-            grant=grant,
-            name="Q1 Report",
-            status=CollectionStatusEnum.OPEN,
-            reporting_period_start_date=datetime.date(2024, 1, 1),
-            reporting_period_end_date=datetime.date(2024, 3, 31),
-            submission_period_start_date=datetime.date(2024, 4, 1),
-            submission_period_end_date=datetime.date(2024, 4, 30),
+        question = factories.question.create(
+            form__collection__grant=grant,
+            form__collection__name="Q1 Report",
+            form__collection__status=CollectionStatusEnum.OPEN,
+            form__collection__reporting_period_start_date=datetime.date(2024, 1, 1),
+            form__collection__reporting_period_end_date=datetime.date(2024, 3, 31),
+            form__collection__submission_period_start_date=datetime.date(2024, 4, 1),
+            form__collection__submission_period_end_date=datetime.date(2024, 4, 30),
         )
+        collection = question.form.collection
         grant_recipient = factories.grant_recipient.create(grant=grant)
         user = factories.user.create()
         factories.user_role.create(
@@ -4707,6 +4708,22 @@ class TestCloseReport:
             grant=None,
             permissions=[RoleEnum.MEMBER, RoleEnum.CERTIFIER],
         )
+        sub = factories.submission.create(
+            collection=collection, answers=[FactoryAnswer(question, TextSingleLineAnswer("hi"))]
+        )
+        sub_submitted = factories.submission.create(
+            collection=collection,
+            status=SubmissionStatusEnum.SUBMITTED,
+            answers=[FactoryAnswer(question, TextSingleLineAnswer("hi"))],
+        )
+        factories.submission_event.create(
+            submission=sub_submitted,
+            event_type=SubmissionEventType.FORM_RUNNER_FORM_COMPLETED,
+            related_entity_id=question.form_id,
+        )
+        factories.submission_event.create(submission=sub_submitted, event_type=SubmissionEventType.SUBMISSION_SUBMITTED)
+        SubmissionHelper(sub_submitted)._sync_submission_data_and_status()
+        assert sub_submitted.status == SubmissionStatusEnum.SUBMITTED
 
         response = authenticated_platform_grant_lifecycle_manager_client.post(
             f"/deliver/admin/reporting-lifecycle/{grant.id}/{collection.id}/close-report",
@@ -4721,6 +4738,13 @@ class TestCloseReport:
 
         soup = BeautifulSoup(response.data, "html.parser")
         assert page_has_flash(soup, "Q1 Report is now closed and grant recipients can make no more changes")
+
+        db_session.refresh(sub)
+        assert sub.status == SubmissionStatusEnum.NOT_SUBMITTED
+
+        db_session.refresh(sub_submitted)
+        assert SubmissionHelper(sub_submitted).status == SubmissionStatusEnum.SUBMITTED
+        assert sub_submitted.status == SubmissionStatusEnum.SUBMITTED
 
     @pytest.mark.freeze_time("2024-05-01 10:00:00")
     def test_post_fails_when_grant_not_open(

--- a/tests/models.py
+++ b/tests/models.py
@@ -19,6 +19,7 @@ from factory.alchemy import SQLAlchemyModelFactory
 from flask import url_for
 from sqlalchemy.exc import NoResultFound
 
+from app import SubmissionStatusEnum
 from app.common.collections.types import (
     AllAnswerTypes,
     DateAnswer,
@@ -74,6 +75,7 @@ from app.common.data.utils import generate_submission_reference
 from app.common.expressions import ExpressionContext
 from app.common.expressions.managed import AnyOf, GreaterThan, Specifically
 from app.common.expressions.references import ExpressionReference
+from app.common.helpers.collections import SubmissionHelper
 from app.common.helpers.submission_events import SubmissionEventHelper
 from app.extensions import db
 from app.types import TRadioItem
@@ -793,19 +795,23 @@ class _SubmissionFactory(SQLAlchemyModelFactory):
         )
     )
     grant_recipient_id = factory.LazyAttribute(lambda o: o.grant_recipient.id if o.grant_recipient else None)
+    status = None
 
     @factory.post_generation
     def answers(obj: Submission, create, extracted: list[FactoryAnswer], **kwargs):
-        if not extracted:
-            return
-        for entry in extracted:
-            obj.data_manager.set(entry.question, entry.answer, add_another_index=entry.add_another_index)
+        if extracted:
+            for entry in extracted:
+                obj.data_manager.set(entry.question, entry.answer, add_another_index=entry.add_another_index)
 
         if create:
-            update_submission_data(obj)
+            SubmissionHelper(obj)._sync_submission_data_and_status()
             db.session.commit()
         else:
             obj._data = obj.data_manager.data
+
+            # TODO: This could be made smarter to work out READY_TO_SUBMIT;
+            if obj.status is None:
+                obj.status = SubmissionStatusEnum.IN_PROGRESS if extracted else SubmissionStatusEnum.NOT_STARTED
 
 
 class _FormFactory(SQLAlchemyModelFactory):

--- a/tests/models.py
+++ b/tests/models.py
@@ -813,6 +813,8 @@ class _SubmissionFactory(SQLAlchemyModelFactory):
             if obj.status is None:
                 obj.status = SubmissionStatusEnum.IN_PROGRESS if extracted else SubmissionStatusEnum.NOT_STARTED
 
+    # TODO: Take 'events' here and process the submission status to get the right thing
+
 
 class _FormFactory(SQLAlchemyModelFactory):
     class Meta:

--- a/tests/unit/common/helpers/test_request_tracing.py
+++ b/tests/unit/common/helpers/test_request_tracing.py
@@ -23,7 +23,7 @@ class TestEncodeAndDecodeLevels:
 
     def test_tampered_token_returns_empty_list(self):
         token = encode_levels([TraceLevelEnum.TRACE], "secret")
-        tampered = token[:-1] + ("a" if token[-1] != "a" else "b")
+        tampered = ("a" if token[0] != "a" else "b") + token[1:]
         assert decode_levels(tampered, "secret") == []
 
     def test_malformed_token_returns_empty_list(self):


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-1405

## 📝 Description
We're seeing performance issues on pages like Deliver's "list submissions" page,
which can show the status of 200+ submissions at once.

At the moment we calculate status dynamically on demand, and it's CPU intensive
work that scans all components and evaluates a lot of conditions. For more than
one submission that is causing extremely long page loads (20+ seconds).

This patch starts to save the submission status in the DB whenever a relevant
action happens

- changing an answer
- performing a key event, such as completing forms or certifying the submission

This will then allow us to just read a cached submission status, making certain
pages much more performant.

This change does not affect anything shown in the UI at the moment - it starts filling the `Submission.status` column in the DB but keeps everything in the UI using the dynamically-calculated status.

After this has been deployed we need to run the `populate-status-for-all-submissions` developer command until it's finished all submissions. Then we can retire the dynamic calculation and point it at the saved submission status.

## 🧪 Testing
Run through a submission locally (try out all manner of answering+questions) and check that the submission status shown in the service always matches the submission status in the DB, excluding any 'Overdue' modifier.

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [-] End-to-end tests have been updated (if applicable)
- [-] Edge cases and error conditions are tested