### PR TITLE
Add grant recipient status

### DIFF
--- a/app/common/data/interfaces/grant_recipients.py
+++ b/app/common/data/interfaces/grant_recipients.py
@@ -7,7 +7,13 @@ from sqlalchemy.orm import joinedload, selectinload
 from app.common.data.interfaces.exceptions import flush_and_rollback_on_exceptions
 from app.common.data.models import Grant, GrantRecipient, Organisation
 from app.common.data.models_user import User, UserRole
-from app.common.data.types import GrantRecipientModeEnum, RoleEnum, SubmissionModeEnum, SubmissionStatusEnum
+from app.common.data.types import (
+    GrantRecipientModeEnum,
+    GrantRecipientStatusEnum,
+    RoleEnum,
+    SubmissionModeEnum,
+    SubmissionStatusEnum,
+)
 from app.extensions import db
 
 
@@ -104,12 +110,17 @@ def get_grant_recipients_count(grant: Grant, mode: GrantRecipientModeEnum = Gran
 
 @flush_and_rollback_on_exceptions()
 def create_grant_recipients(
-    grant: Grant, organisation_ids: list[uuid.UUID], mode: GrantRecipientModeEnum = GrantRecipientModeEnum.LIVE
+    grant: Grant,
+    organisation_ids: list[uuid.UUID],
+    status: GrantRecipientStatusEnum,
+    mode: GrantRecipientModeEnum = GrantRecipientModeEnum.LIVE,
 ) -> None:
     grant_recipients = []
 
     for organisation_id in organisation_ids:
-        grant_recipients.append(GrantRecipient(grant_id=grant.id, organisation_id=organisation_id, mode=mode))
+        grant_recipients.append(
+            GrantRecipient(grant_id=grant.id, organisation_id=organisation_id, mode=mode, status=status)
+        )
 
     db.session.add_all(grant_recipients)
 

--- a/app/common/data/migrations/.current-alembic-head
+++ b/app/common/data/migrations/.current-alembic-head
@@ -1,1 +1,1 @@
-064_remove_data_set_types
+065_add_grant_recipient_status

--- a/app/common/data/migrations/versions/065_add_grant_recipient_status.py
+++ b/app/common/data/migrations/versions/065_add_grant_recipient_status.py
@@ -1,0 +1,40 @@
+"""add grant recipient status
+
+Revision ID: 065_add_grant_recipient_status
+Revises: 064_remove_data_set_types
+Create Date: 2026-06-12 12:34:31.181762
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "065_add_grant_recipient_status"
+down_revision = "064_remove_data_set_types"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    sa.Enum("APPLYING", "ALLOCATED", "AWARDED", name="grantrecipientstatusenum").create(op.get_bind())
+    with op.batch_alter_table("grant_recipient", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "status",
+                postgresql.ENUM("APPLYING", "ALLOCATED", "AWARDED", name="grantrecipientstatusenum", create_type=False),
+                nullable=True,
+            )
+        )
+
+    op.execute("UPDATE grant_recipient SET status = 'AWARDED'")
+
+    with op.batch_alter_table("grant_recipient", schema=None) as batch_op:
+        batch_op.alter_column("status", nullable=False)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("grant_recipient", schema=None) as batch_op:
+        batch_op.drop_column("status")
+
+    sa.Enum("APPLYING", "ALLOCATED", "AWARDED", name="grantrecipientstatusenum").drop(op.get_bind())

--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -45,6 +45,7 @@ from app.common.data.types import (
     ExpressionType,
     FileUploadTypes,
     GrantRecipientModeEnum,
+    GrantRecipientStatusEnum,
     GrantStatusEnum,
     ManagedExpressionsEnum,
     MaximumFileSize,
@@ -1473,6 +1474,7 @@ class GrantRecipient(BaseModel):
     organisation_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("organisation.id"))
     grant_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("grant.id"))
     mode: Mapped[GrantRecipientModeEnum] = mapped_column(default=GrantRecipientModeEnum.LIVE)
+    status: Mapped[GrantRecipientStatusEnum]
 
     organisation: Mapped[Organisation] = relationship("Organisation")
     grant: Mapped[Grant] = relationship("Grant", back_populates="grant_recipients")

--- a/app/common/data/types.py
+++ b/app/common/data/types.py
@@ -120,6 +120,12 @@ class GrantRecipientModeEnum(enum.StrEnum):
         return GrantRecipientModeEnum(mode.value)
 
 
+class GrantRecipientStatusEnum(enum.StrEnum):
+    APPLYING = "applying"
+    ALLOCATED = "allocated"
+    AWARDED = "awarded"
+
+
 class SubmissionStatusEnum(enum.StrEnum):
     NOT_STARTED = "Not started"
     IN_PROGRESS = "In progress"

--- a/app/deliver_grant_funding/admin/entities.py
+++ b/app/deliver_grant_funding/admin/entities.py
@@ -429,8 +429,8 @@ class PlatformAdminGrantRecipientView(FlaskAdminPlatformAdminAccessibleMixin, Pl
     can_edit = False
     can_delete = True
 
-    column_list = ["grant.name", "organisation.name", "mode"]
-    column_filters = ["grant.name", "organisation.name", "mode"]
+    column_list = ["grant.name", "organisation.name", "mode", "status"]
+    column_filters = ["grant.name", "organisation.name", "mode", "status"]
     column_searchable_list = ["grant.name", "organisation.name"]
     column_labels = {"grant.name": "Grant name", "organisation.name": "Organisation name"}
 
@@ -439,7 +439,7 @@ class PlatformAdminGrantRecipientView(FlaskAdminPlatformAdminAccessibleMixin, Pl
         "organisation": lambda v, c, m, n: m.organisation.name,
     }
 
-    form_columns = ["grant", "organisation", "mode"]
+    form_columns = ["grant", "organisation", "mode", "status"]
 
     form_args = {
         "grant": {

--- a/app/deliver_grant_funding/admin/views.py
+++ b/app/deliver_grant_funding/admin/views.py
@@ -46,6 +46,7 @@ from app.common.data.types import (
     CollectionStatusEnum,
     CollectionType,
     GrantRecipientModeEnum,
+    GrantRecipientStatusEnum,
     GrantStatusEnum,
     OrganisationModeEnum,
     ReportAdminEmailTypeEnum,
@@ -451,7 +452,9 @@ class PlatformAdminReportingLifecycleView(FlaskAdminPlatformAdminGrantLifecycleM
         )
 
         if form.validate_on_submit():
-            create_grant_recipients(grant=grant, organisation_ids=form.recipients.data)
+            create_grant_recipients(
+                grant=grant, organisation_ids=form.recipients.data, status=GrantRecipientStatusEnum.AWARDED
+            )
 
             live_organisations = get_organisations(mode=OrganisationModeEnum.LIVE, with_ids=form.recipients.data)
             test_organisations = get_organisations(
@@ -460,7 +463,10 @@ class PlatformAdminReportingLifecycleView(FlaskAdminPlatformAdminGrantLifecycleM
             )
             test_organisation_ids = [org.id for org in test_organisations]
             create_grant_recipients(
-                grant=grant, organisation_ids=test_organisation_ids, mode=GrantRecipientModeEnum.TEST
+                grant=grant,
+                organisation_ids=test_organisation_ids,
+                status=GrantRecipientStatusEnum.AWARDED,
+                mode=GrantRecipientModeEnum.TEST,
             )
 
             # Set up grant team members as data providers/certifiers for the test grant recipients

--- a/app/developers/commands.py
+++ b/app/developers/commands.py
@@ -684,7 +684,12 @@ def sync_test_grant_recipients(commit: bool) -> None:
                 created += 1
                 pass
 
-            create_grant_recipients(grant, [matching_test_organisation.id], mode=GrantRecipientModeEnum.TEST)
+            create_grant_recipients(
+                grant,
+                [matching_test_organisation.id],
+                status=live_grant_recipient.status,
+                mode=GrantRecipientModeEnum.TEST,
+            )
 
             click.echo(
                 f" -> Created test grant recipient for live organisation {live_grant_recipient.organisation.name}"

--- a/app/developers/data/grants.json
+++ b/app/developers/data/grants.json
@@ -1507,13 +1507,15 @@
           "grant_id": "caf0ce3f-5175-f69c-66a9-41e2c2245845",
           "id": "4058b3cf-e06c-4c5a-ba36-fe14c9dc0765",
           "mode": "test",
-          "organisation_id": "04dc200e-bbf3-43c3-9e92-a722cdaea799"
+          "organisation_id": "04dc200e-bbf3-43c3-9e92-a722cdaea799",
+          "status": "awarded"
         },
         {
           "grant_id": "caf0ce3f-5175-f69c-66a9-41e2c2245845",
           "id": "7aa70608-4bd7-4326-bf6a-74010d30f696",
           "mode": "live",
-          "organisation_id": "74b2ee5d-20e6-4ab9-b5d0-150444bf9510"
+          "organisation_id": "74b2ee5d-20e6-4ab9-b5d0-150444bf9510",
+          "status": "awarded"
         }
       ],
       "questions": [

--- a/tests/integration/common/data/interfaces/test_grant_recipients.py
+++ b/tests/integration/common/data/interfaces/test_grant_recipients.py
@@ -16,6 +16,7 @@ from app.common.data.interfaces.grant_recipients import (
 from app.common.data.models import GrantRecipient
 from app.common.data.types import (
     GrantRecipientModeEnum,
+    GrantRecipientStatusEnum,
     RoleEnum,
     SubmissionEventType,
     SubmissionModeEnum,
@@ -498,30 +499,42 @@ class TestCreateGrantRecipients:
         org2 = factories.organisation.create(name="Organisation 2")
         org3 = factories.organisation.create(name="Organisation 3")
 
-        create_grant_recipients(grant, [org1.id, org2.id, org3.id])
+        create_grant_recipients(grant, [org1.id, org2.id, org3.id], status=GrantRecipientStatusEnum.AWARDED)
 
         db_session.expire_all()
         grant_recipients = db_session.query(GrantRecipient).filter_by(grant_id=grant.id).all()
         assert len(grant_recipients) == 3
         assert {gr.organisation_id for gr in grant_recipients} == {org1.id, org2.id, org3.id}
+        assert all(gr.status == GrantRecipientStatusEnum.AWARDED for gr in grant_recipients)
 
     def test_creates_single_grant_recipient(self, factories, db_session):
         grant = factories.grant.create()
         org = factories.organisation.create(name="Organisation 1")
 
-        create_grant_recipients(grant, [org.id])
+        create_grant_recipients(grant, [org.id], status=GrantRecipientStatusEnum.AWARDED)
 
         db_session.expire_all()
         grant_recipients = db_session.query(GrantRecipient).filter_by(grant_id=grant.id).all()
         assert len(grant_recipients) == 1
         assert grant_recipients[0].organisation_id == org.id
         assert grant_recipients[0].grant_id == grant.id
+        assert grant_recipients[0].status == GrantRecipientStatusEnum.AWARDED
+
+    def test_creates_grant_recipients_with_given_status(self, factories, db_session):
+        grant = factories.grant.create()
+        org = factories.organisation.create(name="Organisation 1")
+
+        create_grant_recipients(grant, [org.id], status=GrantRecipientStatusEnum.APPLYING)
+
+        db_session.expire_all()
+        grant_recipient = db_session.query(GrantRecipient).filter_by(grant_id=grant.id).one()
+        assert grant_recipient.status == GrantRecipientStatusEnum.APPLYING
 
     def test_handles_empty_list(self, factories, db_session):
         grant = factories.grant.create()
         initial_count = db_session.query(GrantRecipient).count()
 
-        create_grant_recipients(grant, [])
+        create_grant_recipients(grant, [], status=GrantRecipientStatusEnum.AWARDED)
 
         db_session.expire_all()
         final_count = db_session.query(GrantRecipient).count()
@@ -535,7 +548,7 @@ class TestCreateGrantRecipients:
 
         factories.grant_recipient.create(grant=grant, organisation=org1)
 
-        create_grant_recipients(grant, [org2.id, org3.id])
+        create_grant_recipients(grant, [org2.id, org3.id], status=GrantRecipientStatusEnum.AWARDED)
 
         db_session.expire_all()
         grant_recipients = db_session.query(GrantRecipient).filter_by(grant_id=grant.id).all()

--- a/tests/integration/deliver_grant_funding/admin/test_views.py
+++ b/tests/integration/deliver_grant_funding/admin/test_views.py
@@ -15,6 +15,7 @@ from app.common.data.types import (
     AuditEventType,
     CollectionStatusEnum,
     GrantRecipientModeEnum,
+    GrantRecipientStatusEnum,
     GrantStatusEnum,
     OrganisationModeEnum,
     OrganisationStatus,
@@ -2295,6 +2296,7 @@ class TestSetupGrantRecipients:
         recipient_org_ids = {gr.organisation_id for gr in grant_recipients}
         assert org1.id in recipient_org_ids
         assert org2.id in recipient_org_ids
+        assert all(gr.status == GrantRecipientStatusEnum.AWARDED for gr in grant_recipients)
 
         test_grant_recipients = get_grant_recipients(grant, mode=GrantRecipientModeEnum.TEST)
         assert len(test_grant_recipients) == 2

--- a/tests/models.py
+++ b/tests/models.py
@@ -62,6 +62,7 @@ from app.common.data.types import (
     DataSourceType,
     ExpressionType,
     GrantRecipientModeEnum,
+    GrantRecipientStatusEnum,
     GrantStatusEnum,
     NumberTypeEnum,
     OrganisationModeEnum,
@@ -195,6 +196,7 @@ class _GrantRecipientFactory(SQLAlchemyModelFactory):
     organisation = factory.SubFactory(_OrganisationFactory, can_manage_grants=False)
 
     mode = GrantRecipientModeEnum.LIVE
+    status = GrantRecipientStatusEnum.AWARDED
 
 
 class _UserRoleFactory(SQLAlchemyModelFactory):


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-1353

## 📝 Description
Now that we're starting to bring the grant pre-award stage of funding onto the platform we need to represent organisations who are in line for funding but haven't been awarded it yet.

We'll do this using the existing GrantRecipient table (which may be renamed if we come up with something suitable) and adding a status column that identifies if they're in a pre-award state or an awarded state.

This patch just adds the status but doesn't make use of it anywhere yet.

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [ ] End-to-end tests have been updated (if applicable)
- [ ] Edge cases and error conditions are tested

## 📚 Additional Notes
<!-- Any additional context, concerns, or considerations for reviewers -->
