### PR TITLE
Read submission status from db

### DIFF
--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -358,6 +358,7 @@ def get_all_submissions_with_mode_for_collection(
     *,
     with_full_schema: bool = True,
     with_users: bool = False,
+    with_submission_summary_info: bool = False,
 ) -> Sequence[Submission]:
     """
     Use this function to get all submission data for a collection - it
@@ -366,8 +367,8 @@ def get_all_submissions_with_mode_for_collection(
     through them all individually.
     """
 
-    if with_full_schema and with_users:
-        raise ValueError("Only one of with_full_schema or with_users should be set")
+    if sum([with_full_schema, with_users, with_submission_summary_info]) > 1:
+        raise ValueError("Only one of with_full_schema, with_submission_summary_info or with_users should be set")
 
     # todo: this feels redundant because this interface should probably be limited to a single collection and fetch
     #       that through a specific interface which already exists - this can then focus on submissions
@@ -404,6 +405,9 @@ def get_all_submissions_with_mode_for_collection(
         stmt = stmt.options(
             joinedload(Submission.created_by),
         )
+    elif with_submission_summary_info:
+        stmt = stmt.options(selectinload(Submission.events))
+        stmt = stmt.options(joinedload(Submission.grant_recipient).joinedload(GrantRecipient.organisation))
 
     if grant_recipient_ids is not NOT_PROVIDED:
         stmt = stmt.where(Submission.grant_recipient_id.in_(grant_recipient_ids))

--- a/app/common/data/interfaces/grant_recipients.py
+++ b/app/common/data/interfaces/grant_recipients.py
@@ -5,7 +5,7 @@ from sqlalchemy import String, cast, func, select
 from sqlalchemy.orm import joinedload, selectinload
 
 from app.common.data.interfaces.exceptions import flush_and_rollback_on_exceptions
-from app.common.data.models import Grant, GrantRecipient, Organisation
+from app.common.data.models import Grant, GrantRecipient, Organisation, Submission
 from app.common.data.models_user import User, UserRole
 from app.common.data.types import GrantRecipientModeEnum, RoleEnum, SubmissionModeEnum, SubmissionStatusEnum
 from app.extensions import db
@@ -18,6 +18,8 @@ def get_grant_recipients(
     with_data_providers: bool = False,
     with_certifiers: bool = False,
     with_organisations: bool = False,
+    with_submissions_for_collection: uuid.UUID | None = None,
+    submission_mode: SubmissionModeEnum = SubmissionModeEnum.LIVE,
 ) -> Sequence[GrantRecipient]:
     stmt = select(GrantRecipient).where(GrantRecipient.grant_id == grant.id, GrantRecipient.mode == mode)
 
@@ -29,6 +31,15 @@ def get_grant_recipients(
 
     if with_organisations:
         stmt = stmt.options(selectinload(GrantRecipient.organisation))
+
+    if with_submissions_for_collection:
+        stmt = stmt.options(
+            selectinload(
+                GrantRecipient.submissions.and_(Submission.collection_id == with_submissions_for_collection).and_(
+                    Submission.mode == submission_mode
+                )
+            ).joinedload(Submission.events)
+        )
 
     stmt = stmt.join(Organisation, GrantRecipient.organisation_id == Organisation.id).order_by(Organisation.name)
 

--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-062_add_submission_status
+063_submission_status_not_null

--- a/app/common/data/migrations/versions/063_submission_status_not_null.py
+++ b/app/common/data/migrations/versions/063_submission_status_not_null.py
@@ -1,0 +1,33 @@
+"""Change submission status to not allow nulls
+
+Revision ID: 063_submission_status_not_null
+Revises: 062_add_submission_status
+Create Date: 2026-06-03 15:17:30.589089
+
+"""
+
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "063_submission_status_not_null"
+down_revision = "062_add_submission_status"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("submission", schema=None) as batch_op:
+        batch_op.alter_column(
+            "status",
+            existing_type=postgresql.ENUM(name="submission_status_enum", create_type=False),
+            nullable=False,
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("submission", schema=None) as batch_op:
+        batch_op.alter_column(
+            "status",
+            existing_type=postgresql.ENUM(name="submission_status_enum", create_type=False),
+            nullable=True,
+        )

--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -396,6 +396,13 @@ class Submission(BaseModel):
     )
 
     @property
+    def last_updated_at_utc(self) -> datetime.datetime:
+        from app.common.helpers.submission_events import SubmissionEventHelper
+
+        event_helper = SubmissionEventHelper(self)
+        return max(filter(None, [event_helper.latest_event_utc, self.updated_at_utc]))
+
+    @property
     def s3_key_prefix(self) -> str:
         return f"{current_app.config['SUBMISSION_FILES_PREFIX']}/{self.mode}/{self.collection_id}/{self.id}"
 
@@ -407,6 +414,21 @@ class Submission(BaseModel):
         using the `update_submission_data` interface.
         """
         return SubmissionDataManager(self._data)
+
+    @property
+    def name(self) -> str:
+        """
+        For submissions in a multi-submission collection, this provides a name for the submission based on a provided
+        answer.
+
+        For non-multi-submission collection we just return the submission's generated reference.
+        """
+        question = self.collection.submission_name_question
+        if question:
+            answer = self.data_manager.get(question)
+            if answer is not None:
+                return answer.get_value_for_text_export()
+        return self.reference
 
     __table_args__ = (
         CheckConstraint(

--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -386,13 +386,13 @@ class Submission(BaseModel):
         viewonly=True,
     )
 
-    status: Mapped[SubmissionStatusEnum | None] = mapped_column(
+    status: Mapped[SubmissionStatusEnum] = mapped_column(
         SqlEnum(
             SubmissionStatusEnum,
             name="submission_status_enum",
             validate_strings=True,
         ),
-        nullable=True,
+        nullable=False,
     )
 
     @property

--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -194,18 +194,7 @@ class SubmissionHelper:
 
     @property
     def submission_name(self) -> str:
-        """
-        For submissions in a multi-submission collection, this provides a name for the submission based on a provided
-        answer.
-
-        For non-multi-submission collection we just return the submission's generated reference.
-        """
-        question = self.collection.submission_name_question
-        if question:
-            answer = self.cached_get_answer_for_question(question.id)
-            if answer is not None:
-                return answer.get_value_for_text_export()
-        return self.submission.reference
+        return self.submission.name
 
     @property
     def long_collection_name(self) -> str:
@@ -483,7 +472,7 @@ class SubmissionHelper:
 
     @property
     def last_updated_at_utc(self) -> datetime:
-        return max(filter(None, [self.events.latest_event_utc, self.submission.updated_at_utc]))
+        return self.submission.last_updated_at_utc
 
     @property
     def reopened_at_utc(self) -> datetime | None:

--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -410,7 +410,7 @@ class SubmissionHelper:
 
     @property
     def status(self) -> SubmissionStatusEnum:
-        return self._calculate_submission_status()
+        return self.submission.status
 
     @property
     def submitted_at_utc(self) -> datetime | None:

--- a/app/deliver_grant_funding/routes/reports.py
+++ b/app/deliver_grant_funding/routes/reports.py
@@ -3131,16 +3131,20 @@ def list_submissions(grant_id: UUID, report_id: UUID, submission_mode: Submissio
             )
         )
 
-    helper = AllSubmissionsHelper(collection=report, submission_mode=submission_mode)
-
+    submissions = get_all_submissions_with_mode_for_collection(
+        collection_id=report_id,
+        submission_mode=submission_mode,
+        with_full_schema=False,
+        with_users=False,
+        with_submission_summary_info=True,
+    )
     return render_template(
         "deliver_grant_funding/reports/list_submissions.html",
         grant=report.grant,
         report=report,
-        helper=helper,
         submission_mode=submission_mode,
         delete_all_form=delete_all_form if submission_mode == SubmissionModeEnum.TEST else None,
-        SubmissionHelper=SubmissionHelper,
+        submissions=submissions,
     )
 
 

--- a/app/deliver_grant_funding/routes/reports.py
+++ b/app/deliver_grant_funding/routes/reports.py
@@ -66,6 +66,7 @@ from app.common.data.interfaces.exceptions import (
     DuplicateValueError,
     InvalidReferenceInExpression,
 )
+from app.common.data.interfaces.grant_recipients import get_grant_recipients
 from app.common.data.interfaces.grants import get_grant
 from app.common.data.interfaces.user import get_current_user
 from app.common.data.types import (
@@ -3131,19 +3132,33 @@ def list_submissions(grant_id: UUID, report_id: UUID, submission_mode: Submissio
             )
         )
 
-    submissions = get_all_submissions_with_mode_for_collection(
-        collection_id=report_id,
-        submission_mode=submission_mode,
-        with_full_schema=False,
-        with_users=False,
-        with_submission_summary_info=True,
-    )
+    grant_recipients = []
+    submissions = []
+    if report.allow_multiple_submissions:
+        submissions = get_all_submissions_with_mode_for_collection(
+            collection_id=report_id,
+            submission_mode=submission_mode,
+            with_full_schema=False,
+            with_submission_summary_info=True,
+        )
+    else:
+        grant_recipients = get_grant_recipients(
+            report.grant,
+            mode=GrantRecipientModeEnum.LIVE
+            if submission_mode == SubmissionModeEnum.LIVE
+            else GrantRecipientModeEnum.TEST,
+            with_organisations=True,
+            with_submissions_for_collection=report_id,
+            submission_mode=submission_mode,
+        )
+
     return render_template(
         "deliver_grant_funding/reports/list_submissions.html",
         grant=report.grant,
         report=report,
         submission_mode=submission_mode,
         delete_all_form=delete_all_form if submission_mode == SubmissionModeEnum.TEST else None,
+        grant_recipients=grant_recipients,
         submissions=submissions,
     )
 

--- a/app/deliver_grant_funding/routes/reports.py
+++ b/app/deliver_grant_funding/routes/reports.py
@@ -3131,11 +3131,6 @@ def list_submissions(grant_id: UUID, report_id: UUID, submission_mode: Submissio
             )
         )
 
-    # TODO[FSPT-1405]: remove me; very short term service stability guard
-    submissions = report.live_submissions if submission_mode == SubmissionModeEnum.LIVE else report.test_submissions
-    if len(submissions) > 100:
-        abort(503)
-
     helper = AllSubmissionsHelper(collection=report, submission_mode=submission_mode)
 
     return render_template(

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_submissions.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_submissions.html
@@ -106,6 +106,7 @@
     <div class="govuk-grid-column-full">
       {% if report.allow_multiple_submissions %}
         {% set rows=[] %}
+
         {% for submission in submissions | sort(attribute="grant_recipient.organisation.name,name") %}
           {% set link_to_submission %}
             <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.view_submission', grant_id=grant.id, submission_id=submission.id) }}" data-submission-link> {{ submission.name }} </a>
@@ -151,24 +152,40 @@
         }}
       {% else %}
         {% set rows=[] %}
-        {% for submission in submissions | sort(attribute="grant_recipient.organisation.name") %}
-          {% set link_to_submission %}
-            <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.view_submission', grant_id=grant.id, submission_id=submission.id) }}" data-submission-link>
-              {{ submission.grant_recipient.organisation.name }}
-            </a>
-          {% endset %}
-          {% set submission_status = submission.status %}
-          {%
-            do rows.append([
-              {
-                "html": link_to_submission,
-              }, {
-                "html": submissionStatusTag(submission_status, report.is_closed and not submission.status == enum.submission_status.SUBMITTED),
-              }, {
-                "text": format_date_short(submission.last_updated_at_utc)
-              }
-            ])
-          %}
+        {% for grant_recipient in grant_recipients | sort(attribute="organisation.name") %}
+
+          {% if grant_recipient.submissions %}
+            {% set submission = grant_recipient.submissions[0] %}
+            {% set link_to_submission %}
+              <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.view_submission', grant_id=grant.id, submission_id=submission.id) }}" data-submission-link>
+                {{ submission.grant_recipient.organisation.name }}
+              </a>
+            {% endset %}
+            {% set submission_status = submission.status %}
+            {%
+              do rows.append([
+                {
+                  "html": link_to_submission,
+                }, {
+                  "html": submissionStatusTag(submission_status, report.is_closed and not submission.status == enum.submission_status.SUBMITTED),
+                }, {
+                  "text": format_date_short(submission.last_updated_at_utc)
+                }
+              ])
+            %}
+          {% else %}
+            {%
+              do rows.append([
+                {
+                  "text": grant_recipient.organisation.name
+                }, {
+                  "html": submissionStatusTag(enum.submission_status.NOT_STARTED if not report.is_closed else enum.submission_status.NOT_SUBMITTED, report.is_closed),
+                }, {
+                  "text": ""
+                }
+              ])
+            %}
+          {% endif %}
         {% else %}
           {% set no_collections_text %}
             <span>No submissions found for this monitoring report</span>

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_submissions.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_submissions.html
@@ -10,7 +10,7 @@
 {% set active_item_identifier = "reports" %}
 
 {% block beforeContent %}
-  {% if helper.is_test_mode %}
+  {% if submission_mode==enum.submission_mode.TEST %}
     {{ mhclgInlinePageTestDataBanner("Test submissions") }}
   {% endif %}
   {{ deliver_grant_funding_reports_breadcrumb(grant=grant, this_page_breadcrumb_item={"text":"Submissions"}) }}
@@ -106,22 +106,20 @@
     <div class="govuk-grid-column-full">
       {% if report.allow_multiple_submissions %}
         {% set rows=[] %}
-        {% for submission_helper in helper.submission_helpers.values() | sort(attribute="submission.grant_recipient.organisation.name,submission_name") %}
+        {% for submission in submissions | sort(attribute="grant_recipient.organisation.name,name") %}
           {% set link_to_submission %}
-            <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.view_submission', grant_id=grant.id, submission_id=submission_helper.submission.id) }}" data-submission-link>
-              {{ submission_helper.submission_name }}
-            </a>
+            <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.view_submission', grant_id=grant.id, submission_id=submission.id) }}" data-submission-link> {{ submission.name }} </a>
           {% endset %}
           {%
             do rows.append([
               {
                 "html": link_to_submission,
               }, {
-                "text": submission_helper.submission.grant_recipient.organisation.name,
+                "text": submission.grant_recipient.organisation.name,
               }, {
-                "html": submissionStatusTag(submission_helper.status, submission_helper.is_overdue)
+                "html": submissionStatusTag(submission.status,  report.is_closed and not submission.status == enum.submission_status.SUBMITTED),
               }, {
-                "text": format_date_short(submission_helper.last_updated_at_utc)
+                "text": format_date_short(submission.last_updated_at_utc)
               }
             ])
           %}
@@ -153,26 +151,21 @@
         }}
       {% else %}
         {% set rows=[] %}
-        {% for grant_recipient in helper.grant_recipients | sort(attribute="organisation.name") %}
-          {% set grant_recipient_submission_helper = helper.grant_recipients_submission_helpers[grant_recipient.id] %}
+        {% for submission in submissions | sort(attribute="grant_recipient.organisation.name") %}
           {% set link_to_submission %}
-            {% if grant_recipient_submission_helper %}
-              <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.view_submission', grant_id=grant.id, submission_id=grant_recipient_submission_helper.submission.id) }}" data-submission-link>
-                {{ grant_recipient.organisation.name }}
-              </a>
-            {% else %}
-              {{ grant_recipient.organisation.name }}
-            {% endif %}
+            <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.view_submission', grant_id=grant.id, submission_id=submission.id) }}" data-submission-link>
+              {{ submission.grant_recipient.organisation.name }}
+            </a>
           {% endset %}
-          {% set submission_status = SubmissionHelper.get_status(grant_recipient_submission_helper.submission, report) %}
+          {% set submission_status = submission.status %}
           {%
             do rows.append([
               {
                 "html": link_to_submission,
               }, {
-                "html": submissionStatusTag(submission_status, grant_recipient_submission_helper.is_overdue if grant_recipient_submission_helper else report.is_overdue),
+                "html": submissionStatusTag(submission_status, report.is_closed and not submission.status == enum.submission_status.SUBMITTED),
               }, {
-                "text": format_date_short(grant_recipient_submission_helper.last_updated_at_utc) if grant_recipient_submission_helper else ''
+                "text": format_date_short(submission.last_updated_at_utc)
               }
             ])
           %}

--- a/tests/integration/access_grant_funding/routes/test_reports.py
+++ b/tests/integration/access_grant_funding/routes/test_reports.py
@@ -202,6 +202,7 @@ class TestViewLockedReport:
         organisation = authenticated_grant_recipient_certifier_client.organisation
         grant = authenticated_grant_recipient_certifier_client.grant
 
+        assert submission_awaiting_sign_off.status == SubmissionStatusEnum.AWAITING_SIGN_OFF
         helper = SubmissionHelper(submission_awaiting_sign_off)
         assert helper.status == SubmissionStatusEnum.AWAITING_SIGN_OFF
 
@@ -225,6 +226,7 @@ class TestViewLockedReport:
             grant_id=grant.id,
             submission_id=submission_awaiting_sign_off.id,
         )
+        assert submission_awaiting_sign_off.status == SubmissionStatusEnum.AWAITING_SIGN_OFF
 
         assert helper.status == SubmissionStatusEnum.AWAITING_SIGN_OFF
 
@@ -290,6 +292,7 @@ class TestViewLockedReport:
         factories.submission_event.create(
             submission=submission, event_type=SubmissionEventType.SUBMISSION_SENT_FOR_CERTIFICATION
         )
+        submission.status = SubmissionStatusEnum.AWAITING_SIGN_OFF
 
         response = authenticated_grant_recipient_member_client.get(
             url_for(
@@ -675,6 +678,7 @@ class TestListCollectionSubmissions:
                 event_type=SubmissionEventType.SUBMISSION_SUBMITTED,
                 created_by=user,
             )
+            submission.status = SubmissionStatusEnum.SUBMITTED
 
         response = authenticated_grant_recipient_member_client.get(
             url_for(
@@ -1339,6 +1343,7 @@ class TestConfirmReportSubmission:
             related_entity_id=form.id,
             event_type=SubmissionEventType.FORM_RUNNER_FORM_COMPLETED,
         )
+        submission.status = SubmissionStatusEnum.READY_TO_SUBMIT
 
         certifier = factories.user.create()
         factories.user_role.create(
@@ -1485,7 +1490,7 @@ class TestViewSubmittedConfirmation:
             related_entity_id=question.form.id,
         )
         factories.submission_event.create(submission=submission, event_type=SubmissionEventType.SUBMISSION_SUBMITTED)
-
+        submission.status = SubmissionStatusEnum.SUBMITTED
         response = authenticated_grant_recipient_data_provider_client.get(
             url_for(
                 "access_grant_funding.submitted_confirmation",

--- a/tests/integration/access_grant_funding/routes/test_runner.py
+++ b/tests/integration/access_grant_funding/routes/test_runner.py
@@ -2142,6 +2142,7 @@ class TestConfirmSentForCertification:
         factories.submission_event.create(
             submission=submission, event_type=SubmissionEventType.SUBMISSION_SENT_FOR_CERTIFICATION
         )
+        submission.status = SubmissionStatusEnum.AWAITING_SIGN_OFF
 
         response = client.get(
             url_for(
@@ -2227,6 +2228,7 @@ class TestConfirmSentForCertification:
         factories.submission_event.create(
             submission=submission, event_type=SubmissionEventType.SUBMISSION_SENT_FOR_CERTIFICATION
         )
+        submission.status = SubmissionStatusEnum.AWAITING_SIGN_OFF
 
         response = authenticated_grant_recipient_member_client.get(
             url_for(

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -5146,12 +5146,34 @@ class TestGetSubmissions:
     ):
         collection = factories.collection.create()
 
-        with pytest.raises(ValueError, match="Only one of with_full_schema or with_users should be set"):
+        with pytest.raises(
+            ValueError, match="Only one of with_full_schema, with_submission_summary_info or with_users should be set"
+        ):
             get_all_submissions_with_mode_for_collection(
                 collection_id=collection.id,
                 submission_mode=SubmissionModeEnum.LIVE,
                 with_full_schema=True,
                 with_users=True,
+            )
+        with pytest.raises(
+            ValueError, match="Only one of with_full_schema, with_submission_summary_info or with_users should be set"
+        ):
+            get_all_submissions_with_mode_for_collection(
+                collection_id=collection.id,
+                submission_mode=SubmissionModeEnum.LIVE,
+                with_full_schema=True,
+                with_users=True,
+                with_submission_summary_info=True,
+            )
+        with pytest.raises(
+            ValueError, match="Only one of with_full_schema, with_submission_summary_info or with_users should be set"
+        ):
+            get_all_submissions_with_mode_for_collection(
+                collection_id=collection.id,
+                submission_mode=SubmissionModeEnum.LIVE,
+                with_full_schema=True,
+                with_users=False,
+                with_submission_summary_info=True,
             )
 
     def test_get_all_submissions_with_mode_for_collection_with_full_schema_no_n_plus_one(

--- a/tests/integration/common/data/interfaces/test_grant_recipients.py
+++ b/tests/integration/common/data/interfaces/test_grant_recipients.py
@@ -14,7 +14,13 @@ from app.common.data.interfaces.grant_recipients import (
     get_grant_recipients_with_outstanding_submissions_for_collection,
 )
 from app.common.data.models import GrantRecipient
-from app.common.data.types import GrantRecipientModeEnum, RoleEnum, SubmissionEventType, SubmissionModeEnum
+from app.common.data.types import (
+    GrantRecipientModeEnum,
+    RoleEnum,
+    SubmissionEventType,
+    SubmissionModeEnum,
+    SubmissionStatusEnum,
+)
 from tests.models import FactoryAnswer
 
 
@@ -349,6 +355,7 @@ class TestGetGrantRecipientsWithOutstandingReports:
         factories.submission_event.create(
             submission=submission1, event_type=SubmissionEventType.SUBMISSION_SENT_FOR_CERTIFICATION
         )
+        submission1.status = SubmissionStatusEnum.AWAITING_SIGN_OFF
 
         # gr2 has submitted so should not be in the list
         submission2 = factories.submission.create(
@@ -363,6 +370,7 @@ class TestGetGrantRecipientsWithOutstandingReports:
             event_type=SubmissionEventType.FORM_RUNNER_FORM_COMPLETED,
         )
         factories.submission_event.create(submission=submission2, event_type=SubmissionEventType.SUBMISSION_SUBMITTED)
+        submission2.status = SubmissionStatusEnum.SUBMITTED
 
         # gr3 has had their certification declined, so should be in the list
         submission3 = factories.submission.create(
@@ -382,6 +390,7 @@ class TestGetGrantRecipientsWithOutstandingReports:
         factories.submission_event.create(
             submission=submission3, event_type=SubmissionEventType.SUBMISSION_DECLINED_BY_CERTIFIER
         )
+        submission3.status = SubmissionStatusEnum.IN_PROGRESS
         # org 4 has not started their report yet so should be in the list
 
         result = get_grant_recipients_with_outstanding_submissions_for_collection(

--- a/tests/integration/common/data/test_models.py
+++ b/tests/integration/common/data/test_models.py
@@ -11,6 +11,7 @@ from app.common.data.types import (
     QuestionPresentationOptions,
     RoleEnum,
     SubmissionModeEnum,
+    SubmissionStatusEnum,
 )
 from app.common.expressions.managed import GreaterThan, Specifically
 from app.common.expressions.references import ExpressionReference
@@ -47,6 +48,7 @@ class TestSubmissionModel:
             reference="TEST-R123456",
             created_by_id=user.id,
             grant_recipient_id=None,
+            status=SubmissionStatusEnum.NOT_STARTED,
         )
         db_session.add(submission)
 

--- a/tests/integration/common/helpers/test_collections.py
+++ b/tests/integration/common/helpers/test_collections.py
@@ -1311,12 +1311,7 @@ class TestSubmissionHelper:
                 permissions=[RoleEnum.CERTIFIER],
             )
 
-            factories.submission_event.create(
-                submission=submission_awaiting_sign_off,
-                event_type=SubmissionEventType.SUBMISSION_APPROVED_BY_CERTIFIER,
-                created_by=certifier_user,
-                created_at_utc=datetime(2025, 12, 1, 0, 0, 0),
-            )
+            helper.certify(certifier_user)
 
             with pytest.raises(SubmissionAuthorisationError) as error:
                 helper.submit(submitter_user)
@@ -1381,13 +1376,8 @@ class TestSubmissionHelper:
             helper = SubmissionHelper(submission_awaiting_sign_off)
             assert helper.status == SubmissionStatusEnum.AWAITING_SIGN_OFF
 
-            factories.submission_event.create(
-                created_by=certifier_user,
-                created_at_utc=datetime(2025, 12, 1, 0, 0, 0),
-                related_entity_id=submission_awaiting_sign_off.id,
-                submission=submission_awaiting_sign_off,
-                event_type=SubmissionEventType.SUBMISSION_APPROVED_BY_CERTIFIER,
-            )
+            helper.certify(certifier_user)
+
             assert helper.status == SubmissionStatusEnum.READY_TO_SUBMIT
 
             helper.submit(user=certifier_user)
@@ -1452,13 +1442,7 @@ class TestSubmissionHelper:
         ):
             helper = SubmissionHelper(submission_awaiting_sign_off)
 
-            factories.submission_event.create(
-                created_by=certifier_user,
-                created_at_utc=datetime(2025, 12, 1, 0, 0, 0),
-                related_entity_id=submission_awaiting_sign_off.id,
-                submission=submission_awaiting_sign_off,
-                event_type=SubmissionEventType.SUBMISSION_APPROVED_BY_CERTIFIER,
-            )
+            helper.certify(certifier_user)
             assert helper.status == SubmissionStatusEnum.READY_TO_SUBMIT
             with pytest.raises(SubmissionAuthorisationError) as e:
                 helper.submit(data_provider_user)
@@ -1521,7 +1505,7 @@ class TestSubmissionHelper:
             submission_ready_to_submit.collection.status = CollectionStatusEnum.CLOSED
             helper = SubmissionHelper(submission_ready_to_submit)
 
-            with pytest.raises(ValueError, match="not ready to submit"):
+            with pytest.raises(ValueError, match="as it is in an immutable state"):
                 helper.submit(data_provider_user)
 
             assert len(mock_notification_service_calls) == 0

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -39,6 +39,7 @@ from app.common.data.types import (
     RoleEnum,
     SubmissionEventType,
     SubmissionModeEnum,
+    SubmissionStatusEnum,
 )
 from app.extensions.record_sqlalchemy_queries import QueryInfo, get_recorded_queries
 from tests.conftest import FundingServiceTestClient, _Factories, _precompile_templates
@@ -638,7 +639,9 @@ def grant_recipient(
 
 
 @pytest.fixture(scope="function")
-def submission_in_progress(factories: _Factories, grant_recipient: GrantRecipient, user: User) -> Submission:
+def submission_in_progress(
+    factories: _Factories, db_session, grant_recipient: GrantRecipient, user: User
+) -> Submission:
     question = factories.question.create(
         id=uuid.UUID("d696aebc-49d2-4170-a92f-b6ef42994294"),
         form__collection__grant=grant_recipient.grant,
@@ -652,11 +655,15 @@ def submission_in_progress(factories: _Factories, grant_recipient: GrantRecipien
         mode=SubmissionModeEnum.LIVE,
         answers=[FactoryAnswer(question, TextSingleLineAnswer("Question answer"))],
     )
+    submission.status = SubmissionStatusEnum.IN_PROGRESS
+    db_session.commit()
     return cast(Submission, submission)
 
 
 @pytest.fixture(scope="function")
-def submission_ready_to_submit(factories: _Factories, grant_recipient: GrantRecipient, user: User) -> Submission:
+def submission_ready_to_submit(
+    factories: _Factories, db_session, grant_recipient: GrantRecipient, user: User
+) -> Submission:
     question = factories.question.create(
         id=uuid.UUID("d696aebc-49d2-4170-a92f-b6ef42994294"),
         form__collection__grant=grant_recipient.grant,
@@ -677,11 +684,15 @@ def submission_ready_to_submit(factories: _Factories, grant_recipient: GrantReci
         created_by=user,
         created_at_utc=datetime(2025, 11, 25, 0, 0, 0),
     )
+    submission.status = SubmissionStatusEnum.READY_TO_SUBMIT
+    db_session.commit()
     return cast(Submission, submission)
 
 
 @pytest.fixture(scope="function")
-def submission_awaiting_sign_off(factories: _Factories, grant_recipient: GrantRecipient, user: User) -> Submission:
+def submission_awaiting_sign_off(
+    factories: _Factories, grant_recipient: GrantRecipient, user: User, db_session
+) -> Submission:
     question = factories.question.create(
         id=uuid.UUID("d696aebc-49d2-4170-a92f-b6ef42994294"),
         form__collection__grant=grant_recipient.grant,
@@ -709,11 +720,13 @@ def submission_awaiting_sign_off(factories: _Factories, grant_recipient: GrantRe
         created_by=user,
         created_at_utc=datetime(2025, 11, 25, 0, 0, 1),
     )
+    submission.status = SubmissionStatusEnum.AWAITING_SIGN_OFF
+    db_session.commit()
     return cast(Submission, submission)
 
 
 @pytest.fixture(scope="function")
-def submission_submitted(factories: _Factories, grant_recipient: GrantRecipient, user: User) -> Submission:
+def submission_submitted(factories: _Factories, db_session, grant_recipient: GrantRecipient, user: User) -> Submission:
     question = factories.question.create(
         id=uuid.UUID("d696aebc-49d2-4170-a92f-b6ef42994294"),
         form__collection__grant=grant_recipient.grant,
@@ -750,11 +763,18 @@ def submission_submitted(factories: _Factories, grant_recipient: GrantRecipient,
         event_type=SubmissionEventType.SUBMISSION_SUBMITTED,
         created_by=user,
     )
+    submission.status = SubmissionStatusEnum.SUBMITTED
+    db_session.commit()
+
     return cast(Submission, submission)
 
 
 @pytest.fixture(scope="function")
-def submission_submitted_multiple_submissions(factories: _Factories, grant_recipient, db_session) -> list[Submission]:
+def submission_submitted_multiple_submissions(
+    factories: _Factories,
+    db_session,
+    grant_recipient,
+) -> list[Submission]:
     question = factories.question.create(
         id=uuid.UUID("d696aebc-49d2-4170-a92f-b6ef42994294"),
         data_type=QuestionDataType.TEXT_SINGLE_LINE,
@@ -803,6 +823,9 @@ def submission_submitted_multiple_submissions(factories: _Factories, grant_recip
         event_type=SubmissionEventType.SUBMISSION_SUBMITTED,
         created_by=user,
     )
+    submission_1.status = SubmissionStatusEnum.SUBMITTED
+    submission_2.status = SubmissionStatusEnum.SUBMITTED
+    db_session.commit()
 
     return [submission_1, submission_2]
 

--- a/tests/integration/deliver_grant_funding/admin/test_views.py
+++ b/tests/integration/deliver_grant_funding/admin/test_views.py
@@ -1269,6 +1269,7 @@ class TestSendEmailsToRecipients:
             created_by=user_1,
             grant_recipient=gr1,
             answers=[FactoryAnswer(question, TextSingleLineAnswer("answer 1"))],
+            status=SubmissionStatusEnum.IN_PROGRESS,
         )
 
         # org 2 has submitted their report, so should not be in the list
@@ -1288,6 +1289,7 @@ class TestSendEmailsToRecipients:
         factories.submission_event.create(
             event_type=SubmissionEventType.SUBMISSION_SUBMITTED, submission=submission_2, created_by=user_3
         )
+        submission_2.status = SubmissionStatusEnum.SUBMITTED
         assert SubmissionHelper(submission_2).status == SubmissionStatusEnum.SUBMITTED
 
         # org 3 has not started their report (has no submission) so should be in the list
@@ -1400,6 +1402,7 @@ class TestSendEmailsToRecipients:
             created_by=user_1,
             grant_recipient=gr1,
             answers=[FactoryAnswer(question, TextSingleLineAnswer("answer 1"))],
+            status=SubmissionStatusEnum.IN_PROGRESS,
         )
 
         # org 2 has submitted their report, so should not be in the list
@@ -1419,7 +1422,7 @@ class TestSendEmailsToRecipients:
         factories.submission_event.create(
             event_type=SubmissionEventType.SUBMISSION_SUBMITTED, submission=submission_2, created_by=user_3
         )
-        assert SubmissionHelper(submission_2).status == SubmissionStatusEnum.SUBMITTED
+        submission_2.status = SubmissionStatusEnum.SUBMITTED
 
         # org 3 has not started their report (has no submission) so should be in the list
 
@@ -1507,7 +1510,7 @@ class TestSendEmailsToRecipients:
             submission=submitted_submission,
             created_by=user,
         )
-        assert SubmissionHelper(submitted_submission).is_submitted
+        submitted_submission.status = SubmissionStatusEnum.SUBMITTED
 
         factories.submission.create(
             mode=SubmissionModeEnum.LIVE,

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -8310,12 +8310,14 @@ class TestListSubmissions:
             mode=SubmissionModeEnum.TEST,
             grant_recipient=test_grant_recipient,
             created_by__email="submitter-test@recipient.org",
+            status=SubmissionStatusEnum.NOT_STARTED,
         )
         factories.submission.create(
             collection=report,
             mode=SubmissionModeEnum.LIVE,
             grant_recipient=live_grant_recipient,
             created_by__email="submitter-live@recipient.org",
+            status=SubmissionStatusEnum.NOT_STARTED,
         )
 
         test_response = authenticated_grant_member_client.get(

--- a/tests/models.py
+++ b/tests/models.py
@@ -538,7 +538,10 @@ class _CollectionFactory(SQLAlchemyModelFactory):
         def _create_submission_of_type(submission_mode: SubmissionModeEnum, count: int) -> None:
             for _ in range(0, count):
                 item_choice = faker.Faker().random_int(min=0, max=2) if use_random_data else 0
-                sub = _SubmissionFactory.create(collection=obj, mode=submission_mode)
+                sub = _SubmissionFactory.create(
+                    collection=obj,
+                    mode=submission_mode,
+                )
                 sub.data_manager.set(
                     q1,
                     TextSingleLineAnswer(faker.Faker().name() if use_random_data else "test name"),
@@ -610,6 +613,7 @@ class _CollectionFactory(SQLAlchemyModelFactory):
                         mime_type="application/pdf",
                     ),
                 )
+                sub.status = SubmissionStatusEnum.IN_PROGRESS
 
                 if create:
                     update_submission_data(sub)
@@ -741,6 +745,7 @@ class _CollectionFactory(SQLAlchemyModelFactory):
                     q5,
                     IntegerAnswer(value=random.randint(0, 10) if use_random_data else 3),
                 )
+                sub.status = SubmissionStatusEnum.IN_PROGRESS
 
                 if create:
                     update_submission_data(sub)
@@ -795,7 +800,8 @@ class _SubmissionFactory(SQLAlchemyModelFactory):
         )
     )
     grant_recipient_id = factory.LazyAttribute(lambda o: o.grant_recipient.id if o.grant_recipient else None)
-    status = None
+
+    status = SubmissionStatusEnum.NOT_STARTED
 
     @factory.post_generation
     def answers(obj: Submission, create, extracted: list[FactoryAnswer], **kwargs):

--- a/tests/unit/common/helpers/test_collections.py
+++ b/tests/unit/common/helpers/test_collections.py
@@ -27,6 +27,7 @@ from app.common.data.types import (
     QuestionPresentationOptions,
     SubmissionEventType,
     SubmissionModeEnum,
+    SubmissionStatusEnum,
     TasklistSectionStatusEnum,
 )
 from app.common.expressions import ExpressionContext
@@ -614,6 +615,7 @@ class TestSubmissionHelper:
                     related_entity_id=submission.id,
                 ),
             ]
+            submission.status = SubmissionStatusEnum.SUBMITTED
 
             helper = SubmissionHelper(submission)
             assert helper.is_overdue is False


### PR DESCRIPTION
## 📝 Description
- Reinstates the list_submissions route for all reports
- Updates the submission_helper to read the status directly from the submission model rather than calculating it dynamically
- Updates the list_submissions endpoint and template to not use submission helpers so we reduce the db load and processing time
- Fixes tests that were relying on the dynamic status calculation

## To do before merge

- [x]  Re-examine the queries and performance times using the profiler after [latest commit ](https://github.com/communitiesuk/funding-service/commit/6756f1d4e73f041ebfd2a6e2472be13364c41d76)

## Future thinking
- Can we get the submission event factory to auto calculate the status and update the submission object?
- Or should we change the tests to setup submissions in the right state in a different way?
- Can maybe tie this in with the thinking we already wanted to do around the submission_xxx fixtures in integration tests
- Should we change the multi submissions path to just use grant recipients and then filter out those with no submissions
- Now we have less-intensive interface methods and a persisted status, can we reinstate the helpers with their improved performance?

## 📸 Show the thing (screenshots, gifs)
<!-- Include screenshots for UI changes, new features, or visual modifications -->
<!-- Use "Before" and "After" sections if showing changes to existing functionality -->
