### PR TITLE
Add helper methods to clear caches cleanly

### DIFF
--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -531,6 +531,12 @@ class Form(BaseModel):
         cascade="all, save-update, merge",
     )
 
+    def clear_caches(self):
+        for attr, value in self.__class__.__dict__.items():
+            if isinstance(value, cached_property):
+                if attr in self.__dict__:
+                    del self.__dict__[attr]
+
     @cached_property
     def cached_questions(self) -> list[Question]:
         """Consistently returns all questions in the form, respecting order and any level of nesting."""
@@ -919,6 +925,12 @@ class Group(Component):
     if TYPE_CHECKING:
         # reflect that groups will never have a data type but don't hook in a competing migration
         data_type: None
+
+    def clear_caches(self):
+        for attr, value in self.__class__.__dict__.items():
+            if isinstance(value, cached_property):
+                if attr in self.__dict__:
+                    del self.__dict__[attr]
 
     # todo: rename to something that makes it clear this is processed, something like all_nested_questions
     @cached_property

--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -340,11 +340,11 @@ class SubmissionHelper:
         self.cached_get_all_questions_are_answered_for_form.cache_clear()
         self.cached_get_ordered_visible_questions.cache_clear()
 
-        if "cached_evaluation_context" in self.__dict__:
-            del self.cached_evaluation_context
-
-        if "cached_interpolation_context" in self.__dict__:
-            del self.cached_interpolation_context
+        # Clear all `@cached_property`s
+        for attr, value in self.__class__.__dict__.items():
+            if isinstance(value, cached_property):
+                if attr in self.__dict__:
+                    del self.__dict__[attr]
 
     def _update_submission_status(self):
         self.clear_caches()

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_submissions.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_submissions.html
@@ -132,9 +132,9 @@
         {% endif %}
 
         {% if submission.submission_id %}
-          {% do cells.append({"html": submissionStatusTag(submission.status, report.is_closed and not submission.status == enum.submission_status.SUBMITTED)}) %}
+          {% do cells.append({"html": submissionStatusTag(submission.status, report.is_overdue and not submission.status == enum.submission_status.SUBMITTED)}) %}
         {% else %}
-          {% do cells.append({"html": submissionStatusTag(enum.submission_status.NOT_SUBMITTED if report.is_closed else enum.submission_status.NOT_STARTED, report.is_closed)}) %}
+          {% do cells.append({"html": submissionStatusTag(enum.submission_status.NOT_SUBMITTED if report.is_overdue else enum.submission_status.NOT_STARTED, report.is_closed)}) %}
         {% endif %}
         {% do cells.append({"text": format_date_short(submission.last_updated_at_utc) if submission.last_updated_at_utc else ""}) %}
         {% do rows.append(cells) %}

--- a/tests/integration/common/collections/test_forms.py
+++ b/tests/integration/common/collections/test_forms.py
@@ -222,9 +222,6 @@ def test_reference_data_validation__integer(factories, db_session):
     q1 = factories.question.create(form=form, data_type=QuestionDataType.NUMBER, name="First question")
     q2 = factories.question.create(form=form, data_type=QuestionDataType.NUMBER)
 
