### PR TITLE
Disable postgresql prepared statements

### DIFF
--- a/app/extensions/__init__.py
+++ b/app/extensions/__init__.py
@@ -12,7 +12,7 @@ from app.extensions.record_sqlalchemy_queries import RecordSqlalchemyQueriesExte
 from app.services.notify import NotificationService
 from app.services.s3 import S3Service
 
-db = SQLAlchemy(engine_options={"echo": False})
+db = SQLAlchemy(engine_options={"echo": False, "connect_args": {"prepare_threshold": None}})
 auto_commit_after_request = AutoCommitAfterRequestExtension(db=db)
 migrate = Migrate()
 notification_service = NotificationService()


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
We've been seeing [intermittent errors](https://communitiesuk.sentry.io/issues/126378818) on deployments that include database migrations changing enums.

Our app currently (by default behaviour) uses postgresql prepared statements to optimise query execution. A prepared statement's return value can't change. When we update an enum we change the return value of certain statements, which means when a prepared statement is reused, postgres throws an error for trying to use a stale prepared statement. This results in a 500 for the user.

We haven't actively enabled prepared statements, and while they can offer performance improvements, at our scale it's preferable to have stability and error-free operation than deal with detecting and invalidating prepared statements cleanly, or the complexity of retrying specific SQL statements in the context of a wider transaction.

https://www.psycopg.org/psycopg3/docs/api/connections.html#psycopg.Connection.prepare_threshold

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- [x] No N+1 query problems introduced
- [x] Any new DB queries include appropriate where clauses based on the user's permissions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [ ] I need the reviewer(s) to pull and run this change locally
- [ ] New (non-developer) functionality has appropriate unit and integration tests
- [ ] End-to-end tests have been updated (if applicable)
- [ ] Edge cases and error conditions are tested

## 📚 Additional Notes
<!-- Any additional context, concerns, or considerations for reviewers -->
