### PR TITLE
List submissions optimisations

### DIFF
--- a/app/common/collections/types.py
+++ b/app/common/collections/types.py
@@ -169,6 +169,11 @@ class DecimalAnswer(_NumberAnswer[Decimal]):
 
 
 class SingleChoiceFromListAnswer(SubmissionAnswerBaseModel):
+    """
+    NOTE: If the data structure changes, we may also need to sync/update the following places:
+    - Submission.name (for multi-submissions)
+    """
+
     key: str
     label: str
 

--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -468,9 +468,7 @@ def get_submission_list_for_collection(
         "last_updated_at_utc"
     )
 
-    grant_recipient_mode = (
-        GrantRecipientModeEnum.LIVE if submission_mode == SubmissionModeEnum.LIVE else GrantRecipientModeEnum.TEST
-    )
+    grant_recipient_mode = GrantRecipientModeEnum.from_similar(submission_mode)
     name_column = Submission.name.label("name") if collection.allow_multiple_submissions else null().label("name")
     order_by: List[Any] = [Organisation.name]
     if collection.allow_multiple_submissions:

--- a/app/common/data/interfaces/collections.py
+++ b/app/common/data/interfaces/collections.py
@@ -2,11 +2,12 @@ import datetime
 import uuid
 from collections.abc import Sequence
 from copy import deepcopy
-from typing import Any, Literal, Never, Protocol, Unpack, overload
+from dataclasses import dataclass
+from typing import Any, List, Literal, Never, Protocol, Unpack, overload
 from uuid import UUID
 
 from flask import current_app
-from sqlalchemy import and_, delete, or_, select, text
+from sqlalchemy import and_, delete, func, null, or_, select, text
 from sqlalchemy.exc import IntegrityError, NoResultFound
 from sqlalchemy.orm import joinedload, selectinload
 
