### PR TITLE
Feat: Add default sorting to Reporting Lifecycle tables

### DIFF
--- a/app/common/data/interfaces/organisations.py
+++ b/app/common/data/interfaces/organisations.py
@@ -31,6 +31,8 @@ def get_organisations(
     if with_external_ids is not None:
         statement = statement.where(Organisation.external_id.in_(with_external_ids))
 
+    statement = statement.order_by(Organisation.name)
+
     return db.session.scalars(statement).all()
 
 


### PR DESCRIPTION
## 🎫 Ticket
???

## 📝 Description
Add default sorting to the Reporting Lifecycle tables.

### Data providers
Looking at the views from the screenshot we have the following options:
- `/<uuid:grant_id>/<uuid:collection_id>/add-bulk-data-providers`
- `/<uuid:grant_id>/<uuid:collection_id>/add-individual-data-providers`

The **Grant Recipient** tables are already sorted alphabetically by Organisation name.

Implemented here on the April 27th:
https://github.com/communitiesuk/funding-service/commit/e8f728c1c6b87658cb66d7e5d34c82f7962e6411

### Other tables
#### Set up global certifiers (`set_up_global_certifiers`)
Existing certifiers by organisation - **⚠️ Not sorted ⚠️**
Update `get_organisations` to do an `order_by(Organisation.name)`
This will affect any drop-down that uses this function to list options.

#### Set up grant recipients (`set-up-grant-recipients`)
Existing grant recipients - Same sorting applied already

#### Override certifiers for this grant
Existing grant-specific certifiers by organisation - Same sorting applied already

#### Add form designers to test Access grant funding
Existing grant recipient users - Same sorting applied already


## 📸 Show the thing (screenshots, gifs)

### Before
#### Set up global certifiers - Before
<img width="679" height="758" alt="image" src="https://github.com/user-attachments/assets/6a6c5d32-1200-4d37-9167-96c5a2c1464c" />

#### Set up grant recipients - Before
<img width="857" height="522" alt="image" src="https://github.com/user-attachments/assets/0daee682-987a-444e-87ae-7e3fc6a91b83" />

### After
#### Set up global certifiers - After
<img width="678" height="762" alt="image" src="https://github.com/user-attachments/assets/58b17c01-e9a3-4c5c-b8af-cbf2f590ddea" />

#### Set up grant recipients - After
<img width="852" height="545" alt="image" src="https://github.com/user-attachments/assets/f50675da-a9dd-4064-976e-1e61cf6da1a6" />

## 🧪 Testing
Does adding a global default sorting on `get_organisations()` cause any potential issues?
