### PR TITLE
Turn pytest-fail-slow into warnings

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,5 @@
+import pytest
+
+
+class SlowTestWarning(pytest.PytestWarning):
+    """Issued when a test exceeds its fail_slow threshold."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ from app import create_app
 from app.common.data.models import Grant, GrantRecipient, Organisation
 from app.common.data.models_user import User
 from app.services.notify import Notification
+from tests import SlowTestWarning
 from tests.models import (
     _AuditEventFactory,
     _CollectionFactory,
@@ -41,6 +42,25 @@ from tests.models import (
 )
 
 html5parser = html5lib.HTMLParser(strict=False)
+
+
+FAIL_SLOW_MESSAGE_PREFIX = "passed but took too long to run:"
+
+
+def pytest_configure(config: Config) -> None:
+    config.addinivalue_line("filterwarnings", f"default::{SlowTestWarning.__module__}.{SlowTestWarning.__qualname__}")
+
+
+@pytest.hookimpl(wrapper=True, tryfirst=True)
+def pytest_runtest_makereport(
+    item: pytest.Item, call: pytest.CallInfo
+) -> Generator[None, pytest.TestReport, pytest.TestReport]:
+    report = yield
+    if report.outcome == "failed" and isinstance(report.longrepr, str) and FAIL_SLOW_MESSAGE_PREFIX in report.longrepr:
+        item.warn(SlowTestWarning(report.longrepr))
+        report.outcome = "passed"
+        report.longrepr = None
+    return report
 
 
 def pytest_addoption(parser: Parser) -> None:


### PR DESCRIPTION
## 🎫 Ticket
BAU

## 📝 Description
We're seeing a lot of flaky tests locally and in CI where tests *just* overrun their time allocation.

We haven't been proactively addressing and reducing the time for tests to run so it's just been causing delays and frustration.

Let's turn these into warnings so that we can still see them, but so that they no longer cause us to waste time re-running tests as often for tests that still 'pass', but could just be faster.

## 📸 Show the thing (screenshots, gifs)
<!-- Include screenshots for UI changes, new features, or visual modifications -->
<!-- Use "Before" and "After" sections if showing changes to existing functionality -->

### Before
```
❯ pt -n8
================================================================================================ test session starts =================================================================================================
platform darwin -- Python 3.14.5, pytest-9.0.3, pluggy-1.6.0
rootdir: /Users/sam/git/funding-service
configfile: pyproject.toml
plugins: mock-3.15.1, Faker-40.15.0, flask-1.3.0, xdist-3.8.0, env-1.6.0, fail-slow-0.6.0, base-url-2.1.0, hypothesis-6.142.4, playwright-0.8.0
8 workers [3611 items]
sssssssssssssss............................................................................................................................................................................................... [  5%]
.............................................................................................................................................................................................................. [ 11%]
............................................................x....x..F......................................................................................................................................... [ 17%]
.............................................................................................................................................................................................................. [ 22%]
.............................................................sssss............................................................................................................................................ [ 28%]
.............................................................................................................................................................................................................. [ 34%]
.............................................................................................................................................................................................................. [ 39%]
.............................................................................................................................................................................................................. [ 45%]
.............................................................................................................................................................................................................. [ 51%]
....................................................................................................................................................................x......................................... [ 57%]
.............................................................................................................................................................................................................. [ 62%]
.................................................................................................................................x............................................................................ [ 68%]
.............................................................................................................................................................................................................. [ 74%]
...............................................................................................................................................................x.....x...x.................................... [ 79%]
.............................................................................................................................................................................................................. [ 85%]
.............................................................................................................................................................................................................. [ 91%]
...............................................................................................................................................................sssssssssss.................................... [ 96%]
.............................................................................................................                                                                                                  [100%]
====================================================================================================== FAILURES ======================================================================================================
_____________________________________________________________ TestDeleteCollectionSubmissions.test_delete_preview_collection_submissions_created_by_user _____________________________________________________________
[gw5] darwin -- Python 3.14.5 /Users/sam/git/funding-service/.venv/bin/python
Test passed but took too long to run: Duration 0.528908042004332s > 0.5s
============================================================================================== short test summary info ===============================================================================================
FAILED tests/integration/common/data/interfaces/test_collections.py::TestDeleteCollectionSubmissions::test_delete_preview_collection_submissions_created_by_user - Test passed but took too long to run: Duration 0.528908042004332s > 0.5s
=============================================================================== 1 failed, 3572 passed, 31 skipped, 7 xfailed in 20.57s ===============================================================================
```

### After
```
================================================================================================ test session starts =================================================================================================
platform darwin -- Python 3.14.5, pytest-9.0.3, pluggy-1.6.0
rootdir: /Users/sam/git/funding-service
configfile: pyproject.toml
plugins: mock-3.15.1, Faker-40.15.0, flask-1.3.0, xdist-3.8.0, env-1.6.0, fail-slow-0.6.0, base-url-2.1.0, hypothesis-6.142.4, playwright-0.8.0
8 workers [3611 items]
sssssssssssssss............................................................................................................................................................................................... [  5%]
.............................................................................................................................................................................................................. [ 11%]
..............................................................................x.....x......................................................................................................................... [ 17%]
.............................................................................................................................................................................................................. [ 22%]
.........................................................................ss.sss............................................................................................................................... [ 28%]
.............................................................................................................................................................................................................. [ 34%]
.............................................................................................................................................................................................................. [ 39%]
.............................................................................................................................................................................................................. [ 45%]
.............................................................................................................................................................................................................. [ 51%]
........................................................................................................................................................................x..................................... [ 57%]
.............................................................................................................................................................................................................. [ 62%]
.............................................................................................................................................................................................................. [ 68%]
.............................................................................................................................................................................................................. [ 74%]
..........................................................................................................................................................................x...x..x............................ [ 79%]
.............................................................................................................................................................................................................. [ 85%]
.............................................................................................................................................................................................................. [ 91%]
.......................................................................................................................................................x.......sssssssssss.................................... [ 96%]
.............................................................................................................                                                                                                  [100%]
================================================================================================== warnings summary ==================================================================================================
tests/integration/common/data/interfaces/test_collections.py::TestDeleteCollectionSubmissions::test_delete_preview_collection_submissions_created_by_user
  tests/integration/common/data/interfaces/test_collections.py:3986: SlowTestWarning: Test passed but took too long to run: Duration 0.504725334001705s > 0.5s
    def test_delete_preview_collection_submissions_created_by_user(self, db_session, factories):

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================== 3573 passed, 31 skipped, 7 xfailed, 1 warning in 20.77s ===============================================================================
```

## 🧪 Testing
<!-- Describe how you've tested this change, and how a reviewer can test it -->

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [ ] PR title and description provide sufficient context for reviewers
- [ ] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- [ ] No N+1 query problems introduced
- [ ] Any new DB queries include appropriate where clauses based on the user's permissions

### Testing
- [ ] I have tested this change and it meets the acceptance criteria for the ticket
- [ ] I need the reviewer(s) to pull and run this change locally
- [ ] New (non-developer) functionality has appropriate unit and integration tests
- [ ] End-to-end tests have been updated (if applicable)
- [ ] Edge cases and error conditions are tested

## 📚 Additional Notes
<!-- Any additional context, concerns, or considerations for reviewers -->
