### PR TITLE
FSPT-1342: Flag missing data set data in views

### DIFF
--- a/app/common/data/interfaces/data_sets.py
+++ b/app/common/data/interfaces/data_sets.py
@@ -1,9 +1,12 @@
+import datetime
 import uuid
+from collections.abc import Sequence
+from dataclasses import dataclass
 from decimal import Decimal
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import lazyload, selectinload
+from sqlalchemy.orm import aliased, lazyload, selectinload
 
 from app.common.data.interfaces.collections import raise_if_data_source_has_references
 from app.common.data.interfaces.exceptions import DuplicateDataSourceItemError, flush_and_rollback_on_exceptions
@@ -164,3 +167,58 @@ def delete_data_source(data_source: DataSource) -> None:
         s3_service.delete_file(data_source.file_metadata.s3_key)
 
     db.session.delete(data_source)
+
+
+@dataclass(frozen=True)
+class ListDataSourceData:
+    id: uuid.UUID
+    name: str
+    updated_at_utc: datetime.datetime
+    uploaded_by_name: str | None
+    has_missing_data: bool
+
+
+def get_data_source_list_for_collection(collection_id: uuid.UUID) -> Sequence[ListDataSourceData]:
+    user_updated = aliased(User)
+    user_created = aliased(User)
+
+    stmt = (
+        select(
+            DataSource.id,
+            DataSource.name,
+            DataSource.updated_at_utc,
+            func.coalesce(user_updated.name, user_created.name).label("uploaded_by_name"),
+            DataSource.has_missing_data.label("has_missing_data"),
+        )
+        .outerjoin(user_created, DataSource.created_by_id == user_created.id)
+        .outerjoin(user_updated, DataSource.updated_by_id == user_updated.id)
+        .where(
+            DataSource.collection_id == collection_id,
+            DataSource.type == DataSourceType.GRANT_RECIPIENT,
+        )
+        .order_by(DataSource.name)
+    )
+    return [
+        ListDataSourceData(
+            id=row.id,
+            name=row.name,
+            updated_at_utc=row.updated_at_utc,
+            uploaded_by_name=row.uploaded_by_name,
+            has_missing_data=row.has_missing_data,
+        )
+        for row in db.session.execute(stmt).all()
+    ]
+
+
+def get_collection_ids_with_missing_data_data_sets(grant_id: uuid.UUID) -> set[uuid.UUID]:
+    stmt = (
+        select(DataSource.collection_id)
+        .where(
+            DataSource.grant_id == grant_id,
+            DataSource.type == DataSourceType.GRANT_RECIPIENT,
+            DataSource.collection_id.is_not(None),
+            DataSource.has_missing_data,
+        )
+        .distinct()
+    )
+    return {id for id in db.session.scalars(stmt).all() if id is not None}