@@ -34,6 +35,7 @@ from app.common.data.models import (
     Grant,
     GrantRecipient,
     Group,
+    Organisation,
     Question,
     Submission,
     SubmissionEvent,
@@ -45,6 +47,7 @@ from app.common.data.types import (
     ConditionsOperator,
     DataSourceType,
     ExpressionType,
+    GrantRecipientModeEnum,
     GrantStatusEnum,
     QuestionDataOptions,
     QuestionDataType,
@@ -358,7 +361,6 @@ def get_all_submissions_with_mode_for_collection(
     *,
     with_full_schema: bool = True,
     with_users: bool = False,
-    with_submission_summary_info: bool = False,
 ) -> Sequence[Submission]:
     """
     Use this function to get all submission data for a collection - it
@@ -367,8 +369,8 @@ def get_all_submissions_with_mode_for_collection(
     through them all individually.
     """
 
-    if sum([with_full_schema, with_users, with_submission_summary_info]) > 1:
-        raise ValueError("Only one of with_full_schema, with_submission_summary_info or with_users should be set")
+    if sum([with_full_schema, with_users]) > 1:
+        raise ValueError("Only one of with_full_schema or with_users should be set")
 
     # todo: this feels redundant because this interface should probably be limited to a single collection and fetch
     #       that through a specific interface which already exists - this can then focus on submissions
@@ -405,13 +407,107 @@ def get_all_submissions_with_mode_for_collection(
         stmt = stmt.options(
             joinedload(Submission.created_by),
         )
-    elif with_submission_summary_info:
-        stmt = stmt.options(selectinload(Submission.events))
-        stmt = stmt.options(joinedload(Submission.grant_recipient).joinedload(GrantRecipient.organisation))
 
     if grant_recipient_ids is not NOT_PROVIDED:
         stmt = stmt.where(Submission.grant_recipient_id.in_(grant_recipient_ids))
     return db.session.scalars(stmt).unique().all()
+
+
+@dataclass(frozen=True)
+class ListSubmissionData:
+    """Lightweight view of a row in the submissions list.
+
+    Holds only the fields needed to render a row, avoiding the cost of loading full submission rows
+    (including the potentially large `data` blob and every related event).
+
+    Every grant recipient produces at least one row. For multiple-submission collections a recipient
+    produces one row per submission (plus a single `submission_id=None` row when they have none yet);
+    for single-submission collections a recipient produces exactly one row (with `submission_id=None`
+    if they have not started one yet).
+    """
+
+    organisation_name: str | None
+    name: str | None
+    submission_id: UUID | None
+    status: SubmissionStatusEnum | None
+    last_updated_at_utc: datetime.datetime | None
+
+
+def get_submission_list_for_collection(
+    collection: Collection,
+    submission_mode: SubmissionModeEnum,
+) -> Sequence[ListSubmissionData]:
+    """Fetch the rows needed to render a collection's submissions list.
+
+    Both modes are grant-recipient centric: every grant recipient produces at least one row, so the
+    listing can show recipients who have not started a submission. For multiple-submission collections
+    a recipient with submissions produces one row per submission (and one `submission_id=None` row when
+    they have none yet); for single-submission collections a recipient produces exactly one row.
+
+    Selects only the columns needed to render the list, deriving the submission name in SQL (via the
+    Submission hybrid property) rather than loading the full `data` blob into Python. The last-updated
+    timestamp is derived by left-joining a single pre-aggregated max of event dates per submission,
+    rather than the per-row correlated subquery the `last_updated_at_utc` hybrid would emit. This is a further
+    optimisation for performance, as the correlated subquery can be expensive for large datasets.
+
+    Rows are ordered by organisation name, then by submission name for multiple-submission collections.
+    """
+    # An optimisation to avoid the `Submission.last_updated_at_utc` subquery; here we instead join the max event date
+    # directly to squeak out a bit more performance/efficiency
+    latest_event = (
+        select(
+            SubmissionEvent.submission_id.label("submission_id"),
+            func.max(SubmissionEvent.created_at_utc).label("max_created_at_utc"),
+        )
+        .join(Submission, Submission.id == SubmissionEvent.submission_id)
+        .where(Submission.collection_id == collection.id, Submission.mode == submission_mode)
+        .group_by(SubmissionEvent.submission_id)
+        .subquery()
+    )
+    last_updated_at_utc = func.greatest(Submission.updated_at_utc, latest_event.c.max_created_at_utc).label(
+        "last_updated_at_utc"
+    )
+
+    grant_recipient_mode = (
+        GrantRecipientModeEnum.LIVE if submission_mode == SubmissionModeEnum.LIVE else GrantRecipientModeEnum.TEST
+    )
+    name_column = Submission.name.label("name") if collection.allow_multiple_submissions else null().label("name")
+    order_by: List[Any] = [Organisation.name]
+    if collection.allow_multiple_submissions:
+        order_by.append(name_column)
+
+    stmt = (
+        select(
+            Organisation.name.label("organisation_name"),
+            name_column,
+            Submission.id.label("submission_id"),
+            Submission.status,
+            last_updated_at_utc,
+        )
+        .select_from(GrantRecipient)
+        .join(Organisation, GrantRecipient.organisation_id == Organisation.id)
+        .outerjoin(
+            Submission,
+            and_(
+                Submission.grant_recipient_id == GrantRecipient.id,
+                Submission.collection_id == collection.id,
+                Submission.mode == submission_mode,
+            ),
+        )
+        .outerjoin(latest_event, latest_event.c.submission_id == Submission.id)
+        .where(GrantRecipient.grant_id == collection.grant_id, GrantRecipient.mode == grant_recipient_mode)
+        .order_by(*order_by)
+    )
+    return [
+        ListSubmissionData(
+            organisation_name=row.organisation_name,
+            name=row.name,
+            submission_id=row.submission_id,
+            status=row.status,
+            last_updated_at_utc=row.last_updated_at_utc,
+        )
+        for row in db.session.execute(stmt).all()
+    ]
 
 
 def get_submissions_by_grant_recipient_collection(

--- a/app/common/data/interfaces/grant_recipients.py
+++ b/app/common/data/interfaces/grant_recipients.py
@@ -5,7 +5,7 @@ from sqlalchemy import String, cast, func, select
 from sqlalchemy.orm import joinedload, selectinload
 
 from app.common.data.interfaces.exceptions import flush_and_rollback_on_exceptions
-from app.common.data.models import Grant, GrantRecipient, Organisation, Submission
+from app.common.data.models import Grant, GrantRecipient, Organisation
 from app.common.data.models_user import User, UserRole
 from app.common.data.types import GrantRecipientModeEnum, RoleEnum, SubmissionModeEnum, SubmissionStatusEnum
 from app.extensions import db
@@ -18,8 +18,6 @@ def get_grant_recipients(
     with_data_providers: bool = False,
     with_certifiers: bool = False,
     with_organisations: bool = False,
-    with_submissions_for_collection: uuid.UUID | None = None,
-    submission_mode: SubmissionModeEnum = SubmissionModeEnum.LIVE,
 ) -> Sequence[GrantRecipient]:
     stmt = select(GrantRecipient).where(GrantRecipient.grant_id == grant.id, GrantRecipient.mode == mode)
 
@@ -31,15 +29,6 @@ def get_grant_recipients(
 
     if with_organisations:
         stmt = stmt.options(selectinload(GrantRecipient.organisation))
-
-    if with_submissions_for_collection:
-        stmt = stmt.options(
-            selectinload(
-                GrantRecipient.submissions.and_(Submission.collection_id == with_submissions_for_collection).and_(
-                    Submission.mode == submission_mode
-                )
-            ).joinedload(Submission.events)
-        )
 
     stmt = stmt.join(Organisation, GrantRecipient.organisation_id == Organisation.id).order_by(Organisation.name)
 

--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -414,7 +414,7 @@ class Submission(BaseModel):
         from app.common.helpers.submission_events import SubmissionEventHelper
 
         event_helper = SubmissionEventHelper(self)
-        return max(filter(None, [event_helper.latest_event_utc, self.updated_at_utc]))
+        return max(filter(None, [event.created_at_utc for event in event_helper.events] + [self.updated_at_utc]))
 
     @last_updated_at_utc.inplace.expression
     @classmethod

--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -6,11 +6,25 @@ from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
 from flask import current_app, url_for
-from sqlalchemy import CheckConstraint, ForeignKey, Index, UniqueConstraint, and_, or_, select, text
+from sqlalchemy import (
+    CheckConstraint,
+    ColumnElement,
+    ForeignKey,
+    Index,
+    Text,
+    UniqueConstraint,
+    and_,
+    case,
+    func,
+    or_,
+    select,
+    text,
+)
 from sqlalchemy import Enum as SqlEnum
 from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.ext.orderinglist import OrderingList, ordering_list
-from sqlalchemy.orm import Mapped, column_property, foreign, mapped_column, relationship, remote
+from sqlalchemy.orm import Mapped, aliased, column_property, foreign, mapped_column, relationship, remote
 from sqlalchemy_json import mutable_json_type
 
 from app.common.collections.types import DataSourceAnswerTypes, DecimalAnswer, IntegerAnswer, TextSingleLineAnswer
@@ -395,12 +409,24 @@ class Submission(BaseModel):
         nullable=False,
     )
 
-    @property
+    @hybrid_property
     def last_updated_at_utc(self) -> datetime.datetime:
         from app.common.helpers.submission_events import SubmissionEventHelper
 
         event_helper = SubmissionEventHelper(self)
         return max(filter(None, [event_helper.latest_event_utc, self.updated_at_utc]))
+
+    @last_updated_at_utc.inplace.expression
+    @classmethod
+    def _last_updated_at_utc_expression(cls) -> ColumnElement[datetime.datetime]:
+        # Postgres GREATEST ignores NULLs, so this falls back to updated_at_utc when there are no events.
+        return func.greatest(
+            cls.updated_at_utc,
+            select(func.max(SubmissionEvent.created_at_utc))
+            .where(SubmissionEvent.submission_id == cls.id)
+            .correlate(cls)
+            .scalar_subquery(),
+        )
 
     @property
     def s3_key_prefix(self) -> str:
@@ -415,13 +441,11 @@ class Submission(BaseModel):
         """
         return SubmissionDataManager(self._data)
 
-    @property
+    @hybrid_property
     def name(self) -> str:
         """
         For submissions in a multi-submission collection, this provides a name for the submission based on a provided
-        answer.
-
-        For non-multi-submission collection we just return the submission's generated reference.
+        answer. If the answer hasn't been provided yet, we just use the submission's generated reference.
         """
         question = self.collection.submission_name_question
         if question:
@@ -429,6 +453,37 @@ class Submission(BaseModel):
             if answer is not None:
                 return answer.get_value_for_text_export()
         return self.reference
+
+    @name.inplace.expression
+    @classmethod
+    def _name_expression(cls) -> ColumnElement[str]:
+        # Mirrors `get_value_for_text_export()` for the only data types allowed as a submission name question
+        # (see QUESTION_DATA_TYPES_ALLOWED_FOR_MULTI_SUBMISSION_NAMES). This hardcodes how each answer type is stored
+        # in the `data` blob: TEXT_SINGLE_LINE is the raw value, whereas RADIOS stores a {"key", "label"} object whose
+        # display value is the label. Keep this in sync with the answer models in app.common.collections.types if the
+        # set of allowed name question types or their stored shape changes.
+        name_question = aliased(Component)
+        name_question_key = Collection.submission_name_question_id.cast(Text)
+        answer_value = case(
+            (
+                name_question.data_type == QuestionDataType.TEXT_SINGLE_LINE,
+                cls._data[name_question_key].astext,
+            ),
+            (
+                name_question.data_type == QuestionDataType.RADIOS,
+                cls._data[name_question_key]["label"].astext,
+            ),
+        )
+        # Falls back to the reference when there is no name question (single-submission) or it is unanswered.
+        return func.coalesce(
+            select(answer_value)
+            .select_from(Collection)
+            .join(name_question, name_question.id == Collection.submission_name_question_id)
+            .where(Collection.id == cls.collection_id)
+            .correlate(cls)
+            .scalar_subquery(),
+            cls.reference,
+        )
 
     __table_args__ = (
         CheckConstraint(

--- a/app/common/data/submission_data_manager.py
+++ b/app/common/data/submission_data_manager.py
@@ -64,6 +64,9 @@ class SubmissionDataManager:
 
     This is *only* concerned with managing the structure of the `submission.data` blob, not any higher-level concerns
     such as 'how complete is this submission' or 'what is the current state of the submission'.
+
+    NOTE: If the data structure changes, we may also need to sync/update the following places:
+    - Submission.name (for multi-submissions)
     """
 
     def __init__(self, data: dict[str, Any]) -> None:

--- a/app/common/data/types.py
+++ b/app/common/data/types.py
@@ -97,15 +97,27 @@ class SubmissionModeEnum(enum.StrEnum):
     PREVIEW = "preview"
     LIVE = "live"
 
+    @staticmethod
+    def from_similar(mode: GrantRecipientModeEnum | OrganisationModeEnum) -> SubmissionModeEnum:
+        return SubmissionModeEnum(mode.value)
+
 
 class OrganisationModeEnum(enum.StrEnum):
     LIVE = "live"
     TEST = "test"
 
+    @staticmethod
+    def from_similar(mode: GrantRecipientModeEnum | SubmissionModeEnum) -> OrganisationModeEnum:
+        return OrganisationModeEnum(mode.value)
+
 
 class GrantRecipientModeEnum(enum.StrEnum):
     LIVE = "live"
     TEST = "test"
+
+    @staticmethod
+    def from_similar(mode: OrganisationModeEnum | SubmissionModeEnum) -> GrantRecipientModeEnum:
+        return GrantRecipientModeEnum(mode.value)
 
 
 class SubmissionStatusEnum(enum.StrEnum):

--- a/app/common/helpers/collections.py
+++ b/app/common/helpers/collections.py
@@ -1423,9 +1423,7 @@ class AllSubmissionsHelper:
         self.submissions = [s for s in (get_all_submissions_with_mode_for_collection(collection.id, submission_mode))]
         self.submission_helpers = {s.id: SubmissionHelper(s) for s in self.submissions}
 
-        grant_recipient_mode = (
-            GrantRecipientModeEnum.TEST if submission_mode == SubmissionModeEnum.TEST else GrantRecipientModeEnum.LIVE
-        )
+        grant_recipient_mode = GrantRecipientModeEnum.from_similar(submission_mode)
         self.grant_recipients = get_grant_recipients(
             self.collection.grant, mode=grant_recipient_mode, with_organisations=True
         )

--- a/app/common/helpers/submission_events.py
+++ b/app/common/helpers/submission_events.py
@@ -198,13 +198,6 @@ class SubmissionEventHelper:
     def events(self) -> list[SubmissionEvent]:
         return sorted(self.submission.events, key=lambda x: x.created_at_utc, reverse=False)
 
-    @property
-    def latest_event_utc(self) -> datetime | None:
-        events = self.events
-        if not events:
-            return None
-        return max(e.created_at_utc for e in events)
-
     def form_state(self, form_id: UUID) -> FormState:
         return FormState(**self._reduce([e for e in self.events if e.related_entity_id == form_id]))
 

--- a/app/deliver_grant_funding/routes/reports.py
+++ b/app/deliver_grant_funding/routes/reports.py
@@ -45,6 +45,7 @@ from app.common.data.interfaces.collections import (
     get_form_by_id,
     get_group_by_id,
     get_question_by_id,
+    get_submission_list_for_collection,
     move_component_down,
     move_component_up,
     move_form_down,
@@ -66,7 +67,6 @@ from app.common.data.interfaces.exceptions import (
     DuplicateValueError,
     InvalidReferenceInExpression,
 )
-from app.common.data.interfaces.grant_recipients import get_grant_recipients
 from app.common.data.interfaces.grants import get_grant
 from app.common.data.interfaces.user import get_current_user
 from app.common.data.types import (
@@ -3132,25 +3132,7 @@ def list_submissions(grant_id: UUID, report_id: UUID, submission_mode: Submissio
             )
         )
 
-    grant_recipients = []
-    submissions = []
-    if report.allow_multiple_submissions:
-        submissions = get_all_submissions_with_mode_for_collection(
-            collection_id=report_id,
-            submission_mode=submission_mode,
-            with_full_schema=False,
-            with_submission_summary_info=True,
-        )
-    else:
-        grant_recipients = get_grant_recipients(
-            report.grant,
-            mode=GrantRecipientModeEnum.LIVE
-            if submission_mode == SubmissionModeEnum.LIVE
-            else GrantRecipientModeEnum.TEST,
-            with_organisations=True,
-            with_submissions_for_collection=report_id,
-            submission_mode=submission_mode,
-        )
+    submissions = get_submission_list_for_collection(collection=report, submission_mode=submission_mode)
 
     return render_template(
         "deliver_grant_funding/reports/list_submissions.html",
@@ -3158,7 +3140,6 @@ def list_submissions(grant_id: UUID, report_id: UUID, submission_mode: Submissio
         report=report,
         submission_mode=submission_mode,
         delete_all_form=delete_all_form if submission_mode == SubmissionModeEnum.TEST else None,
-        grant_recipients=grant_recipients,
         submissions=submissions,
     )
 

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_submissions.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/reports/list_submissions.html
@@ -104,114 +104,64 @@
       </p>
     </div>
     <div class="govuk-grid-column-full">
-      {% if report.allow_multiple_submissions %}
-        {% set rows=[] %}
+      {% set rows = [] %}
+      {% set column_count = 4 if report.allow_multiple_submissions else 3 %}
 
-        {% for submission in submissions | sort(attribute="grant_recipient.organisation.name,name") %}
-          {% set link_to_submission %}
-            <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.view_submission', grant_id=grant.id, submission_id=submission.id) }}" data-submission-link> {{ submission.name }} </a>
-          {% endset %}
-          {%
-            do rows.append([
-              {
-                "html": link_to_submission,
-              }, {
-                "text": submission.grant_recipient.organisation.name,
-              }, {
-                "html": submissionStatusTag(submission.status,  report.is_closed and not submission.status == enum.submission_status.SUBMITTED),
-              }, {
-                "text": format_date_short(submission.last_updated_at_utc)
-              }
-            ])
-          %}
-        {% else %}
-          {% set no_submissions_text %}
-            <span>No submissions found for this monitoring report</span>
-          {% endset %}
-          {%
-            do rows.append([
-              {
-                "html": no_submissions_text,
-                "colspan": 4
-              }
-            ])
-          %}
-        {% endfor %}
+      {% for submission in submissions %}
+        {% set cells = [] %}
 
-        {{
-          govukTable({
-            "captionClasses": "govuk-table__caption--m",
-            "head": [
-              { "text": (report.submission_name_question.name | uppercase_first) if report.submission_name_question else "Submission", "classes": "govuk-!-width-one-third" },
-              { "text": "Grant recipient" },
-              { "text": "Status" },
-              { "text": "Last updated" }
-            ],
-            "rows": rows
-          })
-        }}
-      {% else %}
-        {% set rows=[] %}
-        {% for grant_recipient in grant_recipients | sort(attribute="organisation.name") %}
-
-          {% if grant_recipient.submissions %}
-            {% set submission = grant_recipient.submissions[0] %}
-            {% set link_to_submission %}
-              <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.view_submission', grant_id=grant.id, submission_id=submission.id) }}" data-submission-link>
-                {{ submission.grant_recipient.organisation.name }}
-              </a>
+        {% if report.allow_multiple_submissions %}
+          {% if submission.submission_id %}
+            {% set submission_name_link %}
+              <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.view_submission', grant_id=grant.id, submission_id=submission.submission_id) }}" data-submission-link>{{ submission.name }}</a>
             {% endset %}
-            {% set submission_status = submission.status %}
-            {%
-              do rows.append([
-                {
-                  "html": link_to_submission,
-                }, {
-                  "html": submissionStatusTag(submission_status, report.is_closed and not submission.status == enum.submission_status.SUBMITTED),
-                }, {
-                  "text": format_date_short(submission.last_updated_at_utc)
-                }
-              ])
-            %}
+            {% do cells.append({"html": submission_name_link}) %}
           {% else %}
-            {%
-              do rows.append([
-                {
-                  "text": grant_recipient.organisation.name
-                }, {
-                  "html": submissionStatusTag(enum.submission_status.NOT_STARTED if not report.is_closed else enum.submission_status.NOT_SUBMITTED, report.is_closed),
-                }, {
-                  "text": ""
-                }
-              ])
-            %}
+            {% do cells.append({"text": "No submission"}) %}
           {% endif %}
-        {% else %}
-          {% set no_collections_text %}
-            <span>No submissions found for this monitoring report</span>
+          {% do cells.append({"text": submission.organisation_name}) %}
+        {% elif submission.submission_id %}
+          {% set grant_recipient_link %}
+            <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.view_submission', grant_id=grant.id, submission_id=submission.submission_id) }}" data-submission-link
+              >{{ submission.organisation_name }}</a
+            >
           {% endset %}
-          {%
-            do rows.append([
-              {
-                "html": no_collections_text,
-                "colspan": 3
-              }
-            ])
-          %}
-        {% endfor %}
+          {% do cells.append({"html": grant_recipient_link}) %}
+        {% else %}
+          {% do cells.append({"text": submission.organisation_name}) %}
+        {% endif %}
 
-        {{
-          govukTable({
-            "captionClasses": "govuk-table__caption--m",
-            "head": [
-              { "text": "Grant recipient", "classes": "govuk-!-width-one-half" },
-              { "text": "Status" },
-              { "text": "Last updated" }
-            ],
-            "rows": rows
-          })
-        }}
+        {% if submission.submission_id %}
+          {% do cells.append({"html": submissionStatusTag(submission.status, report.is_closed and not submission.status == enum.submission_status.SUBMITTED)}) %}
+        {% else %}
+          {% do cells.append({"html": submissionStatusTag(enum.submission_status.NOT_SUBMITTED if report.is_closed else enum.submission_status.NOT_STARTED, report.is_closed)}) %}
+        {% endif %}
+        {% do cells.append({"text": format_date_short(submission.last_updated_at_utc) if submission.last_updated_at_utc else ""}) %}
+        {% do rows.append(cells) %}
+      {% else %}
+        {% set no_submissions_text %}
+          <span>No submissions found for this monitoring report</span>
+        {% endset %}
+        {% do rows.append([{"html": no_submissions_text, "colspan": column_count}]) %}
+      {% endfor %}
+
+      {% set head = [] %}
+      {% if report.allow_multiple_submissions %}
+        {% do head.append({"text": (report.submission_name_question.name | uppercase_first) if report.submission_name_question else "Submission", "classes": "govuk-!-width-one-third"}) %}
+        {% do head.append({"text": "Grant recipient"}) %}
+      {% else %}
+        {% do head.append({"text": "Grant recipient", "classes": "govuk-!-width-one-half"}) %}
       {% endif %}
+      {% do head.append({"text": "Status"}) %}
+      {% do head.append({"text": "Last updated"}) %}
+
+      {{
+        govukTable({
+          "captionClasses": "govuk-table__caption--m",
+          "head": head,
+          "rows": rows
+        })
+      }}
     </div>
   </div>
 

--- a/app/developers/commands.py
+++ b/app/developers/commands.py
@@ -793,7 +793,7 @@ def create_multi_submissions(  # noqa: C901
         click.echo(f"ERROR: Could not find user {service_user_email_address}")
         return
 
-    submission_mode = SubmissionModeEnum(mode.value)
+    submission_mode = SubmissionModeEnum.from_similar(mode)
     form_cls = build_question_form([question], evaluation_context, interpolation_context)
 
     created = 0

--- a/tests/integration/common/data/interfaces/test_collections.py
+++ b/tests/integration/common/data/interfaces/test_collections.py
@@ -4,7 +4,7 @@ import uuid
 import pytest
 from sqlalchemy.exc import IntegrityError, NoResultFound
 
-from app.common.collections.types import EmailAnswer, TextSingleLineAnswer
+from app.common.collections.types import EmailAnswer, SingleChoiceFromListAnswer, TextSingleLineAnswer
 from app.common.data.interfaces import collections
 from app.common.data.interfaces.collections import (
     AddAnotherDependencyException,
@@ -40,6 +40,7 @@ from app.common.data.interfaces.collections import (
     get_question_by_id,
     get_referenced_data_source_items_by_managed_expression,
     get_submission,
+    get_submission_list_for_collection,
     get_submissions_by_grant_recipient_collection,
     group_name_exists,
     is_component_dependency_order_valid,
@@ -88,6 +89,7 @@ from app.common.data.types import (
     DataSourceSchemaColumn,
     DataSourceType,
     ExpressionType,
+    GrantRecipientModeEnum,
     GrantStatusEnum,
     ManagedExpressionsEnum,
     MultilineTextInputRows,
@@ -5146,34 +5148,12 @@ class TestGetSubmissions:
     ):
         collection = factories.collection.create()
 
-        with pytest.raises(
-            ValueError, match="Only one of with_full_schema, with_submission_summary_info or with_users should be set"
-        ):
+        with pytest.raises(ValueError, match="Only one of with_full_schema or with_users should be set"):
             get_all_submissions_with_mode_for_collection(
                 collection_id=collection.id,
                 submission_mode=SubmissionModeEnum.LIVE,
                 with_full_schema=True,
                 with_users=True,
-            )
-        with pytest.raises(
-            ValueError, match="Only one of with_full_schema, with_submission_summary_info or with_users should be set"
-        ):
-            get_all_submissions_with_mode_for_collection(
-                collection_id=collection.id,
-                submission_mode=SubmissionModeEnum.LIVE,
-                with_full_schema=True,
-                with_users=True,
-                with_submission_summary_info=True,
-            )
-        with pytest.raises(
-            ValueError, match="Only one of with_full_schema, with_submission_summary_info or with_users should be set"
-        ):
-            get_all_submissions_with_mode_for_collection(
-                collection_id=collection.id,
-                submission_mode=SubmissionModeEnum.LIVE,
-                with_full_schema=True,
-                with_users=False,
-                with_submission_summary_info=True,
             )
 
     def test_get_all_submissions_with_mode_for_collection_with_full_schema_no_n_plus_one(
@@ -5263,6 +5243,285 @@ class TestGetSubmissions:
                 for event in submission.events:
                     _ = event.created_by
 
+        assert len(iterate_queries) == baseline
+
+
+class TestGetSubmissionListForCollection:
+    def test_single_submission_collection_returns_a_row_per_grant_recipient(self, db_session, factories):
+        collection = factories.collection.create()
+        recipient_with_submission = factories.grant_recipient.create(
+            grant=collection.grant, organisation__name="Acme Corp"
+        )
+        factories.grant_recipient.create(grant=collection.grant, organisation__name="Beta Ltd")
+        submission = factories.submission.create(
+            collection=collection,
+            mode=SubmissionModeEnum.LIVE,
+            grant_recipient=recipient_with_submission,
+        )
+
+        rows = get_submission_list_for_collection(collection=collection, submission_mode=SubmissionModeEnum.LIVE)
+
+        rows_by_org = {row.organisation_name: row for row in rows}
+        assert set(rows_by_org) == {"Acme Corp", "Beta Ltd"}
+
+        started = rows_by_org["Acme Corp"]
+        assert started.submission_id == submission.id
+        assert started.status == submission.status
+        assert started.name is None
+
+        not_started = rows_by_org["Beta Ltd"]
+        assert not_started.submission_id is None
+        assert not_started.status is None
+        assert not_started.last_updated_at_utc is None
+        assert not_started.name is None
+
+    def test_multi_submission_collection_returns_a_row_per_submission(self, db_session, factories):
+        collection = factories.collection.create(allow_multiple_submissions=True)
+        grant_recipient = factories.grant_recipient.create(grant=collection.grant, organisation__name="Acme Corp")
+        first = factories.submission.create(
+            collection=collection, mode=SubmissionModeEnum.LIVE, grant_recipient=grant_recipient
+        )
+        second = factories.submission.create(
+            collection=collection, mode=SubmissionModeEnum.LIVE, grant_recipient=grant_recipient
+        )
+
+        rows = get_submission_list_for_collection(collection=collection, submission_mode=SubmissionModeEnum.LIVE)
+
+        assert {row.submission_id for row in rows} == {first.id, second.id}
+        assert all(row.organisation_name == "Acme Corp" for row in rows)
+
+    def test_multi_submission_collection_returns_a_row_for_recipients_with_no_submissions(self, db_session, factories):
+        collection = factories.collection.create(allow_multiple_submissions=True)
+        recipient_with_submission = factories.grant_recipient.create(
+            grant=collection.grant, organisation__name="Acme Corp"
+        )
+        factories.grant_recipient.create(grant=collection.grant, organisation__name="Beta Ltd")
+        submission = factories.submission.create(
+            collection=collection,
+            mode=SubmissionModeEnum.LIVE,
+            grant_recipient=recipient_with_submission,
+        )
+
+        rows = get_submission_list_for_collection(collection=collection, submission_mode=SubmissionModeEnum.LIVE)
+
+        rows_by_org = {row.organisation_name: row for row in rows}
+        assert set(rows_by_org) == {"Acme Corp", "Beta Ltd"}
+
+        started = rows_by_org["Acme Corp"]
+        assert started.submission_id == submission.id
+        assert started.status == submission.status
+
+        not_started = rows_by_org["Beta Ltd"]
+        assert not_started.submission_id is None
+        assert not_started.name is None
+        assert not_started.status is None
+        assert not_started.last_updated_at_utc is None
+
+    def test_single_submission_collection_orders_rows_by_organisation_name(self, db_session, factories):
+        collection = factories.collection.create()
+        for org_name in ["Charlie Ltd", "Alpha Ltd", "Bravo Ltd"]:
+            factories.grant_recipient.create(grant=collection.grant, organisation__name=org_name)
+
+        rows = get_submission_list_for_collection(collection=collection, submission_mode=SubmissionModeEnum.LIVE)
+
+        assert [row.organisation_name for row in rows] == ["Alpha Ltd", "Bravo Ltd", "Charlie Ltd"]
+
+    def test_multi_submission_collection_orders_rows_by_organisation_name_then_submission_name(
+        self, db_session, factories
+    ):
+        question = factories.question.create(
+            form__collection__allow_multiple_submissions=True,
+            data_type=QuestionDataType.TEXT_SINGLE_LINE,
+        )
+        collection = question.form.collection
+        collection.submission_name_question_id = question.id
+        db_session.flush()
+        acme = factories.grant_recipient.create(grant=collection.grant, organisation__name="Acme Corp")
+        beta = factories.grant_recipient.create(grant=collection.grant, organisation__name="Beta Ltd")
+        for grant_recipient, submission_name in [
+            (beta, "Project Z"),
+            (acme, "Project B"),
+            (acme, "Project A"),
+        ]:
+            factories.submission.create(
+                collection=collection,
+                mode=SubmissionModeEnum.LIVE,
+                grant_recipient=grant_recipient,
+                answers=[FactoryAnswer(question, TextSingleLineAnswer(submission_name))],
+            )
+
+        rows = get_submission_list_for_collection(collection=collection, submission_mode=SubmissionModeEnum.LIVE)
+
+        assert [(row.organisation_name, row.name) for row in rows] == [
+            ("Acme Corp", "Project A"),
+            ("Acme Corp", "Project B"),
+            ("Beta Ltd", "Project Z"),
+        ]
+
+    def test_uses_submission_name_question_answer_for_name(self, db_session, factories):
+        question = factories.question.create(
+            form__collection__allow_multiple_submissions=True,
+            data_type=QuestionDataType.TEXT_SINGLE_LINE,
+        )
+        collection = question.form.collection
+        collection.submission_name_question_id = question.id
+        db_session.flush()
+        grant_recipient = factories.grant_recipient.create(grant=collection.grant)
+        factories.submission.create(
+            collection=collection,
+            mode=SubmissionModeEnum.LIVE,
+            grant_recipient=grant_recipient,
+            answers=[FactoryAnswer(question, TextSingleLineAnswer("Alpha Project"))],
+        )
+
+        summaries = get_submission_list_for_collection(collection=collection, submission_mode=SubmissionModeEnum.LIVE)
+
+        assert len(summaries) == 1
+        assert summaries[0].name == "Alpha Project"
+
+    def test_uses_radios_name_question_label_for_name(self, db_session, factories):
+        question = factories.question.create(
+            form__collection__allow_multiple_submissions=True,
+            data_type=QuestionDataType.RADIOS,
+        )
+        collection = question.form.collection
+        collection.submission_name_question_id = question.id
+        db_session.flush()
+        grant_recipient = factories.grant_recipient.create(grant=collection.grant)
+        factories.submission.create(
+            collection=collection,
+            mode=SubmissionModeEnum.LIVE,
+            grant_recipient=grant_recipient,
+            answers=[FactoryAnswer(question, SingleChoiceFromListAnswer(key="region-north", label="North region"))],
+        )
+
+        summaries = get_submission_list_for_collection(collection=collection, submission_mode=SubmissionModeEnum.LIVE)
+
+        assert len(summaries) == 1
+        assert summaries[0].name == "North region"
+
+    def test_falls_back_to_reference_when_name_question_unanswered(self, db_session, factories):
+        question = factories.question.create(
+            form__collection__allow_multiple_submissions=True,
+            data_type=QuestionDataType.TEXT_SINGLE_LINE,
+        )
+        collection = question.form.collection
+        collection.submission_name_question_id = question.id
+        db_session.flush()
+        grant_recipient = factories.grant_recipient.create(grant=collection.grant)
+        submission = factories.submission.create(
+            collection=collection, mode=SubmissionModeEnum.LIVE, grant_recipient=grant_recipient
+        )
+
+        summaries = get_submission_list_for_collection(collection=collection, submission_mode=SubmissionModeEnum.LIVE)
+
+        assert len(summaries) == 1
+        assert summaries[0].name == submission.reference
+
+    def test_only_returns_rows_for_the_requested_mode(self, db_session, factories):
+        collection = factories.collection.create(allow_multiple_submissions=True)
+        live_recipient = factories.grant_recipient.create(grant=collection.grant)
+        test_recipient = factories.grant_recipient.create(grant=collection.grant, mode=GrantRecipientModeEnum.TEST)
+        live_submission = factories.submission.create(
+            collection=collection, mode=SubmissionModeEnum.LIVE, grant_recipient=live_recipient
+        )
+        factories.submission.create(collection=collection, mode=SubmissionModeEnum.TEST, grant_recipient=test_recipient)
+
+        rows = get_submission_list_for_collection(collection=collection, submission_mode=SubmissionModeEnum.LIVE)
+
+        assert [row.submission_id for row in rows] == [live_submission.id]
+
+    def test_last_updated_at_utc_reflects_latest_event(self, db_session, factories):
+        collection = factories.collection.create()
+        grant_recipient = factories.grant_recipient.create(grant=collection.grant)
+        submission = factories.submission.create(
+            collection=collection, mode=SubmissionModeEnum.LIVE, grant_recipient=grant_recipient
+        )
+        latest_event_at = datetime.datetime(2030, 1, 1, 12, 0, 0)
+        factories.submission_event.create(submission=submission, created_at_utc=datetime.datetime(2029, 1, 1, 12, 0, 0))
+        factories.submission_event.create(submission=submission, created_at_utc=latest_event_at)
+
+        rows = get_submission_list_for_collection(collection=collection, submission_mode=SubmissionModeEnum.LIVE)
+
+        assert rows[0].last_updated_at_utc == latest_event_at
+
+    def test_constant_query_count_regardless_of_submission_count(self, db_session, factories, track_sql_queries):
+        question = factories.question.create(
+            form__collection__allow_multiple_submissions=True,
+            data_type=QuestionDataType.TEXT_SINGLE_LINE,
+        )
+        collection = question.form.collection
+        collection.submission_name_question_id = question.id
+        db_session.flush()
+
+        def _create_submission(name: str) -> None:
+            grant_recipient = factories.grant_recipient.create(grant=collection.grant)
+            submission = factories.submission.create(
+                collection=collection,
+                mode=SubmissionModeEnum.LIVE,
+                grant_recipient=grant_recipient,
+                answers=[FactoryAnswer(question, TextSingleLineAnswer(name))],
+            )
+            factories.submission_event.create(submission=submission)
+            factories.submission_event.create(submission=submission)
+
+        _create_submission("First")
+
+        db_session.expire_all()
+        with track_sql_queries() as baseline_queries:
+            for summary in get_submission_list_for_collection(
+                collection=collection, submission_mode=SubmissionModeEnum.LIVE
+            ):
+                _ = (summary.name, summary.organisation_name, summary.last_updated_at_utc)
+        baseline = len(baseline_queries)
+
+        for index in range(3):
+            _create_submission(f"Extra {index}")
+
+        db_session.expire_all()
+        with track_sql_queries() as iterate_queries:
+            summaries = get_submission_list_for_collection(
+                collection=collection, submission_mode=SubmissionModeEnum.LIVE
+            )
+            for summary in summaries:
+                _ = (summary.name, summary.organisation_name, summary.last_updated_at_utc)
+
+        assert len(summaries) == 4
+        assert len(iterate_queries) == baseline
+
+    def test_single_submission_collection_constant_query_count(self, db_session, factories, track_sql_queries):
+        collection = factories.collection.create()
+
+        def _create_recipient_with_submission() -> None:
+            grant_recipient = factories.grant_recipient.create(grant=collection.grant)
+            submission = factories.submission.create(
+                collection=collection, mode=SubmissionModeEnum.LIVE, grant_recipient=grant_recipient
+            )
+            factories.submission_event.create(submission=submission)
+            factories.submission_event.create(submission=submission)
+
+        _create_recipient_with_submission()
+        factories.grant_recipient.create(grant=collection.grant)
+
+        db_session.expire_all()
+        with track_sql_queries() as baseline_queries:
+            for row in get_submission_list_for_collection(
+                collection=collection, submission_mode=SubmissionModeEnum.LIVE
+            ):
+                _ = (row.name, row.organisation_name, row.status, row.last_updated_at_utc)
+        baseline = len(baseline_queries)
+
+        for _ in range(3):
+            _create_recipient_with_submission()
+            factories.grant_recipient.create(grant=collection.grant)
+
+        db_session.expire_all()
+        with track_sql_queries() as iterate_queries:
+            rows = get_submission_list_for_collection(collection=collection, submission_mode=SubmissionModeEnum.LIVE)
+            for row in rows:
+                _ = (row.name, row.organisation_name, row.status, row.last_updated_at_utc)
+
+        assert len(rows) == 8
         assert len(iterate_queries) == baseline
 
 

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -8668,12 +8668,35 @@ class TestListSubmissionsMultipleSubmissions:
         assert "Project name" in table_headers
         assert "Grant recipient" in table_headers
 
-    def test_multi_submission_no_submissions_shows_empty_message(
+    def test_multi_submission_no_grant_recipients_shows_empty_message(
+        self, authenticated_grant_member_client_no_grant_recipients, factories, db_session
+    ):
+        report = factories.collection.create(
+            grant=authenticated_grant_member_client_no_grant_recipients.grant,
+            allow_multiple_submissions=True,
+        )
+
+        response = authenticated_grant_member_client_no_grant_recipients.get(
+            url_for(
+                "deliver_grant_funding.list_submissions",
+                grant_id=authenticated_grant_member_client_no_grant_recipients.grant.id,
+                report_id=report.id,
+                submission_mode=SubmissionModeEnum.LIVE,
+            )
+        )
+
+        assert response.status_code == 200
+        assert "No submissions found for this monitoring report" in response.text
+
+    def test_multi_submission_table_shows_no_submission_for_recipients_without_submissions(
         self, authenticated_grant_member_client, factories, db_session
     ):
         report = factories.collection.create(
             grant=authenticated_grant_member_client.grant,
             allow_multiple_submissions=True,
+        )
+        factories.grant_recipient.create(
+            grant=authenticated_grant_member_client.grant, organisation__name="Organisation Without Submission"
         )
 
         response = authenticated_grant_member_client.get(
@@ -8686,7 +8709,12 @@ class TestListSubmissionsMultipleSubmissions:
         )
 
         assert response.status_code == 200
-        assert "No submissions found for this monitoring report" in response.text
+        soup = BeautifulSoup(response.data, "html.parser")
+        assert "Organisation Without Submission" in soup.text
+        assert "No submission" in soup.text
+        assert page_has_link(soup, "No submission") is None
+        submission_tags = soup.select(".govuk-tag")
+        assert {tag.text.strip() for tag in submission_tags} == {"Not started"}
 
 
 class TestExportReportSubmissions:

--- a/tests/unit/common/helpers/test_submission_events.py
+++ b/tests/unit/common/helpers/test_submission_events.py
@@ -135,36 +135,3 @@ class TestSubmissionEventHelper:
             assert events.submission_state.submitted_at_utc == datetime(2025, 11, 25, 0, 0, 0)
             assert events.submission_state.sent_for_certification_by == user
             assert events.submission_state.sent_for_certification_at_utc == datetime(2025, 11, 24, 0, 0, 0)
-
-    class TestLatestEventUTC:
-        def test_latest_event_utc_returns_latest_event(self, factories):
-            form = factories.form.build()
-            user = factories.user.build()
-            submission = factories.submission.build(
-                collection=form.collection,
-            )
-            submission.events = [
-                factories.submission_event.build(
-                    event_type=SubmissionEventType.SUBMISSION_SENT_FOR_CERTIFICATION,
-                    related_entity_id=submission.id,
-                    created_by=user,
-                    data=SubmissionEventHelper.event_from(SubmissionEventType.SUBMISSION_SENT_FOR_CERTIFICATION),
-                    created_at_utc=datetime(2025, 11, 24, 0, 0, 0),
-                ),
-                factories.submission_event.build(
-                    event_type=SubmissionEventType.SUBMISSION_APPROVED_BY_CERTIFIER,
-                    related_entity_id=submission.id,
-                    created_by=user,
-                    data=SubmissionEventHelper.event_from(SubmissionEventType.SUBMISSION_APPROVED_BY_CERTIFIER),
-                    created_at_utc=datetime(2025, 11, 24, 11, 0, 0),
-                ),
-                factories.submission_event.build(
-                    event_type=SubmissionEventType.SUBMISSION_SUBMITTED,
-                    related_entity_id=submission.id,
-                    created_by=user,
-                    data=SubmissionEventHelper.event_from(SubmissionEventType.SUBMISSION_SUBMITTED),
-                    created_at_utc=datetime(2025, 11, 25, 0, 0, 0),
-                ),
-            ]
-            events = SubmissionEventHelper(submission)
-            assert events.latest_event_utc == datetime(2025, 11, 25, 0, 0, 0)


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-1406

## 📝 Description
When a collection has a lot of submissions, the 'list submissions' page was
having to pull back a lot of data from the DB to correctly calculate statuses,
submission names, last updated at timestamps, etc. We were seeing the DB
roundtrip alone take 600ms+ for one of our larger collections.

In reality all we need to display this page is:

- grant recipient name
- submission status 
- submission last updated at (including submission events)
- for multi-submission: the submission's name (based on an answer)

This patch optimises the endpoint to just pull this specific information from
the DB instead of the submission and a huge swathe of rleated entities (grant
recipient, organisation, submission events, all of the data from the submission)
through a few new helper properties in the Submission class:

- `name` - for multi-submission only, this tells SQLAlchemy how to calculate the
  submission's name from SQL (get the collection's 'name' question and find its
  associated answer in the data blob)

- `last_updated_at_utc` - the greatest of the latest timestamp on the submission
  and the latest submission event 

With these calculated in SQL we can just fetch the required attributes directly
and skip sending huge swathes of JSON data and related entities from the DB and
processing them in python.

This should get us down to a reliably fast list submissions endpoint, with the
caveat that the structure of the submission data blob now needs to be understood
by the `Submission.name` property rather than just the SubmissionDataManager.
This optimisation and additional bit of complexity feels acceptable when
contrasted to the performance we'd be leaving on the table by not doing this. We
also feel fairly comfortable with the schema used to store submission data and
its unlikely to churn significantly from now on.

## 🧪 Testing
<!-- Describe how you've tested this change, and how a reviewer can test it -->

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- [x] No N+1 query problems introduced
- [x] Any new DB queries include appropriate where clauses based on the user's permissions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [ ] End-to-end tests have been updated (if applicable)
- [ ] Edge cases and error conditions are tested

## 📚 Additional Notes
<!-- Any additional context, concerns, or considerations for reviewers -->
