### PR TITLE
Tests/datasource factory org items

### DIFF
--- a/tests/integration/common/data/interfaces/test_data_sets.py
+++ b/tests/integration/common/data/interfaces/test_data_sets.py
@@ -462,9 +462,14 @@ class TestGetDataSource:
             get_data_source(uuid.uuid4())
 
     def test_get_data_source_with_organisation_items(self, db_session, factories, track_sql_queries):
-        data_source = factories.data_source.create(items=None)
-        factories.data_source_organisation_item.create(data_source=data_source, external_id="E123")
-        factories.data_source_organisation_item.create(data_source=data_source, external_id="E456")
+        grant = factories.grant.create()
+        factories.grant_recipient.create_batch(2, grant=grant)
+        data_source = factories.data_source.create(
+            grant=grant,
+            collection=factories.collection.create(grant=grant),
+            type=DataSourceType.GRANT_RECIPIENT,
+            create_gr_org_items=True,
+        )
         db_session.expire_all()
 
         from_db = get_data_source(data_source.id, with_organisation_items=True)
@@ -488,8 +493,15 @@ class TestGetDataSource:
         assert len(queries) == 0
 
     def test_get_data_source_with_both_flags(self, db_session, factories, track_sql_queries):
-        data_source = factories.data_source.create(items=None)
-        factories.data_source_organisation_item.create(data_source=data_source, external_id="E123")
+
+        grant = factories.grant.create()
+        factories.grant_recipient.create(grant=grant)
+        data_source = factories.data_source.create(
+            grant=grant,
+            collection=factories.collection.create(grant=grant),
+            type=DataSourceType.GRANT_RECIPIENT,
+            create_gr_org_items=True,
+        )
         db_session.expire_all()
 
         from_db = get_data_source(data_source.id, with_organisation_items=True, with_data_source_items=True)
@@ -501,8 +513,14 @@ class TestGetDataSource:
         assert len(queries) == 0
 
     def test_get_data_source_without_flags_does_not_eagerly_load_items(self, db_session, factories, track_sql_queries):
-        data_source = factories.data_source.create(items=None)
-        factories.data_source_organisation_item.create(data_source=data_source, external_id="E123")
+        grant = factories.grant.create()
+        factories.grant_recipient.create(grant=grant)
+        data_source = factories.data_source.create(
+            grant=grant,
+            collection=factories.collection.create(grant=grant),
+            type=DataSourceType.GRANT_RECIPIENT,
+            create_gr_org_items=True,
+        )
         db_session.expire_all()
 
         get_data_source(data_source.id)
@@ -540,9 +558,17 @@ class TestDeleteDataSource:
         assert mock_s3_service_calls.delete_file_calls[0].args[0] == "data-set-uploads/test.csv"
 
     def test_delete_data_source_cascades_organisation_items(self, db_session, factories):
-        data_source = factories.data_source.create(items=None)
-        factories.data_source_organisation_item.create(data_source=data_source, external_id="E123")
-        factories.data_source_organisation_item.create(data_source=data_source, external_id="E456")
+
+        grant = factories.grant.create()
+        factories.grant_recipient.create_batch(2, grant=grant)
+        data_source = factories.data_source.create(
+            grant=grant,
+            collection=factories.collection.create(grant=grant),
+            type=DataSourceType.GRANT_RECIPIENT,
+            create_gr_org_items=True,
+            file_metadata=None,
+        )
+        assert db_session.scalar(select(func.count()).select_from(DataSourceOrganisationItem)) == 2
 
         delete_data_source(data_source)
         db_session.flush()
@@ -550,11 +576,23 @@ class TestDeleteDataSource:
         assert db_session.scalar(select(func.count()).select_from(DataSourceOrganisationItem)) == 0
 
     def test_delete_only_deletes_target_data_source(self, db_session, factories):
-        data_source_1 = factories.data_source.create(items=None)
-        data_source_2 = factories.data_source.create(items=None)
-        org_item_1 = factories.data_source_organisation_item.create(data_source=data_source_1, external_id="E123")
-        org_item_2 = factories.data_source_organisation_item.create(data_source=data_source_2, external_id="E456")
-
+        grant = factories.grant.create()
+        factories.grant_recipient.create(grant=grant)
+        data_source_1 = factories.data_source.create(
+            grant=grant,
+            collection=factories.collection.create(grant=grant),
+            type=DataSourceType.GRANT_RECIPIENT,
+            create_gr_org_items=True,
+            file_metadata=None,
+        )
+        data_source_2 = factories.data_source.create(
+            name="DS 2",
+            grant=grant,
+            collection=factories.collection.create(grant=grant),
+            type=DataSourceType.GRANT_RECIPIENT,
+            create_gr_org_items=True,
+            file_metadata=None,
+        )
         delete_data_source(data_source_1)
         db_session.flush()
 
@@ -562,14 +600,12 @@ class TestDeleteDataSource:
         assert db_session.get(DataSource, data_source_2.id) is not None
 
         assert db_session.scalar(select(func.count()).select_from(DataSourceOrganisationItem)) == 1
