### PR TITLE
Status in test factories

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,7 +3,7 @@ import os
 import typing as t
 import uuid
 from contextlib import _GeneratorContextManager, contextmanager
-from datetime import date, datetime, timedelta
+from datetime import date, timedelta
 from typing import Any, Generator, cast
 from unittest.mock import patch
 
@@ -37,7 +37,6 @@ from app.common.data.types import (
     GrantStatusEnum,
     QuestionDataType,
     RoleEnum,
-    SubmissionEventType,
     SubmissionModeEnum,
     SubmissionStatusEnum,
 )
@@ -655,8 +654,6 @@ def submission_in_progress(
         mode=SubmissionModeEnum.LIVE,
         answers=[FactoryAnswer(question, TextSingleLineAnswer("Question answer"))],
     )
-    submission.status = SubmissionStatusEnum.IN_PROGRESS
-    db_session.commit()
     return cast(Submission, submission)
 
 
@@ -676,16 +673,8 @@ def submission_ready_to_submit(
         collection=question.form.collection,
         mode=SubmissionModeEnum.LIVE,
         answers=[FactoryAnswer(question, TextSingleLineAnswer("Question answer"))],
+        status=SubmissionStatusEnum.READY_TO_SUBMIT,
     )
-    factories.submission_event.create(
-        submission=submission,
-        related_entity_id=question.form.id,
-        event_type=SubmissionEventType.FORM_RUNNER_FORM_COMPLETED,
-        created_by=user,
-        created_at_utc=datetime(2025, 11, 25, 0, 0, 0),
-    )
-    submission.status = SubmissionStatusEnum.READY_TO_SUBMIT
-    db_session.commit()
     return cast(Submission, submission)
 
 
@@ -706,22 +695,8 @@ def submission_awaiting_sign_off(
         collection=question.form.collection,
         mode=SubmissionModeEnum.LIVE,
         answers=[FactoryAnswer(question, TextSingleLineAnswer("Question answer"))],
+        status=SubmissionStatusEnum.AWAITING_SIGN_OFF,
     )
-    factories.submission_event.create(
-        submission=submission,
-        related_entity_id=question.form.id,
-        event_type=SubmissionEventType.FORM_RUNNER_FORM_COMPLETED,
-        created_by=user,
-        created_at_utc=datetime(2025, 11, 25, 0, 0, 0),
-    )
-    factories.submission_event.create(
-        submission=submission,
-        event_type=SubmissionEventType.SUBMISSION_SENT_FOR_CERTIFICATION,
-        created_by=user,
-        created_at_utc=datetime(2025, 11, 25, 0, 0, 1),
-    )
-    submission.status = SubmissionStatusEnum.AWAITING_SIGN_OFF
-    db_session.commit()
     return cast(Submission, submission)
 
 
@@ -741,30 +716,8 @@ def submission_submitted(factories: _Factories, db_session, grant_recipient: Gra
         collection=question.form.collection,
         mode=SubmissionModeEnum.LIVE,
         answers=[FactoryAnswer(question, TextSingleLineAnswer("Question answer"))],
+        status=SubmissionStatusEnum.SUBMITTED,
     )
-    factories.submission_event.create(
-        submission=submission,
-        related_entity_id=question.form.id,
-        event_type=SubmissionEventType.FORM_RUNNER_FORM_COMPLETED,
-        created_by=user,
-    )
-    factories.submission_event.create(
-        submission=submission,
-        event_type=SubmissionEventType.SUBMISSION_SENT_FOR_CERTIFICATION,
-        created_by=user,
-    )
-    factories.submission_event.create(
-        submission=submission,
-        event_type=SubmissionEventType.SUBMISSION_APPROVED_BY_CERTIFIER,
-        created_by=user,
-    )
-    factories.submission_event.create(
-        submission=submission,
-        event_type=SubmissionEventType.SUBMISSION_SUBMITTED,
-        created_by=user,
-    )
-    submission.status = SubmissionStatusEnum.SUBMITTED
-    db_session.commit()
 
     return cast(Submission, submission)
 
