### PR TITLE
Use 'grant details' as primary landing page

### DIFF
--- a/app/deliver_grant_funding/routes/misc.py
+++ b/app/deliver_grant_funding/routes/misc.py
@@ -16,7 +16,7 @@ from app.types import FlashMessageType
 @deliver_grant_funding_blueprint.route("/<uuid:grant_id>/index", methods=["GET"])
 @has_deliver_grant_role(RoleEnum.MEMBER)
 def grant_homepage(grant_id: UUID) -> ResponseReturnValue:
-    return redirect(url_for("deliver_grant_funding.list_reports", grant_id=grant_id))
+    return redirect(url_for("deliver_grant_funding.grant_details", grant_id=grant_id))
 
 
 @deliver_grant_funding_blueprint.route("/grants", methods=["GET"])

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/grant_base.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/grant_base.html
@@ -3,7 +3,14 @@
 {% set cspNonce = csp_nonce() %}
 
 {% set nav_items = [] %}
-
+{%
+  do nav_items.append({
+      "text": "Grant details",
+      "key": "grant_details",
+      "href": url_for("deliver_grant_funding.grant_details", grant_id=grant.id),
+      "current": active_item_identifier == "details"
+  })
+%}
 {% if feature_flags.PRE_AWARD.is_enabled %}
   {%
     do nav_items.append({
@@ -27,12 +34,6 @@
           "key": "grant_users",
           "href": url_for("deliver_grant_funding.list_users_for_grant", grant_id=grant.id),
           "current": active_item_identifier == "grant_team"
-      },
-      {
-          "text": "Grant details",
-          "key": "grant_details",
-          "href": url_for("deliver_grant_funding.grant_details", grant_id=grant.id),
-          "current": active_item_identifier == "details"
       },
   ])
 %}

--- a/tests/e2e/deliver_grant_funding/pages.py
+++ b/tests/e2e/deliver_grant_funding/pages.py
@@ -33,7 +33,7 @@ class SSOSignInPage(BasePage):
         # If already logged in, this will redirect to /grants
         expect(
             self.title.or_(self.page.get_by_role("heading", name="Grants", exact=True)).or_(
-                self.page.get_by_role("heading", name="Reports")
+                self.page.get_by_role("heading", name="Grant details")
             )
         ).to_be_visible()
 


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-1420

## 📝 Description
Now that grants (can) have both a 'Pre-award' and a 'Reports' tab, we don't know which the user is intending to access, so taking them to the 'Reports' tab by default feels wrong.

This switches the default landing page when clicking into a grant on Deliver to be the 'Grant details' tab, and moves that to the start of the service navigation.


## 📸 Show the thing (screenshots, gifs)
<!-- Include screenshots for UI changes, new features, or visual modifications -->
<!-- Use "Before" and "After" sections if showing changes to existing functionality -->

### Before

<img width="2168" height="1868" alt="2026-06-12 10 46 34" src="https://github.com/user-attachments/assets/916f49df-22ac-4e30-9d03-e8b807204c75" />

### After
<img width="2118" height="1832" alt="2026-06-12 10 46 09" src="https://github.com/user-attachments/assets/6911e307-25b0-498b-a93f-5acc69d7013b" />


## 🧪 Testing
<!-- Describe how you've tested this change, and how a reviewer can test it -->

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [ ] I need the reviewer(s) to pull and run this change locally
- [ ] New (non-developer) functionality has appropriate unit and integration tests
- [ ] End-to-end tests have been updated (if applicable)
- [ ] Edge cases and error conditions are tested

## 📚 Additional Notes
<!-- Any additional context, concerns, or considerations for reviewers -->
