### PR TITLE
FSPT-1342: Update missing data view and flow

### DIFF
--- a/app/deliver_grant_funding/data_sets.py
+++ b/app/deliver_grant_funding/data_sets.py
@@ -65,10 +65,6 @@ class MissingDataResult(BaseModel):
     row_results: list[MissingDataRow] = Field(default_factory=list)
 
     @property
-    def missing_columns_by_row(self) -> dict[int, list[str]]:
-        return {r.row_number: r.missing_columns for r in self.row_results}
-
-    @property
     def has_missing_data(self) -> bool:
         return bool(self.row_results)
 

--- a/app/deliver_grant_funding/data_sets.py
+++ b/app/deliver_grant_funding/data_sets.py
@@ -46,7 +46,6 @@ class BritishPoundsError(CellError):
 class RowValidationResult(BaseModel):
     row_number: int
     cell_errors: list[CellError] = Field(default_factory=list)
-    missing_columns: list[str] = Field(default_factory=list)
 
 
 class DataSetValidationResult(BaseModel):
@@ -56,13 +55,22 @@ class DataSetValidationResult(BaseModel):
     def blocking_errors(self) -> list[CellError]:
         return [e for r in self.row_results for e in r.cell_errors]
 
+
+class MissingDataRow(BaseModel):
+    row_number: int
+    missing_columns: list[str]
+
+
+class MissingDataResult(BaseModel):
+    row_results: list[MissingDataRow] = Field(default_factory=list)
+
     @property
     def missing_columns_by_row(self) -> dict[int, list[str]]:
-        return {r.row_number: r.missing_columns for r in self.row_results if r.missing_columns}
+        return {r.row_number: r.missing_columns for r in self.row_results}
 
     @property
     def has_missing_data(self) -> bool:
-        return any(r.missing_columns for r in self.row_results)
+        return bool(self.row_results)
 
 
 def _validate_decimal(stripped: str, mapping: DataSetColumnMapping, column: str) -> list[CellError]:
