### PR TITLE
Multi submission statuses

### DIFF
--- a/app/common/collections/runner.py
+++ b/app/common/collections/runner.py
@@ -264,8 +264,23 @@ class FormRunner:
 
         return True
 
-    def can_edit_question(self, question: Question) -> bool:
+    def can_edit_form(self, form: Form) -> bool:
+        if form.collection_id != self.submission.collection_id:
+            raise ValueError("Form does not belong to this submission")
+
         if not self.can_edit:
+            return False
+
+        if self.submission.form_is_managed_by_service(form):
+            return False
+
+        return True
+
+    def can_edit_question(self, question: Question) -> bool:
+        if question.form.collection_id != self.submission.collection_id:
+            raise ValueError("Question does not belong to this submission")
+
+        if not self.can_edit_form(question.form):
             return False
 
         if self.submission.answer_to_question_is_managed_by_service(question):

--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -369,7 +369,13 @@ class SubmissionHelper:
     def _calculate_submission_status(self) -> SubmissionStatusEnum:
         submission_state = self.events.submission_state
 
-        form_statuses = {self.get_status_for_form(form) for form in self.collection.forms}
+        form_statuses_by_id = {
+            form.id: self.get_status_for_form(form)
+            for form in self.collection.forms
+            if not self.form_is_managed_by_service(form)
+        }
+
+        form_statuses = {status for form_id, status in form_statuses_by_id.items()}
         all_forms_completed_or_not_needed = form_statuses <= {
             TasklistSectionStatusEnum.COMPLETED,
             TasklistSectionStatusEnum.NOT_NEEDED,
@@ -518,6 +524,29 @@ class SubmissionHelper:
         if add_another_index is not None:
             key += f"/{add_another_index}"
         return key
+
+    def form_is_managed_by_service(self, form: Form) -> bool:
+        if not self.collection.allow_multiple_submissions:
+            return False
+
+        if not self.collection.multiple_submissions_are_managed_by_service:
+            return False
+
+        if not self.collection.submission_name_question:
+            raise RuntimeError("Submission name question is required for multiple submissions")
+
+        submission_name_form = self.collection.submission_name_question.form
+        if form.id != submission_name_form.id:
+            return False
+
+        submission_name_form_questions = self.cached_get_ordered_visible_questions(submission_name_form)
+        if (
+            len(submission_name_form_questions) == 1
+            and submission_name_form_questions[0] == self.collection.submission_name_question
+        ):
+            return True
+
+        return False
 
     def answer_to_question_is_managed_by_service(self, question: Question) -> bool:
         if not self.collection.allow_multiple_submissions:

--- a/app/common/templates/common/macros/collections.html
+++ b/app/common/templates/common/macros/collections.html
@@ -356,7 +356,7 @@
 
   {{ summary_list_for_answers(form, runner) }}
 
-  {% if not runner.can_edit %}
+  {% if not runner.can_edit_form(form) %}
     <p class="govuk-body">
       <a class="govuk-link govuk-link--no-visited-state" href="{{ runner.to_url(enum.form_runner_state.TASKLIST) }}">Return to the task list</a>
     </p>
@@ -410,7 +410,7 @@
                 ''
                 if not first_question else
                 runner.to_url(enum.form_runner_state.QUESTION, question=first_question)
-                if (submission.get_status_for_form(form) == enum.submission_status.NOT_STARTED and runner.can_edit) else
+                if (submission.get_status_for_form(form) == enum.tasklist_section_status.NOT_STARTED and runner.can_edit_form(form)) else
                 runner.to_url(enum.form_runner_state.CHECK_YOUR_ANSWERS, form=form, source=enum.form_runner_state.TASKLIST)
               )
             %}

--- a/app/deliver_grant_funding/admin/entities.py
+++ b/app/deliver_grant_funding/admin/entities.py
@@ -611,6 +611,7 @@ class PlatformAdminSubmissionView(FlaskAdminPlatformAdminGrantLifecycleManagerAc
     ]
     column_filters = [
         "mode",
+        "status",
         "collection.grant.name",
         "grant_recipient.organisation.name",
     ]

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/admin/submission-details.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/admin/submission-details.html
@@ -29,7 +29,7 @@
         <dd class="app-metadata__value" data-testid="submission-status">{{ helper.certified_by.name }}</dd>
       </dl>
     {% endif %}