--- a/app/common/data/models.py
+++ b/app/common/data/models.py
@@ -16,6 +16,7 @@ from sqlalchemy import (
     and_,
     case,
     func,
+    not_,
     or_,
     select,
     text,
@@ -1339,6 +1340,50 @@ class DataSource(BaseModel, SafeDidMixin):
         if self.type == DataSourceType.CUSTOM:
             return None
         return f"{column.original_column_name} from {self.name} data set"
+
+    @hybrid_property
+    def has_missing_data(self) -> bool:
+        if self.type == DataSourceType.CUSTOM:
+            return False
+
+        assert self.schema, f"DataSource {self.id} has type {self.type} but no schema"
+
+        if not self.organisation_items:
+            return True
+
+        schema_columns = set(self.schema.root.keys())
+        return any(item._data.get(col) is None for item in self.organisation_items for col in schema_columns)
+
+    @has_missing_data.inplace.expression
+    @classmethod
+    def _has_missing_data_expression(cls) -> ColumnElement[bool]:
+        has_null_value = (
+            select(DataSourceOrganisationItem.data_source_id)
+            .where(
+                DataSourceOrganisationItem.data_source_id == cls.id,
+                func.jsonb_path_exists(
+                    DataSourceOrganisationItem._data,
+                    # JSONPath expression to check if any top-level value in the org item JSONB object is null
+                    # $.* iterates all top-level values, ? (@ == null) filters to nulls
+                    # ::jsonpath casts the string to Postgres jsonpath type
+                    text("'$.* ? (@ == null)'::jsonpath"),
+                ),
+            )
+            .correlate(cls)
+            .exists()
+        )
+
+        has_no_org_items = not_(
+            select(DataSourceOrganisationItem.data_source_id)
+            .where(DataSourceOrganisationItem.data_source_id == cls.id)
+            .correlate(cls)
+            .exists()
+        )
+
+        return and_(
+            cls.type != DataSourceType.CUSTOM,
+            has_null_value | has_no_org_items,
+        )
 
 
 class DataSourceItem(BaseModel):

--- a/app/deliver_grant_funding/routes/collections.py
+++ b/app/deliver_grant_funding/routes/collections.py
@@ -60,7 +60,12 @@ from app.common.data.interfaces.collections import (
     update_group,
     update_question,
 )
-from app.common.data.interfaces.data_sets import create_uploaded_data_source, delete_data_source, get_data_source
+from app.common.data.interfaces.data_sets import (
+    create_uploaded_data_source,
+    delete_data_source,
+    get_data_source,
+    get_data_source_list_for_collection,
+)
 from app.common.data.interfaces.exceptions import (
     DuplicateDataSourceItemError,
     DuplicateValueError,
@@ -3314,6 +3319,7 @@ def list_collection_data_sets(
     grant_id: UUID, collection_type: CollectionType, collection_id: UUID
 ) -> ResponseReturnValue:
     collection = get_collection(collection_id, grant_id=grant_id, type_=collection_type)
+    data_sources = get_data_source_list_for_collection(collection_id)
 
     form = GenericSubmitForm()
 
@@ -3335,6 +3341,7 @@ def list_collection_data_sets(
         grant=collection.grant,
         collection=collection,
         form=form,
+        data_sources=data_sources,
     )
 
 

--- a/app/deliver_grant_funding/routes/reports.py
+++ b/app/deliver_grant_funding/routes/reports.py
@@ -11,6 +11,7 @@ from app.common.data.interfaces.collections import (
     delete_collection,
     get_collection,
 )
+from app.common.data.interfaces.data_sets import get_collection_ids_with_missing_data_data_sets
 from app.common.data.interfaces.grants import get_grant
 from app.common.data.interfaces.user import get_current_user
 from app.common.data.types import (
@@ -30,6 +31,7 @@ if TYPE_CHECKING:
 @auto_commit_after_request
 def list_reports(grant_id: UUID) -> ResponseReturnValue:
     grant = get_grant(grant_id, with_all_collections=True)
+    collections_with_missing_data_data_sets = get_collection_ids_with_missing_data_data_sets(grant_id)
 
     delete_wtform, delete_report = None, None
     if delete_report_id := request.args.get("delete"):
@@ -57,4 +59,5 @@ def list_reports(grant_id: UUID) -> ResponseReturnValue:
         grant=grant,
         delete_form=delete_wtform,
         delete_report=delete_report,
+        collections_with_missing_data_data_sets=collections_with_missing_data_data_sets,
     )

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/collections/data_sets/view_data_set.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/collections/data_sets/view_data_set.html
@@ -4,6 +4,7 @@
 {% from "govuk_frontend_jinja/components/tag/macro.html" import govukTag %}
 {% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
 {% from "deliver_grant_funding/macros/deliver_grant_funding_collection_breadcrumb.html" import deliver_grant_funding_collection_breadcrumb %}
+{% from "govuk_frontend_jinja/components/warning-text/macro.html" import govukWarningText %}
 
 {% set type_constants = collection.type.constants %}
 {% set active_item_identifier = type_constants.active_nav %}
@@ -96,6 +97,10 @@
 
       {{ govukSummaryList({"rows": summary_rows}) }}
 
+      {% if data_source.has_missing_data %}
+        {{ govukWarningText({"text": ("Grant recipients with missing data will not be able to complete the report until their missing data is uploaded.")}) }}
+      {% endif %}
+
       {% if authorisation_helper.can_edit_collection(current_user, collection.id) %}
         <div class="govuk-button-group">
           <a class="govuk-button govuk-button--warning" href="?delete">Delete data set</a>
@@ -130,7 +135,7 @@
         {% for slug, col_schema in data_source.schema.root.items() %}
           {% set answer = typed_row[slug] %}
           {% if answer is none %}
-            {% do row.append({"html": govukTag({"text": "Data missing", "classes": "govuk-tag--yellow"})}) %}
+            {% do row.append({"html": govukTag({"text": "Data missing", "classes": "govuk-tag--orange"})}) %}
           {% else %}
             {% do row.append({"text": answer.get_value_for_interpolation()}) %}
           {% endif %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/collections/list_data_sets.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/collections/list_data_sets.html
@@ -3,6 +3,7 @@
 {% from "govuk_frontend_jinja/components/notification-banner/macro.html" import govukNotificationBanner %}
 {% from "deliver_grant_funding/macros/deliver_grant_funding_collection_breadcrumb.html" import deliver_grant_funding_collection_breadcrumb %}
 {% from 'govuk_frontend_jinja/components/details/macro.html' import govukDetails %}
+{% from "govuk_frontend_jinja/components/tag/macro.html" import govukTag %}
 
 {% set type_constants = collection.type.constants %}
 {% set page_title = "Data sets for " + collection.name %}
@@ -60,18 +61,21 @@
     </div>
     <div class="govuk-grid-column-full">
       {% set rows = [] %}
-      {% if collection.data_sources | length > 0 %}
+      {% if data_sources %}
 
-        {% for data_set in collection.data_sources|sort(attribute='name') %}
+        {% for data_set in data_sources %}
           {% set data_set_name_html %}
             <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('deliver_grant_funding.view_data_source', grant_id=grant.id, collection_type=collection.type, collection_id=collection.id, data_source_id=data_set.id) }}"
               >{{ data_set.name }}</a
             >
+            {% if data_set.has_missing_data %}
+              {{ govukTag({"text": "Data missing", "classes": "govuk-tag--orange govuk-!-margin-left-1"}) }}
+            {% endif %}
           {% endset %}
           {% set data_set_timestamp %}
             <time datetime="{{ iso_utc(data_set.updated_at_utc) }}">{{ format_datetime_short(data_set.updated_at_utc) }}</time>
           {% endset %}
-          {% do rows.append([{"html": data_set_name_html}, {"html": data_set_timestamp}, {"text": data_set.updated_by.name if data_set.updated_by else data_set.created_by.name}]) %}
+          {% do rows.append([{"html": data_set_name_html}, {"html": data_set_timestamp}, {"text": data_set.uploaded_by_name}]) %}
         {% endfor %}
       {% else %}
         {% set no_data_sets_text %}

--- a/app/deliver_grant_funding/templates/deliver_grant_funding/macros/collection_card.html
+++ b/app/deliver_grant_funding/templates/deliver_grant_funding/macros/collection_card.html
@@ -1,5 +1,6 @@
 {% from "common/macros/status.html" import reportStatusTag with context %}
 {% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
+{% from "govuk_frontend_jinja/components/tag/macro.html" import govukTag %}
 
 {% macro collection_card(collection) %}
   {% set can_edit = authorisation_helper.can_edit_collection(current_user, collection.id) %}
@@ -35,6 +36,9 @@
       {% trans count = collection.data_sources | length %}{{ count }} data set{% pluralize %}{{ count }} data sets{% endtrans %}
       <span class="govuk-visually-hidden"> for {{ collection.name }}</span>
     </a>
+    {% if collections_with_missing_data_data_sets and collection.id in collections_with_missing_data_data_sets %}
+      {{ govukTag({"text": "Data missing", "classes": "govuk-tag--orange govuk-!-margin-left-1"}) }}
+    {% endif %}
   {% endset %}
 
 

--- a/tests/integration/common/data/interfaces/test_data_sets.py
+++ b/tests/integration/common/data/interfaces/test_data_sets.py
@@ -13,7 +13,9 @@ from app.common.data.interfaces.collections import (
 from app.common.data.interfaces.data_sets import (
     create_uploaded_data_source,
     delete_data_source,
+    get_collection_ids_with_missing_data_data_sets,
     get_data_source,
+    get_data_source_list_for_collection,
 )
 from app.common.data.models import ComponentReference, DataSource, DataSourceItem, DataSourceOrganisationItem
 from app.common.data.types import (
@@ -713,3 +715,201 @@ class TestDataSourceOrganisationItemDataProperty:
         # Confirm typed .data returns None
         assert org_item.data["c_notes"] is None
         assert org_item.data["c_capital_allocation"] is None
+
+
+class TestGetDataSourceListForCollection:
+    def test_returns_data_sources_for_collection(self, factories, track_sql_queries):
+        grant = factories.grant.create()
+        collection = factories.collection.create(grant=grant)
+        collection_id = collection.id
+        factories.grant_recipient.create_batch(3, grant=grant)
+        user_1 = factories.user.create()
+        user_2 = factories.user.create()
+        data_source = factories.data_source.create(
+            name="First data set",
+            grant=grant,
+            collection=collection,
+            type=DataSourceType.GRANT_RECIPIENT,
+            create_gr_org_items=True,
+            create_gr_org_items__data=[111, 222, 333],
+            created_by=user_1,
+        )
+        data_source_2 = factories.data_source.create(
+            name="Second data set",
+            grant=grant,
+            collection=collection,
+            type=DataSourceType.GRANT_RECIPIENT,
+            create_gr_org_items=True,
+            create_gr_org_items__data=[111, 222, 333],
+            created_by=user_1,
+            updated_by=user_2,
+        )
+
+        with track_sql_queries() as queries:
+            rows = get_data_source_list_for_collection(collection_id)
+        assert len(queries) == 1
+
+        assert len(rows) == 2
+        assert [(row.name, row.uploaded_by_name) for row in rows] == [
+            (data_source.name, data_source.created_by.name),
+            (data_source_2.name, data_source_2.updated_by.name),
+        ]
+
+    def test_has_missing_data_true_when_org_item_has_null(self, factories):
+        grant = factories.grant.create()
+        collection = factories.collection.create(grant=grant)
+        factories.grant_recipient.create_batch(3, grant=grant)
+        data_source = factories.data_source.create(
+            name="First data set",
+            grant=grant,
+            collection=collection,
+            type=DataSourceType.GRANT_RECIPIENT,
+            create_gr_org_items=True,
+            create_gr_org_items__data=[111, 222, None],
+        )
+        data_source_2 = factories.data_source.create(
+            name="Second data set",
+            grant=grant,
+            collection=collection,
+            type=DataSourceType.GRANT_RECIPIENT,
+            create_gr_org_items=True,
+            create_gr_org_items__data=[111, 222, 333],
+        )
+        rows = get_data_source_list_for_collection(collection.id)
+        rows_by_id = {row.id: row for row in rows}
+        assert rows_by_id[data_source.id].has_missing_data is True
+        assert rows_by_id[data_source_2.id].has_missing_data is False
+
+    def test_excludes_data_sources_from_other_collections(self, factories):
+        grant = factories.grant.create()
+        collection = factories.collection.create(grant=grant)
+        collection_2 = factories.collection.create(grant=grant)
+
+        factories.grant_recipient.create_batch(3, grant=grant)
+
+        data_source = factories.data_source.create(
+            name="First data set",
+            grant=grant,
+            collection=collection,
+            type=DataSourceType.GRANT_RECIPIENT,
+            create_gr_org_items=True,
+            create_gr_org_items__data=[111, 222, None],
+        )
+        factories.data_source.create(
+            name="Second data set",
+            grant=grant,
+            collection=collection_2,
+            type=DataSourceType.GRANT_RECIPIENT,
+            create_gr_org_items=True,
+            create_gr_org_items__data=[111, 222, 333],
+        )
+
+        rows = get_data_source_list_for_collection(collection.id)
+        assert len(rows) == 1
+        assert rows[0].name == data_source.name
+
+    def test_ordering_is_by_name(self, factories):
+        grant = factories.grant.create()
+        collection = factories.collection.create(grant=grant)
+        factories.grant_recipient.create_batch(3, grant=grant)
+        data_source = factories.data_source.create(
+            name="Zzzz data set",
+            grant=grant,
+            collection=collection,
+            type=DataSourceType.GRANT_RECIPIENT,
+            create_gr_org_items=True,
+            create_gr_org_items__data=[111, 222, None],
+        )
+
+        data_source_2 = factories.data_source.create(
+            name="Mmmm data set",
+            grant=grant,
+            collection=collection,
+            type=DataSourceType.GRANT_RECIPIENT,
+            create_gr_org_items=True,
+            create_gr_org_items__data=[111, 222, 333],
+        )
+        data_source_3 = factories.data_source.create(
+            name="Aaaa data set",
+            grant=grant,
+            collection=collection,
+            type=DataSourceType.GRANT_RECIPIENT,
+            create_gr_org_items=True,
+            create_gr_org_items__data=[111, 222, 333],
+        )
+        rows = get_data_source_list_for_collection(collection.id)
+        assert [row.name for row in rows] == [
+            data_source_3.name,
+            data_source_2.name,
+            data_source.name,
+        ]
+
+
+class TestGetCollectionIdsWithMissingDataDataSets:
+    def test_returns_collection_id_when_data_source_has_missing_data(self, factories, track_sql_queries):
+        grant = factories.grant.create()
+        collection = factories.collection.create(grant=grant)
+        collection_2 = factories.collection.create(grant=grant)
+
+        factories.grant_recipient.create_batch(3, grant=grant)
+
+        factories.data_source.create(
+            grant=grant,
+            collection=collection,
+            type=DataSourceType.GRANT_RECIPIENT,
+            create_gr_org_items=True,
+            create_gr_org_items__data=[111, 222, None],
+        )
+        factories.data_source.create(
+            name="Second data set",
+            grant=grant,
+            collection=collection_2,
+            type=DataSourceType.GRANT_RECIPIENT,
+            create_gr_org_items=True,
+            create_gr_org_items__data=[111, 222, 333],
+        )
+
+        grant_id = grant.id
+
+        with track_sql_queries() as queries:
+            result = get_collection_ids_with_missing_data_data_sets(grant_id)
+        assert len(queries) == 1
+
+        assert collection.id in result
+        assert collection_2.id not in result
+
+    def test_excludes_collections_from_other_grants(self, factories):
+        grant = factories.grant.create()
+        grant_2 = factories.grant.create()
+        collection = factories.collection.create(grant=grant)
+        collection_2 = factories.collection.create(grant=grant_2)
+
+        factories.grant_recipient.create_batch(3, grant=grant)
+
+        factories.data_source.create(
+            grant=grant,
+            collection=collection,
+            type=DataSourceType.GRANT_RECIPIENT,
+            create_gr_org_items=True,
+            create_gr_org_items__data=[111, 222, None],
+        )
+        factories.data_source.create(
+            name="Second data set",
+            grant=grant_2,
+            collection=collection_2,
+            type=DataSourceType.GRANT_RECIPIENT,
+            create_gr_org_items=True,
+            create_gr_org_items__data=[111, 222, 333],
+        )
+        result = get_collection_ids_with_missing_data_data_sets(grant.id)
+        assert collection.id in result
+        assert collection_2.id not in result
+
+    def test_returns_empty_set_when_no_data_sources(self, factories):
+        grant = factories.grant.create()
+        factories.collection.create(grant=grant)
+        factories.grant_recipient.create_batch(3, grant=grant)
+
+        result = get_collection_ids_with_missing_data_data_sets(grant.id)
+
+        assert result == set()

--- a/tests/integration/common/data/test_models.py
+++ b/tests/integration/common/data/test_models.py
@@ -2,13 +2,14 @@ from datetime import date
 
 import pytest
 from psycopg.errors import ForeignKeyViolation
+from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
 from app import QuestionDataType
 from app.common.collections.types import (
     TextSingleLineAnswer,
 )
-from app.common.data.models import ComponentReference, Expression, Group
+from app.common.data.models import ComponentReference, DataSource, Expression, Group
 from app.common.data.types import (
     DataSourceType,
     ExpressionType,
@@ -910,3 +911,77 @@ class TestDataSourceModel:
         assert data_source.get_filtered_organisation_item(gr2.organisation.external_id)._data["c_allocation"] == 222
         assert data_source.get_filtered_organisation_item(gr3.organisation.external_id)._data["c_allocation"] == 333
         assert data_source.get_filtered_organisation_item(gr4.organisation.external_id) is None
+
+    def test_has_missing_data_python_true_when_null_values(self, factories):
+        grant = factories.grant.create()
+        report = factories.collection.create(grant=grant)
+        factories.grant_recipient.create_batch(3, grant=grant)
+        data_source = factories.data_source.create(
+            grant=grant,
+            collection=report,
+            type=DataSourceType.GRANT_RECIPIENT,
+            create_gr_org_items=True,
+            create_gr_org_items__data=[111, 222, None],
+        )
+
+        assert data_source.has_missing_data is True
+
+    def test_has_missing_data_python_false_when_all_values_present(self, factories):
+        grant = factories.grant.create()
+        report = factories.collection.create(grant=grant)
+        factories.grant_recipient.create_batch(3, grant=grant)
+        data_source = factories.data_source.create(
+            grant=grant,
+            collection=report,
+            type=DataSourceType.GRANT_RECIPIENT,
+            create_gr_org_items=True,
+            create_gr_org_items__data=[111, 222, 333],
+        )
+
+        assert data_source.has_missing_data is False
+
+    def test_has_missing_data_python_true_when_no_org_items(self, factories):
+        grant = factories.grant.create()
+        report = factories.collection.create(grant=grant)
+        data_source = factories.data_source.create(grant=grant, collection=report, type=DataSourceType.GRANT_RECIPIENT)
+
+        assert data_source.has_missing_data is True
+
+    def test_has_missing_data_sql_true_when_null_values(self, factories, db_session, track_sql_queries):
+        grant = factories.grant.create()
+        report = factories.collection.create(grant=grant)
+        factories.grant_recipient.create_batch(3, grant=grant)
+        data_source = factories.data_source.create(
+            grant=grant,
+            collection=report,
+            type=DataSourceType.GRANT_RECIPIENT,
+            create_gr_org_items=True,
+            create_gr_org_items__data=[111, 222, 333],
+        )
+        data_source_2 = factories.data_source.create(
+            name="Missing data set",
+            grant=grant,
+            collection=report,
+            type=DataSourceType.GRANT_RECIPIENT,
+            create_gr_org_items=True,
+            create_gr_org_items__data=[111, 222, None],
+        )
+
+        results = db_session.scalars(select(DataSource).where(DataSource.has_missing_data)).all()
+        assert data_source_2 in results
+        assert data_source not in results
+
+    def test_has_missing_data_sql_true_when_grant_recipients_and_no_org_items(self, factories, db_session):
+        grant = factories.grant.create()
+        report = factories.collection.create(grant=grant)
+        factories.grant_recipient.create_batch(3, grant=grant)
+        data_source = factories.data_source.create(grant=grant, collection=report, type=DataSourceType.GRANT_RECIPIENT)
+
+        results = db_session.scalars(select(DataSource).where(DataSource.has_missing_data)).all()
+        assert data_source in results
+
+    def test_has_missing_data_sql_false_for_custom_type(self, factories, db_session):
+        data_source = factories.data_source.create(type=DataSourceType.CUSTOM)
+
+        results = db_session.scalars(select(DataSource).where(DataSource.has_missing_data)).all()
+        assert data_source not in results

--- a/tests/integration/deliver_grant_funding/routes/test_collections.py
+++ b/tests/integration/deliver_grant_funding/routes/test_collections.py
@@ -9180,8 +9180,11 @@ class TestListCollectionDataSets:
     def test_get(self, request: FixtureRequest, client_fixture: str, can_upload: bool, factories):
         client = request.getfixturevalue(client_fixture)
         collection = factories.collection.create(grant=client.grant, name="Test Report")
+        factories.grant_recipient.create_batch(3, grant=client.grant)
+
         uploader = factories.user.create(name="Bilbo Baggins")
         uploader_2 = factories.user.create(name="Frodo Baggins")
+
         data_source_1 = factories.data_source.create(
             type=DataSourceType.GRANT_RECIPIENT,
             name="Allocations Data",
@@ -9190,7 +9193,7 @@ class TestListCollectionDataSets:
             created_by=uploader,
             updated_by=None,
             created_at_utc=datetime.datetime(2025, 7, 1, 13, 30, 0),
-            items=None,
+            create_gr_org_items=True,
         )
         data_source_2 = factories.data_source.create(
             type=DataSourceType.GRANT_RECIPIENT,
@@ -9201,6 +9204,7 @@ class TestListCollectionDataSets:
             updated_by=uploader_2,
             created_at_utc=datetime.datetime(2025, 7, 1, 13, 30, 0),
             updated_at_utc=datetime.datetime(2025, 7, 1, 14, 30, 0),
+            create_gr_org_items=True,
         )
 
         other_report = factories.collection.create(name="Other Report")
@@ -9232,10 +9236,50 @@ class TestListCollectionDataSets:
         assert data_source_timestamps[0].text == "1 Jul 2025 at 2:30pm"
         assert data_source_timestamps[1].text == "1 Jul 2025 at 3:30pm"
 
+        data_missing_tags = soup.select(".govuk-tag")
+        assert len(data_missing_tags) == 0
+
         if not can_upload:
             assert page_has_button(soup, button_text="Upload new data set") is None
         else:
             assert page_has_button(soup, button_text="Upload new data set") is not None
+
+    def test_get_shows_missing_data_tag(self, authenticated_org_admin_client, factories):
+        grant = factories.grant.create()
+        collection = factories.collection.create(grant=grant, name="Test Report")
+        factories.grant_recipient.create_batch(3, grant=grant)
+        factories.data_source.create(
+            name="Allocations Data",
+            type=DataSourceType.GRANT_RECIPIENT,
+            grant=grant,
+            collection=collection,
+            create_gr_org_items=True,
+            create_gr_org_items__data=[111, 222, 333],
+        )
+        factories.data_source.create(
+            name="Organisation Data",
+            type=DataSourceType.GRANT_RECIPIENT,
+            grant=grant,
+            collection=collection,
+            create_gr_org_items=True,
+            create_gr_org_items__data=[111, 222, None],
+        )
+
+        response = authenticated_org_admin_client.get(
+            url_for(
+                "deliver_grant_funding.list_collection_data_sets",
+                grant_id=grant.id,
+                collection_type=CollectionType.MONITORING_REPORT,
+                collection_id=collection.id,
+            )
+        )
+
+        soup = BeautifulSoup(response.data, "html.parser")
+        assert response.status_code == 200
+        data_missing_tags = soup.select(".govuk-tag")
+        assert len(data_missing_tags) == 1
+        tag_texts = {tag.text.strip() for tag in data_missing_tags}
+        assert "Data missing" in tag_texts
 
     def test_get_upload_button_not_visible_for_live_report(self, authenticated_org_admin_client, factories):
         grant = factories.grant.create()
@@ -10732,7 +10776,9 @@ class TestViewDataSource:
         assert "Allocation" in soup.text
         assert "£500,000" in soup.text
 
-    def test_get_shows_missing_data_tag_for_empty_values(self, authenticated_grant_member_client, factories):
+    def test_get_shows_missing_data_tag_and_warning_for_empty_values(
+        self, authenticated_grant_member_client, factories
+    ):
         collection = factories.collection.create(grant=authenticated_grant_member_client.grant)
         data_source = factories.data_source.create(
             collection=collection,
@@ -10755,6 +10801,10 @@ class TestViewDataSource:
         assert response.status_code == 200
         soup = BeautifulSoup(response.data, "html.parser")
         assert "Data missing" in soup.text
+        assert (
+            "Grant recipients with missing data will not be able to complete the report"
+            " until their missing data is uploaded" in soup.text
+        )
 
     def test_get_shows_missing_grant_recipient_tag_for_not_set_up_grant_recipient(
         self, authenticated_grant_member_client, factories

--- a/tests/integration/deliver_grant_funding/routes/test_reports.py
+++ b/tests/integration/deliver_grant_funding/routes/test_reports.py
@@ -11,6 +11,7 @@ from app.common.data.models import (
 from app.common.data.types import (
     CollectionStatusEnum,
     CollectionType,
+    DataSourceType,
     SubmissionModeEnum,
 )
 from app.common.forms import GenericConfirmDeletionForm
@@ -136,6 +137,42 @@ class TestListReports:
         assert response.status_code == 200
         soup = BeautifulSoup(response.data, "html.parser")
         assert page_has_button(soup, "Yes, delete this report")
+
+    def test_get_shows_missing_data_tag_for_data_sets(self, authenticated_platform_admin_client, factories):
+        grant = factories.grant.create()
+        report = factories.collection.create(grant=grant, name="Test Report")
+        report_2 = factories.collection.create(grant=grant, name="Test Report 2")
+
+        factories.grant_recipient.create_batch(3, grant=grant)
+        factories.data_source.create(
+            name="Allocations Data",
+            type=DataSourceType.GRANT_RECIPIENT,
+            grant=grant,
+            collection=report,
+            create_gr_org_items=True,
+            create_gr_org_items__data=[111, 222, 333],
+        )
+        factories.data_source.create(
+            name="Organisation Data",
+            type=DataSourceType.GRANT_RECIPIENT,
+            grant=grant,
+            collection=report_2,
+            create_gr_org_items=True,
+            create_gr_org_items__data=[111, 222, None],
+        )
+
+        response = authenticated_platform_admin_client.get(
+            url_for(
+                "deliver_grant_funding.list_reports",
+                grant_id=grant.id,
+            )
+        )
+
+        assert response.status_code == 200
+        soup = BeautifulSoup(response.data, "html.parser")
+        data_missing_tags = soup.select(".govuk-tag")
+        tag_texts = [tag.text.strip() for tag in data_missing_tags]
+        assert tag_texts.count("Data missing") == 1
 
     @pytest.mark.parametrize(
         "client_fixture, can_delete",


### PR DESCRIPTION
## 🎫 Ticket
https://mhclgdigital.atlassian.net/browse/FSPT-1342

## 📝 Description
There are a few places that need to be aware of whether or not a data set has missing data in it (in this instance, missing data specifically means grant recipient rows with missing column values, not missing grant recipients entirely which will come in a later PR). 

Namely:
- The `list_reports` view needs to add a 'Data missing' tag if any data sets belonging to that report have missing data
- The `list_collection_data_sets` view needs to add a 'Data missing' tag if a data set in the list has missing data
- The `view_data_source` view itself needs to add a warning if a data set has missing data

This PR adds a hybrid property to the DataSource model to be able to work this out consistently, and a couple of new interfaces for list_reports and list_collection_data_sets including using a dataclass for the latter to only pull back the key info we need to populate the table, rather than firing off lots of additional queries, following the pattern established by the ListSubmissionsData dataclass.

_NB: The SQL side of the hybrid property had some help from AI to get the jsonb path stuff_


## 📸 Show the thing (screenshots, gifs)
<img width="1039" height="1280" alt="2026-06-16 10 42 08" src="https://github.com/user-attachments/assets/7c482f96-6319-43d3-9f4f-94b240d2615d" />


## 🧪 Testing
Upload some data sets with missing data and some complete ones and see that the tag and warning panel appear in the correct places.

## 📋 Developer Checklist
<!-- Check all applicable items before requesting review -->

### Review Readiness
- [X] PR title and description provide sufficient context for reviewers
- [X] Commits are logical, self-contained, and have clear descriptions

### Performance and security
- [X] No N+1 query problems introduced
- [X] Any new DB queries include appropriate where clauses based on the user's permissions

### Testing
- [X] I have tested this change and it meets the acceptance criteria for the ticket
- [X] I need the reviewer(s) to pull and run this change locally
- [X] New (non-developer) functionality has appropriate unit and integration tests
- ~[ ] End-to-end tests have been updated (if applicable)~
- [X] Edge cases and error conditions are tested