@@ -121,9 +129,7 @@ def _validate_row(row: TUnvalidatedDataSetRow, idx: int, data_set: DataSetUpload
         value = row.get(column, "").strip()
         mapping = data_set.get_column_mapping(column)
 
-        if not value:
-            result.missing_columns.append(column)
-        elif mapping:
+        if value and mapping:
             result.cell_errors.extend(_validate_cell(column, value, mapping))
 
     return result
@@ -221,10 +227,19 @@ def validate_data_set(
     result = DataSetValidationResult()
     for idx, row in enumerate(all_rows):
         row_result = _validate_row(row, idx, data_set)
-        if row_result.cell_errors or row_result.missing_columns:
+        if row_result.cell_errors:
             result.row_results.append(row_result)
     return result
 
 
 def build_data_set_upload_s3_key(grant_id: uuid.UUID, collection_id: uuid.UUID, data_source_id: uuid.UUID) -> str:
     return f"{current_app.config['REFERENCE_FILES_PREFIX']}/{grant_id}/{collection_id}/{data_source_id}"
+
+
+def check_missing_data(data_columns: list[str], all_rows: TUnvalidatedDataSetRows) -> MissingDataResult:
+    result = MissingDataResult()
+    for idx, row in enumerate(all_rows):
+        missing = [col for col in data_columns if not row.get(col, "").strip()]
+        if missing:
+            result.row_results.append(MissingDataRow(row_number=idx, missing_columns=missing))
+    return result

--- a/app/deliver_grant_funding/routes/collections.py
+++ b/app/deliver_grant_funding/routes/collections.py
@@ -117,6 +117,7 @@ from app.deliver_grant_funding.data_sets import (
     BritishPoundsError,
     DataSetValidationResult,
     build_data_set_upload_s3_key,
+    check_missing_data,
     validate_data_set,
     validate_data_set_grant_recipients,
 )
@@ -3384,12 +3385,17 @@ def _parse_data_set_csv(file_storage: FileStorage) -> tuple[list[str], TUnvalida
     return columns, rows
 
 
-def _load_and_validate_data_set(
-    data_set_data: DataSetUploadSessionModel,
-) -> tuple[TUnvalidatedDataSetRows, DataSetValidationResult]:
+def _load_rows(data_set_data: DataSetUploadSessionModel) -> TUnvalidatedDataSetRows:
     file_bytes = s3_service.download_file(data_set_data.s3_key)
     file_storage = FileStorage(stream=io.BytesIO(file_bytes), filename=data_set_data.original_filename)
     _, rows = _parse_data_set_csv(file_storage)
+    return rows
+
+
+def _load_and_validate_data_set(
+    data_set_data: DataSetUploadSessionModel,
+) -> tuple[TUnvalidatedDataSetRows, DataSetValidationResult]:
+    rows = _load_rows(data_set_data)
     return rows, validate_data_set(data_set_data, rows)
 
 
@@ -3461,6 +3467,20 @@ def upload_data_set(grant_id: UUID, collection_type: CollectionType, collection_
                 collection=collection,
                 form=form,
                 gr_errors=gr_errors,
+            )
+
+        missing_result = check_missing_data(session_data.data_columns, rows)
+        if missing_result.has_missing_data:
+            session_data.has_missing_data = True
+            session["data_set_upload"] = session_data.model_dump(mode="json")
+
+            return redirect(
+                url_for(
+                    "deliver_grant_funding.data_set_missing_data",
+                    grant_id=grant_id,
+                    collection_type=collection_type,
+                    collection_id=collection_id,
+                )
             )
 
         return redirect(
@@ -3542,16 +3562,6 @@ def map_data_set_columns(grant_id: UUID, collection_type: CollectionType, collec
 
         if validation_result is None:
             rows, validation_result = _load_and_validate_data_set(data_set_data)
-
-        if validation_result.blocking_errors or validation_result.has_missing_data:
-            return redirect(
-                url_for(
-                    "deliver_grant_funding.data_set_missing_data",
-                    grant_id=grant_id,
-                    collection_type=collection_type,
-                    collection_id=collection_id,
-                )
-            )
 
         try:
             data_source = create_uploaded_data_source(
@@ -3655,16 +3665,6 @@ def map_data_set_number_columns(
             errors = sorted(validation_result.blocking_errors, key=lambda e: e.column)
             column_errors = {col: list(errs) for col, errs in groupby(errors, key=lambda e: e.column)}
             form.columns.errors = form.build_number_column_form_errors(column_errors)
-
-        elif validation_result.has_missing_data:
-            return redirect(
-                url_for(
-                    "deliver_grant_funding.data_set_missing_data",
-                    grant_id=grant_id,
-                    collection_type=collection_type,
-                    collection_id=collection_id,
-                )
-            )
         else:
             data_source = create_uploaded_data_source(
                 name=data_set_data.name,
@@ -3723,7 +3723,6 @@ def map_data_set_number_columns(
 @auto_commit_after_request
 def data_set_missing_data(grant_id: UUID, collection_type: CollectionType, collection_id: UUID) -> ResponseReturnValue:
     collection = get_collection(collection_id, grant_id=grant_id, type_=collection_type)
-    user = get_current_user()
 
     data_set_data = _extract_data_set_data_from_session()
     if not data_set_data:
@@ -3736,44 +3735,25 @@ def data_set_missing_data(grant_id: UUID, collection_type: CollectionType, colle
             )
         )
 
-    rows, validation_result = _load_and_validate_data_set(data_set_data)
+    rows = _load_rows(data_set_data)
+    missing_result = check_missing_data(data_set_data.data_columns, rows)
+
+    if not missing_result.has_missing_data:
+        return redirect(
+            url_for(
+                "deliver_grant_funding.map_data_set_columns",
+                grant_id=grant_id,
+                collection_type=collection_type,
+                collection_id=collection_id,
+            )
+        )
 
     form = GenericSubmitForm()
 
-    if form.validate_on_submit() and not validation_result.blocking_errors:
-        data_source = create_uploaded_data_source(
-            name=data_set_data.name,
-            data_source_type=data_set_data.data_source_type,
-            grant_id=grant_id,
-            collection_id=collection.id,
-            column_mappings=data_set_data.column_mappings,
-            all_rows=rows,
-            user=user,
-            s3_key=data_set_data.s3_key,
-            original_filename=data_set_data.original_filename,
-            data_source_id=data_set_data.data_source_id,
-        )
-
-        s3_service.update_file_tags(data_set_data.s3_key, {"status": DataSourceFileTagEnum.IN_USE})
-
-        data_source_url = url_for(
-            "deliver_grant_funding.view_data_source",
-            grant_id=grant_id,
-            collection_type=collection_type,
-            collection_id=collection_id,
-            data_source_id=data_source.id,
-        )
-        session.pop("data_set_upload", None)
-        # TODO: This should be a nicely repeatable kind of flash message rather than a bespoke flash in the route
-        flash(
-            Markup(
-                f"You can now reference {escape(data_set_data.name)} data in the {escape(collection.name)} grant form. "
-                + f"<a class='govuk-link govuk-link--no-visited-state' href='{data_source_url}'>View data set</a>"
-            )
-        )
+    if form.validate_on_submit():
         return redirect(
             url_for(
-                "deliver_grant_funding.list_collection_data_sets",
+                "deliver_grant_funding.map_data_set_columns",
                 grant_id=grant_id,
                 collection_type=collection_type,
                 collection_id=collection_id,
@@ -3786,7 +3766,7 @@ def data_set_missing_data(grant_id: UUID, collection_type: CollectionType, colle
         collection=collection,
         session_data=data_set_data,
         form=form,
-        validation_result=validation_result,
+        missing_result=missing_result,
         all_rows=rows,
     )
 

--- a/app/deliver_grant_funding/session_models.py
+++ b/app/deliver_grant_funding/session_models.py
@@ -170,6 +170,7 @@ class DataSetUploadSessionModel(BaseModel):
     s3_key: str
     preview_data: TDataSetPreviewData
     column_mappings: list[DataSetColumnMapping] = Field(default_factory=list)
+    has_missing_data: bool = False
 
     @classmethod
     def from_session(cls, session_data: dict[str, Any]) -> DataSetUploadSessionModel:

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/collections/data_sets/data_set_missing_data.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/collections/data_sets/data_set_missing_data.html
@@ -25,31 +25,25 @@
   </div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      {% set table_head = [{"text": "Row"}, {"text": constants.data_set_external_id_column_header}, {"text": constants.data_set_grant_recipient_column_header}] %}
+      {% set table_head = [{"text": constants.data_set_external_id_column_header}, {"text": constants.data_set_grant_recipient_column_header}] %}
       {% for column in session_data.data_columns %}
         {% do table_head.append({"text": column}) %}
       {% endfor %}
 
       {% set rows = [] %}
-      {% for missing_data_row in missing_result.missing_columns_by_row %}
-        {% set data_row = all_rows[missing_data_row] %}
-
-        {# Apologies to future selves - missing_data_row is the index for the row in the list rather than the row
-        in the csv, which is what we need to show in this table so the user knows which rows to fix up #}
+      {% for missing_data_row in missing_result.row_results %}
+        {% set data_row = all_rows[missing_data_row.row_number] %}
         {%
           set row_cells = [
-            {"text": missing_data_row + 2},
             {"text": data_row.get(constants.data_set_external_id_column_header)},
             {"text": data_row.get(constants.data_set_grant_recipient_column_header)}
           ]
         %}
-
         {% for column in session_data.data_columns %}
-          {% set val = data_row.get(column, "") %}
-          {% if not val %}
+          {% if column in missing_data_row.missing_columns %}
             {% do row_cells.append({"html": "<span class='govuk-tag govuk-tag--orange'>Data missing</span>"}) %}
           {% else %}
-            {% do row_cells.append({"text": val}) %}
+            {% do row_cells.append({"text": data_row.get(column, "")}) %}
           {% endif %}
         {% endfor %}
         {% do rows.append(row_cells) %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/collections/data_sets/data_set_missing_data.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/collections/data_sets/data_set_missing_data.html
@@ -6,15 +6,10 @@
 {% set type_constants = collection.type.constants %}
 {% set active_item_identifier = type_constants.active_nav %}
 
-{% set page_title = "Missing data in " ~ session_data.name %}
+{% set page_title = "Review missing data in " ~ session_data.name ~ " data set" %}
 
 {% block beforeContent %}
-  {% set has_manual_formatting = (session_data.column_mappings | selectattr("requires_manual_formatting") | list | length) > 0 %}
-  {% if has_manual_formatting %}
-    {% set back_link = url_for("deliver_grant_funding.map_data_set_number_columns", grant_id=grant.id, collection_type=collection.type, collection_id=collection.id) %}
-  {% else %}
-    {% set back_link = url_for("deliver_grant_funding.map_data_set_columns", grant_id=grant.id, collection_type=collection.type, collection_id=collection.id) %}
-  {% endif %}
+  {% set back_link = url_for("deliver_grant_funding.upload_data_set", grant_id=grant.id, collection_type=collection.type, collection_id=collection.id) %}
   {{ govukBackLink({ "text": "Back", "href": back_link }) }}
 {% endblock beforeContent %}
 
@@ -23,9 +18,9 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">
         <span class="govuk-caption-l">{{ collection.name }}</span>
-        Missing data in {{ session_data.name }}
+        Review missing data in {{ session_data.name }} data set
       </h1>
-      {{ govukWarningText({"text": ("Grant recipients with missing data cannot complete the " ~ type_constants.singular ~ " until the missing data is uploaded.")}) }}
+      {{ govukWarningText({"text": ("Grant recipients will not be able to complete the " ~ type_constants.singular ~ " until their missing data is uploaded. You can replace the data set file to update it later.")}) }}
     </div>
   </div>
   <div class="govuk-grid-row">
@@ -36,7 +31,7 @@
       {% endfor %}
 
       {% set rows = [] %}
-      {% for missing_data_row in validation_result.missing_columns_by_row %}
+      {% for missing_data_row in missing_result.missing_columns_by_row %}
         {% set data_row = all_rows[missing_data_row] %}
 
         {# Apologies to future selves - missing_data_row is the index for the row in the list rather than the row
@@ -52,7 +47,7 @@
         {% for column in session_data.data_columns %}
           {% set val = data_row.get(column, "") %}
           {% if not val %}
-            {% do row_cells.append({"html": "<span class='govuk-tag govuk-tag--yellow'>Data missing</span>"}) %}
+            {% do row_cells.append({"html": "<span class='govuk-tag govuk-tag--orange'>Data missing</span>"}) %}
           {% else %}
             {% do row_cells.append({"text": val}) %}
           {% endif %}
@@ -65,7 +60,7 @@
       <form method="POST" novalidate>
         <div class="govuk-button-group">
           {{ form.csrf_token }}
-          {{ form.submit(params={"text": "Continue and upload data set" }) }}
+          {{ form.submit(params={"text": "Continue" }) }}
           <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.list_collection_data_sets', grant_id=grant.id, collection_type=collection.type, collection_id=collection.id) }}">Cancel</a>
         </div>
       </form>

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/collections/data_sets/map_columns.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/collections/data_sets/map_columns.html
@@ -8,7 +8,11 @@
 {% set page_title = "Map " ~ session_data.name ~ " data columns" %}
 
 {% block beforeContent %}
-  {% set back_link = url_for("deliver_grant_funding.upload_data_set", grant_id=grant.id, collection_type=collection.type, collection_id=collection.id) %}
+  {% if session_data.has_missing_data %}
+    {% set back_link = url_for("deliver_grant_funding.data_set_missing_data", grant_id=grant.id, collection_type=collection.type, collection_id=collection.id) %}
+  {% else %}
+    {% set back_link = url_for("deliver_grant_funding.upload_data_set", grant_id=grant.id, collection_type=collection.type, collection_id=collection.id) %}
+  {% endif %}
   {{ govukBackLink({ "text": "Back", "href": back_link }) }}
 {% endblock beforeContent %}
 

--- a/tests/integration/deliver_grant_funding/routes/test_collections.py
+++ b/tests/integration/deliver_grant_funding/routes/test_collections.py
@@ -9537,6 +9537,48 @@ class TestUploadDataSet:
         assert mock_s3_service_calls.upload_file_calls[0].args[1] == expected_s3_key
         assert mock_s3_service_calls.upload_file_calls[0].args[2] == {"status": DataSourceFileTagEnum.PENDING}
 
+    def test_post_csv_with_missing_data_redirects_to_missing_data(
+        self, authenticated_grant_admin_client, factories, mock_s3_service_calls
+    ):
+        grant = authenticated_grant_admin_client.grant
+        collection = factories.collection.create(grant=grant)
+        factories.grant_recipient.create(grant=grant, organisation__external_id="E123", organisation__name="Rivendell")
+        factories.grant_recipient.create(grant=grant, organisation__external_id="E456", organisation__name="Lothlorien")
+
+        csv_content = "Organisation ID,Grant recipient,Amount\nE123,Rivendell,\nE456,Lothlorien,2000"
+        data = {
+            "name": "Test Data Set",
+            "data_source_type": DataSourceType.GRANT_RECIPIENT,
+            "file": (io.BytesIO(csv_content.encode("utf-8")), "test.csv"),
+        }
+
+        response = authenticated_grant_admin_client.post(
+            url_for(
+                "deliver_grant_funding.upload_data_set",
+                grant_id=grant.id,
+                collection_type=CollectionType.MONITORING_REPORT,
+                collection_id=collection.id,
+            ),
+            data=data,
+            content_type="multipart/form-data",
+        )
+
+        assert response.status_code == 302
+        assert response.location == (
+            url_for(
+                "deliver_grant_funding.data_set_missing_data",
+                grant_id=grant.id,
+                collection_type=CollectionType.MONITORING_REPORT,
+                collection_id=collection.id,
+            )
+        )
+
+        with authenticated_grant_admin_client.session_transaction() as session:
+            session_data = session.get("data_set_upload")
+            assert session_data is not None
+
+        assert session_data["has_missing_data"] is True
+
     def test_post_raises_errors_for_incorrect_grant_recipient_data(
         self, authenticated_grant_admin_client, factories, mock_s3_service_calls
     ):
@@ -9635,7 +9677,8 @@ class TestMapDataSetColumns:
         )
         assert response.status_code == 404
 
-    def test_get_renders_columns_and_preview(self, authenticated_grant_admin_client, factories):
+    @pytest.mark.parametrize("has_missing_data", [True, False])
+    def test_get_renders_columns_and_preview(self, authenticated_grant_admin_client, has_missing_data, factories):
         collection = factories.collection.create(grant=authenticated_grant_admin_client.grant)
 
         with authenticated_grant_admin_client.session_transaction() as session:
@@ -9651,6 +9694,7 @@ class TestMapDataSetColumns:
                 data_source_id=uuid.uuid4(),
                 original_filename="test.csv",
                 s3_key="data-set-uploads/test.csv",
+                has_missing_data=has_missing_data,
             ).model_dump(mode="json")
 
         response = authenticated_grant_admin_client.get(
@@ -9675,6 +9719,21 @@ class TestMapDataSetColumns:
             assert col in soup.text
             select = soup.find("select", {"name": f"columns-{idx}-column_type"})
             assert select is not None
+
+        if has_missing_data:
+            assert page_has_link(soup, "Back").get("href") == url_for(
+                "deliver_grant_funding.data_set_missing_data",
+                grant_id=collection.grant.id,
+                collection_type=CollectionType.MONITORING_REPORT,
+                collection_id=collection.id,
+            )
+        else:
+            assert page_has_link(soup, "Back").get("href") == url_for(
+                "deliver_grant_funding.upload_data_set",
+                grant_id=collection.grant.id,
+                collection_type=CollectionType.MONITORING_REPORT,
+                collection_id=collection.id,
+            )
 
     def test_get_repopulates_form_from_session(self, authenticated_grant_admin_client, factories):
         collection = factories.collection.create(grant=authenticated_grant_admin_client.grant)
@@ -9837,65 +9896,6 @@ class TestMapDataSetColumns:
 
         assert len(mock_s3_service_calls.update_file_tags) == 1
         assert mock_s3_service_calls.update_file_tags[0].args[1] == {"status": DataSourceFileTagEnum.IN_USE}
-
-    def test_post_with_errors_redirects_to_data_set_errors(
-        self, authenticated_grant_admin_client, factories, mock_s3_service_calls, mocker
-    ):
-        collection = factories.collection.create(grant=authenticated_grant_admin_client.grant)
-        grant_recipient = factories.grant_recipient.create(
-            grant=authenticated_grant_admin_client.grant, organisation__external_id="EC123"
-        )
-        grant_recipient_2 = factories.grant_recipient.create(
-            grant=authenticated_grant_admin_client.grant, organisation__external_id="EC456"
-        )
-        with authenticated_grant_admin_client.session_transaction() as session:
-            session["data_set_upload"] = DataSetUploadSessionModel(
-                name="Test Data Set",
-                data_source_type=DataSourceType.GRANT_RECIPIENT,
-                data_columns=["Area description"],
-                preview_data={"Area description": ["A wonderful place"]},
-                data_source_id=uuid.uuid4(),
-                original_filename="test.csv",
-                s3_key="data-set-uploads/test.csv",
-            ).model_dump(mode="json")
-
-        all_rows = [
-            {
-                DATA_SET_GRANT_RECIPIENT_COLUMN_HEADER: grant_recipient.organisation.name,
-                DATA_SET_EXTERNAL_ID_COLUMN_HEADER: grant_recipient.organisation.external_id,
-                "Area description": "",
-            },
-            {
-                DATA_SET_GRANT_RECIPIENT_COLUMN_HEADER: grant_recipient_2.organisation.name,
-                DATA_SET_EXTERNAL_ID_COLUMN_HEADER: grant_recipient_2.organisation.external_id,
-                "Area description": "A wonderful place",
-            },
-        ]
-        mocker.patch("app.services.s3.S3Service.download_file", return_value=_rows_to_csv_bytes(all_rows))
-
-        data = {
-            "columns-0-column_type": "TEXT",
-            "submit": "y",
-        }
-        response = authenticated_grant_admin_client.post(
-            url_for(
-                "deliver_grant_funding.map_data_set_columns",
-                grant_id=collection.grant.id,
-                collection_type=CollectionType.MONITORING_REPORT,
-                collection_id=collection.id,
-            ),
-            data=data,
-            follow_redirects=False,
-        )
-        assert response.status_code == 302
-        assert response.location == (
-            url_for(
-                "deliver_grant_funding.data_set_missing_data",
-                grant_id=authenticated_grant_admin_client.grant.id,
-                collection_type=CollectionType.MONITORING_REPORT,
-                collection_id=collection.id,
-            )
-        )
 
     def test_post_missing_required_field_shows_error(self, authenticated_grant_admin_client, factories):
         collection = factories.collection.create(grant=authenticated_grant_admin_client.grant)
@@ -10224,61 +10224,6 @@ class TestMapDataSetNumberColumns:
         with authenticated_grant_admin_client.session_transaction() as updated_session:
             assert updated_session.get("data_set_upload") is None
 
-    def test_post_redirects_to_data_set_errors_when_missing_data(
-        self, authenticated_grant_admin_client, factories, mock_s3_service_calls, mocker
-    ):
-        collection = factories.collection.create(grant=authenticated_grant_admin_client.grant)
-        with authenticated_grant_admin_client.session_transaction() as session:
-            session["data_set_upload"] = DataSetUploadSessionModel(
-                name="Test Data Set",
-                data_source_type=DataSourceType.GRANT_RECIPIENT,
-                data_columns=["Capital allocation"],
-                preview_data={
-                    "Capital allocation": [],
-                },
-                column_mappings=[
-                    DataSetColumnMapping(column_name="Capital allocation", column_type="INTEGER"),
-                ],
-                data_source_id=uuid.uuid4(),
-                original_filename="test.csv",
-                s3_key="data-set-uploads/test.csv",
-            ).model_dump(mode="json")
-
-        all_rows = [
-            {
-                DATA_SET_EXTERNAL_ID_COLUMN_HEADER: "E123",
-                DATA_SET_GRANT_RECIPIENT_COLUMN_HEADER: "Lothlorien",
-                "Capital allocation": "",
-            }
-        ]
-        mocker.patch("app.services.s3.S3Service.download_file", return_value=_rows_to_csv_bytes(all_rows))
-
-        data = {
-            "columns-0-prefix": "£",
-            "columns-0-suffix": "",
-            "columns-0-max_decimal_places": "",
-            "submit": "y",
-        }
-        response = authenticated_grant_admin_client.post(
-            url_for(
-                "deliver_grant_funding.map_data_set_number_columns",
-                grant_id=collection.grant.id,
-                collection_type=CollectionType.MONITORING_REPORT,
-                collection_id=collection.id,
-            ),
-            data=data,
-            follow_redirects=False,
-        )
-        assert response.status_code == 302
-        assert response.location == (
-            url_for(
-                "deliver_grant_funding.data_set_missing_data",
-                grant_id=authenticated_grant_admin_client.grant.id,
-                collection_type=CollectionType.MONITORING_REPORT,
-                collection_id=collection.id,
-            )
-        )
-
     def test_post_shows_form_errors(self, authenticated_grant_admin_client, factories):
         collection = factories.collection.create(grant=authenticated_grant_admin_client.grant)
         with authenticated_grant_admin_client.session_transaction() as session:
@@ -10471,7 +10416,68 @@ class TestDataSetMissingData:
         assert soup.find("div", {"class": "govuk-error-summary"}) is None
         assert "Data missing" in soup.text
 
-    def test_post_creates_data_source_and_redirects(
+    def test_get_data_set_missing_data_with_no_missing_data_redirects(
+        self, authenticated_grant_admin_client, factories, mocker
+    ):
+        grant = authenticated_grant_admin_client.grant
+        collection = factories.collection.create(grant=grant)
+        gr = factories.grant_recipient.create(
+            grant=grant, organisation__external_id="EC123", organisation__name="Rivendell"
+        )
+        gr2 = factories.grant_recipient.create(
+            grant=grant, organisation__external_id="EC456", organisation__name="Lothlorien"
+        )
+
+        with authenticated_grant_admin_client.session_transaction() as session:
+            session["data_set_upload"] = {
+                "name": "Test Data Set",
+                "data_source_type": DataSourceType.GRANT_RECIPIENT,
+                "data_columns": ["Capital allocation"],
+                "preview_data": {},
+                "column_mappings": [
+                    DataSetColumnMapping(column_name="Capital allocation", column_type="BRITISH_POUNDS").model_dump(
+                        mode="json"
+                    ),
+                ],
+                "data_source_id": uuid.uuid4(),
+                "original_filename": "test.csv",
+                "s3_key": "data-set-uploads/test.csv",
+            }
+
+        all_rows = [
+            {
+                DATA_SET_EXTERNAL_ID_COLUMN_HEADER: gr.organisation.external_id,
+                DATA_SET_GRANT_RECIPIENT_COLUMN_HEADER: gr.organisation.name,
+                "Capital allocation": "£2000.00",
+            },
+            {
+                DATA_SET_EXTERNAL_ID_COLUMN_HEADER: gr2.organisation.external_id,
+                DATA_SET_GRANT_RECIPIENT_COLUMN_HEADER: gr2.organisation.name,
+                "Capital allocation": "£1000.00",
+            },
+        ]
+
+        mocker.patch("app.services.s3.S3Service.download_file", return_value=_rows_to_csv_bytes(all_rows))
+
+        response = authenticated_grant_admin_client.get(
+            url_for(
+                "deliver_grant_funding.data_set_missing_data",
+                grant_id=grant.id,
+                collection_type=CollectionType.MONITORING_REPORT,
+                collection_id=collection.id,
+            ),
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 302
+        assert response.location == url_for(
+            "deliver_grant_funding.map_data_set_columns",
+            grant_id=collection.grant.id,
+            collection_type=CollectionType.MONITORING_REPORT,
+            collection_id=collection.id,
+        )
+
+    def test_post_redirects_to_map_columns(
         self, authenticated_grant_admin_client, factories, db_session, mock_s3_service_calls, mocker
     ):
         collection = factories.collection.create(grant=authenticated_grant_admin_client.grant)
@@ -10537,43 +10543,16 @@ class TestDataSetMissingData:
                 collection_id=collection.id,
             ),
             data=data,
-            follow_redirects=True,
+            follow_redirects=False,
         )
 
-        assert response.status_code == 200
-        soup = BeautifulSoup(response.data, "html.parser")
-        assert page_has_flash(
-            soup, f"You can now reference {session['data_set_upload']['name']} data in the {collection.name} grant form"
+        assert response.status_code == 302
+        assert response.location == url_for(
+            "deliver_grant_funding.map_data_set_columns",
+            grant_id=collection.grant.id,
+            collection_type=CollectionType.MONITORING_REPORT,
+            collection_id=collection.id,
         )
-
-        assert len(mock_s3_service_calls.update_file_tags) == 1
-        assert mock_s3_service_calls.update_file_tags[0].args[1] == {"status": DataSourceFileTagEnum.IN_USE}
-
-        data_sources = db_session.query(DataSource).all()
-
-        assert len(data_sources) == 1
-        data_source = data_sources[0]
-
-        assert data_source.name == session["data_set_upload"]["name"]
-        assert data_source.type == DataSourceType.GRANT_RECIPIENT
-        assert data_source.grant_id == authenticated_grant_admin_client.grant.id
-        schema = data_source.schema.root
-        assert schema is not None
-        assert "c_capital_allocation" in schema
-        assert "c_revenue_allocation" in schema
-        revenue_allocation = schema["c_revenue_allocation"]
-        assert revenue_allocation.presentation_options.prefix == "£"
-
-        org_items = (
-            db_session.query(DataSourceOrganisationItem)
-            .filter_by(data_source_id=data_source.id)
-            .order_by(DataSourceOrganisationItem.external_id)
-            .all()
-        )
-        assert len(org_items) == 2
-        assert org_items[0].external_id == grant_recipient.organisation.external_id
-        assert org_items[1].external_id == grant_recipient_2.organisation.external_id
-        assert org_items[1]._data["c_revenue_allocation"] == "200.00"
 
 
 class TestViewDataSource:

--- a/tests/integration/deliver_grant_funding/test_data_sets.py
+++ b/tests/integration/deliver_grant_funding/test_data_sets.py
@@ -5,6 +5,7 @@ from app.constants import DATA_SET_EXTERNAL_ID_COLUMN_HEADER, DATA_SET_GRANT_REC
 from app.deliver_grant_funding.data_sets import (
     BritishPoundsError,
     DataTypeError,
+    check_missing_data,
     validate_data_set,
     validate_data_set_grant_recipients,
 )
@@ -52,59 +53,6 @@ class TestValidateDataSet:
         result = validate_data_set(data_set, all_rows)
 
         assert not result.blocking_errors
-        assert not result.has_missing_data
-
-    def test_missing_value_is_non_blocking_for_grant_recipient(self, factories):
-        gr = factories.grant_recipient.create(organisation__external_id="EC123")
-        data_set = _make_data_set(
-            data_columns=["Notes"],
-            column_mappings=[DataSetColumnMapping(column_name="Notes", column_type="TEXT")],
-        )
-
-        all_rows = [
-            {
-                DATA_SET_EXTERNAL_ID_COLUMN_HEADER: gr.organisation.external_id,
-                DATA_SET_GRANT_RECIPIENT_COLUMN_HEADER: gr.organisation.name,
-                "Notes": "",
-            }
-        ]
-
-        result = validate_data_set(data_set, all_rows)
-
-        assert not result.blocking_errors
-        assert result.has_missing_data
-        assert result.missing_columns_by_row[0] == ["Notes"]
-
-    def test_missing_columns_by_row_tracks_correct_columns(self, factories):
-        gr = factories.grant_recipient.create(organisation__external_id="EC123")
-        gr2 = factories.grant_recipient.create(organisation__external_id="EC456")
-        data_set = _make_data_set(
-            data_columns=["Notes", "Summary"],
-            column_mappings=[
-                DataSetColumnMapping(column_name="Notes", column_type="TEXT"),
-                DataSetColumnMapping(column_name="Summary", column_type="TEXT"),
-            ],
-        )
-
-        all_rows = [
-            {
-                DATA_SET_EXTERNAL_ID_COLUMN_HEADER: gr.organisation.external_id,
-                DATA_SET_GRANT_RECIPIENT_COLUMN_HEADER: gr.organisation.name,
-                "Notes": "",
-                "Summary": "ok",
-            },
-            {
-                DATA_SET_EXTERNAL_ID_COLUMN_HEADER: gr2.organisation.external_id,
-                DATA_SET_GRANT_RECIPIENT_COLUMN_HEADER: gr2.organisation.name,
-                "Notes": "",
-                "Summary": "",
-            },
-        ]
-
-        result = validate_data_set(data_set, all_rows)
-
-        assert result.missing_columns_by_row[0] == ["Notes"]
-        assert result.missing_columns_by_row[1] == ["Notes", "Summary"]
 
     def test_wrong_prefix_symbol_for_british_pounds_collapses_to_single_error(self, factories):
         gr = factories.grant_recipient.create(organisation__external_id="EC123")
@@ -222,7 +170,7 @@ class TestValidateDataSet:
         assert result.blocking_errors
         assert any(isinstance(e, DataTypeError) for e in result.blocking_errors)
 
-    def test_row_with_both_blocking_error_and_missing_column(self, factories):
+    def test_row_with_blocking_error(self, factories):
         gr = factories.grant_recipient.create(organisation__external_id="EC123")
         data_set = _make_data_set(
             data_columns=["Capital allocation", "Notes"],
@@ -244,9 +192,7 @@ class TestValidateDataSet:
         result = validate_data_set(data_set, all_rows)
 
         assert result.blocking_errors
-        assert result.has_missing_data
         assert any(isinstance(e, BritishPoundsError) for e in result.blocking_errors)
-        assert result.missing_columns_by_row[0] == ["Notes"]
 
     def test_multiple_errors_across_rows(self, factories):
         gr = factories.grant_recipient.create(organisation__external_id="EC123")
@@ -282,6 +228,70 @@ class TestValidateDataSet:
 
         assert sum(isinstance(e, BritishPoundsError) for e in result.blocking_errors) == 2
         assert sum(isinstance(e, DataTypeError) for e in result.blocking_errors) == 1
+
+
+class TestCheckMissingData:
+    def test_missing_data_flagged_and_tracks_correct_columns(self, factories):
+        gr = factories.grant_recipient.create(organisation__external_id="EC123")
+        gr2 = factories.grant_recipient.create(organisation__external_id="EC456")
+        data_set = _make_data_set(
+            data_columns=["Notes", "Summary"],
+            column_mappings=[
+                DataSetColumnMapping(column_name="Notes", column_type="TEXT"),
+                DataSetColumnMapping(column_name="Summary", column_type="TEXT"),
+            ],
+        )
+
+        all_rows = [
+            {
+                DATA_SET_EXTERNAL_ID_COLUMN_HEADER: gr.organisation.external_id,
+                DATA_SET_GRANT_RECIPIENT_COLUMN_HEADER: gr.organisation.name,
+                "Notes": "",
+                "Summary": "ok",
+            },
+            {
+                DATA_SET_EXTERNAL_ID_COLUMN_HEADER: gr2.organisation.external_id,
+                DATA_SET_GRANT_RECIPIENT_COLUMN_HEADER: gr2.organisation.name,
+                "Notes": "",
+                "Summary": "",
+            },
+        ]
+
+        result = check_missing_data(data_set.data_columns, all_rows)
+
+        assert result.row_results[0].missing_columns == ["Notes"]
+        assert result.row_results[1].missing_columns == ["Notes", "Summary"]
+
+    def test_missing_data_returns_empty_result_when_no_missing_data(self, factories):
+        gr = factories.grant_recipient.create(organisation__external_id="EC123")
+        gr2 = factories.grant_recipient.create(organisation__external_id="EC456")
+        data_set = _make_data_set(
+            data_columns=["Notes", "Summary"],
+            column_mappings=[
+                DataSetColumnMapping(column_name="Notes", column_type="TEXT"),
+                DataSetColumnMapping(column_name="Summary", column_type="TEXT"),
+            ],
+        )
+
+        all_rows = [
+            {
+                DATA_SET_EXTERNAL_ID_COLUMN_HEADER: gr.organisation.external_id,
+                DATA_SET_GRANT_RECIPIENT_COLUMN_HEADER: gr.organisation.name,
+                "Notes": "Some notes",
+                "Summary": "ok",
+            },
+            {
+                DATA_SET_EXTERNAL_ID_COLUMN_HEADER: gr2.organisation.external_id,
+                DATA_SET_GRANT_RECIPIENT_COLUMN_HEADER: gr2.organisation.name,
+                "Notes": "Words",
+                "Summary": "More words",
+            },
+        ]
+
+        result = check_missing_data(data_set.data_columns, all_rows)
+
+        assert result.has_missing_data is False
+        assert result.row_results == []
 
 
 class TestValidateDataSetGrantRecipients:


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-1342

## 📝 Description
The 'data set missing data' view would previously be displayed at the end of the data set upload flow as a final check. The revised designs now have this appearing after the initial file upload, allowing the user to proceed if they want or go back/cancel and reupload a fixed file rather than having to proceed through the flow.

This simplifies the upload flow significantly as we only have to check for missing data once after the initial file upload, rather than at every stage of data set validation before upload, and also simplifies the 'missing data' view itself as we no longer need to display the original CSV row number.

## 📸 Show the thing (screenshots, gifs)
<img width="1048" height="786" alt="2026-06-11 11 23 17" src="https://github.com/user-attachments/assets/a8889a9c-1285-4ee0-aff1-7654d1c3ff20" />

## 🧪 Testing
Upload a CSV with missing data - you should hit the 'data set missing data' view directly after upload now, as opposed to the end of the flow, and be able to navigate forward and back correctly through the flow. If you upload a CSV with no missing data, clicking 'back' on the map columns page should take you back to the initial upload page rather than the missing data view.

## 📋 Developer Checklist

### Review Readiness
- [X] PR title and description provide sufficient context for reviewers
- [X] Commits are logical, self-contained, and have clear descriptions

### Testing
- [X] I have tested this change and it meets the acceptance criteria for the ticket
- ~[ ] I need the reviewer(s) to pull and run this change locally~
- [X] New (non-developer) functionality has appropriate unit and integration tests
- ~[ ] End-to-end tests have been updated (if applicable)~
- [X] Edge cases and error conditions are tested