-    <dl class="app-metadata govuk-!-margin-bottom-9">
+    <dl class="app-metadata">
       <dt class="app-metadata__key">Date submitted:</dt>
       <dd class="app-metadata__value" data-testid="submission-status">{{ format_date(helper.submitted_at_utc) }}</dd>
     </dl>

--- a/app/developers/commands.py
+++ b/app/developers/commands.py
@@ -12,7 +12,7 @@ from uuid import UUID
 import click
 from flask import current_app
 from pydantic import BaseModel as PydanticBaseModel
-from sqlalchemy import delete, inspect, or_, select
+from sqlalchemy import delete, inspect, or_, select, update
 from sqlalchemy.exc import NoResultFound
 from werkzeug.datastructures import FileStorage, MultiDict
 
@@ -941,20 +941,53 @@ def check_managed_statements(ctx: click.Context, output: str, s3_key: str | None
 
 
 @developers_blueprint.cli.command(
-    "populate-status-for-all-submissions",
-    help="Load each submission, calculate the status and write this back to the status column on the submission table",
+    "refresh-status-for-multi-submissions",
+    help="Refresh submission statuses for multi-submission collections",
 )
-def populate_status_for_all_submissions() -> None:
-    count = db.session.query(Submission).filter(Submission.status.is_(None)).count()
+@click.option("--commit", is_flag=True, help="Actually commit changes proposed by this command; defaults to a dry run")
+def refresh_status_for_multi_submissions(commit: bool) -> None:
+    submission_ids = db.session.scalars(
+        select(Submission.id).join(Collection).filter(Collection.allow_multiple_submissions.is_(True))
+    ).all()
     updated = 0
 
-    click.echo(f"Found {count} submissions with no existing status")
+    click.echo(f"Found {len(submission_ids)} multi-submissions")
 
-    while submission_id := db.session.scalars(select(Submission.id).where(Submission.status.is_(None))).first():
+    for submission_id in submission_ids:
         helper = SubmissionHelper.load(submission_id)
-        helper.submission.status = helper._calculate_submission_status()
-        db.session.commit()
-        updated += 1
-        click.echo(f"Submission {helper.submission.id} updated with status {helper.submission.status}")
+        submission = helper.submission
 
-    click.echo(f"Updated {updated} submissions with saved statuses")
+        last_updated_at = submission.updated_at_utc
+        from_status = helper.status
+
+        # Manually assign updated_at_utc to prevent it being automatically updated
+        db.session.execute(
+            update(Submission)
+            .where(Submission.id == submission_id)
+            .values(updated_at_utc=last_updated_at, status=helper._calculate_submission_status())
+        )
+
+        db.session.flush()
+        db.session.refresh(submission)
+
+        if submission.updated_at_utc != last_updated_at:
+            click.echo(
+                f"Failed to preserve updated_at_utc on submission {submission_id} "
+                f"(was {last_updated_at}, now is {submission.updated_at_utc}; aborting)"
+            )
+            db.session.rollback()
+            raise click.exceptions.Exit(1)
+
+        if commit:
+            click.echo(f"Updated submission {submission.id} from status {from_status} to {submission.status}")
+            db.session.commit()
+        else:
+            click.echo(f"Would update submission {submission.id} from status {from_status} to {submission.status}")
+            db.session.rollback()
+
+        updated += 1
+
+    if commit:
+        click.echo(f"Updated {updated} submissions with saved statuses")
+    else:
+        click.echo(f"Would update {updated} submissions with saved statuses")

--- a/tests/integration/access_grant_funding/routes/test_runner.py
+++ b/tests/integration/access_grant_funding/routes/test_runner.py
@@ -2051,10 +2051,14 @@ class TestCheckYourAnswers:
         soup = BeautifulSoup(response.data, "html.parser")
 
         change_link = page_has_link(soup, "Change")
+        completed_section = "Have you completed this section?" in soup.text
+
         if multiple_submissions_are_managed_by_service:
             assert change_link is None
+            assert completed_section is False
         else:
             assert change_link is not None
+            assert completed_section is True
 
     def test_redirects_to_view_locked_report_when_collection_closed(
         self, authenticated_grant_recipient_data_provider_client, factories

--- a/tests/integration/common/helpers/test_collections.py
+++ b/tests/integration/common/helpers/test_collections.py
@@ -1094,6 +1094,127 @@ class TestSubmissionHelper:
 
             assert helper.status == SubmissionStatusEnum.SUBMITTED
 
+    class TestIgnoredFormsForSubmissionStatus:
+        @staticmethod
+        def _managed_collection(factories, db_session, extra_name_form_questions=0):
+            name_question = factories.question.create(
+                data_type=QuestionDataType.TEXT_SINGLE_LINE,
+                form__collection__allow_multiple_submissions=True,
+                form__collection__multiple_submissions_are_managed_by_service=True,
+            )
+            collection = name_question.form.collection
+            collection.submission_name_question_id = name_question.id
+            extra_name_questions = [
+                factories.question.create(form=name_question.form, data_type=QuestionDataType.TEXT_SINGLE_LINE)
+                for _ in range(extra_name_form_questions)
+            ]
+            other_form = factories.form.create(collection=collection)
+            other_question = factories.question.create(form=other_form, data_type=QuestionDataType.TEXT_SINGLE_LINE)
+
+            return collection, name_question, extra_name_questions, other_question
+
+        @staticmethod
+        def _answer(helper, question, value, user):
+            helper.submit_answer_for_question(
+                question.id,
+                build_question_form([question], evaluation_context=EC(), interpolation_context=EC())(
+                    **{question.safe_qid: value}
+                ),
+                user,
+            )
+
+        @classmethod
+        def _complete_form(cls, helper, form, questions, user):
+            for question in questions:
+                cls._answer(helper, question, "answer", user)
+            helper.toggle_form_completed(form, user, True)
+
+        def test_completed_name_only_form_is_treated_as_not_started(self, db_session, factories):
+            collection, name_question, _, other_question = self._managed_collection(factories, db_session)
+            submission = factories.submission.create(collection=collection)
+            helper = SubmissionHelper(submission)
+
+            assert helper.form_is_managed_by_service(name_question.form) is True
+            assert helper.status == SubmissionStatusEnum.NOT_STARTED
+
+            self._complete_form(helper, name_question.form, [name_question], submission.created_by)
+
+            assert helper.get_status_for_form(name_question.form) == TasklistSectionStatusEnum.COMPLETED
+            assert helper.status == SubmissionStatusEnum.NOT_STARTED
+
+            self._answer(helper, other_question, "data", submission.created_by)
+
+            assert helper.status == SubmissionStatusEnum.IN_PROGRESS
+
+        def test_name_form_with_additional_questions_counts_towards_status(self, db_session, factories):
+            collection, name_question, extra_name_questions, other_question = self._managed_collection(
+                factories, db_session, extra_name_form_questions=1
+            )
+            submission = factories.submission.create(collection=collection)
+            helper = SubmissionHelper(submission)
+
+            assert helper.form_is_managed_by_service(name_question.form) is False
+            assert helper.status == SubmissionStatusEnum.NOT_STARTED
+
+            self._complete_form(
+                helper, name_question.form, [name_question, *extra_name_questions], submission.created_by
+            )
+
+            assert helper.get_status_for_form(name_question.form) == TasklistSectionStatusEnum.COMPLETED
+            assert helper.status == SubmissionStatusEnum.IN_PROGRESS
+
+            self._complete_form(helper, other_question.form, [other_question], submission.created_by)
+
+            assert helper.get_status_for_form(other_question.form) == TasklistSectionStatusEnum.COMPLETED
+            assert helper.status == SubmissionStatusEnum.READY_TO_SUBMIT
+
+        def test_name_form_counts_when_not_managed_by_service(self, db_session, factories):
+            name_question = factories.question.create(
+                data_type=QuestionDataType.TEXT_SINGLE_LINE,
+                form__collection__allow_multiple_submissions=True,
+                form__collection__multiple_submissions_are_managed_by_service=False,
+            )
+            collection = name_question.form.collection
+            collection.submission_name_question_id = name_question.id
+            factories.question.create(form__collection=collection, data_type=QuestionDataType.TEXT_SINGLE_LINE)
+            db_session.flush()
+            submission = factories.submission.create(collection=collection)
+            helper = SubmissionHelper(submission)
+
+            assert helper.form_is_managed_by_service(name_question.form) is False
+            assert helper.status == SubmissionStatusEnum.NOT_STARTED
+
+            self._complete_form(helper, name_question.form, [name_question], submission.created_by)
+
+            assert helper.status == SubmissionStatusEnum.IN_PROGRESS
+
+        def test_single_submission_collection_ignores_nothing(self, db_session, factories):
+            question = factories.question.create(data_type=QuestionDataType.TEXT_SINGLE_LINE)
+            submission = factories.submission.create(collection=question.form.collection)
+            helper = SubmissionHelper(submission)
+
+            assert helper.form_is_managed_by_service(question.form) is False
+            assert helper.status == SubmissionStatusEnum.NOT_STARTED
+
+            self._answer(helper, question, "data", submission.created_by)
+
+            assert helper.status == SubmissionStatusEnum.IN_PROGRESS
+
+        def test_raises_when_managed_multi_submission_has_no_name_question(self, db_session, factories):
+            question = factories.question.create(
+                data_type=QuestionDataType.TEXT_SINGLE_LINE,
+                form__collection__allow_multiple_submissions=True,
+                form__collection__multiple_submissions_are_managed_by_service=False,
+            )
+            collection = question.form.collection
+            submission = factories.submission.create(collection=collection)
+            collection.multiple_submissions_are_managed_by_service = True
+            db_session.flush()
+            helper = SubmissionHelper(submission)
+
+            with pytest.raises(RuntimeError, match="Submission name question is required for multiple submissions"):
+                helper.form_is_managed_by_service(question.form)
+
     class TestRequiresCertification:
         def test_decline_certification_requires_certification(self, factories, submission_awaiting_sign_off, user):
             collection = submission_awaiting_sign_off.collection


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-1198

## 📝 Description
When a multi-submission report is managed by the service, we automatically fill
in the 'submission name' question. This currently makes the entire submission
appear as 'In progress' (because an answer exists) even though the grant
recipient has not really started doing anything with the submission yet.

This patch makes the SubmissionHelper understand multi-submission question names
are not really user-provided data, and excludes them from submission status
calculations, therefore making a submission that only contains the
submission-name question's answer show as 'Not started'.

We also remove the "Have you completed this section?" question from the check your answers page if the entire section is managed by the service.

This adds a developer command which we can run to re-sync the statuses for
multi-submissions, since these are now stored in the DB.

## 📸 Show the thing (screenshots, gifs)

### List submissions page

| Before | Script | After |
|---|---|---|
| <img width="1001" height="1120" alt="image" src="https://github.com/user-attachments/assets/eb6062b3-1eab-4767-9084-3b5e605f6a67" /> | <img width="767" height="790" alt="image" src="https://github.com/user-attachments/assets/9f2edbf7-76fa-4279-9199-a302a6bbc52d" /> | <img width="1034" height="1207" alt="image" src="https://github.com/user-attachments/assets/d8624cb2-39a7-47ef-a69f-67e7dd390f38" /> |

### Check your answers page (entirely managed form)

| Before | After |
|---|---|
| <img width="1065" height="1076" alt="image" src="https://github.com/user-attachments/assets/10a4cc54-4ca9-459b-aad6-34fe7f1879c7" /> | <img width="1037" height="875" alt="image" src="https://github.com/user-attachments/assets/cfff12fc-8a05-4204-b691-bb01fe8ce4aa" /> |


## 🧪 Testing

- On main branch, create/clone a managed multi-submission report to your local and seed a bunch of reports
- See that status for everything is 'In progress' by default
- Run the script on this branch
- See statuses for everything change to 'Not started'

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [ ] End-to-end tests have been updated (if applicable)
- [ ] Edge cases and error conditions are tested

## 📚 Additional Notes
<!-- Any additional context, concerns, or considerations for reviewers -->