@@ -786,7 +739,6 @@ def submission_submitted_multiple_submissions(
     collection = question.form.collection
     collection.submission_name_question_id = question.id
     db_session.flush()
-    user = factories.user.create()
 
     grant_recipient = factories.grant_recipient.create(grant=collection.grant)
     submission_1 = factories.submission.create(
@@ -794,38 +746,16 @@ def submission_submitted_multiple_submissions(
         grant_recipient=grant_recipient,
         mode=SubmissionModeEnum.LIVE,
         answers=[FactoryAnswer(question, TextSingleLineAnswer("Alpha"))],
+        status=SubmissionStatusEnum.SUBMITTED,
     )
-    factories.submission_event.create(
-        submission=submission_1,
-        related_entity_id=question.form.id,
-        event_type=SubmissionEventType.FORM_RUNNER_FORM_COMPLETED,
-        created_by=user,
-    )
-    factories.submission_event.create(
-        submission=submission_1,
-        event_type=SubmissionEventType.SUBMISSION_SUBMITTED,
-        created_by=user,
-    )
+
     submission_2 = factories.submission.create(
         collection=collection,
         grant_recipient=grant_recipient,
         mode=SubmissionModeEnum.LIVE,
         answers=[FactoryAnswer(question, TextSingleLineAnswer("Beta"))],
+        status=SubmissionStatusEnum.SUBMITTED,
     )
-    factories.submission_event.create(
-        submission=submission_2,
-        related_entity_id=question.form.id,
-        event_type=SubmissionEventType.FORM_RUNNER_FORM_COMPLETED,
-        created_by=user,
-    )
-    factories.submission_event.create(
-        submission=submission_2,
-        event_type=SubmissionEventType.SUBMISSION_SUBMITTED,
-        created_by=user,
-    )
-    submission_1.status = SubmissionStatusEnum.SUBMITTED
-    submission_2.status = SubmissionStatusEnum.SUBMITTED
-    db_session.commit()
 
     return [submission_1, submission_2]
 
@@ -846,6 +776,7 @@ def submission_collection_closed(factories: _Factories, grant_recipient: GrantRe
         mode=SubmissionModeEnum.LIVE,
         answers=[FactoryAnswer(question, TextSingleLineAnswer("Question answer"))],
     )
+    # TODO make this use status=NOT_SUBMITTED when we have events that calculate that
     return cast(Submission, submission)
 
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -19,7 +19,6 @@ from factory.alchemy import SQLAlchemyModelFactory
 from flask import url_for
 from sqlalchemy.exc import NoResultFound
 
-from app import SubmissionStatusEnum
 from app.common.collections.types import (
     AllAnswerTypes,
     DateAnswer,
@@ -70,6 +69,7 @@ from app.common.data.types import (
     RoleEnum,
     SubmissionEventType,
     SubmissionModeEnum,
+    SubmissionStatusEnum,
 )
 from app.common.data.utils import generate_submission_reference
 from app.common.expressions import ExpressionContext
@@ -803,12 +803,92 @@ class _SubmissionFactory(SQLAlchemyModelFactory):
 
     status = SubmissionStatusEnum.NOT_STARTED
 
+    # @factory.post_generation
+    @staticmethod
+    def _build_events_for_status(obj: Submission, desired_status: SubmissionStatusEnum):
+        match desired_status:
+            case None:
+                obj.status = SubmissionStatusEnum.NOT_STARTED
+            case SubmissionStatusEnum.IN_PROGRESS:
+                pass  # no events needed if it is not complete
+            case SubmissionStatusEnum.READY_TO_SUBMIT:
+                for form in obj.collection.forms:
+                    obj.events.append(
+                        _SubmissionEventFactory.build(
+                            submission=obj,
+                            event_type=SubmissionEventType.FORM_RUNNER_FORM_COMPLETED,
+                            related_entity_id=form.id,
+                            created_by=obj.created_by,
+                        )
+                    )
+
+            case SubmissionStatusEnum.AWAITING_SIGN_OFF:
+                for form in obj.collection.forms:
+                    obj.events.append(
+                        _SubmissionEventFactory.build(
+                            submission=obj,
+                            event_type=SubmissionEventType.FORM_RUNNER_FORM_COMPLETED,
+                            related_entity_id=form.id,
+                            created_by=obj.created_by,
+                        )
+                    )
+                obj.events.append(
+                    _SubmissionEventFactory.build(
+                        submission=obj,
+                        event_type=SubmissionEventType.SUBMISSION_SENT_FOR_CERTIFICATION,
+                        created_by=obj.created_by,
+                        created_at_utc=datetime.datetime(2025, 11, 25, 0, 0, 1),
+                    )
+                )
+            case SubmissionStatusEnum.SUBMITTED:
+                for form in obj.collection.forms:
+                    obj.events.append(
+                        _SubmissionEventFactory.build(
+                            submission=obj,
+                            event_type=SubmissionEventType.FORM_RUNNER_FORM_COMPLETED,
+                            related_entity_id=form.id,
+                            created_by=obj.created_by,
+                        )
+                    )
+                if obj.collection.requires_certification:
+                    obj.events.append(
+                        _SubmissionEventFactory.build(
+                            submission=obj,
+                            event_type=SubmissionEventType.SUBMISSION_SENT_FOR_CERTIFICATION,
+                            created_by=obj.created_by,
+                        )
+                    )
+                    obj.events.append(
+                        _SubmissionEventFactory.build(
+                            submission=obj,
+                            event_type=SubmissionEventType.SUBMISSION_APPROVED_BY_CERTIFIER,
+                            created_by=obj.created_by,
+                        )
+                    )
+                    obj.events.append(
+                        _SubmissionEventFactory.build(
+                            submission=obj,
+                            event_type=SubmissionEventType.SUBMISSION_SUBMITTED,
+                            created_by=obj.created_by,
+                        )
+                    )
+                else:
+                    obj.events.append(
+                        _SubmissionEventFactory.build(
+                            submission=obj,
+                            event_type=SubmissionEventType.SUBMISSION_SUBMITTED,
+                            created_by=obj.created_by,
+                        )
+                    )
+
     @factory.post_generation
     def answers(obj: Submission, create, extracted: list[FactoryAnswer], **kwargs):
         if extracted:
             for entry in extracted:
                 obj.data_manager.set(entry.question, entry.answer, add_another_index=entry.add_another_index)
 
+        desired_status = obj.status
+        _SubmissionFactory._build_events_for_status(obj, desired_status)
         if create:
             SubmissionHelper(obj)._sync_submission_data_and_status()
             db.session.commit()


### PR DESCRIPTION
## 🎫 Ticket
<!-- Link to Jira ticket, GitHub issue, or other tracking system -->

## 📝 Description
Now we persist the status on the submission model, it feels redundant to have to create submission events for every submission we want in tests in order for them to be in the right state. But we still need these events for the submission helper to work correctly. 

In #1687 we put in some quick fixes to manually set statuses but this doesn't feel like the best approach.

This PR updates the submission factory to create submission events based on the desired status passed to `factory.create`.

So far the only thing that relies on it is the fixtures in conftest, but this seems to work.

Next steps:
- Review if putting this in the `answers` post generation hook is the right place
- If so, update other tests to use this