-        assert db_session.get(DataSourceOrganisationItem, org_item_1.id) is None
-        assert db_session.get(DataSourceOrganisationItem, org_item_2.id) is not None
+        assert db_session.get(DataSourceOrganisationItem, data_source_1.organisation_items[0].id) is None
 
     def test_delete_blocked_when_column_is_referenced(self, db_session, factories, mock_s3_service_calls):
         grant = factories.grant.create()
         collection = factories.collection.create(grant=grant)
         data_source = factories.data_source.create(
-            name="Budget data",
             grant=grant,
             collection=collection,
             type=DataSourceType.GRANT_RECIPIENT,
@@ -589,7 +625,7 @@ class TestDeleteDataSource:
             delete_data_source(data_source)
 
         assert e.value.data_source_id == data_source.id
-        assert e.value.data_source_name == "Budget data"
+        assert e.value.data_source_name == "Grant allocation"
         assert e.value.referenced_columns == {"c_allocation"}
         assert db_session.get(DataSource, data_source.id) is not None
         assert mock_s3_service_calls.delete_file_calls == []

--- a/tests/integration/common/data/test_models.py
+++ b/tests/integration/common/data/test_models.py
@@ -851,24 +851,18 @@ class TestDataSourceModel:
     def test_filtering_organisation_items(self, factories):
         grant = factories.grant.create()
         report = factories.collection.create(grant=grant)
-        org1, org2, org3, org4 = factories.organisation.create_batch(4)
+        gr1, gr2, gr3 = factories.grant_recipient.create_batch(3, grant=grant)
         data_source = factories.data_source.create(
             name="Test data set",
             grant=grant,
             collection=report,
             type=DataSourceType.GRANT_RECIPIENT,
+            create_gr_org_items=True,
+            create_gr_org_items__data=[111, 222, 333],
         )
-        org1_item = factories.data_source_organisation_item.create(
-            data_source=data_source, external_id=org1.external_id
-        )
-        org2_item = factories.data_source_organisation_item.create(
-            data_source=data_source, external_id=org2.external_id
-        )
-        org3_item = factories.data_source_organisation_item.create(
-            data_source=data_source, external_id=org3.external_id
-        )
+        gr4 = factories.grant_recipient.create(grant=grant)
 
-        assert data_source.get_filtered_organisation_item(org1.external_id) == org1_item
-        assert data_source.get_filtered_organisation_item(org2.external_id) == org2_item
-        assert data_source.get_filtered_organisation_item(org3.external_id) == org3_item
-        assert data_source.get_filtered_organisation_item(org4.external_id) is None
+        assert data_source.get_filtered_organisation_item(gr1.organisation.external_id)._data["c_allocation"] == 111
+        assert data_source.get_filtered_organisation_item(gr2.organisation.external_id)._data["c_allocation"] == 222
+        assert data_source.get_filtered_organisation_item(gr3.organisation.external_id)._data["c_allocation"] == 333
+        assert data_source.get_filtered_organisation_item(gr4.organisation.external_id) is None

--- a/tests/integration/common/data/test_models.py
+++ b/tests/integration/common/data/test_models.py
@@ -750,7 +750,7 @@ class TestComponentReferenceModel:
         grant = factories.grant.create()
         collection = factories.collection.create(grant=grant)
         data_source = factories.data_source.create(
-            name="Budget data", grant=grant, collection=collection, type=DataSourceType.GRANT_RECIPIENT
+            grant=grant, collection=collection, type=DataSourceType.GRANT_RECIPIENT
         )
         question = factories.question.create(form__collection=collection)
 
@@ -780,7 +780,6 @@ class TestComponentReferenceModel:
         grant = factories.grant.create()
         collection = factories.collection.create(grant=grant)
         data_source = factories.data_source.create(
-            name="Budget data",
             grant=grant,
             collection=collection,
             type=DataSourceType.GRANT_RECIPIENT,
@@ -803,7 +802,6 @@ class TestComponentReferenceModel:
         grant = factories.grant.create()
         collection = factories.collection.create(grant=grant)
         data_source = factories.data_source.create(
-            name="Budget data",
             grant=grant,
             collection=collection,
             type=DataSourceType.GRANT_RECIPIENT,
@@ -825,7 +823,6 @@ class TestComponentReferenceModel:
         grant = factories.grant.create()
         collection = factories.collection.create(grant=grant)
         data_source = factories.data_source.create(
-            name="Budget data",
             grant=grant,
             collection=collection,
             type=DataSourceType.GRANT_RECIPIENT,
@@ -853,7 +850,6 @@ class TestDataSourceModel:
         report = factories.collection.create(grant=grant)
         gr1, gr2, gr3 = factories.grant_recipient.create_batch(3, grant=grant)
         data_source = factories.data_source.create(
-            name="Test data set",
             grant=grant,
             collection=report,
             type=DataSourceType.GRANT_RECIPIENT,

--- a/tests/integration/common/expressions/test_init.py
+++ b/tests/integration/common/expressions/test_init.py
@@ -6,7 +6,7 @@ from unittest.mock import PropertyMock
 import pytest
 
 from app.common.collections.types import IntegerAnswer, TextSingleLineAnswer
-from app.common.data.models import Expression
+from app.common.data.models import DataSourceOrganisationItem, Expression
 from app.common.data.types import (
     DataSourceSchema,
     DataSourceSchemaColumn,
@@ -284,18 +284,17 @@ class TestExpressionContext:
             organisation = factories.organisation.create()
             grant_recipient = factories.grant_recipient.create(grant=grant, organisation=organisation)
             submission = factories.submission.create(collection=collection, grant_recipient=grant_recipient)
-            data_source = factories.data_source.create(
+            factories.data_source.create(
                 grant=grant,
                 collection=collection,
                 type=DataSourceType.GRANT_RECIPIENT,
-            )
-            org_item = factories.data_source_organisation_item.create(
-                data_source=data_source,
-                external_id=organisation.external_id,
-                _data={"c_allocation": 1000},
+                create_gr_org_items=True,
+                create_gr_org_items__data=[1000],
             )
 
-            mocker.patch.object(type(org_item), "data", new_callable=PropertyMock, return_value=[{"col": "val"}])
+            mocker.patch.object(
+                DataSourceOrganisationItem, "data", new_callable=PropertyMock, return_value=[{"col": "val"}]
+            )
 
             helper = SubmissionHelper.load(submission.id, grant_recipient_id=grant_recipient.id)
             context = ExpressionContext._build_data_source_context(mode="evaluation", submission_helper=helper)
@@ -311,11 +310,8 @@ class TestExpressionContext:
                 grant=grant,
                 collection=collection,
                 type=DataSourceType.GRANT_RECIPIENT,
-            )
-            factories.data_source_organisation_item.create(
-                data_source=data_source,
-                external_id=organisation.external_id,
-                _data={"c_allocation": 1000},
+                create_gr_org_items=True,
+                create_gr_org_items__data=[1000],
             )
 
             helper = SubmissionHelper.load(submission.id, grant_recipient_id=grant_recipient.id)
@@ -328,28 +324,18 @@ class TestExpressionContext:
             grant = factories.grant.create()
             collection = factories.collection.create(grant=grant)
 
-            organisation = factories.organisation.create()
-            grant_recipient = factories.grant_recipient.create(grant=grant, organisation=organisation)
+            grant_recipient = factories.grant_recipient.create(grant=grant)
             submission = factories.submission.create(collection=collection, grant_recipient=grant_recipient)
 
-            organisation_2 = factories.organisation.create()
-            grant_recipient_2 = factories.grant_recipient.create(grant=grant, organisation=organisation_2)
+            grant_recipient_2 = factories.grant_recipient.create(grant=grant)
             submission_2 = factories.submission.create(collection=collection, grant_recipient=grant_recipient_2)
 
             data_source = factories.data_source.create(
                 grant=grant,
                 collection=collection,
                 type=DataSourceType.GRANT_RECIPIENT,
-            )
-            factories.data_source_organisation_item.create(
-                data_source=data_source,
-                external_id=organisation.external_id,
-                _data={"c_allocation": 1000},
-            )
-            factories.data_source_organisation_item.create(
-                data_source=data_source,
-                external_id=organisation_2.external_id,
-                _data={"c_allocation": 9999},
+                create_gr_org_items=True,
+                create_gr_org_items__data=[1000, 9999],
             )
 
             helper = SubmissionHelper.load(submission.id, grant_recipient_id=grant_recipient.id)
@@ -370,11 +356,8 @@ class TestExpressionContext:
                 grant=grant,
                 collection=collection,
                 type=DataSourceType.GRANT_RECIPIENT,
-            )
-            factories.data_source_organisation_item.create(
-                data_source=data_source,
-                external_id=organisation.external_id,
-                _data={"c_allocation": 1000},
+                create_gr_org_items=True,
+                create_gr_org_items__data=[1000],
             )
 
             helper = SubmissionHelper.load(submission.id, grant_recipient_id=grant_recipient.id)
@@ -396,11 +379,8 @@ class TestExpressionContext:
                 grant=grant,
                 collection=collection,
                 type=DataSourceType.GRANT_RECIPIENT,
-            )
-            factories.data_source_organisation_item.create(
-                data_source=data_source,
-                external_id=organisation.external_id,
-                _data={"c_allocation": None},
+                create_gr_org_items=True,
+                create_gr_org_items__data=[None],
             )
 
             helper = SubmissionHelper.load(submission.id, grant_recipient_id=grant_recipient.id)
@@ -877,11 +857,8 @@ class TestDataSourceInterpolation:
             grant=grant,
             collection=collection,
             type=DataSourceType.GRANT_RECIPIENT,
-        )
-        factories.data_source_organisation_item.create(
-            data_source=data_source,
-            external_id=organisation.external_id,
-            _data={"c_allocation": 1000},
+            create_gr_org_items=True,
+            create_gr_org_items__data=[1000],
         )
 
         helper = SubmissionHelper.load(submission.id, grant_recipient_id=grant_recipient.id)
@@ -928,11 +905,8 @@ class TestDataSourceEvaluation:
             grant=grant,
             collection=collection,
             type=DataSourceType.GRANT_RECIPIENT,
-        )
-        factories.data_source_organisation_item.create(
-            data_source=data_source,
-            external_id=organisation.external_id,
-            _data={"c_allocation": 1000},
+            create_gr_org_items=True,
+            create_gr_org_items__data=[1000],
         )
 
         helper = SubmissionHelper.load(submission.id, grant_recipient_id=grant_recipient.id)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -364,6 +364,7 @@ def authenticated_grant_member_client(
     anonymous_client.user = user
     anonymous_client.grant = grant
     anonymous_client.organisation = grant.organisation
+    anonymous_client.grant_recipient = grant_recipient
     db_session.commit()
 
     yield anonymous_client

--- a/tests/integration/deliver_grant_funding/routes/test_collections.py
+++ b/tests/integration/deliver_grant_funding/routes/test_collections.py
@@ -10819,33 +10819,13 @@ class TestViewDataSource:
 
     def test_get_shows_grant_recipient_table(self, authenticated_grant_member_client, factories):
         collection = factories.collection.create(grant=authenticated_grant_member_client.grant)
-        organisation = factories.organisation.create(external_id="E123", name="Rivendell Council")
-        factories.grant_recipient.create(
-            grant=authenticated_grant_member_client.grant,
-            organisation=organisation,
-            mode=GrantRecipientModeEnum.LIVE,
-        )
+        organisation = authenticated_grant_member_client.grant_recipient.organisation
         data_source = factories.data_source.create(
             collection=collection,
             grant=authenticated_grant_member_client.grant,
-            name="Test data set",
             type=DataSourceType.GRANT_RECIPIENT,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_allocation": {
-                        "data_type": QuestionDataType.NUMBER,
-                        "original_column_name": "Allocation",
-                        "presentation_options": {"prefix": "£", "suffix": ""},
-                        "data_options": {"number_type": NumberTypeEnum.INTEGER, "max_decimal_places": None},
-                    }
-                }
-            ),
-            items=None,
-        )
-        factories.data_source_organisation_item.create(
-            data_source=data_source,
-            external_id="E123",
-            _data={"c_allocation": 500000},
+            create_gr_org_items=True,
+            create_gr_org_items__data=[500_000],
         )
 
         response = authenticated_grant_member_client.get(
@@ -10860,38 +10840,19 @@ class TestViewDataSource:
 
         assert response.status_code == 200
         soup = BeautifulSoup(response.data, "html.parser")
-        assert "E123" in soup.text
-        assert "Rivendell Council" in soup.text
+        assert organisation.external_id in soup.text
+        assert organisation.name in soup.text
         assert "Allocation" in soup.text
         assert "£500,000" in soup.text
 
     def test_get_shows_missing_data_tag_for_empty_values(self, authenticated_grant_member_client, factories):
-        org = factories.organisation.create(can_manage_grants=False, external_id="E123")
-        factories.grant_recipient.create(
-            organisation=org, grant=authenticated_grant_member_client.grant, mode=GrantRecipientModeEnum.LIVE
-        )
         collection = factories.collection.create(grant=authenticated_grant_member_client.grant)
         data_source = factories.data_source.create(
             collection=collection,
             grant=authenticated_grant_member_client.grant,
-            name="Test data set",
             type=DataSourceType.GRANT_RECIPIENT,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_notes": {
-                        "data_type": QuestionDataType.TEXT_SINGLE_LINE,
-                        "original_column_name": "Notes",
-                        "presentation_options": {},
-                        "data_options": {},
-                    }
-                }
-            ),
-            items=None,
-        )
-        factories.data_source_organisation_item.create(
-            data_source=data_source,
-            external_id=org.external_id,
-            _data={"c_notes": None},
+            create_gr_org_items=True,
+            create_gr_org_items__data=[None],
         )
 
         response = authenticated_grant_member_client.get(
@@ -10915,24 +10876,12 @@ class TestViewDataSource:
         data_source = factories.data_source.create(
             collection=collection,
             grant=authenticated_grant_member_client.grant,
-            name="Test data set",
             type=DataSourceType.GRANT_RECIPIENT,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_notes": {
-                        "data_type": QuestionDataType.TEXT_SINGLE_LINE,
-                        "original_column_name": "Notes",
-                        "presentation_options": {},
-                        "data_options": {},
-                    }
-                }
-            ),
-            items=None,
         )
         factories.data_source_organisation_item.create(
             data_source=data_source,
             external_id="E123",
-            _data={"c_notes": None},
+            _data={"c_allocation": None},
         )
 
         response = authenticated_grant_member_client.get(
@@ -10969,23 +10918,11 @@ class TestViewDataSource:
             collection=collection,
             grant=authenticated_grant_member_client.grant,
             type=DataSourceType.GRANT_RECIPIENT,
-            name="Test data set",
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_notes": {
-                        "data_type": QuestionDataType.TEXT_SINGLE_LINE,
-                        "original_column_name": "Notes",
-                        "presentation_options": {},
-                        "data_options": {},
-                    }
-                }
-            ),
-            items=None,
         )
         factories.data_source_organisation_item.create(
             data_source=data_source,
             external_id="E123",
-            _data={"c_notes": "hello"},
+            _data={"c_allocation": 1234},
         )
 
         response = authenticated_grant_member_client.get(
@@ -11074,15 +11011,13 @@ class TestViewDataSource:
         self, authenticated_grant_admin_client, factories, db_session, mock_s3_service_calls
     ):
         collection = factories.collection.create(grant=authenticated_grant_admin_client.grant)