-    if hasattr(form, "cached_all_components"):
-        del form.cached_all_components
-
     interfaces.collections.add_component_validation(
         q2,
         user,
@@ -258,9 +255,6 @@ def test_reference_data_validation__number__custom(factories, db_session):
     q2 = factories.question.create(form=form, data_type=QuestionDataType.NUMBER, name="Second question")
     q3 = factories.question.create(form=form, data_type=QuestionDataType.NUMBER)
 
-    if hasattr(form, "cached_all_components"):
-        del form.cached_all_components
-
     interfaces.collections.add_component_validation(
         q3,
         user,
@@ -290,9 +284,6 @@ def test_reference_data_validation__date(factories, db_session):
     form = factories.form.create()
     q1 = factories.question.create(form=form, data_type=QuestionDataType.DATE, name="First question")
     q2 = factories.question.create(form=form, data_type=QuestionDataType.DATE, name="Second question")
-
-    if hasattr(form, "cached_all_components"):
-        del form.cached_all_components
 
     interfaces.collections.add_component_validation(
         q2,

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -3926,7 +3926,7 @@ class TestDeleteQuestion:
         assert form.cached_questions == [questions[0], questions[1], questions[2], questions[3], questions[4]]
 
         delete_question(questions[2])
-        del form.cached_questions
+        form.clear_caches()
 
         assert [q.order for q in form.cached_questions] == [0, 1, 2, 3]
         assert form.cached_questions == [questions[0], questions[1], questions[3], questions[4]]
@@ -3942,7 +3942,7 @@ class TestDeleteQuestion:
         assert form.cached_questions == [question1, *[q for q in group_questions], question2]
 
         delete_question(group)
-        del form.cached_questions
+        form.clear_caches()
 
         assert db_session.get(Group, group.id) is None
         assert db_session.get(Question, group_questions[0].id) is None
@@ -3960,8 +3960,8 @@ class TestDeleteQuestion:
         assert form.cached_questions == [questions[0], questions[1], questions[2], questions[3], questions[4]]
 
         delete_question(questions[2])
-        del form.cached_questions
-        del group.cached_questions
+        form.clear_caches()
+        group.clear_caches()
 
         assert [c.order for c in form.components] == [0]
         assert [q.order for q in group.cached_questions] == [0, 1, 2, 3]
@@ -4218,9 +4218,6 @@ class TestValidateAndSyncExpressionReferences:
 
         assert len(expression.component_references) == 0
 
-        if hasattr(form, "cached_all_components"):
-            del form.cached_all_components
-
         # This shouldn't raise an IncompatibleDataTypeException as the question evaluated by the managed expression
         # matches the data types of the questions used as reference values. The target_question (the one with the
         # expression attached) is irrelevant in terms of question data type.
@@ -4254,9 +4251,6 @@ class TestValidateAndSyncExpressionReferences:
 
         assert len(expression.component_references) == 0
 
-        if hasattr(form, "cached_all_components"):
-            del form.cached_all_components
-
         _validate_and_sync_expression_references(expression)
         assert len(expression.component_references) == 1
         referenced_components = {ref.depends_on_component for ref in expression.component_references}
@@ -4287,9 +4281,6 @@ class TestValidateAndSyncExpressionReferences:
 
         assert len(expression.component_references) == 0
 
-        if hasattr(form, "cached_all_components"):
-            del form.cached_all_components
-
         with pytest.raises(DependencyOrderException):
             _validate_and_sync_expression_references(expression)
 
@@ -4317,9 +4308,6 @@ class TestValidateAndSyncExpressionReferences:
         db_session.flush()
 
         assert len(expression.component_references) == 0
-
-        if hasattr(form, "cached_all_components"):
-            del form.cached_all_components
 
         with pytest.raises(IncompatibleDataTypeException):
             _validate_and_sync_expression_references(expression)
@@ -4349,9 +4337,6 @@ class TestValidateAndSyncExpressionReferences:
         db_session.flush()
 
         assert len(expression.component_references) == 0
-
-        if hasattr(form, "cached_all_components"):
-            del form.cached_all_components
 
         with pytest.raises(AddAnotherDependencyException):
             _validate_and_sync_expression_references(expression)
@@ -4383,9 +4368,6 @@ class TestValidateAndSyncExpressionReferences:
 
         assert len(expression.component_references) == 0
 
-        if hasattr(form, "cached_all_components"):
-            del form.cached_all_components
-
         with pytest.raises(AddAnotherDependencyException):
             _validate_and_sync_expression_references(expression)
 
@@ -4415,9 +4397,6 @@ class TestValidateAndSyncExpressionReferences:
         db_session.flush()
 
         assert len(expression.component_references) == 0
-
-        if hasattr(form, "cached_all_components"):
-            del form.cached_all_components
 
         with pytest.raises(AddAnotherDependencyException):
             _validate_and_sync_expression_references(expression)

--- a/tests/integration/common/helpers/test_collections.py
+++ b/tests/integration/common/helpers/test_collections.py
@@ -2875,13 +2875,7 @@ class TestSubmissionValidation:
         helper.toggle_form_completed(form, user, True)
 
         submission.data_manager.set(q1, IntegerAnswer(value=150))
-        helper.cached_get_answer_for_question.cache_clear()
-        helper.cached_evaluation_context = ExpressionContext.build_expression_context(
-            collection=submission.collection,
-            submission_helper=helper,
-            data_manager=helper.submission.data_manager,
-            mode="evaluation",
-        )
+        helper.clear_caches()
 
         with pytest.raises(ValueError) as e:
             helper.submit(user)
@@ -2957,13 +2951,7 @@ class TestSubmissionValidation:
         helper.toggle_form_completed(form, user, True)
 
         submission.data_manager.set(q1, IntegerAnswer(value=150))
-        helper.cached_get_answer_for_question.cache_clear()
-        helper.cached_evaluation_context = ExpressionContext.build_expression_context(
-            collection=submission.collection,
-            submission_helper=helper,
-            data_manager=helper.submission.data_manager,
-            mode="evaluation",
-        )
+        helper.clear_caches()
 
         with pytest.raises(ValueError) as e:
             helper.mark_as_sent_for_certification(user)

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -2643,7 +2643,7 @@ class TestMoveQuestion:
                 direction=direction,
             )
         )
-        del form.cached_questions
+        form.clear_caches()
         assert response.status_code == 302
 
         if direction == "up":
@@ -2672,7 +2672,7 @@ class TestMoveQuestion:
                 direction="down",
             )
         )
