### PR TITLE
Protect list_submissions endpoint against overwhelm

### DIFF
--- a/app/deliver_grant_funding/routes/reports.py
+++ b/app/deliver_grant_funding/routes/reports.py
@@ -3131,6 +3131,11 @@ def list_submissions(grant_id: UUID, report_id: UUID, submission_mode: Submissio
             )
         )
 
+    # TODO[FSPT-1405]: remove me; very short term service stability guard
+    submissions = report.live_submissions if submission_mode == SubmissionModeEnum.LIVE else report.test_submissions
+    if len(submissions) > 100:
+        abort(503)
+
     helper = AllSubmissionsHelper(collection=report, submission_mode=submission_mode)
 
     return render_template(


### PR DESCRIPTION
We're currently seeing this endpoint cause large performance issues across the service with a grant that has a lot of submissions. We need to effectively take this offline to protect the service while we're doing the proper fix.

We'll need to take this out ASAP because obviously it's bad. But we need to do the status performance fixes first from FSPT-1405.