+        factories.grant_recipient.create_batch(2, grant=collection.grant)
         data_source = factories.data_source.create(
-            name="Test data set",
             collection=collection,
             grant=authenticated_grant_admin_client.grant,
             type=DataSourceType.GRANT_RECIPIENT,
-            items=None,
+            create_gr_org_items=True,
         )
-        factories.data_source_organisation_item.create(data_source=data_source, external_id="E123")
-        factories.data_source_organisation_item.create(data_source=data_source, external_id="E456")
 
         authenticated_grant_admin_client.post(
             url_for(

--- a/tests/integration/deliver_grant_funding/routes/test_collections.py
+++ b/tests/integration/deliver_grant_funding/routes/test_collections.py
@@ -4159,16 +4159,6 @@ class TestSelectContextSourceDataSet:
             collection=collection,
             name="Test data set",
             type=DataSourceType.GRANT_RECIPIENT,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_capital_allocation": DataSourceSchemaColumn(
-                        data_type=QuestionDataType.NUMBER,
-                        presentation_options=QuestionPresentationOptions(),
-                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                        original_column_name="Capital Allocation",
-                    )
-                }
-            ),
         )
 
         data_source_2 = factories.data_source.create(
@@ -4176,16 +4166,6 @@ class TestSelectContextSourceDataSet:
             collection=collection,
             name="Second data set",
             type=DataSourceType.GRANT_RECIPIENT,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_capital_allocation": DataSourceSchemaColumn(
-                        data_type=QuestionDataType.NUMBER,
-                        presentation_options=QuestionPresentationOptions(),
-                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                        original_column_name="Capital Allocation",
-                    )
-                }
-            ),
         )
 
         data_source_3 = factories.data_source.create(
@@ -4210,16 +4190,6 @@ class TestSelectContextSourceDataSet:
             collection=report_2,
             name="Data set that shouldn't be shown",
             type=DataSourceType.GRANT_RECIPIENT,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_capital_allocation": DataSourceSchemaColumn(
-                        data_type=QuestionDataType.NUMBER,
-                        presentation_options=QuestionPresentationOptions(),
-                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                        original_column_name="Capital Allocation",
-                    )
-                }
-            ),
         )
 
         with authenticated_grant_admin_client.session_transaction() as sess:
@@ -4264,16 +4234,6 @@ class TestSelectContextSourceDataSet:
             collection=collection,
             name="Test data set",
             type=DataSourceType.GRANT_RECIPIENT,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_capital_allocation": DataSourceSchemaColumn(
-                        data_type=QuestionDataType.NUMBER,
-                        presentation_options=QuestionPresentationOptions(),
-                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                        original_column_name="Capital Allocation",
-                    )
-                }
-            ),
         )
 
         data_source_2 = factories.data_source.create(
@@ -4281,16 +4241,6 @@ class TestSelectContextSourceDataSet:
             collection=collection,
             name="Second data set",
             type=DataSourceType.GRANT_RECIPIENT,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_capital_allocation": DataSourceSchemaColumn(
-                        data_type=QuestionDataType.NUMBER,
-                        presentation_options=QuestionPresentationOptions(),
-                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                        original_column_name="Capital Allocation",
-                    )
-                }
-            ),
         )
 
         data_source_3 = factories.data_source.create(
@@ -4367,18 +4317,7 @@ class TestSelectContextSourceDataSet:
         data_source = factories.data_source.create(
             grant=authenticated_grant_admin_client.grant,
             collection=collection,
-            name="Test data set",
             type=DataSourceType.GRANT_RECIPIENT,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_capital_allocation": DataSourceSchemaColumn(
-                        data_type=QuestionDataType.NUMBER,
-                        presentation_options=QuestionPresentationOptions(),
-                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                        original_column_name="Capital Allocation",
-                    )
-                }
-            ),
         )
 
         with authenticated_grant_admin_client.session_transaction() as sess:
@@ -4427,18 +4366,7 @@ class TestSelectContextSourceDataSetColumn:
         data_set = factories.data_source.create(
             grant=client.grant,
             collection=collection,
-            name="Test data set",
             type=DataSourceType.GRANT_RECIPIENT,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_capital_allocation": DataSourceSchemaColumn(
-                        data_type=QuestionDataType.NUMBER,
-                        presentation_options=QuestionPresentationOptions(),
-                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                        original_column_name="Capital Allocation",
-                    )
-                }
-            ),
         )
 
         with client.session_transaction() as sess:
@@ -4476,16 +4404,6 @@ class TestSelectContextSourceDataSetColumn:
             collection=report_2,
             name="Different collection data set",
             type=DataSourceType.GRANT_RECIPIENT,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_capital_allocation": DataSourceSchemaColumn(
-                        data_type=QuestionDataType.NUMBER,
-                        presentation_options=QuestionPresentationOptions(),
-                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                        original_column_name="Capital Allocation",
-                    )
-                }
-            ),
         )
 
         with authenticated_grant_admin_client.session_transaction() as sess:
@@ -4515,18 +4433,7 @@ class TestSelectContextSourceDataSetColumn:
         data_set = factories.data_source.create(
             grant=authenticated_grant_admin_client.grant,
             collection=collection,
-            name="Test data set",
             type=DataSourceType.GRANT_RECIPIENT,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_capital_allocation": DataSourceSchemaColumn(
-                        data_type=QuestionDataType.NUMBER,
-                        presentation_options=QuestionPresentationOptions(),
-                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                        original_column_name="Capital Allocation",
-                    )
-                }
-            ),
         )
 
         response = authenticated_grant_admin_client.get(
@@ -4775,18 +4682,7 @@ class TestSelectContextSourceDataSetColumn:
         data_set = factories.data_source.create(
             grant=authenticated_grant_admin_client.grant,
             collection=collection,
-            name="Test data set",
             type=DataSourceType.GRANT_RECIPIENT,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_capital_allocation": DataSourceSchemaColumn(
-                        data_type=QuestionDataType.NUMBER,
-                        presentation_options=QuestionPresentationOptions(),
-                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                        original_column_name="Capital Allocation",
-                    )
-                }
-            ),
         )
 
         with authenticated_grant_admin_client.session_transaction() as sess:
@@ -4818,7 +4714,7 @@ class TestSelectContextSourceDataSetColumn:
         with authenticated_grant_admin_client.session_transaction() as sess:
             question_data = sess.get("question")
             assert question_data is not None