-        del form.cached_questions
+        form.clear_caches()
 
         assert response.status_code == 302
         assert response.location == AnyStringMatching(r"/deliver/grant/[a-z0-9-]{36}/section/[a-z0-9-]{36}/questions")
@@ -2688,7 +2688,7 @@ class TestMoveQuestion:
                 direction="down",
             )
         )
-        del form.cached_questions
+        form.clear_caches()
         assert response.status_code == 302
         assert response.location == AnyStringMatching(r"/deliver/grant/[a-z0-9-]{36}/group/[a-z0-9-]{36}/questions")
 
@@ -8408,6 +8408,7 @@ class TestListSubmissions:
             grant=authenticated_grant_member_client.grant,
             name="Closed Report",
             status=CollectionStatusEnum.CLOSED,
+            submission_period_end_date=datetime.date(2026, 1, 1),
         )
         factories.grant_recipient.create(
             grant=authenticated_grant_member_client.grant, organisation__name="Organisation Without Submission"

--- a/tests/models.py
+++ b/tests/models.py
@@ -949,14 +949,11 @@ class _QuestionFactory(SQLAlchemyModelFactory):
     conditions_operator = ConditionsOperator.ALL
 
     @factory.post_generation
-    def form_components_join(self, create: bool, extracted: list[Any], **kwargs: Any) -> None:
+    def form_components_join(obj: Question, create: bool, extracted: list[Any], **kwargs: Any) -> None:
         # Force the update of the form list of components as the join doesn't work before this is flushed to database
         if not create:
-            self.form.components = [component for component in self.form.components if component.parent is None]  # type: ignore[attr-defined]
-            if hasattr(self.form, "cached_questions"):
-                del self.form.cached_questions
-            if hasattr(self.form, "cached_all_components"):
-                del self.form.cached_all_components
+            obj.form.components = [component for component in obj.form.components if component.parent is None]  # type: ignore[attr-defined]
+            obj.form.clear_caches()
 
     @factory.post_generation
     def expressions(self, create: bool, extracted: list[Any], **kwargs: Any) -> None:
@@ -971,21 +968,17 @@ class _QuestionFactory(SQLAlchemyModelFactory):
             db.session.commit()
 
     @factory.post_generation
-    def _references(self: "Question", create: bool, extracted: list[Any], **kwargs: Any) -> None:
+    def _references(obj: "Question", create: bool, extracted: list[Any], **kwargs: Any) -> None:
         if not create:
             return
 
         _validate_and_sync_component_references(
-            self,
-            ExpressionContext.build_expression_context(collection=self.form.collection, mode="interpolation"),
+            obj,
+            ExpressionContext.build_expression_context(collection=obj.form.collection, mode="interpolation"),
         )
 
         # Wipe the cache of questions on a form - because we're likely to be creating more forms/questions
-        del self.form.cached_questions
-        try:
-            del self.form.cached_all_components
-        except AttributeError:
-            pass
+        obj.form.clear_caches()
         db.session.commit()
 
 
@@ -1014,14 +1007,11 @@ class _GroupFactory(SQLAlchemyModelFactory):
     conditions_operator = ConditionsOperator.ALL
 
     @factory.post_generation
-    def form_components_join(self, create: bool, extracted: list[Any], **kwargs: Any) -> None:
+    def form_components_join(obj: Group, create: bool, extracted: list[Any], **kwargs: Any) -> None:
         # Force the update of the form list of components as the join doesn't work before this is flushed to database
         if not create:
-            self.form.components = [component for component in self.form.components if component.parent is None]  # type: ignore[attr-defined]
-            if hasattr(self.form, "cached_questions"):
-                del self.form.cached_questions
-            if hasattr(self.form, "cached_all_components"):
-                del self.form.cached_all_components
+            obj.form.components = [component for component in obj.form.components if component.parent is None]  # type: ignore[attr-defined]
+            obj.form.clear_caches()
 
     @factory.post_generation
     def expressions(self, create: bool, extracted: list[Any], **kwargs: Any) -> None:
@@ -1036,21 +1026,18 @@ class _GroupFactory(SQLAlchemyModelFactory):
             db.session.commit()
 
     @factory.post_generation
-    def _references(self: "Group", create: bool, extracted: list[Any], **kwargs: Any) -> None:
+    def _references(obj: "Group", create: bool, extracted: list[Any], **kwargs: Any) -> None:
         if not create:
             return
 
         _validate_and_sync_component_references(
-            self,
-            ExpressionContext.build_expression_context(collection=self.form.collection, mode="interpolation"),
+            obj,
+            ExpressionContext.build_expression_context(collection=obj.form.collection, mode="interpolation"),
         )
 
         # Wipe the cache of questions on a form - because we're likely to be creating more forms/questions
-        del self.form.cached_questions
-        try:
-            del self.form.cached_all_components
-        except AttributeError:
-            pass
+        obj.clear_caches()
+        obj.form.clear_caches()
         db.session.commit()
 
 

--- a/tests/unit/common/collections/test_validation.py
+++ b/tests/unit/common/collections/test_validation.py
@@ -181,9 +181,7 @@ class TestSubmissionValidator:
         assert validator.validate_all_reachable_questions() is None
 
         submission.data_manager.set(q1, IntegerAnswer(value=150))
-        helper.cached_get_answer_for_question.cache_clear()
-
-        del helper.cached_evaluation_context
+        helper.clear_caches()
 
         with pytest.raises(SubmissionValidationFailed) as e:
             validator.validate_all_reachable_questions()

--- a/tests/unit/common/helpers/test_collections.py
+++ b/tests/unit/common/helpers/test_collections.py
@@ -424,8 +424,7 @@ class TestSubmissionHelper:
             all_answered = helper.cached_get_all_questions_are_answered_for_form(q1.form).all_answered
             assert all_answered is False
 
-            helper.cached_get_answer_for_question.cache_clear()
-            helper.cached_get_all_questions_are_answered_for_form.cache_clear()
+            helper.clear_caches()
 
             submission.data_manager.set(q2, TextSingleLineAnswer("answer 2"))
 
@@ -494,8 +493,7 @@ class TestSubmissionHelper:
             all_answered = helper.cached_get_all_questions_are_answered_for_form(group.form).all_answered
             assert all_answered is False
 
-            helper.cached_get_answer_for_question.cache_clear()
-            helper.cached_get_all_questions_are_answered_for_form.cache_clear()
+            helper.clear_caches()
 
             submission.data_manager.set(q2, TextSingleLineAnswer("answer 1"), add_another_index=0)
             submission.data_manager.set(q2, TextSingleLineAnswer("answer 2"), add_another_index=1)
@@ -524,8 +522,7 @@ class TestSubmissionHelper:
             all_answered = helper.cached_get_all_questions_are_answered_for_form(group.form).all_answered
             assert all_answered is False
 
-            helper.cached_get_answer_for_question.cache_clear()
-            helper.cached_get_all_questions_are_answered_for_form.cache_clear()
+            helper.clear_caches()
 
             submission.data_manager.set(q2, TextSingleLineAnswer("answer 3"), add_another_index=2)
 
@@ -544,11 +541,8 @@ class TestSubmissionHelper:
 
             # empty collections are not completed
             assert helper.all_needed_forms_are_completed is False
-            del helper.all_needed_forms_are_completed
 
             submission.data_manager.set(question_one, TextSingleLineAnswer("User submitted data"))
-            helper.cached_get_answer_for_question.cache_clear()
-            helper.cached_get_all_questions_are_answered_for_form.cache_clear()
             submission.events = [
                 factories.submission_event.build(
                     submission=submission,
@@ -556,17 +550,16 @@ class TestSubmissionHelper:
                     event_type=SubmissionEventType.FORM_RUNNER_FORM_COMPLETED,
                 )
             ]
+            helper.clear_caches()
 
             # one complete form and one incomplete is still not completed
             assert helper.all_needed_forms_are_completed is False
 
             submission.data_manager.set(question_two, TextSingleLineAnswer("User submitted data"))
-            helper.cached_get_answer_for_question.cache_clear()
-            helper.cached_get_all_questions_are_answered_for_form.cache_clear()
+            helper.clear_caches()
 
             # all questions complete but a form not marked as completed is still not completed
             assert helper.all_needed_forms_are_completed is False
-            del helper.all_needed_forms_are_completed
 
             submission.events.append(
                 factories.submission_event.build(
@@ -575,6 +568,7 @@ class TestSubmissionHelper:
                     event_type=SubmissionEventType.FORM_RUNNER_FORM_COMPLETED,
                 )
             )
+            helper.clear_caches()
 
             # all questions answered and all marked as complete is complete
             assert helper.all_needed_forms_are_completed is True


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
While working on [the persisted submission status](https://github.com/communitiesuk/funding-service/pull/1681) PR, we noticed that cache clearing was quite manual and fragmented.

This adds helpers to our classes that cache some properties to reliably clear all cached properties and updates the tests to stop just poking specific cached properties.

There were also a lot of tests that were just unnecessarily clearing caches.

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [ ] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [ ] End-to-end tests have been updated (if applicable)
- [ ] Edge cases and error conditions are tested

## 📚 Additional Notes
<!-- Any additional context, concerns, or considerations for reviewers -->
