### PR TITLE
FSPT-1331 - Regenerate data set CSV template

### DIFF
--- a/app/common/data/interfaces/data_sets.py
+++ b/app/common/data/interfaces/data_sets.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import lazyload, selectinload
 
 from app.common.data.interfaces.collections import raise_if_data_source_has_references
 from app.common.data.interfaces.exceptions import DuplicateDataSourceItemError, flush_and_rollback_on_exceptions
@@ -31,15 +31,12 @@ def get_data_source(
     data_source_id: uuid.UUID,
     *,
     with_organisation_items: bool = False,
-    with_data_source_items: bool = False,
 ) -> DataSource:
     stmt = select(DataSource).where(DataSource.id == data_source_id)
 
     if with_organisation_items:
         stmt = stmt.options(selectinload(DataSource.organisation_items))
-
-    if with_data_source_items:
-        stmt = stmt.options(selectinload(DataSource.items))
+        stmt = stmt.options(lazyload(DataSource.items))
 
     return db.session.execute(stmt).scalar_one()
 

--- a/app/deliver_grant_funding/data_sets.py
+++ b/app/deliver_grant_funding/data_sets.py
@@ -7,17 +7,24 @@ from typing import TYPE_CHECKING, Sequence
 from flask import current_app
 from pydantic import BaseModel, Field
 
+from app.common.data.interfaces.grant_recipients import get_grant_recipients
 from app.common.data.types import (
+    DataSourceType,
     NumberTypeEnum,
+    OrganisationModeEnum,
     QuestionDataType,
     TUnvalidatedDataSetRow,
     TUnvalidatedDataSetRows,
 )
-from app.constants import DATA_SET_EXTERNAL_ID_COLUMN_HEADER, DATA_SET_GRANT_RECIPIENT_COLUMN_HEADER
+from app.constants import (
+    DATA_SET_EXTERNAL_ID_COLUMN_HEADER,
+    DATA_SET_GRANT_RECIPIENT_COLUMN_HEADER,
+    DATA_SET_IDENTIFIER_COLUMN_HEADERS,
+)
 from app.deliver_grant_funding.session_models import DataSetColumnMapping, DataSetUploadSessionModel
 
 if TYPE_CHECKING:
-    from app.common.data.models import GrantRecipient
+    from app.common.data.models import DataSource, GrantRecipient
 
 
 class CellError(BaseModel):