-            expected_reference = ExpressionReference.from_data_source_column(data_set, "c_capital_allocation")
+            expected_reference = ExpressionReference.from_data_source_column(data_set, "c_allocation")
             assert question_data["component_form_data"]["text"] == f"Test question text {expected_reference.wrapped}"
 
     def test_post_with_component_session_model_existing_question_redirects_and_updates_session(
@@ -4830,18 +4726,7 @@ class TestSelectContextSourceDataSetColumn:
         data_set = factories.data_source.create(
             grant=authenticated_grant_admin_client.grant,
             collection=collection,
-            name="Test data set",
             type=DataSourceType.GRANT_RECIPIENT,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_capital_allocation": DataSourceSchemaColumn(
-                        data_type=QuestionDataType.NUMBER,
-                        presentation_options=QuestionPresentationOptions(),
-                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                        original_column_name="Capital Allocation",
-                    )
-                }
-            ),
         )
 
         with authenticated_grant_admin_client.session_transaction() as sess:
@@ -4873,7 +4758,7 @@ class TestSelectContextSourceDataSetColumn:
         with authenticated_grant_admin_client.session_transaction() as sess:
             question_data = sess.get("question")
             assert question_data is not None
-            expected_reference = ExpressionReference.from_data_source_column(data_set, "c_capital_allocation")
+            expected_reference = ExpressionReference.from_data_source_column(data_set, "c_allocation")
             assert question_data["component_form_data"]["text"] == f"Test question text {expected_reference.wrapped}"
 
     def test_post_with_guidance_session_model_redirects_and_updates_session(
@@ -4885,18 +4770,7 @@ class TestSelectContextSourceDataSetColumn:
         data_set = factories.data_source.create(
             grant=authenticated_grant_admin_client.grant,
             collection=collection,
-            name="Test data set",
             type=DataSourceType.GRANT_RECIPIENT,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_capital_allocation": DataSourceSchemaColumn(
-                        data_type=QuestionDataType.NUMBER,
-                        presentation_options=QuestionPresentationOptions(),
-                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                        original_column_name="Capital Allocation",
-                    )
-                }
-            ),
         )
 
         with authenticated_grant_admin_client.session_transaction() as sess:
@@ -4928,7 +4802,7 @@ class TestSelectContextSourceDataSetColumn:
         with authenticated_grant_admin_client.session_transaction() as sess:
             question_data = sess.get("question")
             assert question_data is not None
-            expected_reference = ExpressionReference.from_data_source_column(data_set, "c_capital_allocation")
+            expected_reference = ExpressionReference.from_data_source_column(data_set, "c_allocation")
             assert (
                 question_data["component_form_data"]["guidance_body"]
                 == f"Some guidance text {expected_reference.wrapped}"
@@ -4943,18 +4817,7 @@ class TestSelectContextSourceDataSetColumn:
         data_set = factories.data_source.create(
             grant=authenticated_grant_admin_client.grant,
             collection=collection,
-            name="Test data set",
             type=DataSourceType.GRANT_RECIPIENT,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_capital_allocation": DataSourceSchemaColumn(
-                        data_type=QuestionDataType.NUMBER,
-                        presentation_options=QuestionPresentationOptions(),
-                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                        original_column_name="Capital Allocation",
-                    )
-                }
-            ),
         )
 
         with authenticated_grant_admin_client.session_transaction() as sess:
@@ -4988,7 +4851,7 @@ class TestSelectContextSourceDataSetColumn:
         with authenticated_grant_admin_client.session_transaction() as sess:
             question_data = sess.get("question")
             assert question_data is not None
-            expected_reference = ExpressionReference.from_data_source_column(data_set, "c_capital_allocation")
+            expected_reference = ExpressionReference.from_data_source_column(data_set, "c_allocation")
             assert question_data["expression_form_data"]["greater_than_expression"] == expected_reference.wrapped
 
     def test_post_with_custom_validation_expressions_session_model_redirects_and_updates_session(
@@ -5000,18 +4863,7 @@ class TestSelectContextSourceDataSetColumn:
         data_set = factories.data_source.create(
             grant=authenticated_grant_admin_client.grant,
             collection=collection,
-            name="Test data set",
             type=DataSourceType.GRANT_RECIPIENT,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_capital_allocation": DataSourceSchemaColumn(
-                        data_type=QuestionDataType.NUMBER,
-                        presentation_options=QuestionPresentationOptions(),
-                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                        original_column_name="Capital Allocation",
-                    )
-                }
-            ),
         )
 
         with authenticated_grant_admin_client.session_transaction() as sess:
@@ -5043,7 +4895,7 @@ class TestSelectContextSourceDataSetColumn:
         with authenticated_grant_admin_client.session_transaction() as sess:
             question_data = sess.get("question")
             assert question_data is not None
-            expected_reference = ExpressionReference.from_data_source_column(data_set, "c_capital_allocation")
+            expected_reference = ExpressionReference.from_data_source_column(data_set, "c_allocation")
             assert (
                 question_data["expression_form_data"]["custom_expression"]
                 == f"some existing text {expected_reference.wrapped}"
@@ -5058,18 +4910,7 @@ class TestSelectContextSourceDataSetColumn:
         data_set = factories.data_source.create(
             grant=authenticated_grant_admin_client.grant,
             collection=collection,
-            name="Test data set",
             type=DataSourceType.GRANT_RECIPIENT,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_capital_allocation": DataSourceSchemaColumn(
-                        data_type=QuestionDataType.NUMBER,
-                        presentation_options=QuestionPresentationOptions(),
-                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                        original_column_name="Capital Allocation",
-                    )
-                }
-            ),
         )
 
         with authenticated_grant_admin_client.session_transaction() as sess:
@@ -5101,7 +4942,7 @@ class TestSelectContextSourceDataSetColumn:
         with authenticated_grant_admin_client.session_transaction() as sess:
             question_data = sess.get("question")
             assert question_data is not None
-            expected_reference = ExpressionReference.from_data_source_column(data_set, "c_capital_allocation")
+            expected_reference = ExpressionReference.from_data_source_column(data_set, "c_allocation")
             assert (
                 question_data["expression_form_data"]["custom_expression"]
                 == f"some existing text {expected_reference.wrapped}"
@@ -5116,18 +4957,7 @@ class TestSelectContextSourceDataSetColumn:
         data_set = factories.data_source.create(
             grant=authenticated_grant_admin_client.grant,
             collection=collection,
-            name="Allocations",
             type=DataSourceType.GRANT_RECIPIENT,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_capital_allocation": DataSourceSchemaColumn(
-                        data_type=QuestionDataType.NUMBER,
-                        presentation_options=QuestionPresentationOptions(),
-                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                        original_column_name="Capital Allocation",
-                    )
-                }
-            ),
         )
 
         with authenticated_grant_admin_client.session_transaction() as sess:
@@ -5148,7 +4978,7 @@ class TestSelectContextSourceDataSetColumn:
 
         assert response.status_code == 302
         assert response.location == AnyStringMatching(
-            "^/deliver/grant/[a-z0-9-]{36}/question/[a-z0-9-]{36}/add-condition/d_[0-9a-f]{32}.c_capital_allocation"
+            "^/deliver/grant/[a-z0-9-]{36}/question/[a-z0-9-]{36}/add-condition/d_[0-9a-f]{32}.c_allocation"
         )
         with authenticated_grant_admin_client.session_transaction() as sess:
             assert sess.get("question") is None
@@ -5158,7 +4988,7 @@ class TestSelectContextSourceDataSetColumn:
         follow_response = authenticated_grant_admin_client.get(response.location)
         assert follow_response.status_code == 200
         soup = BeautifulSoup(follow_response.data, "html.parser")
-        assert "Capital Allocation from Allocations data set" in soup.text
+        assert "Allocation from Grant allocation data set" in soup.text
 
 
 class TestEditQuestion:
@@ -6294,21 +6124,10 @@ class TestAddQuestionCondition:
         data_set = factories.data_source.create(
             grant=authenticated_grant_admin_client.grant,
             collection=collection,
-            name="Test data set",
             type=DataSourceType.GRANT_RECIPIENT,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_capital_allocation": DataSourceSchemaColumn(
-                        data_type=QuestionDataType.NUMBER,
-                        presentation_options=QuestionPresentationOptions(),
-                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                        original_column_name="Capital Allocation",
-                    )
-                }
-            ),
         )
 
-        reference = ExpressionReference.from_data_source_column(data_set, "c_capital_allocation")
+        reference = ExpressionReference.from_data_source_column(data_set, "c_allocation")
 
         ConditionForm = build_managed_expression_form(ExpressionType.CONDITION, reference)
         form = ConditionForm(
@@ -6342,7 +6161,7 @@ class TestAddQuestionCondition:
         assert expression.managed.subject_reference == reference
         assert len(expression.component_references) == 1
         assert expression.component_references[0].depends_on_data_source_id == data_set.id
-        assert expression.component_references[0].depends_on_column_name == "c_capital_allocation"
+        assert expression.component_references[0].depends_on_column_name == "c_allocation"
 
     def test_post_duplicate_condition(self, authenticated_grant_admin_client, factories, db_session):
         collection = factories.collection.create(grant=authenticated_grant_admin_client.grant, name="Test Report")
@@ -11041,21 +10860,9 @@ class TestViewDataSource:
         grant = authenticated_grant_admin_client.grant
         collection = factories.collection.create(grant=grant)
         data_source = factories.data_source.create(
-            name="Budget data",
             grant=grant,
             collection=collection,
             type=DataSourceType.GRANT_RECIPIENT,
-            items=None,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_allocation": DataSourceSchemaColumn(
-                        data_type=QuestionDataType.NUMBER,
-                        presentation_options=QuestionPresentationOptions(prefix="£"),
-                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                        original_column_name="Allocation",
-                    ),
-                }
-            ),
         )
         form = factories.form.create(collection=collection)
         question = factories.question.create(
@@ -11101,21 +10908,9 @@ class TestViewDataSource:
         grant = authenticated_grant_admin_client.grant
         collection = factories.collection.create(grant=grant)
         data_source = factories.data_source.create(
-            name="Budget data",
             grant=grant,
             collection=collection,
             type=DataSourceType.GRANT_RECIPIENT,
-            items=None,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_allocation": DataSourceSchemaColumn(
-                        data_type=QuestionDataType.NUMBER,
-                        presentation_options=QuestionPresentationOptions(prefix="£"),
-                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                        original_column_name="Allocation",
-                    ),
-                }
-            ),
         )
         form = factories.form.create(collection=collection)
         group = factories.group.create(form=form, text=f"Allocation overview (({data_source.safe_did}.c_allocation))")
@@ -11149,21 +10944,9 @@ class TestViewDataSource:
         grant = authenticated_grant_admin_client.grant
         collection = factories.collection.create(grant=grant)
         data_source = factories.data_source.create(
-            name="Budget data",
             grant=grant,
             collection=collection,
             type=DataSourceType.GRANT_RECIPIENT,
-            items=None,
-            schema=DataSourceSchema.model_validate(
-                {
-                    "c_allocation": DataSourceSchemaColumn(
-                        data_type=QuestionDataType.NUMBER,
-                        presentation_options=QuestionPresentationOptions(prefix="£"),
-                        data_options=QuestionDataOptions(number_type=NumberTypeEnum.INTEGER),
-                        original_column_name="Allocation",
-                    ),
-                }
-            ),
         )
         form = factories.form.create(collection=collection)
         question = factories.question.create(
@@ -11207,7 +10990,6 @@ class TestViewDataSource:
         grant = authenticated_grant_admin_client.grant
         collection = factories.collection.create(grant=grant)
         data_source = factories.data_source.create(
-            name="Budget data",
             grant=grant,
             collection=collection,
             type=DataSourceType.GRANT_RECIPIENT,

--- a/tests/integration/deliver_grant_funding/routes/test_runner.py
+++ b/tests/integration/deliver_grant_funding/routes/test_runner.py
@@ -920,11 +920,8 @@ class TestGroupValidation:
             grant=client.grant,
             collection=group.form.collection,
             type=DataSourceType.GRANT_RECIPIENT,
-        )
-        factories.data_source_organisation_item.create(
-            data_source=data_source,
-            external_id=organisation.external_id,
-            _data={"c_allocation": 1000},
+            create_gr_org_items=True,
+            create_gr_org_items__data=[1000],
         )
 
         add_component_validation(

--- a/tests/models.py
+++ b/tests/models.py
@@ -890,11 +890,7 @@ class _DataSourceFactory(SQLAlchemyModelFactory):
 
     # No organisation items are created by default - tests which need them should create them explicitly and set the
     # items size to 0
-    organisation_items = factory.RelatedFactoryList(
-        _DataSourceOrganisationItemFactory,
-        size=0,
-        factory_related_name="data_source",
-    )
+    organisation_items = []
     items = factory.Maybe(
         factory.LazyAttribute(lambda o: o.type == DataSourceType.CUSTOM),
         yes_declaration=factory.RelatedFactoryList(
@@ -922,6 +918,18 @@ class _DataSourceFactory(SQLAlchemyModelFactory):
                 pass
 
         return kwargs
+
+    @factory.post_generation
+    def create_gr_org_items(obj: DataSource, create: bool, extracted: list[Any], **kwargs: Any) -> None:
+        if create and extracted:
+            if obj.collection and obj.collection.grant:
+                gr_data = kwargs.get("data", [])
+                for i, gr in enumerate(obj.collection.grant.grant_recipients):
+                    _DataSourceOrganisationItemFactory.create(
+                        data_source=obj,
+                        external_id=gr.organisation.external_id,
+                        _data={"c_allocation": gr_data[i] if gr_data else faker.Faker().random_int(min=1000, max=2000)},
+                    )
 
     grant = None
     grant_id = factory.LazyAttribute(lambda o: o.grant.id if o.grant else None)

--- a/tests/unit/common/data/test_models.py
+++ b/tests/unit/common/data/test_models.py
@@ -576,21 +576,19 @@ class TestDataSourceMakePydanticModel:
         data_source = factories.data_source.build(
             name="Test data set",
             type=DataSourceType.GRANT_RECIPIENT,
-            schema=DataSourceSchema.model_validate({"allocation": _decimal_col("Allocation", prefix="£")}),
         )
 
-        result = data_source.build_typed_org_item_data({"allocation": None})
-        assert result["allocation"] is None
+        result = data_source.build_typed_org_item_data({"c_allocation": None})
+        assert result["c_allocation"] is None
 
     def test_missing_key_in_row_treated_as_none(self, factories):
         data_source = factories.data_source.build(
             name="Test data set",
             type=DataSourceType.GRANT_RECIPIENT,
-            schema=DataSourceSchema.model_validate({"allocation": _decimal_col("Allocation", prefix="£")}),
         )
 
         result = data_source.build_typed_org_item_data({})
-        assert result["allocation"] is None
+        assert result["c_allocation"] is None
 
     def test_multiple_columns_all_typed_correctly(self, factories):
         data_source = factories.data_source.build(
@@ -643,12 +641,10 @@ class TestDataSourceBuildAnswerForColumn:
 
     def test_integer_value_stored_as_int_is_correctly_parsed(self, factories):
         data_source = factories.data_source.build(
-            name="Test data set",
             type=DataSourceType.GRANT_RECIPIENT,
-            schema=DataSourceSchema.model_validate({"allocation": _integer_col("Allocation")}),
         )
 
-        result = data_source._build_answer_for_column(42, data_source.schema.root["allocation"])
+        result = data_source._build_answer_for_column(42, data_source.schema.root["c_allocation"])
 
         assert isinstance(result, IntegerAnswer)
         assert result.value == 42


### PR DESCRIPTION
## 🎫 Ticket
Extension to [FSPT-1344](https://mhclgdigital.atlassian.net/browse/FSPT-1344)

## 📝 Description
The above ticket updates the test factories to automatically create the right data for a grant recipient type data source. This PR extends that so that the factory will also create data source org items (the actual values for each grant recipient) for a new data source.

This is enabled by passing in `create_gr_org_items=True` to the factory. The factory assumes the schema is the default one provided by the factory (a single column called `c_allocation`) and adds data for each grant recipient for that column.

The exact data for each grant recipient can be supplied to the factory by passing `create_gr_org_items__data=[1,2,3]`, but if no data is supplied then a random number will be used for each data source organisation item.

The PR also updates the existing tests to use this rather than manually create the rows for each test.


[FSPT-1344]: https://mhclgdigital.atlassian.net/browse/FSPT-1344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