@@ -243,13 +250,36 @@ def check_missing_data(data_columns: list[str], all_rows: TUnvalidatedDataSetRow
     return result
 
 
-def generate_latest_csv_template() -> str:
-    headers = ["Organisation ID", "Grant recipient"]
+def generate_latest_csv_template(data_source: DataSource) -> StringIO:
+    if not data_source.type == DataSourceType.GRANT_RECIPIENT or not data_source.grant or not data_source.schema:
+        raise NotImplementedError("Cannot generate latest CSV template for a non-grant recipient data source")
+
+    headers = []
+    headers += DATA_SET_IDENTIFIER_COLUMN_HEADERS
+    for _, col_schema in data_source.schema.root.items():
+        headers.append(col_schema.original_column_name)
+
     csv_output = StringIO()
     csv_writer = csv.DictWriter(csv_output, fieldnames=headers)
     csv_writer.writeheader()
-    #
-    # row_data = {}
-    # csv_writer.writerow(row_data)
+    grant_recipients = get_grant_recipients(grant=data_source.grant, with_organisations=True)
+    for gr in grant_recipients:
+        if gr.organisation.mode == OrganisationModeEnum.TEST:
+            continue
 
-    return csv_output.getvalue()
+        row_data = {
+            DATA_SET_EXTERNAL_ID_COLUMN_HEADER: gr.organisation.external_id,
+            DATA_SET_GRANT_RECIPIENT_COLUMN_HEADER: gr.organisation.name,
+        }
+        organisation_data_item = data_source.get_filtered_organisation_item(
+            organisation_external_id=gr.organisation.external_id
+        )
+        if organisation_data_item and organisation_data_item.data:
+            for k, v in organisation_data_item.data.items():
+                if not v:
+                    continue
+                row_data[data_source.schema.root[k].original_column_name] = str(v.get_value_for_evaluation())
+
+        csv_writer.writerow(row_data)
+
+    return csv_output

--- a/app/deliver_grant_funding/data_sets.py
+++ b/app/deliver_grant_funding/data_sets.py
@@ -1,5 +1,7 @@
+import csv
 import uuid
 from decimal import Decimal, InvalidOperation
+from io import StringIO
 from typing import TYPE_CHECKING, Sequence
 
 from flask import current_app
@@ -239,3 +241,15 @@ def check_missing_data(data_columns: list[str], all_rows: TUnvalidatedDataSetRow
         if missing:
             result.row_results.append(MissingDataRow(row_number=idx, missing_columns=missing))
     return result
+
+
+def generate_latest_csv_template() -> str:
+    headers = ["Organisation ID", "Grant recipient"]
+    csv_output = StringIO()
+    csv_writer = csv.DictWriter(csv_output, fieldnames=headers)
+    csv_writer.writeheader()
+    #
+    # row_data = {}
+    # csv_writer.writerow(row_data)
+
+    return csv_output.getvalue()

--- a/app/deliver_grant_funding/routes/collections.py
+++ b/app/deliver_grant_funding/routes/collections.py
@@ -108,6 +108,7 @@ from app.common.helpers.collections import (
     SubmissionHelper,
     SubmissionIsNotSubmittedError,
 )
+from app.common.utils import slugify
 from app.constants import (
     DATA_SET_EXTERNAL_ID_COLUMN_HEADER,
     DATA_SET_GRANT_RECIPIENT_COLUMN_HEADER,
@@ -118,6 +119,7 @@ from app.deliver_grant_funding.data_sets import (
     DataSetValidationResult,
     build_data_set_upload_s3_key,
     check_missing_data,
+    generate_latest_csv_template,
     validate_data_set,
     validate_data_set_grant_recipients,
 )
@@ -3368,6 +3370,33 @@ def download_grant_recipient_data_set_template(
         mimetype="text/csv",
         as_attachment=True,
         download_name=f"{collection.slug}-grant-recipient-data-template.csv",
+        max_age=0,
+    )
+
+
+@deliver_grant_funding_blueprint.route(
+    "/grant/<uuid:grant_id>/<collection_type:collection_type>/<uuid:collection_id>/data-sets/<uuid:data_source_id>/template",
+    methods=["GET"],
+)
+@has_deliver_grant_role(RoleEnum.MEMBER)
+def download_latest_data_set_template(
+    grant_id: UUID, collection_type: CollectionType, collection_id: UUID, data_source_id: UUID
+) -> ResponseReturnValue:
+    collection = get_collection(
+        collection_id=collection_id, grant_id=grant_id, with_full_schema=False, type_=collection_type
+    )
+    data_source = get_data_source(data_source_id, with_organisation_items=True)
+
+    # TODO FSPT-1044: We should do this filtering in the interface rather than here
+    if data_source.collection_id != collection_id or data_source.grant_id != grant_id:
+        abort(404)
+
+    csv_content = generate_latest_csv_template(data_source)
+    return send_file(
+        io.BytesIO(csv_content.getvalue().encode("utf-8-sig")),
+        mimetype="text/csv",
+        as_attachment=True,
+        download_name=f"{collection.slug}-{slugify(data_source.name)}-template.csv",  # ty:ignore[invalid-argument-type]
         max_age=0,
     )
 

--- a/app/deliver_grant_funding/routes/collections.py
+++ b/app/deliver_grant_funding/routes/collections.py
@@ -3782,7 +3782,7 @@ def view_data_source(
 ) -> ResponseReturnValue:
     collection = get_collection(collection_id, grant_id=grant_id, type_=collection_type)
 
-    data_source = get_data_source(data_source_id, with_organisation_items=True, with_data_source_items=True)
+    data_source = get_data_source(data_source_id, with_organisation_items=True)
 
     # TODO FSPT-1044: We should do this filtering in the interface rather than here
     if data_source.collection_id != collection_id or data_source.grant_id != grant_id:

--- a/tests/integration/common/data/interfaces/test_data_sets.py
+++ b/tests/integration/common/data/interfaces/test_data_sets.py
@@ -480,38 +480,6 @@ class TestGetDataSource:
 
         assert len(queries) == 0
 
-    def test_get_data_source_with_data_source_items(self, db_session, factories, track_sql_queries):
-        data_source = factories.data_source.create()
-        db_session.expire_all()
-
-        from_db = get_data_source(data_source.id, with_data_source_items=True)
-
-        with track_sql_queries() as queries:
-            items = from_db.items
-            assert len(items) == 3
-
-        assert len(queries) == 0
-
-    def test_get_data_source_with_both_flags(self, db_session, factories, track_sql_queries):
-
-        grant = factories.grant.create()
-        factories.grant_recipient.create(grant=grant)
-        data_source = factories.data_source.create(
-            grant=grant,
-            collection=factories.collection.create(grant=grant),
-            type=DataSourceType.GRANT_RECIPIENT,
-            create_gr_org_items=True,
-        )
-        db_session.expire_all()
-
-        from_db = get_data_source(data_source.id, with_organisation_items=True, with_data_source_items=True)
-
-        with track_sql_queries() as queries:
-            assert len(from_db.organisation_items) == 1
-            assert len(from_db.items) == 0
-
-        assert len(queries) == 0
-
     def test_get_data_source_without_flags_does_not_eagerly_load_items(self, db_session, factories, track_sql_queries):
         grant = factories.grant.create()
         factories.grant_recipient.create(grant=grant)

--- a/tests/integration/deliver_grant_funding/routes/test_collections.py
+++ b/tests/integration/deliver_grant_funding/routes/test_collections.py
@@ -11208,6 +11208,110 @@ class TestDownloadDataSourceCsv:
         assert mock_s3_service_calls.download_file_calls[0].args[0] == "data-set-uploads/test.csv"
 
 
+class TestDownloadLatestDataSetTemplate:
+    def test_404(self, authenticated_grant_member_client):
+        response = authenticated_grant_member_client.get(
+            url_for(
+                "deliver_grant_funding.download_latest_data_set_template",
+                grant_id=uuid.uuid4(),
+                collection_type=CollectionType.MONITORING_REPORT,
+                collection_id=uuid.uuid4(),
+                data_source_id=uuid.uuid4(),
+            )
+        )
+        assert response.status_code == 404
+
+    def test_404_when_data_source_doesnt_belong_to_collection(
+        self, authenticated_grant_admin_client, factories, mock_s3_service_calls
+    ):
+        grant = authenticated_grant_admin_client.grant
+        collection = factories.collection.create(grant=authenticated_grant_admin_client.grant)
+
+        grant2 = factories.grant.create()
+        collection2 = factories.collection.create(grant=grant2)
+        data_source2 = factories.data_source.create(
+            name="Test data set",
+            collection=collection2,
+            grant=grant2,
+            type=DataSourceType.GRANT_RECIPIENT,
+        )
+
+        response = authenticated_grant_admin_client.get(
+            url_for(
+                "deliver_grant_funding.download_latest_data_set_template",
+                grant_id=grant.id,
+                collection_type=CollectionType.MONITORING_REPORT,
+                collection_id=collection.id,
+                data_source_id=data_source2.id,
+            )
+        )
+        assert response.status_code == 404
+
+    @pytest.mark.parametrize(
+        "client_fixture, can_access",
+        (
+            ("authenticated_no_role_client", False),
+            ("authenticated_grant_member_client", True),
+        ),
+    )
+    def test_get_access(
+        self, request: FixtureRequest, client_fixture: str, can_access: bool, factories, mock_s3_service_calls
+    ):
+        client = request.getfixturevalue(client_fixture)
+        grant = client.grant or factories.grant.create()
+        collection = factories.collection.create(grant=grant)
+        _ = client.grant_recipient or factories.grant_recipient.create(grant=grant)
+        data_source = factories.data_source.create(
+            name="Test data set",
+            collection=collection,
+            grant=grant,
+            type=DataSourceType.GRANT_RECIPIENT,
+            create_gr_org_items=True,
+        )
+        response = client.get(
+            url_for(
+                "deliver_grant_funding.download_latest_data_set_template",
+                grant_id=grant.id,
+                collection_type=CollectionType.MONITORING_REPORT,
+                collection_id=collection.id,
+                data_source_id=data_source.id,
+            )
+        )
+        if not can_access:
+            assert response.status_code == 403
+        else:
+            assert response.status_code == 200
+
+    def test_get_returns_file_with_correct_name_and_content(
+        self, authenticated_grant_admin_client, factories, mock_s3_service_calls
+    ):
+        collection = factories.collection.create(grant=authenticated_grant_admin_client.grant)
+        grant = authenticated_grant_admin_client.grant
+        factories.grant_recipient.create(grant=grant, organisation__external_id="E123", organisation__name="Test org")
+        data_source = factories.data_source.create(
+            collection=collection,
+            grant=authenticated_grant_admin_client.grant,
+            type=DataSourceType.GRANT_RECIPIENT,
+            create_gr_org_items=True,
+            create_gr_org_items__data=[1000],
+        )
+
+        response = authenticated_grant_admin_client.get(
+            url_for(
+                "deliver_grant_funding.download_latest_data_set_template",
+                grant_id=authenticated_grant_admin_client.grant.id,
+                collection_type=CollectionType.MONITORING_REPORT,
+                collection_id=collection.id,
+                data_source_id=data_source.id,
+            )
+        )
+
+        assert response.status_code == 200
+        assert response.content_type.startswith("text/csv")
+        assert f"filename={collection.slug}-grant-allocation-template.csv" in response.headers["Content-Disposition"]
+        assert b"Organisation ID,Grant recipient,Allocation\r\nE123,Test org,1000" in response.data
+
+
 class TestAddCustomQuestionValidation:
     def test_post_success(self, authenticated_platform_admin_client, factories, db_session):
         collection = factories.collection.create(name="Test Report")

--- a/tests/integration/deliver_grant_funding/test_data_sets.py
+++ b/tests/integration/deliver_grant_funding/test_data_sets.py
@@ -2,6 +2,7 @@ import csv
 import uuid
 from io import StringIO
 
+from app.common.data.interfaces.data_sets import get_data_source
 from app.common.data.types import (
     DataSourceSchemaColumn,
     DataSourceType,
@@ -509,7 +510,7 @@ class TestGenerateLatestCsvTemplate:
         )
 
         csv_content = generate_latest_csv_template(data_source)
-        reader = csv.reader(StringIO(csv_content))
+        reader = csv.reader(StringIO(csv_content.getvalue()))
 
         rows = list(reader)
         assert len(rows) == 4
@@ -545,7 +546,7 @@ class TestGenerateLatestCsvTemplate:
         )
 
         csv_content = generate_latest_csv_template(data_source)
-        reader = csv.reader(StringIO(csv_content))
+        reader = csv.reader(StringIO(csv_content.getvalue()))
 
         rows = list(reader)
         assert len(rows) == 5
@@ -575,7 +576,7 @@ class TestGenerateLatestCsvTemplate:
         db_session.delete(gr3)
 
         csv_content = generate_latest_csv_template(data_source)
-        reader = csv.reader(StringIO(csv_content))
+        reader = csv.reader(StringIO(csv_content.getvalue()))
 
         rows = list(reader)
         assert len(rows) == 3
@@ -601,7 +602,7 @@ class TestGenerateLatestCsvTemplate:
         )
 
         csv_content = generate_latest_csv_template(data_source)
-        reader = csv.reader(StringIO(csv_content))
+        reader = csv.reader(StringIO(csv_content.getvalue()))
 
         rows = list(reader)
         assert len(rows) == 4
@@ -646,7 +647,7 @@ class TestGenerateLatestCsvTemplate:
         db_session.flush()
 
         csv_content = generate_latest_csv_template(data_source)
-        reader = csv.reader(StringIO(csv_content))
+        reader = csv.reader(StringIO(csv_content.getvalue()))
 
         rows = list(reader)
         assert len(rows) == 4
@@ -681,7 +682,7 @@ class TestGenerateLatestCsvTemplate:
         db_session.flush()
 
         csv_content = generate_latest_csv_template(data_source)
-        reader = csv.reader(StringIO(csv_content))
+        reader = csv.reader(StringIO(csv_content.getvalue()))
 
         rows = list(reader)
         assert len(rows) == 4
@@ -690,3 +691,28 @@ class TestGenerateLatestCsvTemplate:
         assert rows[1] == ["EC123", gr.organisation.name, "1", ""]
         assert rows[2] == ["EC456", gr2.organisation.name, "2", ""]
         assert rows[3] == ["EC789", gr3.organisation.name, "3", ""]
+
+    def test_generate_csv_large(self, factories, track_sql_queries, db_session):
+        grant = factories.grant.create()
+        factories.grant_recipient.create_batch(20, grant=grant)
+
+        collection = factories.collection.create(grant=grant)
+
+        data_source = factories.data_source.create(
+            grant=grant,
+            collection=collection,
+            type=DataSourceType.GRANT_RECIPIENT,
+            create_gr_org_items=True,
+        )
+        db_session.expire_all()
+
+        # retrieve this here to mimic the behaviour of the route
+        data_source = get_data_source(data_source_id=data_source.id, with_organisation_items=True)
+        with track_sql_queries() as queries:
+            result = generate_latest_csv_template(data_source)
+
+        reader = csv.reader(StringIO(result.getvalue()))
+
+        rows = list(reader)
+        assert len(rows) == 21
+        assert len(queries) == 3

--- a/tests/integration/deliver_grant_funding/test_data_sets.py
+++ b/tests/integration/deliver_grant_funding/test_data_sets.py
@@ -1,11 +1,20 @@
+import csv
 import uuid
+from io import StringIO
 
-from app.common.data.types import DataSourceType
+from app.common.data.types import (
+    DataSourceSchemaColumn,
+    DataSourceType,
+    QuestionDataOptions,
+    QuestionDataType,
+    QuestionPresentationOptions,
+)
 from app.constants import DATA_SET_EXTERNAL_ID_COLUMN_HEADER, DATA_SET_GRANT_RECIPIENT_COLUMN_HEADER
 from app.deliver_grant_funding.data_sets import (
     BritishPoundsError,
     DataTypeError,
     check_missing_data,
+    generate_latest_csv_template,
     validate_data_set,
     validate_data_set_grant_recipients,
 )
@@ -480,3 +489,204 @@ class TestValidateDataSetGrantRecipients:
         assert any(f"'{gr3.organisation.name}' is missing from the CSV" in e for e in errors)
         assert any(f"{DATA_SET_EXTERNAL_ID_COLUMN_HEADER} 'AB1111' not found in grant recipients" in e for e in errors)
         assert any("Grant recipient 'Rivendell' not found in grant recipients" in e for e in errors)
+
+
+class TestGenerateLatestCsvTemplate:
+    def test_generate_no_changes(self, factories):
+        grant = factories.grant.create()
+        gr = factories.grant_recipient.create(grant=grant, organisation__external_id="EC123")
+        gr2 = factories.grant_recipient.create(grant=grant, organisation__external_id="EC456")
+        gr3 = factories.grant_recipient.create(grant=grant, organisation__external_id="EC789")
+
+        collection = factories.collection.create(grant=grant)
+
+        data_source = factories.data_source.create(
+            grant=grant,
+            collection=collection,
+            type=DataSourceType.GRANT_RECIPIENT,
+            create_gr_org_items=True,
+            create_gr_org_items__data=[123, 456, 789],
+        )
+
+        csv_content = generate_latest_csv_template(data_source)
+        reader = csv.reader(StringIO(csv_content))
+
+        rows = list(reader)
+        assert len(rows) == 4
+
+        assert rows[0] == ["Organisation ID", "Grant recipient", "Allocation"]
+        assert rows[1] == ["EC123", gr.organisation.name, "123"]
+        assert rows[2] == ["EC456", gr2.organisation.name, "456"]
+        assert rows[3] == ["EC789", gr3.organisation.name, "789"]
+
+    def test_generate_grant_recipient_added(self, factories):
+        grant = factories.grant.create()
+        gr = factories.grant_recipient.create(
+            grant=grant, organisation__external_id="EC123", organisation__name="AAA org"
+        )
+        gr2 = factories.grant_recipient.create(
+            grant=grant, organisation__external_id="EC456", organisation__name="BBB org"
+        )
+        gr3 = factories.grant_recipient.create(
+            grant=grant, organisation__external_id="EC789", organisation__name="CCC org"
+        )
+
+        collection = factories.collection.create(grant=grant)
+
+        data_source = factories.data_source.create(
+            grant=grant,
+            collection=collection,
+            type=DataSourceType.GRANT_RECIPIENT,
+            create_gr_org_items=True,
+            create_gr_org_items__data=[123, 456, 789],
+        )
+        gr4 = factories.grant_recipient.create(
+            grant=grant, organisation__external_id="EC124", organisation__name="AAB org"
+        )
+
+        csv_content = generate_latest_csv_template(data_source)
+        reader = csv.reader(StringIO(csv_content))
+
+        rows = list(reader)
+        assert len(rows) == 5
+
+        assert rows[0] == ["Organisation ID", "Grant recipient", "Allocation"]
+        assert rows[1] == ["EC123", gr.organisation.name, "123"]
+        assert rows[2] == ["EC124", gr4.organisation.name, ""]
+        assert rows[3] == ["EC456", gr2.organisation.name, "456"]
+        assert rows[4] == ["EC789", gr3.organisation.name, "789"]
+
+    def test_generate_grant_recipient_removed(self, factories, db_session):
+        grant = factories.grant.create()
+        gr = factories.grant_recipient.create(grant=grant, organisation__external_id="EC123")
+        gr2 = factories.grant_recipient.create(grant=grant, organisation__external_id="EC456")
+        gr3 = factories.grant_recipient.create(grant=grant, organisation__external_id="TO_REMOVE")
+
+        collection = factories.collection.create(grant=grant)
+
+        data_source = factories.data_source.create(
+            grant=grant,
+            collection=collection,
+            type=DataSourceType.GRANT_RECIPIENT,
+            create_gr_org_items=True,
+            create_gr_org_items__data=[123, 456, 789],
+        )
+
+        db_session.delete(gr3)
+
+        csv_content = generate_latest_csv_template(data_source)
+        reader = csv.reader(StringIO(csv_content))
+
+        rows = list(reader)
+        assert len(rows) == 3
+
+        assert rows[0] == ["Organisation ID", "Grant recipient", "Allocation"]
+        assert rows[1] == ["EC123", gr.organisation.name, "123"]
+        assert rows[2] == ["EC456", gr2.organisation.name, "456"]
+
+    def test_generate_no_changes_data_missing(self, factories):
+        grant = factories.grant.create()
+        gr = factories.grant_recipient.create(grant=grant, organisation__external_id="EC123")
+        gr2 = factories.grant_recipient.create(grant=grant, organisation__external_id="EC456")
+        gr3 = factories.grant_recipient.create(grant=grant, organisation__external_id="EC789")
+
+        collection = factories.collection.create(grant=grant)
+
+        data_source = factories.data_source.create(
+            grant=grant,
+            collection=collection,
+            type=DataSourceType.GRANT_RECIPIENT,
+            create_gr_org_items=True,
+            create_gr_org_items__data=[123, None, 789],
+        )
+
+        csv_content = generate_latest_csv_template(data_source)
+        reader = csv.reader(StringIO(csv_content))
+
+        rows = list(reader)
+        assert len(rows) == 4
+
+        assert rows[0] == ["Organisation ID", "Grant recipient", "Allocation"]
+        assert rows[1] == ["EC123", gr.organisation.name, "123"]
+        assert rows[2] == ["EC456", gr2.organisation.name, ""]
+        assert rows[3] == ["EC789", gr3.organisation.name, "789"]
+
+    def test_generate_columns_added_with_data(self, factories, db_session):
+        grant = factories.grant.create()
+        gr = factories.grant_recipient.create(grant=grant, organisation__external_id="EC123")
+        gr2 = factories.grant_recipient.create(grant=grant, organisation__external_id="EC456")
+        gr3 = factories.grant_recipient.create(grant=grant, organisation__external_id="EC789")
+
+        collection = factories.collection.create(grant=grant)
+
+        data_source = factories.data_source.create(
+            grant=grant,
+            collection=collection,
+            type=DataSourceType.GRANT_RECIPIENT,
+        )
+
+        ds_org_item_1 = factories.data_source_organisation_item.create(
+            data_source=data_source, external_id="EC123", _data={"c_allocation": "123"}
+        )
+        ds_org_item_2 = factories.data_source_organisation_item.create(
+            data_source=data_source, external_id="EC456", _data={"c_allocation": "456"}
+        )
+        ds_org_item_3 = factories.data_source_organisation_item.create(
+            data_source=data_source, external_id="EC789", _data={"c_allocation": "789"}
+        )
+        data_source.schema.root["c_added_col"] = DataSourceSchemaColumn(
+            data_type=QuestionDataType.TEXT_SINGLE_LINE,
+            presentation_options=QuestionPresentationOptions(),
+            data_options=QuestionDataOptions(),
+            original_column_name="Added column",
+        )
+        ds_org_item_1._data["c_added_col"] = "one"
+        ds_org_item_2._data["c_added_col"] = "two"
+        ds_org_item_3._data["c_added_col"] = "three"
+        db_session.flush()
+
+        csv_content = generate_latest_csv_template(data_source)
+        reader = csv.reader(StringIO(csv_content))
+
+        rows = list(reader)
+        assert len(rows) == 4
+
+        assert rows[0] == ["Organisation ID", "Grant recipient", "Allocation", "Added column"]
+        assert rows[1] == ["EC123", gr.organisation.name, "123", "one"]
+        assert rows[2] == ["EC456", gr2.organisation.name, "456", "two"]
+        assert rows[3] == ["EC789", gr3.organisation.name, "789", "three"]
+
+    def test_generate_columns_added_no_data(self, factories, db_session):
+        grant = factories.grant.create()
+        gr = factories.grant_recipient.create(grant=grant, organisation__external_id="EC123")
+        gr2 = factories.grant_recipient.create(grant=grant, organisation__external_id="EC456")
+        gr3 = factories.grant_recipient.create(grant=grant, organisation__external_id="EC789")
+
+        collection = factories.collection.create(grant=grant)
+
+        data_source = factories.data_source.create(
+            grant=grant,
+            collection=collection,
+            type=DataSourceType.GRANT_RECIPIENT,
+            create_gr_org_items=True,
+            create_gr_org_items__data=[1, 2, 3],
+        )
+
+        data_source.schema.root["c_added_col"] = DataSourceSchemaColumn(
+            data_type=QuestionDataType.TEXT_SINGLE_LINE,
+            presentation_options=QuestionPresentationOptions(),
+            data_options=QuestionDataOptions(),
+            original_column_name="Added column",
+        )
+        db_session.flush()
+
+        csv_content = generate_latest_csv_template(data_source)
+        reader = csv.reader(StringIO(csv_content))
+
+        rows = list(reader)
+        assert len(rows) == 4
+
+        assert rows[0] == ["Organisation ID", "Grant recipient", "Allocation", "Added column"]
+        assert rows[1] == ["EC123", gr.organisation.name, "1", ""]
+        assert rows[2] == ["EC456", gr2.organisation.name, "2", ""]
+        assert rows[3] == ["EC789", gr3.organisation.name, "3", ""]

--- a/tests/models.py
+++ b/tests/models.py
@@ -887,10 +887,6 @@ class _DataSourceFactory(SQLAlchemyModelFactory):
         sqlalchemy_session_factory = lambda: db.session  # noqa: E731
         sqlalchemy_session_persistence = "commit"
 
-    #
-    # class Params:
-    #     create_gr_org_items = False
-
     id = factory.LazyFunction(uuid4)
     type = DataSourceType.CUSTOM
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -887,6 +887,10 @@ class _DataSourceFactory(SQLAlchemyModelFactory):
         sqlalchemy_session_factory = lambda: db.session  # noqa: E731
         sqlalchemy_session_persistence = "commit"
 
+    #
+    # class Params:
+    #     create_gr_org_items = False
+
     id = factory.LazyFunction(uuid4)
     type = DataSourceType.CUSTOM
 

--- a/tests/unit/test_all_routes_access.py
+++ b/tests/unit/test_all_routes_access.py
@@ -142,6 +142,7 @@ routes_with_expected_member_only_access = [
     "deliver_grant_funding.view_data_source",
     "deliver_grant_funding.download_data_source_csv",
     "deliver_grant_funding.reopen_submission",
+    "deliver_grant_funding.download_latest_data_set_template",
 ]
 
 routes_with_expected_access_grant_funding_logged_in_access = [


### PR DESCRIPTION
## 🎫 Ticket
[FSPT-1331](https://mhclgdigital.atlassian.net/browse/FSPT-1331)

## 📝 Description
When a form designer wants to update a dataset with new or missing values, they need to be able to download a csv template containing all existing grant recipients (including those added since the data set was created or any with missing data) so that they can add missing values and re-upload it.

This PR builds that functionality and exposes it on a new route. This route isn't used anywhere yet but will be used by upcoming work.

## 🧪 Testing
- Download the CSV template for a report and add at least one column
- Create a dataset using this csv
- Add a new grant recipient to the report
- Go to the view dataset page and append `/template` to the URL
- It should download a new CSV with a blank row for the new grant recipient

## 📋 Developer Checklist

### Review Readiness
- [x] PR title and description provide sufficient context for reviewers
- [x] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- [x] No N+1 query problems introduced
- [ ] Any new DB queries include appropriate where clauses based on the user's permissions

### Testing
- [x] I have tested this change and it meets the acceptance criteria for the ticket
- [x] I need the reviewer(s) to pull and run this change locally
- [x] New (non-developer) functionality has appropriate unit and integration tests
- [x] Edge cases and error conditions are tested



[FSPT-1331]: https://mhclgdigital.atlassian.net/browse/FSPT-1331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